### PR TITLE
Removed match.cs from build file

### DIFF
--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -66,7 +66,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DSL\Descriptors\GetDescriptor.cs" />
-    <Compile Include="DSL\Descriptors\Query\Match.cs" />
     <Compile Include="DSL\Factory\Query\MatchQueryBuilder.cs" />
     <Compile Include="ElasticClient-MultiGet.cs" />
     <Compile Include="Domain\Settings\NgramTokenFiler.cs" />


### PR DESCRIPTION
Match.cs wasn't suppose to be with the earlier commit since we are not
using the Match class anywhere and the build will fail
