### PR TITLE
Made IElasticClient interface public

### DIFF
--- a/src/Nest/IElasticClient.cs
+++ b/src/Nest/IElasticClient.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 namespace Nest
 {
-	interface IElasticClient
+	public interface IElasticClient
 	{
 		IndicesOperationResponse Alias(AliasParams aliasParams);
 		IndicesOperationResponse Alias(System.Collections.Generic.IEnumerable<AliasParams> aliases);


### PR DESCRIPTION
Making IElasticClient interface public, makes it easy to dependency inject ElasticClient into other types as well as mock usages etc.
