### PR TITLE
Fixes to typos, formatting, verbiage, naming conventions, etc.

### DIFF
--- a/new_docs/contents/elasticsearch-net/building-requests.md
+++ b/new_docs/contents/elasticsearch-net/building-requests.md
@@ -7,7 +7,7 @@ menuitem: esnet-building-requests
 
 # Building Requests
 
-This section decribes how to build requests to elasticsearch.
+This section decribes how to build requests to Elasticsearch.
 
 ## Calling an API endpoint
 

--- a/new_docs/contents/elasticsearch-net/cluster-failover.md
+++ b/new_docs/contents/elasticsearch-net/cluster-failover.md
@@ -7,7 +7,7 @@ menuitem: esnet-cluster-failover
 
 # Connection pooling & Cluster failover
 
-One of the major benefits of `elasticsearch` is that it can handle dying and respawning  nodes. 
+One of the major benefits of `Elasticsearch` is that it can handle dying and respawning  nodes. 
 As long as enough nodes agree that the cluster is healthy, the cluster will continue to operate.
 `Elasticsearch.net` comes with builtin support to handle falling over to a different node when the requested node failed.
 
@@ -38,7 +38,7 @@ Sets the timeout before a node is retried. The default `DateTimeProvider` will i
 Sets the maximum time a node may be marked dead.
 
 #### DisablePings()
-By default before a previously dead node is retried a short ping will be send to the node to make sure the node will respond. 
+By default before a previously dead node is retried a short ping will be sent to the node to make sure the node will respond. 
 The reason for a separate call is that a ping will call an elasticsearch endpoint that won't stress the JVM. If a node is having issues retrying a possible heavy search operation on it might cause the request to fail later rather then asap. This setting allows you to disable these pings before retries.
 
 #### SetMaxRetries(int retries)

--- a/new_docs/contents/elasticsearch-net/errors.md
+++ b/new_docs/contents/elasticsearch-net/errors.md
@@ -7,7 +7,7 @@ menuitem: esnet-errors
 
 # Errors
 
-`Elasticsearch.Net` will not throw if gets a http response other then 200 from Elasticsearch. The response object's `Success` property will be false and `.Error` will contain information on the failed response.
+`Elasticsearch.Net` will not throw if it gets an http response other then 200 from Elasticsearch. The response object's `Success` property will be false and `.Error` will contain information on the failed response.
 
 You can throw custom exceptions if you need too by specifying a custom connectionhandler
 
@@ -20,7 +20,7 @@ You can throw custom exceptions if you need too by specifying a custom connectio
 
 ## Exceptions
 
-If a request has been retried the maximum amount of times a `MaxRetryException` is thrown. Note that requests are only retried when elasticsearch responds with a `503` or an unspecified connection exception (i.e timeout) occured on a node. 
+If a request has been retried the maximum amount of times a `MaxRetryException` is thrown. Note that requests are only retried when elasticsearch responds with a `503` or an unspecified connection exception (i.e timeout) has occured on a node. 
 
 `MaxRetryException` will hold the original exception as `.InnerException`.
 

--- a/new_docs/contents/elasticsearch-net/quick-start.md
+++ b/new_docs/contents/elasticsearch-net/quick-start.md
@@ -7,7 +7,7 @@ menuitem: esnet-quick-start
 
 # Quick Start
 
-`Elasticsearch.Net` is a low level client to talk to elasticsearch.
+`Elasticsearch.Net` is a low level client to talk to Elasticsearch.
 
 ## Installing
 

--- a/new_docs/contents/index.md
+++ b/new_docs/contents/index.md
@@ -7,7 +7,7 @@ menuitem: introduction
 
 # Introduction
 
-You've reached the documentation page for `Elasticsearch.Net` and `NEST`. Two .net clients to talk with elasticsearch. So why two clients I hear you say?
+You've reached the documentation page for `Elasticsearch.Net` and `NEST`. Two .net clients to talk with Elasticsearch. So why two clients I hear you say?
 
 `Elasticsearch.Net` is a very low level, dependency free, client that has no opinions how you build and represent your requests and responses. It has abstracted 
 enough so that **all** the elasticsearch API endpoints are represented as methods but not too much to get in the way of how you want to build your json/request/response objects. It also comes with builtin, configurable/overridable, cluster failover retry mechanisms. Elasticsearch is elastic so why not your client?
