### PR TITLE
Updating links to elasticsearch.org documentation

### DIFF
--- a/new_docs/contents/facets/date-histogram.markdown
+++ b/new_docs/contents/facets/date-histogram.markdown
@@ -21,4 +21,4 @@ A specific histogram facet that can work with date field types enhancing it over
       )
     );
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/date-histogram-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-date-histogram-facet.html) for more information

--- a/new_docs/contents/facets/filter.markdown
+++ b/new_docs/contents/facets/filter.markdown
@@ -19,4 +19,4 @@ A filter facet (not to be confused with a facet filter) allows you to return a c
 		)
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/filter-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-filter-facet.html) for more information

--- a/new_docs/contents/facets/geo-distance.markdown
+++ b/new_docs/contents/facets/geo-distance.markdown
@@ -26,6 +26,6 @@ The geo_distance facet is a facet providing information for ranges of distances 
 		)
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/geo-distance-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-geo-distance-facet.html) for more information
 
 

--- a/new_docs/contents/facets/handling.markdown
+++ b/new_docs/contents/facets/handling.markdown
@@ -7,7 +7,7 @@ menuitem: handling
 
 
 # Faceting
-For a good overview of what facets are see the [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/) on the subject.
+For a good overview of what facets are see the [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-) on the subject.
 
 ## Specify facets during search.
 In its simplest form you can add a facet to your query like this:

--- a/new_docs/contents/facets/histogram.markdown
+++ b/new_docs/contents/facets/histogram.markdown
@@ -17,6 +17,6 @@ The histogram facet works with numeric data by building a histogram across inter
 		.FacetHistogram(h => h.OnField(f=>f.LOC).Interval(100))
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/histogram-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-histogram-facet.html) for more information
 
 

--- a/new_docs/contents/facets/query.markdown
+++ b/new_docs/contents/facets/query.markdown
@@ -20,5 +20,5 @@ A facet query allows to return a count of the hits matching the facet query. The
 		);
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/query-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-query-facet.html) for more information
 

--- a/new_docs/contents/facets/range.markdown
+++ b/new_docs/contents/facets/range.markdown
@@ -76,5 +76,5 @@ or alternative key/value fields
 	);
 	//SNIP
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/range-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-range-facet.html) for more information
 

--- a/new_docs/contents/facets/statistical.markdown
+++ b/new_docs/contents/facets/statistical.markdown
@@ -19,5 +19,5 @@ Statistical facet allows to compute statistical data on a numeric fields. The st
 		)
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/statistical-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-statistical-facet.html) for more information
 

--- a/new_docs/contents/facets/term-stats.markdown
+++ b/new_docs/contents/facets/term-stats.markdown
@@ -17,6 +17,6 @@ The terms_stats facet combines both the terms and statistical allowing to comput
 		.FacetTerm(t => t.OnField(f => f.Country).Size(20))
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/terms-stats-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-stats-facet.html) for more information
 
 

--- a/new_docs/contents/facets/terms.markdown
+++ b/new_docs/contents/facets/terms.markdown
@@ -16,6 +16,6 @@ Allow to specify field facets that return the N most frequent terms. For example
 		.FacetTerm(t => t.OnField(f => f.Country).Size(20))
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/reference/api/search/facets/terms-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-facet.html) for more information
 
 

--- a/new_docs/contents/indices/optimize.markdown
+++ b/new_docs/contents/indices/optimize.markdown
@@ -18,5 +18,5 @@ The optimize API allows to optimize one or more indices through an API. The opti
 
 	var r = this.ConnectedClient.Optimize(new[] { "index", "index2" }, new OptimizeParams {MaximumSegments=2});
 
-More overloads exists and all OptimizeParams are mapped. See [the original docs](http://www.elasticsearch.org/guide/reference/api/admin-indices-optimize.html) for parameters
+More overloads exists and all OptimizeParams are mapped. See [the original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-optimize.html) for parameters
 


### PR DESCRIPTION
The elasticsearch.org site changed and most of the links to the original docs 404'd. Hopefully I fixed all the bad links.
