### PR TITLE
Unify ConnectionSettings _uri, _host, _port

### DIFF
--- a/src/Nest.Tests.Integration/ConnectionTests.cs
+++ b/src/Nest.Tests.Integration/ConnectionTests.cs
@@ -15,10 +15,20 @@ namespace Nest.Tests.Integration
 		{
 			Assert.AreEqual(this._settings.Host, ElasticsearchConfiguration.Settings().Host);
 			Assert.AreEqual(this._settings.Port, Test.Default.Port);
+            Assert.AreEqual(new Uri(string.Format("http://{0}:{1}", ElasticsearchConfiguration.Settings().Host, Test.Default.Port)), this._settings.Uri);
 			Assert.AreEqual(ElasticsearchConfiguration.DefaultIndex, ElasticsearchConfiguration.DefaultIndex);
 			Assert.AreEqual(this._settings.MaximumAsyncConnections, Test.Default.MaximumAsyncConnections);
 		}
-		[Test]
+        [Test]
+        public void TestSettingsWithUri()
+        {
+            var uri = new Uri(string.Format("http://{0}:{1}", ElasticsearchConfiguration.Settings().Host, ElasticsearchConfiguration.Settings().Port));
+            var settings = new ConnectionSettings(uri);
+            Assert.AreEqual(settings.Host, ElasticsearchConfiguration.Settings().Host);
+            Assert.AreEqual(settings.Port, Test.Default.Port);
+            Assert.AreEqual(uri, this._settings.Uri);
+        }
+        [Test]
 		public void TestConnectSuccess()
 		{
 			ConnectionStatus status;

--- a/src/Nest/Domain/Connection/ConnectionSettings.cs
+++ b/src/Nest/Domain/Connection/ConnectionSettings.cs
@@ -93,6 +93,8 @@ namespace Nest
 			uri.ThrowIfNull("uri");
 
 			this._uri = uri;
+		    this._host = uri.Host;
+		    this._port = uri.Port;
 			this._password = password;
 			this._username = username;
 			this._timeout = timeout;
@@ -129,6 +131,7 @@ namespace Nest
 
 			this._host = host;
 			this._password = password;
+		    this._uri = uri;
 			this._username = username;
 			this._timeout = timeout;
 			this._port = port;


### PR DESCRIPTION
At least gets _uri, _host, _port to be the same until you can collapse down further