@@ -20,9 +20,9 @@ Please read the getting started guide for both.
 ## Who's using Nest
 * [stackoverflow.com](http://www.stackoverflow.com) (and the rest of the stackexchange family).
 * [7digital.com](http://www.7digital.com) (run NEST on mono).
-* [rijksmuseum.nl](https://www.rijksmuseum.nl/en) (elasticsearch is the only datastorage hit for each page).
+* [rijksmuseum.nl](https://www.rijksmuseum.nl/en) (Elasticsearch is the only datastorage hit for each page).
 * [Kiln](http://www.fogcreek.com/kiln/) FogCreek's version control & code review tooling. 
-  They are so pleased with elasticsearch that [they made a video about how pleased they are!](http://blog.fogcreek.com/kiln-powered-by-elasticsearch/)
+  They are so pleased with Elasticsearch that [they made a video about how pleased they are!](http://blog.fogcreek.com/kiln-powered-by-elasticsearch/)
 
 
 ## Other resources

--- a/new_docs/contents/nest/cluster/health.markdown
+++ b/new_docs/contents/nest/cluster/health.markdown
@@ -11,7 +11,7 @@ Get cluster health simple
 
     var r = this._client.Health(HealthLevel.Cluster);
 
-Cluster health just for one (or more) index
+Cluster health for one (or more) indexes
 
     var r = this._client.Health(new[] { Test.Default.DefaultIndex }, HealthLevel.Cluster);
 

--- a/new_docs/contents/nest/cluster/nodes-stats.markdown
+++ b/new_docs/contents/nest/cluster/nodes-stats.markdown
@@ -12,7 +12,7 @@ var r = this._client.NodeInfo(NodesInfo.All);
 
             var node = r.Nodes.First();
 
-you can than traverse the node info objects i.e:
+You can than traverse the node info objects i.e:
 
             node.Value.OS.Cpu.CacheSizeInBytes;
 

--- a/new_docs/contents/nest/connecting.markdown
+++ b/new_docs/contents/nest/connecting.markdown
@@ -30,12 +30,12 @@ If you want a failover client instead of passing a `Uri` pass an `IConnectionPoo
 
 ## Changing the underlying connection 
 
-By default NEST will use HTTP to chat with elasticsearch, alternative implementation of the transport layer can be injected in the constructors optional second parameter
+By default NEST will use HTTP to chat with elasticsearch, alternative implementation of the transport layer can be injected using the constructors optional second parameter
 
 	var client = new ElasticClient(settings, new ThriftConnection(settings));
 
-Nest comes with a Htpp connection `HttpConnection`, Thrift Connection `ThriftConnection` 
-and an in memory connection that nevers hits elasticsearch `InMemoryConnection`.
+NEST comes with an Http Connection `HttpConnection`, Thrift Connection `ThriftConnection` 
+and an In-Memory Connection `InMemoryConnection`, that nevers hits elasticsearch.
 
 ## Settings
 
@@ -50,8 +50,8 @@ The easiest way to pass `IConnectionSettingsValues` is to instantiate `Connectio
         .PluralizeTypeNames();
 
 ####AddContractJsonConverters
-Add a custom JsonConverter to the build in json serialization by passing
-in a predicate for a type.  This way they will be part of the cached Json.net contract for a type.
+Add a custom JsonConverter to the built in JSON serialization by passing
+in a predicate for a type.  This way they will be part of the cached Json.NET contract for a type.
 
     settings.AddContractJsonConverters(t => 
         typeof (Enum).IsAssignableFrom(t) 
@@ -74,15 +74,15 @@ Index to default to when no index is specified.
 ####SetDefaultPropertyNameInferrer
 By default NEST camelCases property names (EmailAddress => emailAddress)
 that do not have an explicit propertyname either via an ElasticProperty attribute
-or because they are part of Dictionary where the keys should be treated verbatim.
+or because they are part of a Dictionary where the keys should be treated verbatim.
 Here you can register a function that transforms propertynames (default
 casing, pre- or suffixing)
 
 ####SetDefaultTypeNameInferrer
-Allows you to override how type names should be reprented, the default will
+Allows you to override how type names should be represented, the default will
 call .ToLowerInvariant() on the type's name.
 
 ####SetJsonSerializerSettingsModifier
-Allows you to update internal the json.net serializer settings to your liking.
-Do not use this to add custom json converters use `AddContractJsonConverters` instead.
+Allows you to update the internal Json.NET Serializer settings to your liking.
+Do not use this to add custom JSON converters use `AddContractJsonConverters` instead.
 

--- a/new_docs/contents/nest/core/bulk.markdown
+++ b/new_docs/contents/nest/core/bulk.markdown
@@ -8,7 +8,7 @@ menuitem: bulk
 
 # Bulk
 
-Nest long supported bulk index and deletes (through `IndexMany()` and `DeleteMany()`) but this shielded you from all that the elasticsearch `_bulk` api enpoint has to offer. Now you can use `Bulk()` to create any bulk request you'd like. E.g if you want to do index/create/delete's in a certain order.
+NEST long supported bulk index and deletes (through `IndexMany()` and `DeleteMany()`) but this shielded you from all that the Elasticsearch `_bulk` api enpoint has to offer. Now you can use `Bulk()` to create any bulk request you'd like. E.g if you want to do index/create/delete's in a certain order.
 
 # Examples
 
@@ -18,7 +18,7 @@ Nest long supported bulk index and deletes (through `IndexMany()` and `DeleteMan
 		.Delete<ElasticSearchProject>(i => i.Object(new ElasticSearchProject { Id = 4 }))
 	);
 
-Each bulk operation can also be anotated with the right behaviours:
+Each bulk operation can also be annotated with the right behaviours:
 
 	.Index<ElasticSearchProject>(i => i
 		.Routing(...)

--- a/new_docs/contents/nest/core/count.markdown
+++ b/new_docs/contents/nest/core/count.markdown
@@ -13,7 +13,7 @@ The count API allows to easily execute a query and get the number of matches for
 	var countResults = this._client.CountAll(q=>q.MatchAll());
 	Assert.True(countResults.Count > 0);
 
-The above will do a count query across all indices. (The result type here is not)
+The above will do a count query across all indices. (The result type here is not limited)
 
 If you want to limit the scope to just the default index for the type:
 

--- a/new_docs/contents/nest/core/delete-by-query.markdown
+++ b/new_docs/contents/nest/core/delete-by-query.markdown
@@ -19,7 +19,7 @@ Elasticsearch allows you to delete over multiple types and indexes, so does NEST
 
 As always `*Async` variants are available too.
 
-You can also delete by query over all the indexes and types:
+You can also delete by query over all the indices and types:
 
 	this.ConnectedClient.DeleteByQuery<ElasticSearchProject>(q => q
 		.AllIndices()

--- a/new_docs/contents/nest/core/get.markdown
+++ b/new_docs/contents/nest/core/get.markdown
@@ -8,20 +8,20 @@ menuitem: get
 
 # Get a document
 
-gets a single document from Elasticsearch
+Gets a single document from Elasticsearch
 
 ## By Id
 
 	var foundDocument = this.ConnectedClient.Get<ElasticSearchProject>(hit.Id);
 
-index and type are infered but overloads exists for full control
+Index and type are infered but overloads exists for full control
 
 	var foundDocument = this.ConnectedClient.Get<ElasticSearchProject>("myalternateindex", "elasticprojs", hit.Id);
 
 ## Full response
 
-The `Get<T>()` call immediatly returns `T` which is handy in alot of cases but sometimes you'll want to get the complete metadata object back from Elasticsearch
-using `GetFull()` you get a proper `IGetResponse<T>` back that holds the usual `IsValid` and `ConnectionStatus` properties amongst the `Index`, `Type`, `Id` and `Version` properties.
+The `Get<T>()` call immediatly returns `T` which is handy in alot of cases but sometimes you'll want to get the complete metadata object back from Elasticsearch.
+Using `GetFull()` you get a proper `IGetResponse<T>` back that holds the usual `IsValid` and `ConnectionStatus` properties amongst the `Index`, `Type`, `Id` and `Version` properties.
 
 	var result = this._client.GetFull<ElasticSearchProject>(g => g
 		.Index("nest_test_data")
@@ -39,13 +39,13 @@ using `GetFull()` you get a proper `IGetResponse<T>` back that holds the usual `
 
 Follows the same inferring rules as `.Get(id)` would.
 
-Infact you could even just pass an object:
+In fact you could even just pass an object:
 
     var result = this._client.GetFull<SomeDto>(g => g
 		.Object(new SomeDto { AlternateId = Guid.NewGuid() })
 	);
 
-provided SomeDto is mapped properly to use `AlternateId` as the alternate id field
+Provided SomeDto is mapped properly to use `AlternateId` as the alternate id field.
 
 	[ElasticType(IdProperty = "AlternateId")]
 	internal class SomeDto
@@ -53,7 +53,7 @@ provided SomeDto is mapped properly to use `AlternateId` as the alternate id fie
 		public Guid AlternateId { get; set; }
 	}
 
-You can also use GetFull to query just some fields of a single document
+You can also use `GetFull` to query just some fields of a single document
 
 	var result = this._client.GetFull<ElasticSearchProject>(g => g
 		.Index("nest_test_data")
@@ -69,7 +69,7 @@ These fields are exposed as followed:
 	var doubleValue = result.Fields.FieldValue<double>(p => p.DoubleValue);
 
 
-Remember `p => p.Name` can also be written as `"name"` and Nest does not force you to write expressions everywhere (although it is much encouraged!).
+Remember `p => p.Name` can also be written as `"name"` and NEST does not force you to write expressions everywhere (although it is much encouraged!).
 
 
  

--- a/new_docs/contents/nest/core/index.markdown
+++ b/new_docs/contents/nest/core/index.markdown
@@ -13,13 +13,13 @@ Indexing is as simple as:
 	var post = new Post() { Id = 12, ... }
 	var status = client.Index<Post>(post);
 
-of course C# is smart enough to infer Post so
+Of course C# is smart enough to infer Post so
 
 	var status = client.Index(post);
 
 is sufficient. this will index post too `/[default index]/posts/12`. The typename`posts` is automatically inferred from the type.
 
-if you need more control there are plenty of overloads, i.e:
+If you need more control there are plenty of overloads, i.e:
 
 	client.Index(post, "index", "type", "id");
 
@@ -47,13 +47,13 @@ Instead of passing `T` just pass an `IEnumerable<T>` to `IndexMany()` or `IndexM
 
 **Note**
 For asynchronous commands there's a special connection setting which automatically semaphores threaded communication
-to ES for you:
+to Elasticsearch for you:
 
 	var elasticSettings = new ConnectionSettings("127.0.0.1.", 9200)
 							  .SetDefaultIndex("mpdreamz")
 							  .SetMaximumAsyncConnections(20);
 
-this ensures that at most there are 20 asynchronous connections to ES others are enqueued until a slot is 
+This ensures that at most there are 20 asynchronous connections to Elasticsearch. All others are enqueued until a slot is 
 available.
 
 ## Aditional parameters

--- a/new_docs/contents/nest/core/multi-get.markdown
+++ b/new_docs/contents/nest/core/multi-get.markdown
@@ -15,7 +15,7 @@ Get multiple documents in a single request.
 	var ids = new [] { hit1.Id, hit2.Id };
 	var foundDocuments = this.ConnectedClient.MultiGet<ElasticSearchProject>(ids);
 
-index and type are infered but overloads exists for full control
+Index and type are infered but overloads exists for full control.
 
 	var foundDocuments = this.ConnectedClient.MultiGet<ElasticSearchProject>("myalternateindex", "elasticprojs", ids);
 
@@ -38,7 +38,7 @@ These could then be pulled out of the result:
 
 `Get` returns `T` and `GetWithMetaData` returns a `MultiGetHit<T>` which also exposes the document's metadata such as `_index` and `_version`. 
 
-Incase the document was not found then `Get` would return a `null` but `GetWithMetaData` still returns the a `MultiGetHit<T>` but with an `.Exists` of `false` this maps to the way elasticsearch returns not found objects in a `multi_get` call.
+In case the document was not found then `Get` would return a `null` but `GetWithMetaData` still returns the a `MultiGetHit<T>` but with an `.Exists` of `false` this maps to the way elasticsearch returns not found objects in a `multi_get` call.
 
 You can even get field selections for some of the documents:
 
@@ -62,4 +62,4 @@ You can then get the returned fields like so:
 	var id = fields.FieldValue<int>(p => p.Id);
 	var firstNames = fields.FieldValue<string[]>(p => p.Followers.First().FirstName);
 
-Remember `p => p.Followers.First().FirstName` can be interchanged with `"followers.firstName"` if you prefer or need to reference a non mapped field.
+Remember `p => p.Followers.First().FirstName` can be interchanged with `"followers.firstName"` if you prefer or need to reference a non-mapped field.

--- a/new_docs/contents/nest/core/percolate.markdown
+++ b/new_docs/contents/nest/core/percolate.markdown
@@ -9,7 +9,7 @@ menuitem: percolate
 # Percolation
 The percolator allows to register queries against an index, and then send percolate requests which include a doc, and getting back the queries that match on that doc out of the set of registered queries. 
 
-The percolate is a complex but awesome elasticsearch feature be sure to read the [official documentation](http://www.elasticsearch.org/guide/reference/api/percolate/)
+Percolate is a complex but awesome Elasticsearch feature, so be sure to read the [official documentation](http://www.elasticsearch.org/guide/reference/api/percolate/)
 
 # Register a percolator
 

--- a/new_docs/contents/nest/core/search.markdown
+++ b/new_docs/contents/nest/core/search.markdown
@@ -8,7 +8,7 @@ menuitem: search
 
 # Search
 
-Search is **THE** call you'll probably use the most as it exposes elasticsearch's key functionality: search!
+Search is **THE** call you'll probably use the most as it exposes Elasticsearch's key functionality: search!
 
 **NOTE:** be sure to also read [how to use NEST's Query DSL](/concepts/writing-queries.html)
 
@@ -24,7 +24,7 @@ You can start a search like so,
 
 This will get all the documents on the `my-index` index and `my-type` type. 
 
-`result` is an `IQueryResponse<dynamic>` which has a `Documents` `IEnumerable<dynamic>` property that holds all the results. NOTE: remember in the absent of paging it will default to the first 10). 
+`result` is an `IQueryResponse<dynamic>` which has a `Documents` `IEnumerable<dynamic>` property that holds all the results. NOTE: remember in the absense of paging it will default to the first 10). 
 
 ## Typed results
 

--- a/new_docs/contents/nest/facets/date-histogram.markdown
+++ b/new_docs/contents/nest/facets/date-histogram.markdown
@@ -21,4 +21,4 @@ A specific histogram facet that can work with date field types enhancing it over
       )
     );
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-date-histogram-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-date-histogram-facet.html) for more information.

--- a/new_docs/contents/nest/facets/filter.markdown
+++ b/new_docs/contents/nest/facets/filter.markdown
@@ -19,4 +19,4 @@ A filter facet (not to be confused with a facet filter) allows you to return a c
 		)
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-filter-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-filter-facet.html) for more information.

--- a/new_docs/contents/nest/facets/geo-distance.markdown
+++ b/new_docs/contents/nest/facets/geo-distance.markdown
@@ -26,6 +26,6 @@ The geo_distance facet is a facet providing information for ranges of distances 
 		)
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-geo-distance-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-geo-distance-facet.html) for more information.
 
 

--- a/new_docs/contents/nest/facets/handling.markdown
+++ b/new_docs/contents/nest/facets/handling.markdown
@@ -38,7 +38,7 @@ Adding more then one facet is also really easy:
         )
 	);
 
-Nest supports all the additional properties you can set on facets 
+NEST supports all the additional properties you can set on facets 
 	
 	var queryResults = this.ConnectedClient.Search<ElasticSearchProject>(s=>s
 		.From(0)
@@ -61,7 +61,7 @@ Nest supports all the additional properties you can set on facets
       )
 	);
 
-Allowing you to take advantage of all the cool facets stuff built in to elasticsearch.
+Allowing you to take advantage of all the cool facets stuff built into Elasticsearch.
 
 ###  Getting to your facet
 
@@ -69,9 +69,9 @@ If you are interested in the facet meta data (such as missing, total) you can us
 
 	var facet = queryResults.Facet<TermFacet>(p=>p.Followers.Select(f=>f.LastName));
 
-this will return a `TermFacet` object which has an `.Items` property holding all the facets.
+This will return a `TermFacet` object which has an `.Items` property holding all the facets.
 
-`queryResult` also holds a `.Facets` dictionary one can use to itterate over the facets returned from the query.
+`queryResult` also holds a `.Facets` dictionary one can use to iterate over the facets returned from the query.
 
 ## Shortcut to facet items
 
@@ -107,6 +107,6 @@ The following lists the elasticsearch facet type and their corresponding NEST st
 
 ***filter*** => [FilterFacet]({{root}}/facets/filter.html)
 
-See also each individual facet's documentation
+See also each individual facet's documentation.
 					
 

--- a/new_docs/contents/nest/facets/histogram.markdown
+++ b/new_docs/contents/nest/facets/histogram.markdown
@@ -17,6 +17,6 @@ The histogram facet works with numeric data by building a histogram across inter
 		.FacetHistogram(h => h.OnField(f=>f.LOC).Interval(100))
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-histogram-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-histogram-facet.html) for more information.
 
 

--- a/new_docs/contents/nest/facets/query.markdown
+++ b/new_docs/contents/nest/facets/query.markdown
@@ -20,5 +20,5 @@ A facet query allows to return a count of the hits matching the facet query. The
 		);
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-query-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-query-facet.html) for more information.
 

--- a/new_docs/contents/nest/facets/range.markdown
+++ b/new_docs/contents/nest/facets/range.markdown
@@ -8,7 +8,7 @@ menuitem: range
 
 # Range Facet
 
-range facet allow to specify a set of ranges and get both the number of docs (count) that fall within each range, and aggregated data either based on the field, or using another field. Here is a simple example:
+Range faceting allows you to specify a set of ranges and get both the number of docs (count) that fall within each range, and aggregated data either based on the field, or using another field. Here is a simple example:
 
 
 	this.ConnectedClient.Search<ElasticSearchProject>(s=>s
@@ -76,5 +76,5 @@ or alternative key/value fields
 	);
 	//SNIP
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-range-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-range-facet.html) for more information.
 

--- a/new_docs/contents/nest/facets/statistical.markdown
+++ b/new_docs/contents/nest/facets/statistical.markdown
@@ -7,7 +7,7 @@ menuitem: statistical
 
 # Statistical Facet
 
-Statistical facet allows to compute statistical data on a numeric fields. The statistical data include count, total, sum of squares, mean (average), minimum, maximum, variance, and standard deviation. Here is an example:
+Statistical faceting allows you to compute statistical data on numeric fields. The statistical data includes count, total, sum of squares, mean (average), minimum, maximum, variance, and standard deviation. Here is an example:
 
 
 	this.ConnectedClient.Search<ElasticSearchProject>(s=>s
@@ -19,5 +19,5 @@ Statistical facet allows to compute statistical data on a numeric fields. The st
 		)
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-statistical-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-statistical-facet.html) for more information.
 

--- a/new_docs/contents/nest/facets/term-stats.markdown
+++ b/new_docs/contents/nest/facets/term-stats.markdown
@@ -7,7 +7,7 @@ menuitem: term-stats
 
 # Term Stats Facet
 
-The terms_stats facet combines both the terms and statistical allowing to compute stats computed on a field, per term value driven by another field. For example:
+The terms_stats facet combines both the terms and statistical allowing you to obtain stats computed on a field, per term value driven by another field. For example:
 
 
 	this.ConnectedClient.Search<ElasticSearchProject>(s=>s
@@ -17,6 +17,6 @@ The terms_stats facet combines both the terms and statistical allowing to comput
 		.FacetTerm(t => t.OnField(f => f.Country).Size(20))
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-stats-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-stats-facet.html) for more information.
 
 

--- a/new_docs/contents/nest/facets/terms.markdown
+++ b/new_docs/contents/nest/facets/terms.markdown
@@ -7,7 +7,7 @@ menuitem: terms
 
 # Terms Facet
 
-Allow to specify field facets that return the N most frequent terms. For example:
+Allows you to specify field facets that return the N most frequent terms. For example:
 
 	this.ConnectedClient.Search<ElasticSearchProject>(s=>s
 		.From(0)
@@ -16,6 +16,6 @@ Allow to specify field facets that return the N most frequent terms. For example
 		.FacetTerm(t => t.OnField(f => f.Country).Size(20))
 	);
 
-See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-facet.html) for more information
+See [original docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-facet.html) for more information.
 
 

--- a/new_docs/contents/nest/handling-responses.markdown
+++ b/new_docs/contents/nest/handling-responses.markdown
@@ -18,9 +18,9 @@ All the return objects from API calls in NEST client implement:
 		ElasticInferrer Infer { get; }
 	}
 
-`IsValid` will return whether a response is valid or not. A response is usually only valid when a HTTP return result in the 200 range was returned. Some calls allow for 404 to be a valid response too however.
+`IsValid` will return whether a response is valid or not. A response is usually only valid when an HTTP return result in the 200 range was returned. Some calls allow for 404 to be a valid response too however.
 
 If a response returns 200 in Elasticsearch sometimes it will contain more information on the validity of the call inside its response. It's highly recommended to read the documentation for a call and check for these properties on the responses as well. 
 
-`ConnectionStatus` is the response as it was returned by `Elasticsearch.net` it's section on 
+`ConnectionStatus` is the response as it was returned by `Elasticsearch.net`. It's section on 
 [handling responses](/elasticsearch-net/handling-responses.html) applies here as well.

--- a/new_docs/contents/nest/index-type-inference.markdown
+++ b/new_docs/contents/nest/index-type-inference.markdown
@@ -28,7 +28,7 @@ That we would like to index in elasticsearch
 
 This will index the object to `/my-default-index/person/1`. 
 
-`NEST` is smart enough to infer the index and typename for the `Person` CLR type. It was also able to get the id of `1` by convention of looking for `Id` property on the specified object. Where it will look for the Id can be specified using the `ElasticType` attribute.
+`NEST` is smart enough to infer the index and typename for the `Person` CLR type. It was also able to get the id of `1` by the convention of looking for `Id` property on the specified object. Where it will look for the Id can be specified using the `ElasticType` attribute.
 
 As noted in the [quick start](/nest/quick-start.html) you can always pass **explicit values** for infered ones.
 
@@ -46,7 +46,7 @@ There are a couple of places within NEST where inference comes in to play
 
 ## Index name inference
 
-Whenever an explicit index name is not provided nest will look to see if the type has it's own default index name on the connection settings.
+Whenever an explicit index name is not provided NEST will look to see if the type has it's own default index name on the connection settings.
 
      settings.MapDefaultTypeIndices(d=>d
         .Add(typeof(MyType), "my-type-index")
@@ -63,7 +63,7 @@ Whenever an explicit index name is not provided nest will look to see if the typ
 
 ## Type name inference
 
-Whenever nest needs a type name but is not given one explicitly it will use the given CLR type to infer it's elasticsearch type name.
+Whenever NEST needs a type name but is not given one explicitly it will use the given CLR type to infer it's Elasticsearch type name.
 
     settings.MapDefaultTypeNames(d=>d
         .Add(typeof(MyType), "MY_TYPO")
@@ -75,27 +75,27 @@ Whenever nest needs a type name but is not given one explicitly it will use the 
     // searches in /inferred-index/person/_search
     client.Search<Person>();
 
-Another way of setting an explicit infer value for a type is through setting an attribute
+Another way of setting an explicit inferred value for a type is through setting an attribute
 
     [ElasticType(Name="automobile")]
     public class Car {} 
 
-As you can also see in the search example is that  NEST by default lowercases typenames that due not have a configured infer value.
+As you can also see in the search example, NEST by default lowercases typenames that do not have a configured inferred value.
 
     settings.SetDefaultTypeNameInferrer(t=>t.Name.ToUpperInvariant());
 
-now all type names that have not been explictly specified or have not been explicitly configured will be uppercased.
+Now all type names that have not been explictly specified or have not been explicitly configured will be uppercased.
 
-Prior to NEST 1.0 typenames were by default lowercases AND pluralized, if you want this behaviour back call
+Prior to NEST 1.0 typenames were by default lowercased AND pluralized, if you want this behaviour back use
 
     settings.PluralizeTypeNames();
 
 ## Property name inference
-In many places `NEST` allows you to pass property names and json paths as C# expressions i.e
+In many places `NEST` allows you to pass property names and JSON paths as C# expressions i.e
 
     .Query(q=>q.Term(p=>p.Followers.First().FirstName, "martijn"))
 
-Or while indexing property names need to be translated to json. 
+Or while indexing property names need to be translated to JSON. 
 
 `NEST` by default will camelCase properties. So `followers.firstName` in the previous example.
 
@@ -109,9 +109,9 @@ Properties marked with `[ElasticAttibute(Name="")]` or `[JsonProperty(Name="")]`
 
 ## Id inference
 
-Whenever an object is passed that needs to specify an id (i.e index, bulk operations) the object is inspected to see if it has an `Id` property and if so it's value will be used.
+Whenever an object is passed that needs to specify an id (i.e index, bulk operations) the object is inspected to see if it has an `Id` property and if so, that value will be used.
 
-This inspection happens once per type and the resulting function that given an object of type T returns its id is cached per T throughout the applications lifetime.
+This inspection happens once per type. The result of the function call that returns the id for an object of type T is cached; therfore, it is only called once per object of type T throughout the applications lifetime.
 
 An example of this is at the top of this documentation where the `Index()` call could figure out the object's id was `1`.
 

--- a/new_docs/contents/nest/indices/aliases.markdown
+++ b/new_docs/contents/nest/indices/aliases.markdown
@@ -10,7 +10,6 @@ menuitem: aliases
 
 ## Adding
 
-
 	var response = this.ConnectedClient.Alias("nest_test_data", "nest_test_data2");
 
 

--- a/new_docs/contents/nest/indices/analyze.markdown
+++ b/new_docs/contents/nest/indices/analyze.markdown
@@ -7,7 +7,7 @@ menuitem: analyze
 
 #Analyze 
 
-Performs the analysis process on a text and return the tokens breakdown of the text.
+Performs the analysis process on the specified text and returns the token breakdown for the text.
 
 ## Analyze using default index's default analyzer
 

--- a/new_docs/contents/nest/indices/create-indices.markdown
+++ b/new_docs/contents/nest/indices/create-indices.markdown
@@ -7,10 +7,10 @@ menuitem: create-indices
 
 
 # Create index 
-The create index API allows to instantiate an index. ElasticSearch provides support for multiple indices, including executing operations across several indices. Each index created can have specific settings associated with it.
+The create index API allows to instantiate an index. Elasticsearch provides support for multiple indices, including executing operations across several indices. Each index created can have specific settings associated with it.
 
 ## Note 
-When adding settings strip the `index.` prefix when passing settings found for example here:http://www.elasticsearch.org/guide/reference/index-modules/
+When adding settings strip the `index.` prefix. This applies to settings found in the [Index Module](http://www.elasticsearch.org/guide/reference/index-modules/) documentation.
 
 ## Simple example
 

--- a/new_docs/contents/nest/indices/delete-indices.markdown
+++ b/new_docs/contents/nest/indices/delete-indices.markdown
@@ -7,7 +7,7 @@ menuitem: delete-indices
 
 
 # Delete Index
-The delete index API allows to delete an existing index.
+The delete index API allows you to delete an existing index.
 
 The delete index API can also be applied to more than one index, or on `_all` indices (be careful!). All indices will also be deleted when no specific index is provided. In order to disable allowing to delete all indices, set `action.disable_delete_all_indices` setting in the config to `true`.
 

--- a/new_docs/contents/nest/indices/delete-mapping.markdown
+++ b/new_docs/contents/nest/indices/delete-mapping.markdown
@@ -7,9 +7,9 @@ menuitem: delete-mapping
 
 
 # Delete Mapping
-Allow to delete a mapping (type) along with its data. The REST endpoint is `/{index}/{type}` with `DELETE` method.
+Allows you to delete a mapping (type) along with its data. The REST endpoint is `/{index}/{type}` with `DELETE` method.
 
-Note, most times, it make more sense to reindex the data into a fresh index compared to delete large chunks of it.
+Note: Most times, it make more sense to reindex the data into a fresh index as compared to deleting large chunks of it.
 
 ## Examples
 Using the default index and the inferred type name

--- a/new_docs/contents/nest/indices/get-mapping.markdown
+++ b/new_docs/contents/nest/indices/get-mapping.markdown
@@ -8,7 +8,7 @@ menuitem: get-mapping
 
 # Get mapping
 
-The get mapping API allows to retrieve mapping definition of index or index/type.
+The get mapping API allows you to retrieve mapping definitions of the index or a specific index/type.
 
 	var mapping = this.ConnectedClient.GetMapping<ElasticSearchProject>();
 

--- a/new_docs/contents/nest/indices/open-close.markdown
+++ b/new_docs/contents/nest/indices/open-close.markdown
@@ -8,7 +8,7 @@ menuitem: open-close
 
 # Open/Close Index
 
-The open and close index APIs allow to close an index, and later on opening it. A closed index has almost no overhead on the cluster (except for maintaining its metadata), and is blocked for read/write operations. A closed index can be opened which will then go through the normal recovery process.
+The open and close index APIs allow you to close an index, and later on open it. A closed index has almost no overhead on the cluster (except for maintaining its metadata), and is blocked for read/write operations. A closed index can be opened which will then go through the normal recovery process.
 
 ## Open and close and index by name
 

--- a/new_docs/contents/nest/indices/optimize.markdown
+++ b/new_docs/contents/nest/indices/optimize.markdown
@@ -8,7 +8,7 @@ menuitem: optimize
 
 # Optimize 
 
-The optimize API allows to optimize one or more indices through an API. The optimize process basically optimizes the index for faster search operations (and relates to the number of segments a lucene index within each shard). The optimize operation allows to optimize the number of segments to optimize to.
+The optimize API allows you to optimize one or more indices through an API. The optimize process basically optimizes the index for faster search operations (and relates to the number of segments a Lucene index maintains within each shard). The optimize operation allows you to specify the maximum number of segments to use during the optimization.
 
 ## Optimize all
 

--- a/new_docs/contents/nest/indices/put-mapping.markdown
+++ b/new_docs/contents/nest/indices/put-mapping.markdown
@@ -12,7 +12,7 @@ The put mapping API allows to register specific mapping definition for a specifi
 
 ## Attribute based mapping
 
-You can decorate your classes with `ElasticProperty` and `ElasticType` attributes to describe how they should be mapped in ES.
+You can decorate your classes with `ElasticProperty` and `ElasticType` attributes to describe how they should be mapped in Elasticsearch.
 
 	[ElasticType(
 		Name = "elasticsearchprojects2",

--- a/new_docs/contents/nest/indices/update-settings.markdown
+++ b/new_docs/contents/nest/indices/update-settings.markdown
@@ -8,7 +8,7 @@ menuitem: update-settings
 
 #Update Settings
 This call allows you to update the index settings. 
-NEST whitelists which settings can be updated based on the allowed values mentioned [here in the elasticsearch documentation]( http://www.elasticsearch.org/guide/reference/api/admin-indices-update-settings.html) this allows you to reuse an `IndexSettings` object.
+NEST whitelists which settings can be updated based on the allowed values mentioned [here in the Elasticsearch documentation]( http://www.elasticsearch.org/guide/reference/api/admin-indices-update-settings.html) this allows you to reuse an `IndexSettings` object.
 
 ##Example
 this example first creates an index and then uses the same IndexSettings to update the index.

--- a/new_docs/contents/nest/query/flt-field.markdown
+++ b/new_docs/contents/nest/query/flt-field.markdown
@@ -8,5 +8,5 @@ menuitem: flt-field
 
 # Fuzzy Like This Field Query
 
-Nest opted out of mapping this one because this query type is merely an alias into the [fuzzy like this]({{root}}/query/flt.html) query.
+NEST opted out of mapping this one because this query type is merely an alias into the [fuzzy like this]({{root}}/query/flt.html) query.
 

--- a/new_docs/contents/nest/query/mlt-field.markdown
+++ b/new_docs/contents/nest/query/mlt-field.markdown
@@ -8,5 +8,5 @@ menuitem: mlt-field
 
 # More Like This Field Query
 
-Since this is merely an alias in elasticsearch for a regular [More Like This query]({{root}}/query/mlt.html)  NEST has no special method for this.
+Since this is merely an alias in Elasticsearch for a regular [More Like This query]({{root}}/query/mlt.html)  NEST has no special method for this.
 

--- a/new_docs/contents/nest/quick-start.md
+++ b/new_docs/contents/nest/quick-start.md
@@ -7,7 +7,7 @@ menuitem: quick-start
 
 # Quick Start
 
-`NEST` is a high level `elasticsearch` client that still maps very close to the original `elasticsearch` API. 
+`NEST` is a high level `elasticsearch` client that still maps very closely to the original `elasticsearch` API. 
 Requests and Responses have been mapped to CLR objects and `NEST` also comes with a powerful strongly typed query dsl.
 
 ## Installing
@@ -44,10 +44,10 @@ To connect to your local node from C# simply:
     );
     var client = new ElasticClient(settings);
 
-Here we create new connection to our `node` and specify a `default index` to use when we don't explictly specify one. 
+Here we create new a connection to our `node` and specify a `default index` to use when we don't explictly specify one. 
 This can greatly reduce the places a magic string or constant has to be used.
 
-**NOTE:** specifying defaultIndex is optional but NEST might throw later on if no index is specified. In fact a simple `new ElasticClient()` is sufficient to chat with
+**NOTE:** specifying defaultIndex is optional but NEST might throw an exception later on if no index is specified. In fact a simple `new ElasticClient()` is sufficient to chat with
 `http://localhost:9200` but explicitly specifying connection settings is recommended.
 
 `node` here is a `Uri` but can also be an `IConnectionPool` see the 
@@ -64,7 +64,7 @@ Now imagine we have a Person [POCO](http://en.wikipedia.org/wiki/Plain_Old_CLR_O
         public string Lastname { get; set; }
     }
 
-That we would like to index in elasticsearch indexing is now as simple as calling.
+That we would like to index in elasticsearch. Indexing is now as simple as calling.
 
     var person = new Person
     {
@@ -74,7 +74,7 @@ That we would like to index in elasticsearch indexing is now as simple as callin
     };
     var index = client.Index(person);
 
-This will index the object to `/my-application/person/1`. `NEST` is smart enough to infer the index and typename for the `Person` CLR type. It was also able to get the id of `1` by convention of looking for `Id` property on the specified object. Where it will look for the Id can be specified using the `ElasticType` attribute.
+This will index the object to `/my-application/person/1`. `NEST` is smart enough to infer the index and typename for the `Person` CLR type. It was also able to get the id of `1` through convention,  by looking for an `Id` property on the specified object. Which property it will use for the Id can also be specified using the `ElasticType` attribute.
 
 The default index and type names are configurable per type see the [nest section on connecting](/nest/connecting.html)
 
@@ -102,11 +102,11 @@ Now that we have indexed some documents we can begin to search for them.
         )
     );
 
-`searchResults.Documents`now holds the first 10 people it knows who's first name is `Martijn`
+`searchResults.Documents` now holds the first 10 people it knows who's first name is `Martijn`
 
-Please see [the section on writing queries](http://localhost:8080/nest/writing-queries.html) how NEST helps you write terse elasticsearch queries.
+Please see [the section on writing queries](http://localhost:8080/nest/writing-queries.html) for details on how NEST helps you write terse elasticsearch queries.
 
-Again the same inferring rules apply as this will hit `/my-application/person/_search` and the same rule that inferring can be overruled also applies.
+Again the same inferring rules apply as this will hit `/my-application/person/_search` and the same rule that inferring can be overridden also applies.
 
     // uses /other-index/other-type/_search
     var searchResults = client.Search<Person>(s=>s

--- a/new_docs/contents/nest/search/basics.markdown
+++ b/new_docs/contents/nest/search/basics.markdown
@@ -29,14 +29,14 @@ If you want to search across all indices
 	    ...
 	)
 
-Or if you want to search one index (thats not the default index)
+Or if you want to search one index (that is not the default index)
 
 	client.Search<MyObject>(s=>s.
 	    .Index("Index_A")
 	    ...
 	)
 
-Remember since elasticsearch 19.8 you can also specify wildcards on index names
+Remember that since Elasticsearch 19.8 you can also specify wildcards on index names
 
 	client.Search<MyObject>(s=>s
 	    .Index("Index_*")
@@ -60,7 +60,7 @@ Using
 
 	.ConcreteTypeSelector(Func<dynamic, Hit<dynamic>, Type>)
 
-you can manually specify the type of each hit based on some json value (on dynamic) or on the hit metadata.
+you can manually specify the type of each hit based on some JSON value (on dynamic) or on the hit metadata.
 
 #Routing
 You can specify the routing for the search request using 

--- a/new_docs/contents/nest/search/fields.markdown
+++ b/new_docs/contents/nest/search/fields.markdown
@@ -16,5 +16,5 @@ Using
 
 You can limit the returned fields for each hit.
 
-An overload taking plain strings also exists
+An overload taking plain strings also exists.
 

--- a/new_docs/contents/nest/search/named-filters.markdown
+++ b/new_docs/contents/nest/search/named-filters.markdown
@@ -14,7 +14,7 @@ Each filter allows you specify a name i.e
 
 This will allow you to see on each with which filter applied to it.
 
-Right now I'm waiting on this active elasticsearch issue to complete mapping this functionality
+Right now I'm waiting on this active Elasticsearch issue to complete mapping this functionality
 
 https://github.com/elasticsearch/elasticsearch/issues/3097
 

--- a/new_docs/contents/nest/search/scroll.markdown
+++ b/new_docs/contents/nest/search/scroll.markdown
@@ -7,7 +7,7 @@ menuitem: scroll
 
 # Scroll
 
-The scroll api allows you to efficiently page through a large dataset as it keeps the query alive in the cluster. 
+The scroll API allows you to efficiently page through a large dataset as it keeps the query alive in the cluster. 
 
 	var scanResults = this._client.Search<ElasticSearchProject>(s => s
 		.From(0)

--- a/new_docs/contents/nest/search/sort.markdown
+++ b/new_docs/contents/nest/search/sort.markdown
@@ -8,7 +8,7 @@ menuitem: sort
 
 # Sort
 
-Apply a sort over the search results, do note that sorting and boosting are mutually exclusive.
+Apply a sort over the search results. Please note that sorting and boosting are mutually exclusive.
 
 	.SortAscending(p=> p.Name.Suffix("sort"))
 

--- a/new_docs/contents/nest/writing-queries.markdown
+++ b/new_docs/contents/nest/writing-queries.markdown
@@ -6,7 +6,7 @@ menuitem: writing-queries
 ---
 
 # Writing Queries
-One of the most important things to grasp using Nest is how to write queries. Nest offers you several possibilities. By the way all examples on this page assume being wrapped in
+One of the most important things to grasp when using Nest is how to write queries. Nest offers you several possibilities. By the way all examples on this page assume being wrapped in
 
     var result = client.Search<ElasticSearchProject>(s=>s
         .From(0)
@@ -15,30 +15,30 @@ One of the most important things to grasp using Nest is how to write queries. Ne
     );
 
 ## Raw strings
-Although not preffered by me personally many folks like to build their own json strings and just pass that along.
+Although not preferred by me personally, many folks like to build their own JSON strings and just pass that along.
 
     .QueryRaw("\"match_all\" : { }")
     .FilterRaw("\"match_all\" : { }")
 
-Nest does not modify this in anyway and just writes this straight into the json output. 
+Nest does not modify this in anyway and just writes this straight into the JSON output. 
 
 ## Query DSL
-The preffered way to write queries since it gives you alot of cool feautures.
+The preferred way to write queries, since it gives you alot of cool features.
 
 ### Lambda expressions
     .Query(q=>q
         .Term(p=>p.Name, "NEST")
     )
 
-Here you'll see we can use expressions to adres properties in a type safe matter. This also works for `IEnumerable` types i.e
+Here you'll see we can use expressions to address properties in a type safe matter. This also works for `IEnumerable` types e.g.
 
     .Query(q=>q
         .Term(p=>p.Followers.First().FirstName, "NEST")
     )
 
-Because these property lookups are expressions you dont have to do any null checks. The previous would expand to the `followers.firstName` property name. 
+Because these property lookups are expressions you don't have to do any null checks. The previous would expand to the `followers.firstName` property name. 
 
-Of course if you need to pass the property name as string Nest will allow you to do so.
+Of course if you need to pass the property name as string NEST will allow you to do so.
 
     .Query(q=>q
         .Term("followers.firstName", "martijn")
@@ -59,14 +59,14 @@ Sometimes you'll need to resuse a filter or query often. To aid with this you ca
         )
     )
 
-similarly `Filter<T>.[Filter]()` methods exist for filters.
+Similarly `Filter<T>.[Filter]()` methods exist for filters.
 
 ### Boolean queries 
-As can be seen in the previous example writing out boolean queries can turn into a really tedious and verbose effort. Luckily Nest supports bitwise operators and so we can rewrite the previous as such:
+As can be seen in the previous example writing out boolean queries can turn into a really tedious and verbose effort. Luckily NEST supports bitwise operators and so we can rewrite the previous as such:
 
     .Query(q=>q.MatchAll() && termQuery)
 
-Note how we are mixing and matching the lambda and static queries here
+Note how we are mixing and matching the lambda and static queries here.
 
 Similary an `OR` looks like this
 
@@ -82,19 +82,19 @@ Similary an `OR` looks like this
         && !q.Term("name", "Elastica")
     )
 
-This will query for all the php clients except `Elastica`
+This will query for all the php clients except `Elastica`.
 
-You can mix and match this to any complexity until it satisfies your query requirements.
+You can mix and match this to any level of complexity until it satisfies your query requirements.
 
     .Query(q=>q
         (q.Term("language", "php")
             && !q.Term("name", "Elastica")
         )
         ||
-        q.Term("name", "Nest")
+        q.Term("name", "NEST")
     )
 
-will query all php clients except elastica or where the name equals Nest.
+Will query all php clients except 'Elastica` or where the name equals `NEST`.
 
 #### Clean output support
 Normally writing three boolean must clauses looks like this (psuedo code)
@@ -104,7 +104,7 @@ Normally writing three boolean must clauses looks like this (psuedo code)
         clause2
         clause3
 
-A naive implemenation of the bitwise operators would make all the queries sent to elasticsearch look like
+A naive implemenation of the bitwise operators would make all the queries sent to Elasticsearch look like
 
     must
         must
@@ -112,11 +112,11 @@ A naive implemenation of the bitwise operators would make all the queries sent t
             clause2
         clause3
 
-This degrades rather rapidly so and makes inspecting generated queries quite a chore. Nest does it's best to detect these cases and always write them in the first clean form.
+This degrades rather rapidly and makes inspecting generated queries quite a chore. NEST does it's best to detect these cases and will always write them in the first, cleaner form.
 
 ## Conditionless queries
 
-Writing complex boolean queries is one thing but more often then not you'll want to make decisions on how to query based on user input. 
+Writing complex boolean queries is one thing, but more often then not you'll want to make decisions on how to query based on user input. 
 
     public class UserInput
     {
@@ -139,7 +139,7 @@ and then
             return query;
         })
 
-This again turns tedious and verbose rather quickly too. Therefor nest allows you to write the previous query as:
+This again becomes tedious and verbose rather quickly as well. Therefore, NEST allows you to write the previous query as:
 
     .Query(q=>
         q.Term(p=>p.Name, userInput.Name);
@@ -147,11 +147,11 @@ This again turns tedious and verbose rather quickly too. Therefor nest allows yo
         && q.Range(r=>r.OnField(p=>p.Loc).From(userInput.Loc))
     )
 
-If any of the queries would result in an empty query they won't be sent to elasticsearch. 
+If any of the queries would result in an empty query they won't be sent to Elasticsearch. 
 
 So if all the terms are null (or empty string) on `userInput` except `userInput.Loc` it wouldn't even wrap the range query in a boolean query but just issue a plain range query. 
 
-If all of them empty it will result in a `match_all` query. 
+If all of them are empty it will result in a `match_all` query. 
 
 This conditionless behavior is turned on by default but can be turned of like so:
 
@@ -172,7 +172,7 @@ However queries themselves can opt back in or out.
 
 In this example if `userInput.Name` is null or empty it will result in a `DslException`. The range query will use conditionless logic no matter if the SearchDescriptor uses `.Strict()` or not.
 
-Also good to note is that conditionless query logic propagates:
+Please note that conditionless query logic propagates:
 
     q.Strict().Term(p=>p.Name, userInput.Name);
     && q.Term("followers.firstName", userInput.FirstName)
@@ -183,7 +183,7 @@ Also good to note is that conditionless query logic propagates:
         )
     )
 
-If both `userInput.Countries` and `userInput.Loc` are null or empty the entire `filtered` query will be not be issued. 
+If both `userInput.Countries` and `userInput.Loc` are null or empty the entire `filtered` query will not be issued. 
 
 
 


### PR DESCRIPTION
Went through the new_docs directory and cleaned up some typos, formatting, verbiage and naming conventions in the documentation. Please feel free to reject any changes that you do not feel are appropriate.

Additionally, I just signed a http://www.elasticsearch.org/contributor-agreement/ 

Please let me know if you need anything additional from me to consider this pull request.
