### PR TITLE
Allow any object type to be used for a partial update during upsert

### DIFF
--- a/src/Nest.Tests.Unit/Core/Update/UpdateTests.cs
+++ b/src/Nest.Tests.Unit/Core/Update/UpdateTests.cs
@@ -30,7 +30,7 @@ namespace Nest.Tests.Unit.Core.Update
 		[Test]
 		public void UpsertUsingScriptAndPartialObject()
 		{
-			var s = new UpdateDescriptor<ElasticSearchProject, object>()
+			var s = new UpdateDescriptor<object, object>()
 			  .Script("ctx._source.counter += count")
 			  .Params(p => p
 				  .Add("count", 4)

--- a/src/Nest/DSL/BulkUpdateDescriptor.cs
+++ b/src/Nest/DSL/BulkUpdateDescriptor.cs
@@ -158,7 +158,7 @@ namespace Nest
 		/// <summary>
 		/// The full document to be created if an existing document does not exist for a partial merge.
 		/// </summary>
-		public BulkUpdateDescriptor<T, K> Upsert(K upsertObject)
+		public BulkUpdateDescriptor<T, K> Upsert(T upsertObject)
 		{
 			upsertObject.ThrowIfNull("upsertObject");
 			this._Upsert = upsertObject;

--- a/src/Nest/DSL/UpdateDescriptor.cs
+++ b/src/Nest/DSL/UpdateDescriptor.cs
@@ -75,7 +75,7 @@ namespace Nest
 		/// <summary>
 		/// The full document to be created if an existing document does not exist for a partial merge.
 		/// </summary>
-		public UpdateDescriptor<T, K> Upsert(K upsertObject)
+		public UpdateDescriptor<T, K> Upsert(T upsertObject)
 		{
 			upsertObject.ThrowIfNull("upsertObject");
 			this._Upsert = upsertObject;


### PR DESCRIPTION
Hi,

I have made a minor change to the Document() upsert API so that you can supply any object as the partial update (eg, a mutation object) and not require the strong object to be supplied for a partial update.

This is in reference to the upsert/doc API at http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html

There is a use case where I have a document type (say ShoppingCart) and I want to perform an upsert using a less-descriptive object type (eg, ShoppingCartMutation).

Previously this use case was not possible because of the type restriction on the Document() method that restricted what partial update object could be supplied:

``` csharp
// Classes
class ShoppingCart
{
    public string Name;
    public double Total;
    public DateTime Created;
}

class ShoppingCartMutation
{
    public string Name;
    public double Total;
}

// Instance
var newCart = new ShoppingCart();
newCart.Created = DateTime.UtcNow;
newCart.Name = "New Cart";
newCart.Total = 0;

var mutation = new ShoppingCartMutation();
mutation.Total = 5;

// Example
client.Update<ShoppingCart>(x => x
    .Type(typeof(ShoppingCart))
    .Document(mutation)
    .Upsert(newCart)
);
```

Previously this would not compile because both Document() and Upsert() overloads needed to be of the same type.

If this was the case then I would need to always suppy a ShoppingCart instance for both arguments, which would overwrite the Created date (as its not nullable in this example) during a partial update when that is not intended.
