### PR TITLE
Add facts to DateEntry

### DIFF
--- a/src/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -104,6 +104,10 @@
     <Compile Include="Search\Facets\HistogramFacetJson.cs" />
     <Compile Include="Search\Facets\QueryFacetJson.cs" />
     <Compile Include="Search\Facets\RangeFacetJson.cs" />
+    <Compile Include="Search\Facets\ResponseDeserialisation\DateEntriesConstraint.cs" />
+    <Compile Include="Search\Facets\ResponseDeserialisation\DateEntrySequenceEqualityComparer.cs" />
+    <Compile Include="Search\Facets\ResponseDeserialisation\when_date_histogram_query_has_no_value_field.cs" />
+    <Compile Include="Search\Facets\ResponseDeserialisation\when_date_histogram_query_has_value_field.cs" />
     <Compile Include="Search\Facets\StatisticalFacetJson.cs" />
     <Compile Include="Search\Facets\TermsFacetJson.cs" />
     <Compile Include="Search\Facets\TermsStatsFacetJson.cs" />

--- a/src/Nest.Tests.Unit/Search/Facets/HistogramFacetJson.cs
+++ b/src/Nest.Tests.Unit/Search/Facets/HistogramFacetJson.cs
@@ -4,19 +4,19 @@ using Nest.Tests.MockData.Domain;
 
 namespace Nest.Tests.Unit.Search.Facets
 {
-  [TestFixture]
-  public class HistogramFacetJson
-  {
-    [Test]
-    public void HistogramTest()
+    [TestFixture]
+    public class HistogramFacetJson
     {
-      var s = new SearchDescriptor<ElasticSearchProject>()
-        .From(0)
-        .Size(10)
-        .QueryRaw(@"{ raw : ""query""}")
-        .FacetHistogram(h => h.OnField(f=>f.LOC).Interval(100));
-      var json = TestElasticClient.Serialize(s);
-      var expected = @"{ from: 0, size: 10, 
+        [Test]
+        public void HistogramTest()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .QueryRaw(@"{ raw : ""query""}")
+                .FacetHistogram(h => h.OnField(f => f.LOC).Interval(100));
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"{ from: 0, size: 10, 
           facets :  {
             ""loc"" :  {
                 histogram : {
@@ -26,67 +26,23 @@ namespace Nest.Tests.Unit.Search.Facets
             }
           }, query : { raw : ""query""}
       }";
-      Assert.True(json.JsonEquals(expected), json);
-    }
-    [Test]
-    public void HistogramTestTimeInterval()
-    {
-      var s = new SearchDescriptor<ElasticSearchProject>()
-        .From(0)
-        .Size(10)
-        .QueryRaw(@"{ raw : ""query""}")
-        .FacetHistogram(h => h.OnField(f => f.StartedOn).TimeInterval("1.5h"));
-      var json = TestElasticClient.Serialize(s);
-      var expected = @"{ from: 0, size: 10, 
-          facets :  {
-            ""startedOn"" :  {
-                histogram : {
-                    field : ""startedOn"",
-                    time_interval : ""1.5h""
-                } 
-            }
-          }, query : { raw : ""query""}
-      }";
-      Assert.True(json.JsonEquals(expected), json);
-    }
-    [Test]
-    public void HistogramTestTimeSpanInterval()
-    {
-      var s = new SearchDescriptor<ElasticSearchProject>()
-        .From(0)
-        .Size(10)
-        .QueryRaw(@"{ raw : ""query""}")
-        .FacetHistogram(h => h
-          .OnField(f => f.StartedOn)
-          .TimeInterval(TimeSpan.FromHours(1.5))
-        );
-      var json = TestElasticClient.Serialize(s);
-      var expected = @"{ from: 0, size: 10, 
-          facets :  {
-            ""startedOn"" :  {
-                histogram : {
-                    field : ""startedOn"",
-                    time_interval : ""01:30:00""
-                } 
-            }
-          }, query : { raw : ""query""}
-      }";
-      Assert.True(json.JsonEquals(expected), json);
-    }
-    [Test]
-    public void HistogramTestKeyField()
-    {
-      var s = new SearchDescriptor<ElasticSearchProject>()
-        .From(0)
-        .Size(10)
-        .QueryRaw(@"{ raw : ""query""}")
-        .FacetHistogram("needs_a_name", h => h
-          .KeyField("key_field_name")
-          .ValueField("value_field_name")
-          .Interval(100)
-        );
-      var json = TestElasticClient.Serialize(s);
-      var expected = @"{ from: 0, size: 10, 
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void HistogramTestKeyField()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .QueryRaw(@"{ raw : ""query""}")
+                .FacetHistogram("needs_a_name", h => h
+                                                         .KeyField("key_field_name")
+                                                         .ValueField("value_field_name")
+                                                         .Interval(100)
+                );
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"{ from: 0, size: 10, 
           facets :  {
             ""needs_a_name"" :  {
                 histogram : {
@@ -97,22 +53,23 @@ namespace Nest.Tests.Unit.Search.Facets
             }
           }, query : { raw : ""query""}
       }";
-      Assert.True(json.JsonEquals(expected), json);
-    }
-    [Test]
-    public void HistogramTestKeyScript()
-    {
-      var s = new SearchDescriptor<ElasticSearchProject>()
-        .From(0)
-        .Size(10)
-        .QueryRaw(@"{ raw : ""query""}")
-        .FacetHistogram("needs_a_name", h => h
-          .KeyScript("doc['date'].date.minuteOfHour")
-          .ValueScript("doc['num1'].value")
-          .Interval(100)
-        );
-      var json = TestElasticClient.Serialize(s);
-      var expected = @"{ from: 0, size: 10, 
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void HistogramTestKeyScript()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .QueryRaw(@"{ raw : ""query""}")
+                .FacetHistogram("needs_a_name", h => h
+                                                         .KeyScript("doc['date'].date.minuteOfHour")
+                                                         .ValueScript("doc['num1'].value")
+                                                         .Interval(100)
+                );
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"{ from: 0, size: 10, 
           facets :  {
             ""needs_a_name"" :  {
                 histogram : {
@@ -123,27 +80,28 @@ namespace Nest.Tests.Unit.Search.Facets
             }
           }, query : { raw : ""query""}
       }";
-      Assert.True(json.JsonEquals(expected), json);
-    }
-    [Test]
-    public void HistogramTestKeyScriptParams()
-    {
-      var s = new SearchDescriptor<ElasticSearchProject>()
-        .From(0)
-        .Size(10)
-        .QueryRaw(@"{ raw : ""query""}")
-        .FacetHistogram("needs_a_name", h => h
-          .KeyScript("doc['date'].date.minuteOfHour * factor1")
-          .ValueScript("doc['num1'].value * factor2")
-          .Interval(100)
-          .Params(p=>p
-            .Add("factor1", 2)
-            .Add("factor2", 3)
-            .Add("randomString", "stringy")
-          )
-        );
-      var json = TestElasticClient.Serialize(s);
-      var expected = @"{ from: 0, size: 10, 
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void HistogramTestKeyScriptParams()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .QueryRaw(@"{ raw : ""query""}")
+                .FacetHistogram("needs_a_name", h => h
+                                                         .KeyScript("doc['date'].date.minuteOfHour * factor1")
+                                                         .ValueScript("doc['num1'].value * factor2")
+                                                         .Interval(100)
+                                                         .Params(p => p
+                                                                          .Add("factor1", 2)
+                                                                          .Add("factor2", 3)
+                                                                          .Add("randomString", "stringy")
+                                                         )
+                );
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"{ from: 0, size: 10, 
           facets :  {
             ""needs_a_name"" :  {
                 histogram : {
@@ -159,7 +117,55 @@ namespace Nest.Tests.Unit.Search.Facets
             }
           }, query : { raw : ""query""}
       }";
-      Assert.True(json.JsonEquals(expected), json);
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void HistogramTestTimeInterval()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .QueryRaw(@"{ raw : ""query""}")
+                .FacetHistogram(h => h.OnField(f => f.StartedOn).TimeInterval("1.5h"));
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"{ from: 0, size: 10, 
+          facets :  {
+            ""startedOn"" :  {
+                histogram : {
+                    field : ""startedOn"",
+                    time_interval : ""1.5h""
+                } 
+            }
+          }, query : { raw : ""query""}
+      }";
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
+        [Test]
+        public void HistogramTestTimeSpanInterval()
+        {
+            var s = new SearchDescriptor<ElasticSearchProject>()
+                .From(0)
+                .Size(10)
+                .QueryRaw(@"{ raw : ""query""}")
+                .FacetHistogram(h => h
+                                         .OnField(f => f.StartedOn)
+                                         .TimeInterval(TimeSpan.FromHours(1.5))
+                );
+            var json = TestElasticClient.Serialize(s);
+            var expected = @"{ from: 0, size: 10, 
+          facets :  {
+            ""startedOn"" :  {
+                histogram : {
+                    field : ""startedOn"",
+                    time_interval : ""01:30:00""
+                } 
+            }
+          }, query : { raw : ""query""}
+      }";
+            Assert.True(json.JsonEquals(expected), json);
+        }
+
     }
