### PR TITLE
Add Error property to BulkOperationResponseItem

### DIFF
--- a/src/Nest/Domain/Responses/BulkCreateResponseItem.cs
+++ b/src/Nest/Domain/Responses/BulkCreateResponseItem.cs
@@ -16,6 +16,7 @@ namespace Nest
 		public override string Version { get; internal set; }
 		[JsonProperty("ok")]
 		public override bool OK { get; internal set; }
-
+		[JsonProperty("error")]
+		public override string Error { get; internal set; }
 	}
 }

--- a/src/Nest/Domain/Responses/BulkDeleteResponseItem.cs
+++ b/src/Nest/Domain/Responses/BulkDeleteResponseItem.cs
@@ -16,6 +16,7 @@ namespace Nest
 		public override string Version { get; internal set; }
 		[JsonProperty("ok")]
 		public override bool OK { get; internal set; }
-
+		[JsonProperty("error")]
+		public override string Error { get; internal set; }
 	}
 }

--- a/src/Nest/Domain/Responses/BulkIndexResponseItem.cs
+++ b/src/Nest/Domain/Responses/BulkIndexResponseItem.cs
@@ -16,6 +16,7 @@ namespace Nest
 		public override string Version { get; internal set; }
 		[JsonProperty("ok")]
 		public override bool OK { get; internal set; }
-
+		[JsonProperty("error")]
+		public override string Error { get; internal set; }
 	}
 }

--- a/src/Nest/Domain/Responses/BulkOperationResponseItem.cs
+++ b/src/Nest/Domain/Responses/BulkOperationResponseItem.cs
@@ -11,5 +11,6 @@ namespace Nest
 		public abstract string Id { get; internal set; }
 		public abstract string Version { get; internal set; }
 		public abstract bool OK { get; internal set; }
+		public abstract string Error { get; internal set; }
 	}
 }


### PR DESCRIPTION
Just a start, but at least this way you can inspect what went wrong (if anything) with individual bulk response items.
