### PR TITLE
Fix #134: Sort query doesn't take into account ElasticProperty "AddSortField"

### DIFF
--- a/src/Nest.Tests.Unit/SortTests.cs
+++ b/src/Nest.Tests.Unit/SortTests.cs
@@ -13,93 +13,190 @@ using Nest.Tests.MockData.Domain;
 
 namespace Nest.Tests.Unit
 {
-	[TestFixture]
-	public class SortTests
-	{
-		[Test]
-		public void TestSort()
-		{
-			var s = new SearchDescriptor<ElasticSearchProject>()
-				.From(0)
-				.Size(10)
-		.Sort(sort=>sort
-		  .OnField(e=>e.Name)
-		  .MissingLast()
-		  .Descending()
-	  );
-			var json = TestElasticClient.Serialize(s);
-			var expected = @"  {
-		  from: 0,
-		  size: 10,
-		  sort: {
-			name: {
-			  missing: ""_last"",
-			  order: ""desc""
-			}
-		  }
-		}";
-			Assert.True(json.JsonEquals(expected), json);
-		}
-	[Test]
-	public void TestSortGeo()
-	{
-	  var s = new SearchDescriptor<ElasticSearchProject>()
-		.From(0)
-		.Size(10)
-		.SortGeoDistance(sort => sort
-		  .OnField(e => e.Origin)
-		  .MissingLast()
-		  .Descending()
-		  .PinTo(40, -70)
-		  .Unit(GeoUnit.km)
-	  );
-	  var json = TestElasticClient.Serialize(s);
-	  var expected = @"  {
-		  from: 0,
-		  size: 10,
-		  sort: {
-			_geo_distance: {
-			  missing: ""_last"",
-			  order: ""desc"",
-			  ""origin"": ""40, -70"",
-			  unit: ""km""
-			}
-		  }
-		}";
-	  Assert.True(json.JsonEquals(expected), json);
-	}
-	[Test]
-	public void TestSortScript()
-	{
-	  var s = new SearchDescriptor<ElasticSearchProject>()
-		.From(0)
-		.Size(10)
-		.SortScript(sort => sort
-		  .MissingLast()
-		  .Descending()
-		  .Script("doc['field_name'].value * factor")
-		  .Params(p=>p
-			.Add("factor", 1.1)
-		  )
-		  .Type("number")
-	  );
-	  var json = TestElasticClient.Serialize(s);
-	  var expected = @"  {
-		  from: 0,
-		  size: 10,
-		  sort: {
-			_script: {
-			  missing: ""_last"",
-			  order: ""desc"",
-			  type: ""number"",
-			  script: ""doc['field_name'].value * factor"",
-			  params: {
-				factor: 1.1
-			  }
-			}
-		  }
-		}";
-	  Assert.True(json.JsonEquals(expected), json);
-	}
-	}
+    [TestFixture]
+    public class SortTests
+    {
+        [Test]
+        public void TestSort()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+        .Sort(sort => sort
+          .OnField(e => e.Country)
+          .MissingLast()
+          .Descending()
+      );
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"  {
+          from: 0,
+          size: 10,
+          sort: {
+            country: {
+              missing: ""_last"",
+              order: ""desc""
+            }
+          }
+        }";
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void TestSortOnSortField()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+        .Sort(sort => sort
+          .OnField(e => e.Name)
+          .MissingLast()
+          .Descending()
+      );
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"  {
+          from: 0,
+          size: 10,
+          sort: {
+            ""name.sort"": {
+              missing: ""_last"",
+              order: ""desc""
+            }
+          }
+        }";
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void TestSortAscending()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .SortAscending(f => f.Country);
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"  {
+          from: 0,
+          size: 10,
+          sort: {
+            country : ""asc""
+            }          
+        }";
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void TestSortDescending()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .SortDescending(f => f.Country);
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"  {
+          from: 0,
+          size: 10,
+          sort: {
+            country : ""desc""
+            }          
+        }";
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void TestSortAscendingOnSortField()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .SortAscending(f => f.Name);
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"  {
+          from: 0,
+          size: 10,
+          sort: {
+            ""name.sort"" : ""asc""
+            }          
+        }";
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void TestSortDescendingOnSortField()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .SortDescending(f => f.Name);
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"  {
+          from: 0,
+          size: 10,
+          sort: {
+            ""name.sort"" : ""desc""
+            }          
+        }";
+            Assert.True(json.JsonEquals(expected), json);
+        }
+    [Test]
+    public void TestSortGeo()
+    {
+      var s = new SearchDescriptor<ElasticSearchProject>()
+        .From(0)
+        .Size(10)
+        .SortGeoDistance(sort => sort
+          .OnField(e => e.Origin)
+          .MissingLast()
+          .Descending()
+          .PinTo(40, -70)
+          .Unit(GeoUnit.km)
+      );
+      var json = TestElasticClient.Serialize(s);
+      var expected = @"  {
+          from: 0,
+          size: 10,
+          sort: {
+            _geo_distance: {
+              missing: ""_last"",
+              order: ""desc"",
+              ""origin"": ""40, -70"",
+              unit: ""km""
+            }
+          }
+        }";
+      Assert.True(json.JsonEquals(expected), json);
+    }
+    [Test]
+    public void TestSortScript()
+    {
+      var s = new SearchDescriptor<ElasticSearchProject>()
+        .From(0)
+        .Size(10)
+        .SortScript(sort => sort
+          .MissingLast()
+          .Descending()
+          .Script("doc['field_name'].value * factor")
+          .Params(p=>p
+            .Add("factor", 1.1)
+          )
+          .Type("number")
+      );
+      var json = TestElasticClient.Serialize(s);
+      var expected = @"  {
+          from: 0,
+          size: 10,
+          sort: {
+            _script: {
+              missing: ""_last"",
+              order: ""desc"",
+              type: ""number"",
+              script: ""doc['field_name'].value * factor"",
+              params: {
+                factor: 1.1
+              }
+            }
+          }
+        }";
+      Assert.True(json.JsonEquals(expected), json);
+    }
+    }
 }

