### PR TITLE
Correctly handle empty response bodies in Thrift

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
@@ -274,13 +274,13 @@ namespace Elasticsearch.Net.Connection.Thrift
 					if (result.Status == Status.OK || result.Status == Status.CREATED || result.Status == Status.ACCEPTED)
 					{
 						var response = ElasticsearchResponse<Stream>.Create(
-							this._connectionSettings, (int)result.Status, method, path, requestData, new MemoryStream(result.Body));
+							this._connectionSettings, (int)result.Status, method, path, requestData, new MemoryStream(result.Body ?? new byte[0]));
 						return response;
 					}
 					else
 					{
 						var response = ElasticsearchResponse<Stream>.Create(
-							this._connectionSettings, (int)result.Status, method, path, requestData, new MemoryStream(result.Body));
+							this._connectionSettings, (int)result.Status, method, path, requestData, new MemoryStream(result.Body ?? new byte[0]));
 						return response;
 					}
 				}

--- a/src/Tests/Nest.Tests.Integration/Connection/Thrift/ThiftBugReportTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Connection/Thrift/ThiftBugReportTests.cs
@@ -26,5 +26,16 @@ namespace Nest.Tests.Integration.Core.Bulk
 			unknownIndexResult.ConnectionStatus.HttpStatusCode.Should().Be(404);
 
 		}
+
+		[Test]
+		public void EmptyResponseShouldNotThrowError()
+		{
+			var isValidThriftConnection = this._thriftClient.RootNodeInfo().IsValid;
+			isValidThriftConnection.Should().BeTrue();
+
+			var result = this._thriftClient.Connection.HeadSync(ElasticsearchConfiguration.CreateBaseUri(9500));
+			result.Success.Should().BeTrue();
+			result.OriginalException.Should().BeNull();
+		}
 	}
 }


### PR DESCRIPTION
The thrift representation of an empty array is the same as null, so when the body is empty (such as with a HeadSync), the current implementation of Execute will throw an exception because MemoryStream cannot handle nulls. Instead return an empty byte array. Also add integration test for this case.
