### PR TITLE
Added new TokenChars field to NGramTokenizers

### DIFF
--- a/src/Nest/Domain/Analysis/Tokenizer/EdgeNGramTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/EdgeNGramTokenizer.cs
@@ -21,5 +21,8 @@ namespace Nest
 
 		[JsonProperty("side")]
 		public string Side { get; set; }
+
+        [JsonProperty("token_chars")]
+        public IList<string> TokenChars { get; set; }
     }
 }

--- a/src/Nest/Domain/Analysis/Tokenizer/NGramTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/NGramTokenizer.cs
@@ -18,5 +18,8 @@ namespace Nest
 
 		[JsonProperty("max_gram")]
 		public int? MaxGram { get; set; }
+
+        [JsonProperty("token_chars")]
+        public IList<string> TokenChars { get; set; }
     }
 }


### PR DESCRIPTION
In 0.90.2 NGramTokenizer and EdgeNGramTokenizer support passing in
character classes in the token_chars field as documented here: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html

I didn't find any related tests for these classes so there are no tests with this PR.  I did test this out on our live system running 0.90.3.  