--- a/src/Nest/DSL/Descriptors/SearchDescriptor.cs
+++ b/src/Nest/DSL/Descriptors/SearchDescriptor.cs
@@ -430,13 +430,23 @@ namespace Nest
 		/// Sort ascending.
 		/// </para>
 		/// </summary>
-		public SearchDescriptor<T> SortAscending(Expression<Func<T, object>> objectPath)
-		{
-			if (this._Sort == null)
-				this._Sort = new Dictionary<string, object>();
-			this._Sort.Add(new PropertyNameResolver().Resolve(objectPath), "asc");
-			return this;
-		}
+        public SearchDescriptor<T> SortAscending(Expression<Func<T, object>> objectPath)
+        {
+            if (this._Sort == null)
+                this._Sort = new Dictionary<string, object>();
+
+            var resolver = new PropertyNameResolver();
+            var fieldName = resolver.Resolve(objectPath);
+
+            var fieldAttributes = resolver.ResolvePropertyAttributes(objectPath);
+            if ((fieldAttributes.Where(x => x.AddSortField == true)).Any())
+            {
+                fieldName += ".sort";
+            }
+
+            this._Sort.Add(fieldName, "asc");
+            return this;
+        }
 		/// <summary>
 		/// <para>Allows to add one or more sort on specific fields. Each sort can be reversed as well.
 		/// The sort is defined on a per field level, with special field name for _score to sort by score.
@@ -445,15 +455,23 @@ namespace Nest
 		/// Sort descending.
 		/// </para>
 		/// </summary>
-		public SearchDescriptor<T> SortDescending(Expression<Func<T, object>> objectPath)
-		{
-			if (this._Sort == null)
-				this._Sort = new Dictionary<string, object>();
+        public SearchDescriptor<T> SortDescending(Expression<Func<T, object>> objectPath)
+        {
+            if (this._Sort == null)
+                this._Sort = new Dictionary<string, object>();
 
-			var key = new PropertyNameResolver().Resolve(objectPath);
-			this._Sort.Add(key, "desc");
-			return this;
-		}
+            var resolver = new PropertyNameResolver();
+            var fieldName = resolver.Resolve(objectPath);
+
+            var fieldAttributes = resolver.ResolvePropertyAttributes(objectPath);
+            if ((fieldAttributes.Where(x => x.AddSortField == true)).Any())
+            {
+                fieldName += ".sort";
+            }
+
+            this._Sort.Add(fieldName, "desc");
+            return this;
+        }
 		/// <summary>
 		/// <para>Allows to add one or more sort on specific fields. Each sort can be reversed as well.
 		/// The sort is defined on a per field level, with special field name for _score to sort by score.

--- a/src/Nest/DSL/Descriptors/SortDescriptor.cs
+++ b/src/Nest/DSL/Descriptors/SortDescriptor.cs
@@ -23,10 +23,20 @@ namespace Nest.DSL.Descriptors
       this._Field = field;
       return this;
     }
+
     public virtual SortDescriptor<T> OnField(Expression<Func<T, object>> objectPath)
     {
-      var fieldName = new PropertyNameResolver().Resolve(objectPath);
-      return this.OnField(fieldName);
+        var resolver = new PropertyNameResolver();
+
+        var fieldName = resolver.Resolve(objectPath);
+
+        var fieldAttributes = resolver.ResolvePropertyAttributes(objectPath);
+        if ((fieldAttributes.Where(x => x.AddSortField == true)).Any())
+        {
+            fieldName += ".sort";
+        }
+
+        return this.OnField(fieldName);
     }
 
     public virtual SortDescriptor<T> MissingLast()

