### PR TITLE
Support for synonym token filter

### DIFF
--- a/src/Nest/Domain/Settings/SynonymTokenFilter.cs
+++ b/src/Nest/Domain/Settings/SynonymTokenFilter.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Nest
+{
+    public class SynonymTokenFilter : TokenFilterSettings
+    {
+        public SynonymTokenFilter() : base("synonym")
+        {
+
+        }
+
+        [JsonProperty("synonyms_path", NullValueHandling = NullValueHandling.Ignore)]
+        public string SynonymsPath { get; set; }
+
+        [JsonProperty("format", NullValueHandling=NullValueHandling.Ignore)]
+        public string Format { get; set; }
+
+        [JsonProperty("synonyms", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<string> Synonyms { get; set; }
+    }
+}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -65,6 +65,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Domain\Settings\SynonymTokenFilter.cs" />
     <Compile Include="ElasticClient-Scroll.cs" />
     <Compile Include="Domain\Hit\ValidationExplanation.cs" />
     <Compile Include="Domain\Responses\ValidateResponse.cs" />


### PR DESCRIPTION
Added SynonymTokenFilterSettings to support synonyms on an index.

http://www.elasticsearch.org/guide/reference/index-modules/analysis/synonym-tokenfilter.html
