### PR TITLE
Correction of the the unit option for the GeoDistance filter (changed fr...

### DIFF
--- a/src/Nest.Tests.Unit/Search/Filter/Singles/GeoDistanceFilterJson.cs
+++ b/src/Nest.Tests.Unit/Search/Filter/Singles/GeoDistanceFilterJson.cs
@@ -27,7 +27,7 @@ namespace Nest.Tests.Unit.Search.Filter.Singles
 				filter : {
 					geo_distance: {
 						distance: 12.0,
-						distance_unit: ""km"",
+						unit: ""km"",
 						optimize_bbox: ""memory"",
 						origin: ""40, -70"",
 						_cache: true,

--- a/src/Nest/DSL/FilterDescriptor.cs
+++ b/src/Nest/DSL/FilterDescriptor.cs
@@ -405,7 +405,7 @@ namespace Nest
 				dd.Add("distance", filter._Distance);
 
 				if (!string.IsNullOrWhiteSpace(filter._GeoUnit))
-					dd.Add("distance_unit", filter._GeoUnit);
+					dd.Add("unit", filter._GeoUnit);
 
 				if (!string.IsNullOrWhiteSpace(filter._GeoOptimizeBBox))
 					dd.Add("optimize_bbox", filter._GeoOptimizeBBox);


### PR DESCRIPTION
This change fixes the unit option on the GeoDistance filter.  There was an error in the Elasticsearch documentation stating that the parameter for specifying the distance unit was "distance_unit", however it is actually just "unit".  This has since been corrected (See: https://github.com/elasticsearch/elasticsearch/issues/2771), but NEST was using the incorrect "distance_unit" parameter.  Before this change, specifying the distance unit would cause Elasticsearch to throw a parsing exception.  I've tested and confirmed this change in my application and have updated the unit test accordingly.
