### PR TITLE
GetMapping<T> crashes with infinite loop

### DIFF
--- a/src/Nest/ElasticClient-MappingType.cs
+++ b/src/Nest/ElasticClient-MappingType.cs
@@ -220,7 +220,7 @@ namespace Nest
 		public TypeMapping GetMapping<T>() where T : class
 		{
 			var index = this.Settings.GetIndexForType<T>();
-      return this.GetMapping<T>();
+            return this.GetMapping<T>(index);
 		}
 		/// <summary>
 		/// Get the current mapping for T at the specified index


### PR DESCRIPTION
Currently, the code for retrieving the mapping for a class is this:

```
public TypeMapping GetMapping<T>() where T : class
{
    var index = this.Settings.GetIndexForType<T>();
    return this.GetMapping<T>();
}
```

The `index` variable is unused, so this method keeps calling itself, which results into a StackOverflowException.

This pull request fixes that and uses the `index` variable to call the `GetMapping<T>( string index )` overload. 
I've not included any tests, since a test for this method is already present in `IndicesTest.PutMapping()`. It crashed before, but now it passes.

You have the honour of receiving my very first pull request, so if I did things wrong or you want me to add change anything, just let me know.
