### PR TITLE
when tracing is enabled, log the actual json request

### DIFF
--- a/src/Elasticsearch.Net/Domain/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Domain/ElasticsearchResponse.cs
@@ -196,12 +196,19 @@ namespace Elasticsearch.Net
 			else if (typeof(T) == typeof(byte[]))
 				response = (this.Response as byte[]).Utf8String();
 
+			string requestJson = null;
+		    
+            if (r.Request != null)
+            {
+                requestJson = r.Request.Utf8String();
+            }
+				
 			var print = _printFormat.F(
 			  Environment.NewLine,
 			  r.HttpStatusCode.HasValue ? r.HttpStatusCode.Value.ToString(CultureInfo.InvariantCulture) : "-1",
 			  r.RequestMethod,
 			  r.RequestUrl,
-			  r.Request,
+			  requestJson,
 			  response
 			);
 			if (!this.Success && e != null)


### PR DESCRIPTION
Was just logging "byte[]" which was no help. This way we can see the command sent to ES. Still doesn't log the response the way it should. Someone need to fix that as well. right now it says "Response stream not captured or already read to completion by serializer" every time for me.
