### PR TITLE
Explicit HTTP Basic Auth if credentials specified in URI

### DIFF
--- a/src/Nest/Domain/Connection/Connection.cs
+++ b/src/Nest/Domain/Connection/Connection.cs
@@ -121,6 +121,14 @@ namespace Nest
 				url += (string.IsNullOrEmpty(uri.Query) ? "?" : "&") + "pretty=true";
 			}
 			HttpWebRequest myReq = (HttpWebRequest)WebRequest.Create(url);
+
+            var myUri = this._ConnectionSettings.Uri;
+            if (myUri != null && !string.IsNullOrEmpty(myUri.UserInfo))
+            {
+                myReq.Headers["Authorization"] =
+                    "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(myUri.UserInfo));
+            }
+
 			myReq.Accept = "application/json";
 			myReq.ContentType = "application/json";
 


### PR DESCRIPTION
This patch allows HTTP credentials specified in the URI to flow through to the HttpWebRequest.

The manual header-setting method is used to avoid an extra round-trip; doing this via NetworkCredentials objects/etc would have meant .Net would generate an extra initial unauthenticated HTTP request to check if it really needs to use the supplied credentials.
