### PR TITLE
If the search is filtered to only return some fields, _source is not included in each hit. Include the returned fields in the Hit.

### DIFF
--- a/src/ElasticSearch.Client/Domain/Hit/Hit.cs
+++ b/src/ElasticSearch.Client/Domain/Hit/Hit.cs
@@ -9,6 +9,8 @@ namespace ElasticSearch.Client
 	[JsonObject]
 	public class Hit<T> where T : class
 	{
+		[JsonProperty(PropertyName = "fields")]
+		public T Fields { get; internal set; }
 		[JsonProperty(PropertyName = "_source")]
 		public T Source { get; internal set; }
 		[JsonProperty(PropertyName = "_index")]

--- a/src/ElasticSearch.Client/Domain/Responses/QueryResponse.cs
+++ b/src/ElasticSearch.Client/Domain/Responses/QueryResponse.cs
@@ -69,7 +69,7 @@ namespace ElasticSearch.Client
 				{
 					foreach (var hit in this.Hits.Hits)
 					{
-						yield return hit.Source;
+						yield return hit.Source ?? hit.Fields;
 					}
 				}
 			}


### PR DESCRIPTION
Rebase of [this commit](https://github.com/kevingessner/NEST/commit/749f4fc68b20c2384b04f14a8144a10664a5aac7), so you can pull it without my other change.
