### PR TITLE
Added Boost method to RangeQueryDescriptor

### DIFF
--- a/src/Nest/DSL/Query/RangeQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/RangeQueryDescriptor.cs
@@ -62,6 +62,16 @@ namespace Nest
 			this._FromInclusive = false;
 			return this;
 		}
+		
+		/// <summary>
+		/// Boosts the range query by the specified boost factor
+		/// </summary>
+		/// <param name="boost">Boost factor</param>
+		public RangeQueryDescriptor<T> Boost(double boost)
+		{
+			this._Boost = boost;
+			return this;
+		}
 
 
 		#region int


### PR DESCRIPTION
I added a Boost method to the RangeQueryDescriptor. It looks like some of the plumbing had already been set up for it, so I just need to expose it as a public method. I tested it and it seems to work properly in terms of how it writes out the query json.
