### PR TITLE
Add support to MultiGet to just have ids and indexName as params

### DIFF
--- a/src/Nest/ElasticClient-MultiGet.cs
+++ b/src/Nest/ElasticClient-MultiGet.cs
@@ -31,6 +31,24 @@ namespace Nest
 			return this.MultiGet<T>(ids, this.PathResolver.CreateIndexTypePath(index, typeName));
 		}
 		/// <summary>
+		/// Gets multiple documents of T by id in the specified index
+		/// </summary>
+		public IEnumerable<T> MultiGet<T>(string index, IEnumerable<int> ids)
+			where T : class
+		{
+			return this.MultiGet<T>(index, ids.Select(i => Convert.ToString(i)));
+		}
+		/// <summary>
+		/// Gets multiple documents of T by id in the specified index
+		/// </summary>
+		public IEnumerable<T> MultiGet<T>(string index, IEnumerable<string> ids)
+			where T : class
+		{
+			var typeName = this.GetTypeNameFor<T>();
+			
+			return this.MultiGet<T>(ids, this.PathResolver.CreateIndexTypePath(index, typeName));
+		}
+		/// <summary>
 		/// Gets multiple documents of T by id in the specified index and the specified typename for T
 		/// </summary>
 		public IEnumerable<T> MultiGet<T>(string index, string type, IEnumerable<int> ids)


### PR DESCRIPTION
Thought it would be neat to have the opportunity to just supply index name and let the type be inferred from T. Some other places in NEST already have this different options (with or without type)
