### PR TITLE
Add error handling to GetIndicesPointingToAlias

### DIFF
--- a/src/Nest/ElasticClient-Aliases.cs
+++ b/src/Nest/ElasticClient-Aliases.cs
@@ -30,18 +30,22 @@ namespace Nest
 			return cmd;
 		}
 
-		/// <summary>
-		/// Get all the indices pointing to an alias
-		/// </summary>
-		public IEnumerable<string> GetIndicesPointingToAlias(string alias)
-		{
-			var path = this.PathResolver.CreateIndexPath(alias, "/_aliases");
-			var status = this.Connection.GetSync(path);
-			var r = this.Deserialize<Dictionary<string, object>>(status.Result);
-			return r == null ? Enumerable.Empty<string>() : r.Keys;
-		}
+	    /// <summary>
+	    /// Get all the indices pointing to an alias
+	    /// </summary>
+	    public IEnumerable<string> GetIndicesPointingToAlias(string alias)
+	    {
+	        var path = this.PathResolver.CreateIndexPath(alias, "/_aliases");
+	        var status = this.Connection.GetSync(path);
+	        if (!status.Success)
+	        {
+	            return Enumerable.Empty<string>();
+	        }
+	        var r = this.Deserialize<Dictionary<string, object>>(status.Result);
+	        return r == null ? Enumerable.Empty<string>() : r.Keys;
+	    }
 
-		/// <summary>
+	    /// <summary>
 		/// Repoint an alias from a set of old indices to a set of new indices in one operation
 		/// </summary>
 		public IIndicesOperationResponse Swap(string alias, IEnumerable<string> oldIndices, IEnumerable<string> newIndices)


### PR DESCRIPTION
/wrongname/_aliases used to return an empty array (e.g. in ES 0.20) for a non-existing alias, but in more recent ES versions (0.90) it returns

{"error":"IndexMissingException[[wrongname] missing]","status":404}

So we need to add explicit error handling here, otherwise GetIndicesPointingToAlias returns two "indices" called "error" and "status".
