### PR TITLE
Bug fix: type names were being serialized to json as 'Nest.Resolvers.Typ...

### DIFF
--- a/src/Nest/ElasticClient-MultiSearch.cs
+++ b/src/Nest/ElasticClient-MultiSearch.cs
@@ -35,7 +35,7 @@ namespace Nest
 							multiSearchDescriptor._FixedIndex ??
 				            new IndexNameResolver(this._connectionSettings).GetIndexForType(operation._ClrType);
 				
-				var types = operation._Types.HasAny() ? string.Join(",", operation._Types) : null;
+				var types =  operation._Types.HasAny() ? string.Join(",", operation._Types.Select(x => x.Resolve(this.Settings)) ) : null;
 
 				var typeName = types
 							   ?? multiSearchDescriptor._FixedType


### PR DESCRIPTION
...eNameMarkers' rather than type names
