### PR TITLE
Actually use the setting to customize the serializer settings

### DIFF
--- a/src/Nest/ExposedInternals/ElasticSerializer.cs
+++ b/src/Nest/ExposedInternals/ElasticSerializer.cs
@@ -92,13 +92,18 @@ namespace Nest
 				? extraConverters.ToList()
 				: null;
 			var piggyBackState = new JsonConverterPiggyBackState { ActualJsonConverter = piggyBackJsonConverter };
-			return new JsonSerializerSettings()
+            var settings = new JsonSerializerSettings()
 			{
 				ContractResolver = new ElasticContractResolver(this._settings) { PiggyBackState = piggyBackState },
 				DefaultValueHandling = DefaultValueHandling.Include,
 				NullValueHandling = NullValueHandling.Ignore,
 				Converters = converters,
 			};
+
+            if (_settings.ModifyJsonSerializerSettings != null)
+		        _settings.ModifyJsonSerializerSettings(settings);
+
+		    return settings;
 		}
 
 


### PR DESCRIPTION
There's a setting exposed to customize the JSON serializer, by providing a delegate that takes the serializer settings and modifies it. However, the setting isn't used anywhere.

My project requires me to hook up some various changes to the serializer. Without this working properly, I'm forced to tap the private fields in NEST using reflection in order to customize the serializer, which is horribly hackish. Since this setting is exposed in NEST, I'm assuming it was intended to do something. :)
