### PR TITLE
Renamed QueryString to Query on the MatchQueryDescriptor

### DIFF
--- a/src/Nest.Tests.Unit/Search/Query/Singles/MatchQueryJson.cs
+++ b/src/Nest.Tests.Unit/Search/Query/Singles/MatchQueryJson.cs
@@ -15,7 +15,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 				.Query(q=>q
 					.Match(t=>t
 						.OnField(f=>f.Name)
-						.QueryString("this is a test")
+						.Query("this is a test")
 					)
 			);
 				
@@ -40,7 +40,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 				.Query(q => q
 					.Match(t => t
 						.OnField(f => f.Name)
-						.QueryString("this is a test")
+						.Query("this is a test")
 						.Fuzziness(1.0)
 						.Analyzer("my_analyzer")
 						.CutoffFrequency(0.3)

--- a/src/Nest/DSL/Query/MatchQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MatchQueryDescriptor.cs
@@ -68,9 +68,9 @@ namespace Nest
 			return this.OnField(fieldName);
 		}
 
-		public MatchQueryDescriptor<T> QueryString(string queryString)
+		public MatchQueryDescriptor<T> Query(string query)
 		{
-			this._Query = queryString;
+			this._Query = query;
 			return this;
 		}
 		public MatchQueryDescriptor<T> Analyzer(string analyzer)


### PR DESCRIPTION
It was a bit misleading because the query text in an Elasticsearch Match query isn't actually a query string.

This is a breaking change!