-  }
 }

--- a/src/Nest.Tests.Unit/Search/Facets/ResponseDeserialisation/DateEntriesConstraint.cs
+++ b/src/Nest.Tests.Unit/Search/Facets/ResponseDeserialisation/DateEntriesConstraint.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework.Constraints;
+
+namespace Nest.Tests.Unit.Search.Facets.ResponseDeserialisation
+{
+    internal class DateEntriesConstraint : EqualConstraint
+    {
+        private DateEntriesConstraint(object expected) : base(expected)
+        {
+            this.Using<IEnumerable<DateEntry>>(new DateEntrySequenceEqualityComparer());
+        }
+
+        internal static DateEntriesConstraint Sequence(IEnumerable<DateEntry> dateEntries)
+        {
+            return new DateEntriesConstraint(dateEntries);
+        }
+    }
+}

--- a/src/Nest.Tests.Unit/Search/Facets/ResponseDeserialisation/DateEntrySequenceEqualityComparer.cs
+++ b/src/Nest.Tests.Unit/Search/Facets/ResponseDeserialisation/DateEntrySequenceEqualityComparer.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Nest.Tests.Unit.Search.Facets.ResponseDeserialisation
+{
+    internal class DateEntrySequenceEqualityComparer : IEqualityComparer<IEnumerable<DateEntry>>, IEqualityComparer<DateEntry>
+    {
+        public bool Equals(DateEntry x, DateEntry y)
+        {
+            return x.Count == y.Count &&
+                   x.Max == y.Max &&
+                   x.Mean == y.Mean &&
+                   x.Min == y.Min &&
+                   x.Time == y.Time;
+        }
+
+        public int GetHashCode(DateEntry obj)
+        {
+            return obj.GetHashCode();
+        }
+
+        public bool Equals(IEnumerable<DateEntry> x, IEnumerable<DateEntry> y)
+        {
+            var xArray = x as DateEntry[] ?? x.ToArray();
+            var yArray = y as DateEntry[] ?? y.ToArray();
+
+            return xArray.Count() == yArray.Count() && xArray.SequenceEqual(yArray, this);
+        }
+
+        public int GetHashCode(IEnumerable<DateEntry> sequence)
+        {
+            return sequence.Aggregate(0, (current, dateEntry) => current*dateEntry.GetHashCode());
+        }
+    }
+}

