### PR TITLE
Fix NodeStats for 0.90+

### DIFF
--- a/src/Nest/Domain/Stats/NodeStats.cs
+++ b/src/Nest/Domain/Stats/NodeStats.cs
@@ -19,7 +19,7 @@ namespace Nest
         public string Hostname { get; internal set; }
 
         [JsonProperty("indices")]
-        public Dictionary<string, NodeStatsIndexes> Indices { get; internal set; }
+        public NodeStatsIndexes Indices { get; internal set; }
 
         [JsonProperty("os")]
         public OSStats OS { get; internal set; }


### PR DESCRIPTION
This fixes the mapping for ES 0.90+, it's one listing per node, not one per index per node any longer.
