### PR TITLE
Allow ID to be of type long

### DIFF
--- a/src/Nest/DSL/BulkIndexDescriptor.cs
+++ b/src/Nest/DSL/BulkIndexDescriptor.cs
@@ -56,6 +56,14 @@ namespace Nest
 		/// <summary>
 		/// Manually set the id for the newly created object
 		/// </summary>
+		public BulkIndexDescriptor<T> Id(long id)
+		{
+			return this.Id(id.ToString(CultureInfo.InvariantCulture));
+		}
+		
+		/// <summary>
+		/// Manually set the id for the newly created object
+		/// </summary>
 		public BulkIndexDescriptor<T> Id(int id)
 		{
 			return this.Id(id.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
In the case we have "long" IDs, we should allow for that overload.
