### PR TITLE
fixed broken querystring construction

### DIFF
--- a/src/Nest/ElasticClient-Update.cs
+++ b/src/Nest/ElasticClient-Update.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -20,41 +21,38 @@ namespace Nest
 			var path = this.CreateUpdatePath<T, K>(updateDescriptor);
 			return this._Update(path, data);
 		}
-		private string CreateUpdatePath<T, K>(UpdateDescriptor<T, K> s) 
-			where T : class
-			where K : class
-		{
-			var index = s._Index ?? this.IndexNameResolver.GetIndexForType<T>();
-			var type = s._Type != null ? s._Type.Resolve(this.Settings) : this.GetTypeNameFor<T>();
-			var id = s._Id ?? this.IdResolver.GetIdFor(s._Object);
+        private string CreateUpdatePath<T, K>(UpdateDescriptor<T, K> s)
+            where T : class
+            where K : class
+        {
+            var index = s._Index ?? this.IndexNameResolver.GetIndexForType<T>();
+            var type = s._Type != null ? s._Type.Resolve(this.Settings) : this.GetTypeNameFor<T>();
+            var id = s._Id ?? this.IdResolver.GetIdFor(s._Object);
 
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			id.ThrowIfNullOrEmpty("id");
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            id.ThrowIfNullOrEmpty("id");
 
-			var path = this.PathResolver.CreateIndexTypeIdPath(index, type, id, "_update") + "/?";
-			if (s._Consistency.HasValue)
-				path += "consistency=" + Enum.GetName(typeof(Consistency), s._Consistency.Value);
-			if (s._Replication.HasValue)
-				path += "replication=" + Enum.GetName(typeof(Replication), s._Replication.Value);
-			if (s._Refresh.HasValue)
-				path += "refresh=" + s._Refresh.Value.ToString().ToLower();
+            var querystringPairs = new List<string>();
 
-			if (s._Timeout.HasValue)
-				path += "timeout=" + s._Timeout.ToString();
-			if (s._Timeout.HasValue)
-				path += "timeout=" + s._Timeout.ToString();
+            if (s._Consistency.HasValue)
+                querystringPairs.Add("consistency=" + Enum.GetName(typeof(Consistency), s._Consistency.Value));
+            if (s._Replication.HasValue)
+                querystringPairs.Add("replication=" + Enum.GetName(typeof (Replication), s._Replication.Value));
+            if (s._Refresh.HasValue)
+                querystringPairs.Add("refresh=" + s._Refresh.Value.ToString().ToLower());
+            if (s._Timeout.HasValue)
+                querystringPairs.Add("timeout=" + s._Timeout);
+            if (!string.IsNullOrWhiteSpace(s._Percolate))
+                querystringPairs.Add("percolate=" + s._Percolate);
+            if (!string.IsNullOrWhiteSpace(s._Parent))
+                querystringPairs.Add("parent=" + s._Parent);
+            if (!string.IsNullOrWhiteSpace(s._Routing))
+                querystringPairs.Add("routing=" + s._Routing);
+            if (s._RetriesOnConflict.HasValue)
+                querystringPairs.Add("retries_on_conflict=" + s._RetriesOnConflict);
 
-			if (!string.IsNullOrWhiteSpace(s._Percolate))
-				path += "percolate=" + s._Percolate;
-
-			if (!string.IsNullOrWhiteSpace(s._Parent))
-				path += "parent=" + s._Parent;
-
-			if (!string.IsNullOrWhiteSpace(s._Routing))
-				path += "routing=" + s._Routing;
-
-			return path;
+            return this.PathResolver.CreateIndexTypeIdPath(index, type, id, "_update") + "/?" + string.Join("&", querystringPairs);
 		}
 
 


### PR DESCRIPTION
Hi, 

I have fixed the construction of the querystring for the path that is returned by CreateUpdatePath<T, K>(UpdateDescriptor<T, K> s). It previously did not work with more than one parameter, and did not implement retries_on_conflict.

cheers,

Matt
