### PR TITLE
Added Size property to CompletionSuggestDescriptor

### DIFF
--- a/src/Nest/DSL/Suggest/CompletionSuggestDescriptor.cs
+++ b/src/Nest/DSL/Suggest/CompletionSuggestDescriptor.cs
@@ -14,6 +14,12 @@ namespace Nest
 		[JsonProperty(PropertyName = "fuzzy")]
 		internal FuzzySuggestDescriptor<T> _Fuzzy { get; set; }
 
+		public CompletionSuggestDescriptor<T> Size(int size)
+		{
+			this._Size = size;
+			return this;
+		} 
+
 		public CompletionSuggestDescriptor<T> Text(string text)
 		{
 			this._Text = text;


### PR DESCRIPTION
This will allow users to now specify the size of the completion results, which defaults to 5. Thanks for the great framework!
