### PR TITLE
Added CustomParameter method to SearchDescriptor and MultiSearchDescript...

### DIFF
--- a/src/Nest/DSL/MultiSearchDescriptor.cs
+++ b/src/Nest/DSL/MultiSearchDescriptor.cs
@@ -13,6 +13,9 @@ namespace Nest
 	{
 		internal string _FixedIndex { get; set; }
 		internal string _FixedType { get; set; }
+		
+		[JsonIgnore]
+		internal Dictionary<string, string> _CustomParameters { get; set; }
 
 		[JsonConverter(typeof(DictionaryKeysAreNotPropertyNamesJsonConverter))]
 		internal IDictionary<string, SearchDescriptorBase> _Operations = new Dictionary<string, SearchDescriptorBase>();
@@ -45,5 +48,22 @@ namespace Nest
 			this._FixedType = type;
 			return this;
 		}
+
+		/// <summary>
+		/// Adds custom query string parameters and values to request (e.g. for logging purposes, etc.)
+		/// </summary>
+		public MultiSearchDescriptor CustomParameter(string name, string value)
+		{
+			if (this._CustomParameters == null)
+				_CustomParameters = new Dictionary<string, string>();
+
+			if (!_CustomParameters.ContainsKey(name))
+				_CustomParameters.Add(name, value);
+			else
+				_CustomParameters[name] = value;
+
+			return this;
+		}
+
 	}
 }

--- a/src/Nest/DSL/SearchDescriptor.cs
+++ b/src/Nest/DSL/SearchDescriptor.cs
@@ -31,6 +31,7 @@ namespace Nest
 	public class SearchDescriptor<T> : SearchDescriptorBase where T : class
 	{
 		private readonly TypeNameResolver typeNameResolver;
+		internal Dictionary<string, string> _CustomParameters { get; set; }
 
 		public SearchDescriptor()
 		{
@@ -1000,6 +1001,22 @@ namespace Nest
 		public SearchDescriptor<T> ConcreteTypeSelector(Func<dynamic, Hit<dynamic>, Type> typeSelector)
 		{
 			this._ConcreteTypeSelector = typeSelector;
+			return this;
+		}
+
+		/// <summary>
+		/// Adds custom query string parameters and values to request (e.g. for logging purposes, etc.)
+		/// </summary>
+		public SearchDescriptor<T> CustomParameter(string name, string value)
+		{
+			if (this._CustomParameters == null)
+				_CustomParameters = new Dictionary<string, string>();
+
+			if (!_CustomParameters.ContainsKey(name))
+				_CustomParameters.Add(name, value);
+			else
+				_CustomParameters[name] = value;
+
 			return this;
 		}
 	}

--- a/src/Nest/ElasticClient-MultiSearch.cs
+++ b/src/Nest/ElasticClient-MultiSearch.cs
@@ -60,6 +60,10 @@ namespace Nest
 					path = multiSearchDescriptor._FixedType + "/" + path;
 				path = multiSearchDescriptor._FixedIndex + "/" + path;
 			}
+
+			if (multiSearchDescriptor._CustomParameters != null && multiSearchDescriptor._CustomParameters.Count > 0)
+				path = string.Format("{0}?{1}", path, string.Join("&", multiSearchDescriptor._CustomParameters.Select(kv => "{0}={1}".EscapedFormat(kv.Key, kv.Value))));
+
 			var status = this.Connection.PostSync(path, json);
 
 			var multiSearchConverter = new MultiSearchConverter(this._connectionSettings, multiSearchDescriptor);

--- a/src/Nest/Resolvers/PathResolver.cs
+++ b/src/Nest/Resolvers/PathResolver.cs
@@ -466,6 +466,15 @@ namespace Nest.Resolvers
 			if (!descriptor._Scroll.IsNullOrEmpty())
 				dict.Add("scroll", descriptor._Scroll);
 			this.AddSearchType<T>(descriptor, dict);
+			
+			if (descriptor._CustomParameters != null)
+			{
+				foreach (string key in descriptor._CustomParameters.Keys)
+				{
+					if (!dict.ContainsKey(key))
+						dict.Add(key, descriptor._CustomParameters[key]);
+				}
+			}			
 			return dict;
 		}
 


### PR DESCRIPTION
Added CustomParameter method to SearchDescriptor and MultiSearchDescriptor - this allows for custom querystring parameters to be added to URL passed in to search for various purposes. 

For the purposes of the project I'm currently working on, I am passing in the end-user's search term, which by being passed in as a custom querystring parameter, can be logged to the web logs for future analysis.

Though perhaps somewhat out of scope, hopefully this feature is helpful enough to others to be included in main solution.
