### PR TITLE
Fixed bug in geo distance filter. Should use "distance_unit" not "distance_type"

### DIFF
--- a/src/Nest.Tests.Unit/Search/Filter/Singles/GeoDistanceFilterJson.cs
+++ b/src/Nest.Tests.Unit/Search/Filter/Singles/GeoDistanceFilterJson.cs
@@ -27,7 +27,7 @@ namespace Nest.Tests.Unit.Search.Filter.Singles
 				filter : {
 					geo_distance: {
 						distance: 12.0,
-						distance_type: ""km"",
+						distance_unit: ""km"",
 						optimize_bbox: ""memory"",
 						origin: ""40, -70"",
 						_cache: true,

--- a/src/Nest/DSL/FilterDescriptor.cs
+++ b/src/Nest/DSL/FilterDescriptor.cs
@@ -388,7 +388,7 @@ namespace Nest
 				dd.Add("distance", filter._Distance);
 
 				if (!string.IsNullOrWhiteSpace(filter._GeoUnit))
-					dd.Add("distance_type", filter._GeoUnit);
+					dd.Add("distance_unit", filter._GeoUnit);
 
 				if (!string.IsNullOrWhiteSpace(filter._GeoOptimizeBBox))
 					dd.Add("optimize_bbox", filter._GeoOptimizeBBox);


### PR DESCRIPTION
The geo_distance filter should output "distance_unit"
for mi/km instead of "distance_type". "distance_type" is for
selecting between arc and plane. Described here:
http://www.elasticsearch.org/guide/reference/query-dsl/geo-distance-filter/
