### PR TITLE
PhoneticTokenFilter.cs - Added replace and encoder JSON properties

### DIFF
--- a/src/Nest/Domain/Analysis/TokenFilter/PhoneticTokenFilter.cs
+++ b/src/Nest/Domain/Analysis/TokenFilter/PhoneticTokenFilter.cs
@@ -11,8 +11,17 @@ namespace Nest
 			: base("phonetic")
 		{
 
-		}
+        }
+
+        [JsonProperty("encoder")]
+        public string Encoder { get; set; }
+
+        [JsonProperty("replace")]
+        public bool Replace { get; set; }
 
 	}
 
 }
+
+
+


### PR DESCRIPTION
Looks like encoder and replace props are missing: https://github.com/elasticsearch/elasticsearch-analysis-phonetic/blob/master/README.md

Including this makes subclassing superfluously.

Sample usage:

``` csharp
var settings = new IndexSettings();

settings.Analysis.Analyzers.Add("phoneticanalyzer", new CustomAnalyzer() { Tokenizer = "standard", Filter = new string[] { "standard", "lowercase", "metaphonetf" } });

settings.Analysis.TokenFilters.Add("metaphonetf", new PhoneticTokenFilter() { Encoder = "doublemetaphone", Replace = false });
```
