### PR TITLE
Add HTTP auth and unify proxy settings under Proxy property

### DIFF
--- a/src/Nest/Domain/Connection/Connection.cs
+++ b/src/Nest/Domain/Connection/Connection.cs
@@ -128,15 +128,17 @@ namespace Nest
 			myReq.ReadWriteTimeout = timeout; // 1 minute timeout.
 			myReq.Method = method;
 
-			if (!string.IsNullOrEmpty(this._ConnectionSettings.ProxyAddress))
+			if (this._ConnectionSettings.Proxy != null)
 			{
-				var proxy = new WebProxy();
-				var uri = new Uri(this._ConnectionSettings.ProxyAddress);
-				var credentials = new NetworkCredential(this._ConnectionSettings.Username, this._ConnectionSettings.Password);
-				proxy.Address = uri;
-				proxy.Credentials = credentials;
-				myReq.Proxy = proxy;
+				myReq.Proxy = this._ConnectionSettings.Proxy;
 			}
+
+            if (!string.IsNullOrEmpty(this._ConnectionSettings.Username) ||
+                !string.IsNullOrEmpty(this._ConnectionSettings.Password))
+            {
+                myReq.Credentials = new NetworkCredential(this._ConnectionSettings.Username, this._ConnectionSettings.Password);
+            }
+
 			return myReq;
 		}
 

--- a/src/Nest/Domain/Connection/ConnectionSettings.cs
+++ b/src/Nest/Domain/Connection/ConnectionSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 
 namespace Nest
@@ -22,10 +23,10 @@ namespace Nest
 		{
 			get { return this._host; }
 		}
-		private readonly string _proxyAddress;
-		public string ProxyAddress
+		private readonly IWebProxy _proxy;
+		public IWebProxy Proxy
 		{
-			get { return this._proxyAddress; }
+			get { return this._proxy; }
 		}
 		private readonly int _port;
 		public int Port
@@ -85,10 +86,10 @@ namespace Nest
 		/// </summary>
 		/// <param name="uri">A Uri to describe the elasticsearch endpoint</param>
 		/// <param name="timeout">time out in milliseconds</param>
-		/// <param name="proxyAddress">proxy address</param>
-		/// <param name="username">proxy username</param>
-		/// <param name="password">proxy password</param>
-		public ConnectionSettings(Uri uri, int timeout, string proxyAddress, string username, string password)
+        /// <param name="proxy">A proxy to use for connecting to elasticsearch</param>
+		/// <param name="username">username for HTTP authentication</param>
+		/// <param name="password">password for HTTP authentication</param>
+		public ConnectionSettings(Uri uri, int timeout, IWebProxy proxy, string username, string password)
 		{
 			uri.ThrowIfNull("uri");
 
@@ -96,7 +97,7 @@ namespace Nest
 			this._password = password;
 			this._username = username;
 			this._timeout = timeout;
-			this._proxyAddress = proxyAddress;
+            this._proxy = proxy;
 			this.MaximumAsyncConnections = 20;
 			this._defaultTypeIndices = new FluentDictionary<Type, string>();
 		}
@@ -119,10 +120,10 @@ namespace Nest
 		/// <param name="host">host (sans http(s)://), use the Uri constructor overload for more control</param>
 		/// <param name="port">port of the host (elasticsearch defaults on 9200)</param>
 		/// <param name="timeout">time out in milliseconds</param>
-		/// <param name="proxyAddress">proxy address</param>
-		/// <param name="username">proxy username</param>
-		/// <param name="password">proxy password</param>
-		public ConnectionSettings(string host, int port, int timeout, string proxyAddress, string username, string password)
+        /// <param name="proxy">A proxy to use for connecting to elasticsearch</param>
+        /// <param name="username">username for HTTP authentication</param>
+        /// <param name="password">password for HTTP authentication</param>
+		public ConnectionSettings(string host, int port, int timeout, IWebProxy proxy, string username, string password)
 		{
 			host.ThrowIfNullOrEmpty("host");
 			var uri = new Uri("http://" + host + ":" + port);
@@ -132,7 +133,7 @@ namespace Nest
 			this._username = username;
 			this._timeout = timeout;
 			this._port = port;
-			this._proxyAddress = proxyAddress;
+			this._proxy = proxy;
 			this.MaximumAsyncConnections = 20;
 			this._defaultTypeIndices = new FluentDictionary<Type, string>();
 		}

--- a/src/Nest/Domain/Connection/IConnectionSettings.cs
+++ b/src/Nest/Domain/Connection/IConnectionSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 
 namespace Nest
@@ -13,7 +14,7 @@ namespace Nest
 		string Host { get; }
 		int Port { get; }
 		int Timeout { get; }
-		string ProxyAddress { get; }
+        IWebProxy Proxy { get; }
 		string Username { get; }
 		string Password { get; }
 


### PR DESCRIPTION
This adds support for HTTP authentication, for example for the basic auth module elasticsearch-http-basic or cloud hosted elasticsearch providers that secure write access with http auth.

The Username and Password settings conflicted with the ones used by proxy settings, and since username/password made more sense from a elasticsearch auth perspective, I've unified all proxy settings under the Proxy property instead.
