### PR TITLE
Thrift connection pool does not clean up stale connections

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
@@ -283,6 +284,16 @@ namespace Elasticsearch.Net.Connection.Thrift
 							this._connectionSettings, (int)result.Status, method, path, requestData, new MemoryStream(result.Body));
 						return response;
 					}
+				}
+				catch (SocketException)
+				{
+					client.InputProtocol.Transport.Close();
+					throw;
+				}
+				catch (IOException)
+				{
+					client.InputProtocol.Transport.Close();
+					throw;
 				}
 				finally
 				{

--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TBufferedTransport.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TBufferedTransport.cs
@@ -78,6 +78,10 @@ namespace Elasticsearch.Net.Connection.Thrift.Transport
 			{
 				outputBuffer.Close();
 			}
+			if (transport != null)
+			{
+				transport.Close();
+			}
 		}
 
 		public override int Read(byte[] buf, int off, int len)


### PR DESCRIPTION
Hi,

I ran into this issue after doing a rolling restart. Basically what happens is that when a connection gets disconnected, the corresponding `Rest.Client` gets added back into the connection pool without the underlying connection being cleaned up. 

My fix simply closes the underlying connection. The next time the `Rest.Client` is used, a new connection will be opened automatically.
