### PR TITLE
Added ExecuteOnPrimaryFirst read preference.

### DIFF
--- a/src/Nest.Tests.Unit/Search/SearchOptions/SearchOptionTests.cs
+++ b/src/Nest.Tests.Unit/Search/SearchOptions/SearchOptionTests.cs
@@ -90,6 +90,16 @@ namespace Nest.Tests.Unit.Search.SearchOptions
 			StringAssert.Contains("preference=_primary", result.ConnectionStatus.RequestUrl);
 		}
 		[Test]
+		public void TestExecuteOnPrimaryFirst()
+		{
+			var s = new SearchDescriptor<ElasticSearchProject>()
+				.From(0)
+				.Size(10)
+				.ExecuteOnPrimaryFirst();
+			var result = this._client.Search(s);
+			StringAssert.Contains("preference=_primary_first", result.ConnectionStatus.RequestUrl);
+		}
+		[Test]
 		public void TestExecuteOnLocalShard()
 		{
 			var s = new SearchDescriptor<ElasticSearchProject>()

--- a/src/Nest/DSL/SearchDescriptor.cs
+++ b/src/Nest/DSL/SearchDescriptor.cs
@@ -373,6 +373,21 @@ namespace Nest
 		/// By default, the operation is randomized between the each shard replicas.
 		/// </para>
 		/// <para>
+		/// The operation will go and be executed on the primary shard, and if not available (failover), 
+		/// will execute on other shards.
+		/// </para>
+		/// </summary>
+		public SearchDescriptor<T> ExecuteOnPrimaryFirst()
+		{
+			this._Preference = "_primary_first";
+			return this;
+		}
+		/// <summary>
+		/// <para>
+		/// Controls a preference of which shard replicas to execute the search request on. 
+		/// By default, the operation is randomized between the each shard replicas.
+		/// </para>
+		/// <para>
 		/// The operation will prefer to be executed on a local allocated shard is possible.
 		/// </para>
 		/// </summary>


### PR DESCRIPTION
Added another read preference; "_primary_first"
"The operation will go and be executed on the primary shard, and if not available (failover), will execute on other shards."

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-preference.html
