### PR TITLE
Fixed ArgumentNullException in call to GetFull

### DIFF
--- a/src/Nest/ElasticClient-GetFull.cs
+++ b/src/Nest/ElasticClient-GetFull.cs
@@ -71,17 +71,21 @@ namespace Nest
 			var response = this.Connection.GetSync(path);
 			var getResponse = this.ToParsedResponse<GetResponse<T>>(response);
 
-			var f = new FieldSelection<T>();
-			var o = JObject.Parse(response.Result);
-			var source = o["fields"];
-			if (source != null)
+			if (response.Result != null)
 			{
-				var json = source.ToString();
-				f.Document = getResponse.Source;
-				f.FieldValues = this.Deserialize<Dictionary<string, object>>(json);
+				var f = new FieldSelection<T>();
+				var o = JObject.Parse(response.Result);
+				var source = o["fields"];
+				if (source != null)
+				{
+					var json = source.ToString();
+					f.Document = getResponse.Source;
+					f.FieldValues = this.Deserialize<Dictionary<string, object>>(json);
 
+				}
+				getResponse.Fields = f;
 			}
-			getResponse.Fields = f;
+
 			return getResponse;
 		}
 


### PR DESCRIPTION
Calling `GetFull` when connection to elasticsearch server is unavailable results in an `ArgumentNullException`. This is different from the behavior of other methods which typically return connection error information as part of the `IReponse.ConnectionStatus` property.

A question concerning this issue:
Is checking the `ConnectionStatus` the proper strategy for determining if the ES server was unreachable? Would `ElasticClient` throwing an exception of some sort not be a more appropriate strategy? An exception would allow for a high level exception handler rather than having to check the `ConnectionStatus` response every place `ElasticClient` used. Just trying to understand the reasoning.

Thanks!
