### PR TITLE
Fix for issue #340 https://github.com/Mpdreamz/NEST/issues/340

### DIFF
--- a/src/Nest.Tests.Integration/Cluster/StateTests.cs
+++ b/src/Nest.Tests.Integration/Cluster/StateTests.cs
@@ -16,6 +16,12 @@ namespace Nest.Tests.Integration.Cluster
             Assert.NotNull(r.Metadata);
             Assert.NotNull(r.Metadata.Indices);
             Assert.True(r.Metadata.Indices.Count > 0);
+            foreach (var index in r.Metadata.Indices)
+            {
+                Assert.NotNull(index.Value.Mappings);
+                Assert.True(index.Value.Mappings.Count > 0);
+            }
+
             Assert.NotNull(r.Nodes);
             Assert.True(r.Nodes.Count > 0);
             Assert.NotNull(r.RoutingNodes);

--- a/src/Nest/Domain/State/ClusterState.cs
+++ b/src/Nest/Domain/State/ClusterState.cs
@@ -77,8 +77,8 @@ namespace Nest
         [JsonProperty("settings")]
         public Dictionary<string, string> Settings { get; internal set; }
 
-        //[JsonProperty("mappings")]
-        //public Dictionary<string, MetadataIndexStateMapping> Mappings { get; internal set; }
+        [JsonProperty("mappings")]
+        public Dictionary<string, dynamic> Mappings { get; internal set; }
 
         //[JsonProperty("aliases")]
         //public ?? Aliases { get; internal set; }


### PR DESCRIPTION
Return type mapping as a dictionary of the type name followed by the mapping as "dynamic" object.
Fix ClusterState API to have Mappings also.
