### PR TITLE
Fix the properties names of numeric-range-filter (include_lower and include_upper)

### DIFF
--- a/src/Nest.Tests.Integration/Facet/BaseFacetTestFixture.cs
+++ b/src/Nest.Tests.Integration/Facet/BaseFacetTestFixture.cs
@@ -1,10 +1,9 @@
 ﻿using System.Linq;
-using Nest;
 using NUnit.Framework;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 
-namespace Nest.Tests.Integration.Integration.FacetResponses
+namespace Nest.Tests.Integration.Facet
 {
     public class BaseFacetTestFixture : BaseElasticSearchTests
     {

--- a/src/Nest.Tests.Integration/Facet/GeoDistanceFacetResponseTests.cs
+++ b/src/Nest.Tests.Integration/Facet/GeoDistanceFacetResponseTests.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using HackerNews.Indexer.Domain;
-using Nest.Tests.MockData;
+﻿using System.Linq;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
-namespace Nest.Tests.Integration.Integration.FacetResponses
+namespace Nest.Tests.Integration.Facet
 {
 	[TestFixture]
 	public class GeoDistanceFacetResponseTests : BaseFacetTestFixture

--- a/src/Nest.Tests.Integration/Facet/HistogramFacetResponseTests.cs
+++ b/src/Nest.Tests.Integration/Facet/HistogramFacetResponseTests.cs
@@ -1,15 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Nest;
-using HackerNews.Indexer.Domain;
-using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
-namespace Nest.Tests.Integration.Integration.FacetResponses
+namespace Nest.Tests.Integration.Facet
 {
 	/// <summary>
 	///  Tests that test whether the query response can be successfully mapped or not

--- a/src/Nest.Tests.Integration/Facet/RangeFacetResponseTests.cs
+++ b/src/Nest.Tests.Integration/Facet/RangeFacetResponseTests.cs
@@ -1,15 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Nest;
-using HackerNews.Indexer.Domain;
-using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
-namespace Nest.Tests.Integration.Integration.FacetResponses
+namespace Nest.Tests.Integration.Facet
 {
 	/// <summary>
 	///  Tests that test whether the query response can be successfully mapped or not

--- a/src/Nest.Tests.Integration/Facet/StatisticalFacetResponseTests.cs
+++ b/src/Nest.Tests.Integration/Facet/StatisticalFacetResponseTests.cs
@@ -1,8 +1,7 @@
-﻿using Nest;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 
-namespace Nest.Tests.Integration.Integration.FacetResponses
+namespace Nest.Tests.Integration.Facet
 {
     /// <summary>
     ///  Tests that test whether the query response can be successfully mapped or not

--- a/src/Nest.Tests.Integration/Facet/TermFacetResponseTests.cs
+++ b/src/Nest.Tests.Integration/Facet/TermFacetResponseTests.cs
@@ -1,10 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Nest;
+﻿using System.Linq;
 using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 
-namespace Nest.Tests.Integration.Integration.FacetResponses
+namespace Nest.Tests.Integration.Facet
 {
 	/// <summary>
 	///  Tests that test whether the query response can be successfully mapped or not

--- a/src/Nest.Tests.Integration/Facet/TermStatsFacetResponseTests.cs
+++ b/src/Nest.Tests.Integration/Facet/TermStatsFacetResponseTests.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using HackerNews.Indexer.Domain;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
-namespace Nest.Tests.Integration.Integration.FacetResponses
+namespace Nest.Tests.Integration.Facet
 {
 	/// <summary>
 	///  Tests that test whether the query response can be successfully mapped or not

--- a/src/Nest.Tests.Integration/Indices/AliasTests.cs
+++ b/src/Nest.Tests.Integration/Indices/AliasTests.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class AliasTest : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/AnalyzeTests.cs
+++ b/src/Nest.Tests.Integration/Indices/AnalyzeTests.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
+﻿using System.Linq;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class AnalyzeTest : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/ClearCacheTests.cs
+++ b/src/Nest.Tests.Integration/Indices/ClearCacheTests.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
+﻿using System.Collections.Generic;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class ClearCacheTest : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/ExistsTests.cs
+++ b/src/Nest.Tests.Integration/Indices/ExistsTests.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class ExistsTest : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/FlushTests.cs
+++ b/src/Nest.Tests.Integration/Indices/FlushTests.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class FlushTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/IndicesTests.cs
+++ b/src/Nest.Tests.Integration/Indices/IndicesTests.cs
@@ -1,17 +1,11 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Nest;
-
-
-using HackerNews.Indexer.Domain;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-namespace Nest.Tests.Integration
+namespace Nest.Tests.Integration.Indices
 {
 	/// <summary>
 	///  Tests that test whether the query response can be successfully mapped or not

--- a/src/Nest.Tests.Integration/Indices/OpenCloseTests.cs
+++ b/src/Nest.Tests.Integration/Indices/OpenCloseTests.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class OpenCloseTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/OptimizeTests.cs
+++ b/src/Nest.Tests.Integration/Indices/OptimizeTests.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class OptimizeTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/RefreshTests.cs
+++ b/src/Nest.Tests.Integration/Indices/RefreshTests.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class RefreshTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/SegmentsTests.cs
+++ b/src/Nest.Tests.Integration/Indices/SegmentsTests.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using System.Linq;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class SegmentsTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/SnapshotTests.cs
+++ b/src/Nest.Tests.Integration/Indices/SnapshotTests.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class SnapshotTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Indices/StatsTests.cs
+++ b/src/Nest.Tests.Integration/Indices/StatsTests.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using System.Collections.Generic;
 using NUnit.Framework;
 
-
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Indices
 {
 	[TestFixture]
 	public class StatsTest : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Integration/AsyncTests.cs
+++ b/src/Nest.Tests.Integration/Integration/AsyncTests.cs
@@ -1,17 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-using HackerNews.Indexer.Domain;
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
-using System.Threading;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 using System.Diagnostics;
 using System.Net;
 
-namespace Nest.Tests.Integration.Integration.Integration
+namespace Nest.Tests.Integration.Integration
 {
 	[TestFixture]
 	public class AsyncTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Integration/DeleteTests.cs
+++ b/src/Nest.Tests.Integration/Integration/DeleteTests.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Nest;
-using HackerNews.Indexer.Domain;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
-using System.Threading;
 using NUnit.Framework;
 
-namespace Nest.Tests.Integration.Integration.Integration
+namespace Nest.Tests.Integration.Integration
 {
 	[TestFixture]
 	public class DeleteTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Integration/Filter/BoolFilterTests.cs
+++ b/src/Nest.Tests.Integration/Integration/Filter/BoolFilterTests.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using NUnit.Framework;
-
+﻿using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 
-namespace Nest.Tests.Integration.Integration.Integration.Filter
+namespace Nest.Tests.Integration.Integration.Filter
 {
 	[TestFixture]
 	public class BoolFilterTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Integration/Filter/NumericRangeFilterTests.cs
+++ b/src/Nest.Tests.Integration/Integration/Filter/NumericRangeFilterTests.cs
@@ -1,0 +1,81 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Nest.Tests.MockData;
+using Nest.Tests.MockData.Domain;
+
+namespace Nest.Tests.Integration.Integration.Filter
+{
+	/// <summary>
+	/// Integrated tests of NumericRangeFilter with elasticsearch.
+	/// </summary>
+	[TestFixture]
+	public class NumericRangeFilterTests : BaseElasticSearchTests
+	{
+		/// <summary>
+		/// Document used in test.
+		/// </summary>
+		private ElasticSearchProject _LookFor = NestTestData.Data.First();
+
+		/// <summary>
+		/// Test control. If this test fail, the problem not in NumericRangeFilter.
+		/// </summary>
+		[Test]
+		public void TestControl()
+		{
+			var id = _LookFor.Id;
+			var filterId = Filter<ElasticSearchProject>.Term(e => e.Id, id.ToString());
+
+			var results = this.ConnectedClient.Search<ElasticSearchProject>(
+				s => s.Filter(filterId && filterId)
+				);
+
+			Assert.True(results.IsValid, results.ConnectionStatus.Result);
+			Assert.True(results.ConnectionStatus.Success, results.ConnectionStatus.Result);
+			Assert.AreEqual(results.Total, 1);
+		}
+
+		/// <summary>
+		/// Set of filters that should not filter de documento _LookFor.
+		/// </summary>
+		[Test]
+		public void TestNotFiltered()
+		{
+			var id = _LookFor.Id;
+			var filterId = Filter<ElasticSearchProject>.Term(e => e.Id, id.ToString());
+			var filterInclusive = Filter<ElasticSearchProject>.NumericRange(range => range.OnField(e => e.Id).From(id).To(id));
+			var filterExclusive = Filter<ElasticSearchProject>.NumericRange(range => range.OnField(e => e.Id).From(id - 1).To(id + 1).FromExclusive().ToExclusive());
+			var filterGreaterOrEquals = Filter<ElasticSearchProject>.NumericRange(range => range.OnField(e => e.Id).GreaterOrEquals(id));
+			var filterLowerOrEquals = Filter<ElasticSearchProject>.NumericRange(range => range.OnField(e => e.Id).LowerOrEquals(id));
+
+			var results = this.ConnectedClient.Search<ElasticSearchProject>(
+				s => s.Filter(filterId && filterInclusive && filterExclusive && filterGreaterOrEquals && filterLowerOrEquals)
+				);
+
+			Assert.True(results.IsValid, results.ConnectionStatus.Result);
+			Assert.True(results.ConnectionStatus.Success, results.ConnectionStatus.Result);
+			Assert.AreEqual(1, results.Total);
+		}
+
+		/// <summary>
+		/// Set of filters that should filter de documento _LookFor.
+		/// </summary>
+		[Test]
+		public void TestFiltered()
+		{
+			var id = _LookFor.Id;
+			var filterId = Filter<ElasticSearchProject>.Term(e => e.Id, id.ToString());
+			var filterFromInclusive = Filter<ElasticSearchProject>.NumericRange(range => range.OnField(e => e.Id).From(id + 1));
+			var filterToInclusive = Filter<ElasticSearchProject>.NumericRange(range => range.OnField(e => e.Id).To(id - 1));
+			var filterFromExclusive = Filter<ElasticSearchProject>.NumericRange(range => range.OnField(e => e.Id).From(id).FromExclusive());
+			var filterToExclusive = Filter<ElasticSearchProject>.NumericRange(range => range.OnField(e => e.Id).To(id).ToExclusive());
+
+			var results = this.ConnectedClient.Search<ElasticSearchProject>(
+				s => s.Filter(filterId && (filterFromInclusive || filterToInclusive || filterFromExclusive || filterToExclusive))
+				);
+
+			Assert.True(results.IsValid, results.ConnectionStatus.Result);
+			Assert.True(results.ConnectionStatus.Success, results.ConnectionStatus.Result);
+			Assert.AreEqual(0, results.Total);
+		}
+	}
+}

--- a/src/Nest.Tests.Integration/Integration/HighlightTests.cs
+++ b/src/Nest.Tests.Integration/Integration/HighlightTests.cs
@@ -1,17 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using NUnit.Framework;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
-using Nest;
-using Newtonsoft.Json.Converters;
-using Nest.Resolvers.Converters;
 using Nest.Tests.MockData.Domain;
 
-namespace Nest.Tests.Integration.Integration.Integration
+namespace Nest.Tests.Integration.Integration
 {
 	[TestFixture]
 	public class HighlightIntegrationTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Integration/Query/TermQueryDynamic.cs
+++ b/src/Nest.Tests.Integration/Integration/Query/TermQueryDynamic.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using NUnit.Framework;
-
 using Nest.Tests.MockData.Domain;
 
-namespace Nest.Tests.Integration.Integration.Integration.Query
+namespace Nest.Tests.Integration.Integration.Query
 {
 	[TestFixture]
 	public class TermQueryDynamic : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Integration/UpdateTests.cs
+++ b/src/Nest.Tests.Integration/Integration/UpdateTests.cs
@@ -1,17 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using NUnit.Framework;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
-using Nest;
-using Newtonsoft.Json.Converters;
-using Nest.Resolvers.Converters;
+﻿using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 
-namespace Nest.Tests.Integration.Integration.Integration
+namespace Nest.Tests.Integration.Integration
 {
 	[TestFixture]
 	public class UpdateIntegrationTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Mapping/MapTests.cs
+++ b/src/Nest.Tests.Integration/Mapping/MapTests.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-
-using Nest.Tests.MockData;
-using Nest.Tests.MockData.Domain;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-namespace Nest.Tests.Integration.Integration.Mapping
+namespace Nest.Tests.Integration.Mapping
 {
 	[TestFixture]
 	public class MapTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Mapping/NotAnalyzedTest.cs
+++ b/src/Nest.Tests.Integration/Mapping/NotAnalyzedTest.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
-
-using Nest.Tests.MockData;
+﻿using System.Linq;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-namespace Nest.Tests.Integration.Integration.Mapping
+namespace Nest.Tests.Integration.Mapping
 {
 	[TestFixture]
 	public class NotAnalyzedTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Indices\ExistsTests.cs" />
     <Compile Include="Indices\StatsTests.cs" />
     <Compile Include="Integration\AsyncTests.cs" />
+    <Compile Include="Integration\Filter\NumericRangeFilterTests.cs" />
     <Compile Include="Integration\UpdateTests.cs" />
     <Compile Include="Integration\Filter\BoolFilterTests.cs" />
     <Compile Include="Integration\HighlightTests.cs" />

--- a/src/Nest.Tests.Integration/Search/CountTests.cs
+++ b/src/Nest.Tests.Integration/Search/CountTests.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
+﻿using System.Linq;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Search
 {
 	[TestFixture]
 	public class CountTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Search/ExplainTests.cs
+++ b/src/Nest.Tests.Integration/Search/ExplainTests.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
+﻿using System.Linq;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Search
 {
 	[TestFixture]
 	public class ExplainTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Search/PercolateTests.cs
+++ b/src/Nest.Tests.Integration/Search/PercolateTests.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
+﻿using System.Linq;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Search
 {
 	[TestFixture]
 	public class PercolateTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Search/QueryDSLTests.cs
+++ b/src/Nest.Tests.Integration/Search/QueryDSLTests.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using NUnit.Framework;
-using Nest;
-using HackerNews.Indexer.Domain;
-
 using Nest.Tests.MockData.Domain;
 
-namespace Nest.Tests.Integration
+namespace Nest.Tests.Integration.Search
 {
   [TestFixture]
   public class QueryDSLTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Integration/Search/QueryResponseMapperTests.cs
+++ b/src/Nest.Tests.Integration/Search/QueryResponseMapperTests.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Nest;
 using HackerNews.Indexer.Domain;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
-namespace Nest.Tests.Integration
+namespace Nest.Tests.Integration.Search
 {
 	/// <summary>
 	///  Tests that test whether the query response can be successfully mapped or not

--- a/src/Nest.Tests.Integration/Search/VersionTests.cs
+++ b/src/Nest.Tests.Integration/Search/VersionTests.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest;
+﻿using System.Linq;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
-
-namespace Nest.Tests.Integration.Integration.Search
+namespace Nest.Tests.Integration.Search
 {
 	[TestFixture]
 	public class VersionTests : BaseElasticSearchTests

--- a/src/Nest.Tests.Unit/FilterTests/NumericRangeFilterJson.cs
+++ b/src/Nest.Tests.Unit/FilterTests/NumericRangeFilterJson.cs
@@ -33,7 +33,7 @@ namespace Nest.Tests.Unit.FilterTests
 							""loc.sort"": {
 								from: 10,
 								to: 20,
-								from_inclusive: false
+								include_lower: false
 							}
 						}
 
@@ -62,8 +62,8 @@ namespace Nest.Tests.Unit.FilterTests
 							""loc.sort"": {
 								from: 10,
 								to: 20,
-								from_inclusive: true,
-								to_inclusive: true
+								include_lower: true,
+								include_upper: true
 							},
 							_cache: true
 						}
@@ -94,7 +94,7 @@ namespace Nest.Tests.Unit.FilterTests
 							""loc.sort"": {
 								from: 10.0,
 								to: 20.0,
-								from_inclusive: false
+								include_lower: false
 							}
 						}
 
@@ -127,7 +127,7 @@ namespace Nest.Tests.Unit.FilterTests
 							""startedOn"": {
 								from: """ + lowerBound.ToString(format) + @""",
 								to: """ + upperBound.ToString(format) + @""",
-								from_inclusive: false
+								include_lower: false
 							}
 						}
 

--- a/src/Nest.Tests.Unit/Inferno/MapTypeIndicesTests.cs
+++ b/src/Nest.Tests.Unit/Inferno/MapTypeIndicesTests.cs
@@ -17,33 +17,19 @@ namespace Nest.Tests.Unit.Inferno
 	[TestFixture]
 	public class MapTypeIndicesTests
 	{
-    [Test]
+		[Test]
 		public void ResolvesToTypeIndex()
-    {
-      var clientSettings = new ConnectionSettings(Test.Default.Uri)
-        .SetDefaultIndex("mydefaultindex")
-        .MapTypeIndices(p =>
-          p.Add(typeof(ElasticSearchProject), "mysuperindex")
-        );
-      var c = new ElasticClient(clientSettings);
-      var searchPath = c.GetPathForTyped(new SearchDescriptor<ElasticSearchProject>());
-      StringAssert.StartsWith("mysuperindex", searchPath);
-      searchPath = c.GetPathForTyped(new SearchDescriptor<GeoLocation>());
-      StringAssert.StartsWith("mydefaultindex", searchPath);
-    }
-    [Test]
-    public void ResolvesToTypeIndex()
-    {
-      var clientSettings = new ConnectionSettings(Test.Default.Uri)
-        .SetDefaultIndex("mydefaultindex")
-        .MapTypeIndices(p =>
-          p.Add(typeof(ElasticSearchProject), "mysuperindex")
-        );
-      var c = new ElasticClient(clientSettings);
-      var searchPath = c.GetPathForTyped(new SearchDescriptor<ElasticSearchProject>());
-      StringAssert.StartsWith("mysuperindex", searchPath);
-      searchPath = c.GetPathForTyped(new SearchDescriptor<GeoLocation>());
-      StringAssert.StartsWith("mydefaultindex", searchPath);
-    }
+		{
+			var clientSettings = new ConnectionSettings(Test.Default.Uri)
+				.SetDefaultIndex("mydefaultindex")
+				.MapTypeIndices(p =>
+					p.Add(typeof(ElasticSearchProject), "mysuperindex")
+			);
+			var c = new ElasticClient(clientSettings);
+			var searchPath = c.GetPathForTyped(new SearchDescriptor<ElasticSearchProject>());
+			StringAssert.StartsWith("mysuperindex", searchPath);
+			searchPath = c.GetPathForTyped(new SearchDescriptor<GeoLocation>());
+			StringAssert.StartsWith("mydefaultindex", searchPath);
+		}
 	}
 }

--- a/src/Nest/DSL/Descriptors/Filter/NumericRangeFilterDescriptor.cs
+++ b/src/Nest/DSL/Descriptors/Filter/NumericRangeFilterDescriptor.cs
@@ -7,6 +7,10 @@ using System.Linq.Expressions;
 
 namespace Nest
 {
+	/// <summary>
+	/// Filters documents with fields that have values within a certain numeric range. Similar to range filter, except that it works only with numeric values
+	/// </summary>
+	/// <typeparam name="T">Type of document</typeparam>
 	[JsonObject(MemberSerialization=MemberSerialization.OptIn)]
 	public class NumericRangeFilterDescriptor<T> : FilterBase where T : class
 	{
@@ -14,9 +18,9 @@ namespace Nest
 		internal object _From { get; set;}
 		[JsonProperty("to")]
 		internal object _To { get; set; }
-		[JsonProperty("from_inclusive")]
+		[JsonProperty("include_lower")]
 		internal bool? _FromInclusive { get; set; }
-		[JsonProperty("to_inclusive")]
+		[JsonProperty("include_upper")]
 		internal bool? _ToInclusive { get; set; }
 
 		internal string _Field { get; set; }
@@ -72,7 +76,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Same as setting from and from_inclusive to false.
+		/// Same as setting from and include_lower to false.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> Greater(int from)
 		{
@@ -81,7 +85,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting from and from_inclusive to true.
+		/// Same as setting from and include_lower to true.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> GreaterOrEquals(int from)
 		{
@@ -90,7 +94,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to false.
+		/// Same as setting to and include_upper to false.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> Lower(int to)
 		{
@@ -99,7 +103,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to true.
+		/// Same as setting to and include_upper to true.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> LowerOrEquals(int to)
 		{
@@ -129,7 +133,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Same as setting from and from_inclusive to false.
+		/// Same as setting from and include_lower to false.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> Greater(double from)
 		{
@@ -138,7 +142,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting from and from_inclusive to true.
+		/// Same as setting from and include_lower to true.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> GreaterOrEquals(double from)
 		{
@@ -147,7 +151,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to false.
+		/// Same as setting to and include_upper to false.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> Lower(double to)
 		{
@@ -156,7 +160,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to true.
+		/// Same as setting to and include_upper to true.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> LowerOrEquals(double to)
 		{
@@ -186,7 +190,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Same as setting from and from_inclusive to false.
+		/// Same as setting from and include_lower to false.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> Greater(string from)
 		{
@@ -195,7 +199,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting from and from_inclusive to true.
+		/// Same as setting from and include_lower to true.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> GreaterOrEquals(string from)
 		{
@@ -204,7 +208,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to false.
+		/// Same as setting to and include_upper to false.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> Lower(string to)
 		{
@@ -213,7 +217,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to true.
+		/// Same as setting to and include_upper to true.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> LowerOrEquals(string to)
 		{
@@ -243,7 +247,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Same as setting from and from_inclusive to false.
+		/// Same as setting from and include_lower to false.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> Greater(DateTime from, string format = "yyyy/MM/dd HH:mm:ss")
 		{
@@ -252,7 +256,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting from and from_inclusive to true.
+		/// Same as setting from and include_lower to true.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> GreaterOrEquals(DateTime from, string format = "yyyy/MM/dd HH:mm:ss")
 		{
@@ -261,7 +265,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to false.
+		/// Same as setting to and include_upper to false.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> Lower(DateTime to, string format = "yyyy/MM/dd HH:mm:ss")
 		{
@@ -270,7 +274,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to true.
+		/// Same as setting to and include_upper to true.
 		/// </summary>
 		public NumericRangeFilterDescriptor<T> LowerOrEquals(DateTime to, string format = "yyyy/MM/dd HH:mm:ss")
 		{

--- a/src/Nest/DSL/Descriptors/Filter/RangeFilterDescriptor.cs
+++ b/src/Nest/DSL/Descriptors/Filter/RangeFilterDescriptor.cs
@@ -70,7 +70,7 @@ namespace Nest
 		}
 		
 		/// <summary>
-		/// Same as setting from and from_inclusive to false.
+		/// Same as setting from and include_lower to false.
 		/// </summary>
 		public RangeFilterDescriptor<T> Greater(string from)
 		{
@@ -79,7 +79,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting from and from_inclusive to true.
+		/// Same as setting from and include_lower to true.
 		/// </summary>
 		public RangeFilterDescriptor<T> GreaterOrEquals(string from)
 		{
@@ -88,7 +88,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to false.
+		/// Same as setting to and include_upper to false.
 		/// </summary>
 		public RangeFilterDescriptor<T> Lower(string to)
 		{
@@ -128,7 +128,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Same as setting from and from_inclusive to false.
+		/// Same as setting from and include_lower to false.
 		/// </summary>
 		public RangeFilterDescriptor<T> Greater(int from)
 		{
@@ -137,7 +137,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting from and from_inclusive to true.
+		/// Same as setting from and include_lower to true.
 		/// </summary>
 		public RangeFilterDescriptor<T> GreaterOrEquals(int from)
 		{
@@ -146,7 +146,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to false.
+		/// Same as setting to and include_upper to false.
 		/// </summary>
 		public RangeFilterDescriptor<T> Lower(int to)
 		{
@@ -155,7 +155,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to true.
+		/// Same as setting to and include_upper to true.
 		/// </summary>
 		public RangeFilterDescriptor<T> LowerOrEquals(int to)
 		{
@@ -186,7 +186,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Same as setting from and from_inclusive to false.
+		/// Same as setting from and include_lower to false.
 		/// </summary>
 		public RangeFilterDescriptor<T> Greater(double from)
 		{
@@ -195,7 +195,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting from and from_inclusive to true.
+		/// Same as setting from and include_lower to true.
 		/// </summary>
 		public RangeFilterDescriptor<T> GreaterOrEquals(double from)
 		{
@@ -204,7 +204,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to false.
+		/// Same as setting to and include_upper to false.
 		/// </summary>
 		public RangeFilterDescriptor<T> Lower(double to)
 		{
@@ -213,7 +213,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to true.
+		/// Same as setting to and include_upper to true.
 		/// </summary>
 		public RangeFilterDescriptor<T> LowerOrEquals(double to)
 		{
@@ -244,7 +244,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Same as setting from and from_inclusive to false.
+		/// Same as setting from and include_lower to false.
 		/// </summary>
 		public RangeFilterDescriptor<T> Greater(DateTime from, string format = "yyyy/MM/dd HH:mm:ss")
 		{
@@ -253,7 +253,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting from and from_inclusive to true.
+		/// Same as setting from and include_lower to true.
 		/// </summary>
 		public RangeFilterDescriptor<T> GreaterOrEquals(DateTime from, string format = "yyyy/MM/dd HH:mm:ss")
 		{
@@ -262,7 +262,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to false.
+		/// Same as setting to and include_upper to false.
 		/// </summary>
 		public RangeFilterDescriptor<T> Lower(DateTime to, string format = "yyyy/MM/dd HH:mm:ss")
 		{
@@ -271,7 +271,7 @@ namespace Nest
 			return this;
 		}
 		/// <summary>
-		/// Same as setting to and to_inclusive to true.
+		/// Same as setting to and include_upper to true.
 		/// </summary>
 		public RangeFilterDescriptor<T> LowerOrEquals(DateTime to, string format = "yyyy/MM/dd HH:mm:ss")
 		{


### PR DESCRIPTION
Fix the properties names of numeric-range-filter (include_lower and include_upper)

FIX: [numeric_range] filter does not support [from_inclusive]
FIX: [numeric_range] filter does not support [to_inclusive]
Fix of tests namespaces.
Remove of duplicated method MapTypeIndicesTests.ResolvesToTypeIndex()
