### PR TITLE
Bug fix: MultiSearch was returning derived types as base type (as specif...

### DIFF
--- a/src/Nest/Resolvers/Converters/MultiSearchConverter.cs
+++ b/src/Nest/Resolvers/Converters/MultiSearchConverter.cs
@@ -71,10 +71,44 @@ namespace Nest.Resolvers.Converters
 				return multiSearchDescriptor;
 
 			var withMeta = docsJarray.Zip(this._descriptor._Operations, (doc, desc) => new MultiHitTuple { Hit = doc, Descriptor = desc });
+			var originalConverters = serializer.Converters.ToList();
+			var originalResolver = serializer.ContractResolver;
 			foreach (var m in withMeta)
 			{
+				bool newConverter = false;
+				if (m.Descriptor.Value._Types != null && m.Descriptor.Value._Types.Count() > 0 && m.Descriptor.Value._Types.Count() > m.Descriptor.Value._Types.Where(x => x.Type == m.Descriptor.Value._ClrType).Count())
+				{
+					var typeDict = m.Descriptor.Value._Types.ToDictionary(t => t.Resolve(this._settings), t => t.Type);
+					Func<dynamic, Hit<dynamic>, Type> typeSelector = (o, h) =>
+					{
+						Type t;
+						if (!typeDict.TryGetValue(h.Type, out t))
+							return m.Descriptor.Value._ClrType;
+						return t;
+					};
+					serializer.Converters.Clear();
+					foreach (var orig in originalConverters)
+					{
+						if (!(orig is MultiSearchConverter))
+							serializer.Converters.Add(orig);
+					}
+					var converter = new ConcreteTypeConverter(m.Descriptor.Value._ClrType, typeSelector);
+					serializer.Converters.Add(converter);
+					serializer.ContractResolver = new ElasticContractResolver(this._settings);
+					(serializer.ContractResolver as ElasticContractResolver).ConcreteTypeConverter = converter;
+					newConverter = true;
+				}
+
 				var generic = MakeDelegateMethodInfo.MakeGenericMethod(m.Descriptor.Value._ClrType);
 				generic.Invoke(null, new object[] { m, serializer, response._Responses, this._settings });
+
+				if (newConverter)
+				{
+					serializer.Converters.Clear();
+					serializer.ContractResolver = originalResolver;
+					foreach (var converter in originalConverters)
+						serializer.Converters.Add(converter);
+				}
 			}
 
 			return response;


### PR DESCRIPTION
...ied in generic)

This fix adds the ConcreteTypeConverter when multiple Types are passed in. Due to my lack of intimate knowledge of how all of the code works, my fix may look a little kludgy/hacky - I wanted to avoid breaking existing functionality with the multisearch - please feel free to revise/clean-up as needed.