--- a/src/Nest/Resolvers/PropertyNameResolver.cs
+++ b/src/Nest/Resolvers/PropertyNameResolver.cs
@@ -11,116 +11,126 @@ using System.Runtime.CompilerServices;
 
 namespace Nest.Resolvers
 {
-	//Shout out to http://tomlev2.wordpress.com/2010/10/03/entity-framework-using-include-with-lambda-expressions/
-	//replaces my sloppy 300+ lines (though working!) first attempt, thanks Thomas Levesque.
+    //Shout out to http://tomlev2.wordpress.com/2010/10/03/entity-framework-using-include-with-lambda-expressions/
+    //replaces my sloppy 300+ lines (though working!) first attempt, thanks Thomas Levesque.
 
-	public class PropertyNameResolver : ExpressionVisitor
-	{
-		private static readonly ElasticResolver ContractResolver = new ElasticResolver();
+    public class PropertyNameResolver : ExpressionVisitor
+    {
+        private static readonly ElasticResolver ContractResolver = new ElasticResolver();
 
-		public ElasticPropertyAttribute GetElasticProperty(MemberInfo info)
-		{
-			var attributes = info.GetCustomAttributes(typeof(ElasticPropertyAttribute), true);
-			if (attributes != null && attributes.Any())
-				return ((ElasticPropertyAttribute)attributes.First());
-			return null;
-		}
+        public ElasticPropertyAttribute GetElasticProperty(MemberInfo info)
+        {
+            var attributes = info.GetCustomAttributes(typeof(ElasticPropertyAttribute), true);
+            if (attributes != null && attributes.Any())
+                return ((ElasticPropertyAttribute)attributes.First());
+            return null;
+        }
 
-		public ElasticTypeAttribute GetElasticPropertyFor<T>() where T : class
-		{
-			return GetElasticPropertyForType(typeof(T));
-		}
+        public ElasticTypeAttribute GetElasticPropertyFor<T>() where T : class
+        {
+            return GetElasticPropertyForType(typeof(T));
+        }
 
-		public ElasticTypeAttribute GetElasticPropertyFor(Type type)
-		{
-			if (!type.IsClass && !type.IsInterface)
-				throw new ArgumentException("Type is not a class or interface", "type");
-			return GetElasticPropertyForType(type);
-		}
+        public ElasticTypeAttribute GetElasticPropertyFor(Type type)
+        {
+            if (!type.IsClass && !type.IsInterface)
+                throw new ArgumentException("Type is not a class or interface", "type");
+            return GetElasticPropertyForType(type);
+        }
 
-		private ElasticTypeAttribute GetElasticPropertyForType(Type type)
-		{
-			if (!type.IsClass && !type.IsInterface)
-				throw new ArgumentException("Type is not a class or interface", "type");
+        private ElasticTypeAttribute GetElasticPropertyForType(Type type)
+        {
+            if (!type.IsClass && !type.IsInterface)
+                throw new ArgumentException("Type is not a class or interface", "type");
 
-			var attributes = type.GetCustomAttributes(typeof(ElasticTypeAttribute), true);
-			if (attributes != null && attributes.Any())
-				return ((ElasticTypeAttribute)attributes.First());
-			return null;
-		}
+            var attributes = type.GetCustomAttributes(typeof(ElasticTypeAttribute), true);
+            if (attributes != null && attributes.Any())
+                return ((ElasticTypeAttribute)attributes.First());
+            return null;
+        }
 
-		public string Resolve(MemberInfo info)
-		{
-			var name = info.Name;
-			var resolvedName = ContractResolver.Resolve(name);
-			resolvedName = resolvedName.ToCamelCase();
-			var att = this.GetElasticProperty(info);
-			if (att != null && !att.Name.IsNullOrEmpty())
-				resolvedName = att.Name;
+        public string Resolve(MemberInfo info)
+        {
+            var name = info.Name;
+            var resolvedName = ContractResolver.Resolve(name);
+            resolvedName = resolvedName.ToCamelCase();
+            var att = this.GetElasticProperty(info);
+            if (att != null && !att.Name.IsNullOrEmpty())
+                resolvedName = att.Name;
 
-			return resolvedName;
-		}
+            return resolvedName;
+        }
 
 
-		public string Resolve(Expression expression)
-		{
-			var stack = new Stack<string>();
-			var properties = new Stack<ElasticPropertyAttribute>();
-			Visit(expression, stack, properties);
-			return stack
-				.Aggregate(
-					new StringBuilder(),
-					(sb, name) =>
-						(sb.Length > 0 ? sb.Append(".") : sb).Append(name))
-				.ToString();
-		}
+        public string Resolve(Expression expression)
+        {
+            var stack = new Stack<string>();
+            var properties = new Stack<ElasticPropertyAttribute>();
+            Visit(expression, stack, properties);
+            return stack
+                .Aggregate(
+                    new StringBuilder(),
+                    (sb, name) =>
+                        (sb.Length > 0 ? sb.Append(".") : sb).Append(name))
+                .ToString();
+        }
 
-		protected override Expression VisitMemberAccess(MemberExpression expression, Stack<string> stack, Stack<ElasticPropertyAttribute> properties)
-		{
-			if (stack != null)
-			{
-				var name = expression.Member.Name;
-				var resolvedName = ContractResolver.Resolve(name).ToCamelCase();
+        public Stack<ElasticPropertyAttribute> ResolvePropertyAttributes(Expression expression)
+        {
+            var stack = new Stack<string>();
+            var attributes = new Stack<ElasticPropertyAttribute>();
 
-				var att = this.GetElasticProperty(expression.Member);
-				if (att != null)
-				{
-					properties.Push(att);
-				}
-				if (att != null && !att.Name.IsNullOrEmpty())
-				{
+            Visit(expression, stack, attributes);
 
-					resolvedName = att.Name;
-				}
-				stack.Push(resolvedName);
-			}
-			return base.VisitMemberAccess(expression, stack, properties);
-		}
+            return attributes;
+        }
 
-		protected override Expression VisitMethodCall(MethodCallExpression m, Stack<string> stack, Stack<ElasticPropertyAttribute> properties)
-		{
-			if (m.Method.Name == "Suffix" && m.Arguments.Any())
-			{
-				var constantExpression = m.Arguments.Last() as ConstantExpression;
-				if (constantExpression != null)
-					stack.Push(constantExpression.Value as string);
-			}
-			if (IsLinqOperator(m.Method))
-			{
-				for (int i = 1; i < m.Arguments.Count; i++)
-				{
-					Visit(m.Arguments[i], stack, properties);
-				}
-				Visit(m.Arguments[0], stack, properties);
-				return m;
-			}
-			return base.VisitMethodCall(m, stack, properties);
-		}
-		private static bool IsLinqOperator(MethodInfo method)
-		{
-			if (method.DeclaringType != typeof(Queryable) && method.DeclaringType != typeof(Enumerable))
-				return false;
-			return Attribute.GetCustomAttribute(method, typeof(ExtensionAttribute)) != null;
-		}
-	}
+        protected override Expression VisitMemberAccess(MemberExpression expression, Stack<string> stack, Stack<ElasticPropertyAttribute> properties)
+        {
+            if (stack != null)
+            {
+                var name = expression.Member.Name;
+                var resolvedName = ContractResolver.Resolve(name).ToCamelCase();
+
+                var att = this.GetElasticProperty(expression.Member);
+                if (att != null)
+                {
+                    properties.Push(att);
+                }
+                if (att != null && !att.Name.IsNullOrEmpty())
+                {
+
+                    resolvedName = att.Name;
+                }
+                stack.Push(resolvedName);
+            }
+            return base.VisitMemberAccess(expression, stack, properties);
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression m, Stack<string> stack, Stack<ElasticPropertyAttribute> properties)
+        {
+            if (m.Method.Name == "Suffix" && m.Arguments.Any())
+            {
+                var constantExpression = m.Arguments.Last() as ConstantExpression;
+                if (constantExpression != null)
+                    stack.Push(constantExpression.Value as string);
+            }
+            if (IsLinqOperator(m.Method))
+            {
+                for (int i = 1; i < m.Arguments.Count; i++)
+                {
+                    Visit(m.Arguments[i], stack, properties);
+                }
+                Visit(m.Arguments[0], stack, properties);
+                return m;
+            }
+            return base.VisitMethodCall(m, stack, properties);
+        }
+        private static bool IsLinqOperator(MethodInfo method)
+        {
+            if (method.DeclaringType != typeof(Queryable) && method.DeclaringType != typeof(Enumerable))
+                return false;
+            return Attribute.GetCustomAttribute(method, typeof(ExtensionAttribute)) != null;
+        }
+    }
 }


### PR DESCRIPTION
FIX: Sort query doesn't take into account ElasticProperty
"AddSortField", so result query contains sortting on common parent
multi_field typed field instead of special nested "sort" field. As
result we have error reply (e.g. "IOException[Can't sort on string types
with more than one value per doc, or more than one token per field]")
without any found items.
