### PR TITLE
fixed culture dependency breaking the json parsing

### DIFF
--- a/src/Nest/Resolvers/Writers/WritePropertiesFromAttributeVisitor.cs
+++ b/src/Nest/Resolvers/Writers/WritePropertiesFromAttributeVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Writers {
@@ -116,12 +117,12 @@ namespace Nest.Resolvers.Writers {
             if (att.Boost != 1)
             {
                 this._jsonWriter.WritePropertyName("boost");
-                this._jsonWriter.WriteRawValue(att.Boost.ToString());
+                this._jsonWriter.WriteRawValue(att.Boost.ToString(CultureInfo.InvariantCulture));
             }
             if (att.PrecisionStep != 4)
             {
                 this._jsonWriter.WritePropertyName("precision_step");
-                this._jsonWriter.WriteRawValue(att.PrecisionStep.ToString());
+                this._jsonWriter.WriteRawValue(att.PrecisionStep.ToString(CultureInfo.InvariantCulture));
             }
 
             if (!att.Similarity.IsNullOrEmpty())


### PR DESCRIPTION
when Culture = dutch then NEST.fail == true

```
Newtonsoft.Json.JsonReaderException was unhandled by user code
  HResult=-2146233088
  Message=Invalid character after parsing property name. Expected ':' but got: }. Path 'indexableobjects.properties.makernames.boost', line 53, position 7.
  Source=Newtonsoft.Json
  LineNumber=53
  LinePosition=7
  Path=indexableobjects.properties.makernames.boost
  StackTrace:
       at Newtonsoft.Json.JsonTextReader.ParseProperty()
       at Newtonsoft.Json.JsonTextReader.ParseObject()
       at Newtonsoft.Json.JsonTextReader.ReadInternal()
       at Newtonsoft.Json.JsonTextReader.Read()
       at Newtonsoft.Json.Linq.JContainer.ReadContentFrom(JsonReader r)
       at Newtonsoft.Json.Linq.JContainer.ReadTokenFrom(JsonReader reader)
       at Newtonsoft.Json.Linq.JObject.Load(JsonReader reader)
       at Newtonsoft.Json.Linq.JObject.Parse(String json)
       at Nest.Resolvers.Writers.TypeMappingWriter.RootObjectMappingFromAttributes() in d:\Projects\NEST\src\Nest\Resolvers\Writers\TypeMappingWriter.cs:line 72
       at Nest.ElasticClient.CreateMapFor(Type t, String type, Int32 maxRecursion) in d:\Projects\NEST\src\Nest\ElasticClient-MappingType.cs:line 150
```

WritePropertiesFromAttributeVisitor function output resulted in (invalid) json (excerpt) when the following attribute [ElasticProperty(Boost = 1.5)] was found on property:

```
"makernames": {
        "type": "string",        "boost": 1,5      }
```

thus generating exception on JObject.Parse()