--- a/src/Nest.Tests.Unit/Search/Facets/ResponseDeserialisation/when_date_histogram_query_has_no_value_field.cs
+++ b/src/Nest.Tests.Unit/Search/Facets/ResponseDeserialisation/when_date_histogram_query_has_no_value_field.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Moq;
+using NUnit.Framework;
+
+namespace Nest.Tests.Unit.Search.Facets.ResponseDeserialisation
+{
+    [TestFixture]
+    public class when_date_histogram_query_has_no_value_field
+    {
+        [Test]
+        public void should_de_serialise_date_entry_histogram()
+        {
+            var widget1Histogram = new[]
+                                   {
+                                       new DateEntry
+                                       {
+                                           Count = 5181,
+                                           Time = new DateTime(2012, 11, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                                       },
+                                       new DateEntry
+                                       {
+                                           Count = 5509,
+                                           Time = new DateTime(2012, 12, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                                       }
+                                   };
+
+            var widget2Histogram = new[]
+                                   {
+                                       new DateEntry
+                                       {
+                                           Count = 173,
+                                           Time = new DateTime(2012, 3, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                                       },
+                                       new DateEntry
+                                       {
+                                           Count = 162,
+                                           Time = new DateTime(2012, 4, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                                       }
+                                   };
+
+            const string mockJsonResponse =
+                @"{""took"":378,""timed_out"":false,""_shards"":{""total"":4,""successful"":4,""failed"":0},""hits"":{""total"":3700979,""max_score"":1,""hits"":[]},""facets"":{""widget_1:histogram"":{""_type"":""date_histogram"",""entries"":[{""time"":1351728000000,""count"":5181},{""time"":1354320000000,""count"":5509}]},""widget_2:histogram"":{""_type"":""date_histogram"",""entries"":[{""time"":1330560000000,""count"":173},{""time"":1333238400000,""count"":162}]},""widget_1:terms"":{""_type"":""terms"",""missing"":0,""total"":14797,""other"":0,""terms"":[{""term"":""widget 1"",""count"":14797}]},""widget_2:terms"":{""_type"":""terms"",""missing"":0,""total"":2002,""other"":0,""terms"":[{""term"":""widget 2"",""count"":2002}]}}}";
+
+            var connectionMockery = new Mock<IConnection>();
+
+            connectionMockery
+                .Setup(status => status.PostSync("index/_search", "{}"))
+                .Returns(new ConnectionStatus(mockJsonResponse));
+
+            var connectionSettings = new ConnectionSettings(Test.Default.Uri).SetDefaultIndex("index");
+            var client = new ElasticClient(connectionSettings, connectionMockery.Object);
+
+            var response = client.Search(descriptor => descriptor);
+
+            Assert.That(response.FacetItems<DateEntry>("widget_1:histogram"), DateEntriesConstraint.Sequence(widget1Histogram));
+            Assert.That(response.FacetItems<DateEntry>("widget_2:histogram"), DateEntriesConstraint.Sequence(widget2Histogram));
+        }
+    }
+}

--- a/src/Nest.Tests.Unit/Search/Facets/ResponseDeserialisation/when_date_histogram_query_has_value_field.cs
+++ b/src/Nest.Tests.Unit/Search/Facets/ResponseDeserialisation/when_date_histogram_query_has_value_field.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Moq;
+using NUnit.Framework;
+
+namespace Nest.Tests.Unit.Search.Facets.ResponseDeserialisation
+{
+    [TestFixture]
+    public class when_date_histogram_query_has_value_field
+    {
+        [Test]
+        public void should_de_serialise_date_entry_histogram()
+        {
+            var widget1Histogram = new[]
+                                   {
+                                       new DateEntry
+                                       {
+                                           Count = 5181,
+                                           Max = 7.9899997711181641,
+                                           Mean = 7.9899997711181641,
+                                           Min = 7.9899997711181641,
+                                           Time = new DateTime(2012, 11, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                                           Total = 41396.18881416321,
+                                           TotalCount = 5181
+                                       },
+                                       new DateEntry
+                                       {
+                                           Count = 5509,
+                                           Max = 7.9899997711181641,
+                                           Mean = 7.9899997711181641,
+                                           Min = 7.9899997711181641,
+                                           Time = new DateTime(2012, 12, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                                           Total = 44016.908739089966,
+                                           TotalCount = 5509
+                                       }
+                                   };
+
+            var widget2Histogram = new[]
+                                   {
+                                       new DateEntry
+                                       {
+                                           Count = 173,
+                                           Max = 7.989999771118164,
+                                           Mean = 7.9899997711181641,
+                                           Min = 7.9899997711181641,
+                                           Time = new DateTime(2012, 3, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                                           Total = 1382.2699604034424,
+                                           TotalCount = 173
+                                       },
+                                       new DateEntry
+                                       {
+                                           Count = 162,
+                                           Max = 7.989999771118164,
+                                           Mean = 7.989999771118164,
+                                           Min = 7.989999771118164,
+                                           Time = new DateTime(2012, 4, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                                           Total = 1294.3799629211426,
+                                           TotalCount = 162
+                                       }
+                                   };
+
+            const string mockJsonResponse =
+                @"{""took"":378,""timed_out"":false,""_shards"":{""total"":4,""successful"":4,""failed"":0},""hits"":{""total"":3700979,""max_score"":1,""hits"":[]},""facets"":{""widget_1:histogram"":{""_type"":""date_histogram"",""entries"":[{""time"":1351728000000,""count"":5181,""min"":7.989999771118164,""max"":7.989999771118164,""total"":41396.18881416321,""total_count"":5181,""mean"":7.989999771118164},{""time"":1354320000000,""count"":5509,""min"":7.989999771118164,""max"":7.989999771118164,""total"":44016.908739089966,""total_count"":5509,""mean"":7.989999771118164}]},""widget_2:histogram"":{""_type"":""date_histogram"",""entries"":[{""time"":1330560000000,""count"":173,""min"":7.989999771118164,""max"":7.989999771118164,""total"":1382.2699604034424,""total_count"":173,""mean"":7.989999771118164},{""time"":1333238400000,""count"":162,""min"":7.989999771118164,""max"":7.989999771118164,""total"":1294.3799629211426,""total_count"":162,""mean"":7.989999771118164}]},""widget_1:terms"":{""_type"":""terms"",""missing"":0,""total"":14797,""other"":0,""terms"":[{""term"":""widget 1"",""count"":14797}]},""widget_2:terms"":{""_type"":""terms"",""missing"":0,""total"":2002,""other"":0,""terms"":[{""term"":""widget 2"",""count"":2002}]}}}";
+
+            var connectionMockery = new Mock<IConnection>();
+
+            connectionMockery
+                .Setup(status => status.PostSync("index/_search", "{}"))
+                .Returns(new ConnectionStatus(mockJsonResponse));
+
+            var connectionSettings = new ConnectionSettings(Test.Default.Uri).SetDefaultIndex("index");
+            var client = new ElasticClient(connectionSettings, connectionMockery.Object);
+
+            var response = client.Search(descriptor => descriptor);
+
+            Assert.That(response.FacetItems<DateEntry>("widget_1:histogram"), DateEntriesConstraint.Sequence(widget1Histogram));
+            Assert.That(response.FacetItems<DateEntry>("widget_2:histogram"), DateEntriesConstraint.Sequence(widget2Histogram));
+        }
+    }
+}

--- a/src/Nest/Domain/Facets/DateHistogramFacet.cs
+++ b/src/Nest/Domain/Facets/DateHistogramFacet.cs
@@ -17,5 +17,15 @@ namespace Nest
         [JsonConverter(typeof(UnixDateTimeConverter))]
         [JsonProperty("time")]
         public DateTime Time { get; internal set; }
+        [JsonProperty("total")]
+        public double? Total { get; internal set; }
+        [JsonProperty("total_count")]
+        public double? TotalCount { get; internal set; }
+        [JsonProperty("min")]
+        public double? Min { get; internal set; }
+        [JsonProperty("max")]
+        public double? Max { get; internal set; }
+        [JsonProperty("mean")]
+        public double? Mean { get; internal set; }
     }
 }


### PR DESCRIPTION
If a facets date histogram query includes value_field or value_script then the additional json fields are included in the response. These are de-serialised as the facts: Total, TotalCount, Min, Max and Mean. They are nullable so do not impact current consumers of DateEntry.

http://www.elasticsearch.org/guide/reference/api/search/facets/date-histogram-facet/
