### PR TITLE
Solution to issue '#130 SearchDescriptor.TrackScores() generates elastic unrecognized string'

### DIFF
--- a/src/Nest/DSL/Descriptors/SearchDescriptor.cs
+++ b/src/Nest/DSL/Descriptors/SearchDescriptor.cs
@@ -169,7 +169,7 @@ namespace Nest
 		internal bool? _Explain { get; set; }
 		[JsonProperty(PropertyName = "version")]
 		internal bool? _Version { get; set; }
-		[JsonProperty(PropertyName = "track_scores ")]
+		[JsonProperty(PropertyName = "track_scores")]
 		internal bool? _TrackScores { get; set; }
 
 		[JsonProperty(PropertyName = "min_score")]


### PR DESCRIPTION
Removes an space after the property 'track_scores' causing issue #130  
"SearchDescriptor.TrackScores() generates elastic unrecognized string"
