### PR TITLE
Renamed QueryString to Query on the MultiMatchQueryDescriptor

### DIFF
--- a/src/Nest.Tests.Unit/Search/Query/Singles/MultiMatch/MultiMatchJson.cs
+++ b/src/Nest.Tests.Unit/Search/Query/Singles/MultiMatch/MultiMatchJson.cs
@@ -16,7 +16,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles.MultiMatch
 				.Query(q => q
 					.MultiMatch(m=>m
 						.OnFields(p=>p.Name, p=>p.Country)
-						.QueryString("this is a query")
+						.Query("this is a query")
 						.UseDisMax(true)
 						.TieBreaker(0.7)
 					)

--- a/src/Nest/DSL/Query/MultiMatchQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MultiMatchQueryDescriptor.cs
@@ -78,9 +78,9 @@ namespace Nest
 			return this.OnFields(fieldNames);
 		}
 
-		public MultiMatchQueryDescriptor<T> QueryString(string queryString)
+		public MultiMatchQueryDescriptor<T> Query(string query)
 		{
-			this._Query = queryString;
+			this._Query = query;
 			return this;
 		}
 		public MultiMatchQueryDescriptor<T> Analyzer(string analyzer)


### PR DESCRIPTION
This is similar to pull request #444.  I just realized the MultiMatchQueryDescriptor had the same issue.
