### PR TITLE
CustomAnalyzer ctor to set AnalyzerBase.Type

### DIFF
--- a/src/Nest/Domain/Analysis/Analyzers/CustomAnalyzer.cs
+++ b/src/Nest/Domain/Analysis/Analyzers/CustomAnalyzer.cs
@@ -15,8 +15,7 @@ namespace Nest
 	        Type = type;
 	    }
 
-        [Obsolete("ctor(string) is preferred")]
-	    public CustomAnalyzer() : this("custom") {}
+        public CustomAnalyzer() : this("custom") {}
 
 	    [JsonProperty("tokenizer")]
         public string Tokenizer { get; set; }


### PR DESCRIPTION
It is not obvious that the Type property should be set on a class that inherits from CustomAnalyzer.

By providing a ctor that sets the Type property users will not need to remember
to set the type property manually.

Removing the default ctor is ideal, but would be a breaking change.  Marking it obsolete
should lead most people to "the pit of success".
