### PR TITLE
Added both the Preferred and Custom preference

### DIFF
--- a/src/Nest.Tests.Unit/Search/SearchOptions/SearchOptionTests.cs
+++ b/src/Nest.Tests.Unit/Search/SearchOptions/SearchOptionTests.cs
@@ -120,16 +120,6 @@ namespace Nest.Tests.Unit.Search.SearchOptions
 			StringAssert.Contains("preference=_only_node:somenode", result.ConnectionStatus.RequestUrl);
 		}
 		[Test]
-		public void TestExecuteOnCustomNode()
-		{
-			var s = new SearchDescriptor<ElasticSearchProject>()
-				.From(0)
-				.Size(10)
-				.ExecuteOnCustomNode("somenode");
-			var result = this._client.Search(s);
-			StringAssert.Contains("preference=somenode", result.ConnectionStatus.RequestUrl);
-		}
-		[Test]
 		public void TestExecuteOnPreferredNode()
 		{
 			var s = new SearchDescriptor<ElasticSearchProject>()

--- a/src/Nest/DSL/SearchDescriptor.cs
+++ b/src/Nest/DSL/SearchDescriptor.cs
@@ -417,24 +417,6 @@ namespace Nest
 		/// By default, the operation is randomized between the each shard replicas.
 		/// </para>
 		/// <para>
-		/// A custom value will be used to guarantee that the same shards will be used for 
-		/// the same custom value. This can help with "jumping values" when hitting different 
-		/// shards in different refresh states. A sample value can be something like the 
-		/// web session id, or the user name.
-		/// </para>
-		/// </summary>
-		public SearchDescriptor<T> ExecuteOnCustomNode(string node)
-		{
-			node.ThrowIfNull("node");
-			this._Preference = node;
-			return this;
-		}
-		/// <summary>
-		/// <para>
-		/// Controls a preference of which shard replicas to execute the search request on. 
-		/// By default, the operation is randomized between the each shard replicas.
-		/// </para>
-		/// <para>
 		/// Prefers execution on the node with the provided node id if applicable.
 		/// </para>
 		/// </summary>


### PR DESCRIPTION
Added the rest of the preferences currently supported by ElasticSearch.
1. Custom
2. PreferNode (_prefer_node:xyz)

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-preference.html
