### PR TITLE
allow type name to be overridden when adding mappings at index creation

### DIFF
--- a/src/Nest/DSL/CreateIndexDescriptor.cs
+++ b/src/Nest/DSL/CreateIndexDescriptor.cs
@@ -118,7 +118,16 @@ namespace Nest
 			typeMappingDescriptor.ThrowIfNull("typeMappingDescriptor");
 			var d = typeMappingDescriptor(new PutMappingDescriptor<T>(this._connectionSettings));
 			var typeMapping = d._Mapping;
-			typeMapping.Name = typeof (T);
+
+			if (d._Type != null)
+			{
+				typeMapping.Name = d._Type.Name != null ? (PropertyNameMarker)d._Type.Name : d._Type.Type;
+			}
+			else
+			{
+				typeMapping.Name = typeof(T);
+			}
+
 			this._IndexSettings.Mappings.Add(typeMapping);
 
 			return this;
@@ -133,7 +142,16 @@ namespace Nest
 			typeMappingDescriptor.ThrowIfNull("typeMappingDescriptor");
 			var d = typeMappingDescriptor(new PutMappingDescriptor<T>(this._connectionSettings) { _Mapping = rootObjectMapping,});
 			var typeMapping = d._Mapping;
-			typeMapping.Name = typeof (T);
+
+			if (d._Type != null)
+			{
+				typeMapping.Name = d._Type.Name != null ? (PropertyNameMarker)d._Type.Name : d._Type.Type;
+			}
+			else
+			{
+				typeMapping.Name = typeof (T);
+			}
+
 			this._IndexSettings.Mappings.Add(typeMapping);
 
 			return this;

--- a/src/Tests/Nest.Tests.Integration/Indices/IndicesTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Indices/IndicesTests.cs
@@ -259,6 +259,10 @@ namespace Nest.Tests.Integration.Indices
 				.AddMapping<Person>(m => m
 					.MapFromAttributes()
 				)
+				.AddMapping<Person>(m => m
+					.MapFromAttributes()
+					.Type("override")
+				)
 				.Analysis(a=>a
 					.Analyzers(an=>an
 						.Add("standard", new StandardAnalyzer()


### PR DESCRIPTION
This change allows you to use the PutMappingDescriptor's existing Type method to override the type name of a mapping at index creation.

Since it was already supported for PutMapping, having it at index creation too made sense.

The use case is pretty simple. If you have a base class which you want to either use attribute mappings for, or fluent mapping, you could put that base class mapping as "_default_" by doing something like:

``` csharp
_client.CreateIndex("index",
                    c =>
                    c.AddMapping<Entity>(
                        map =>
                            map.Type("_default_")
                               .Properties(p => p.String(s => s.Name(n => n.Name)
                                                           .Index(FieldIndexOption.analyzed)
                                                           .Store(false)
                                                           .IncludeInAll()))
                               .DynamicTemplates(d => d.Add(a =>
                                                            a.Name("other")
                                                             .Match("*")
                                                             .Mapping(m => m.Generic(g => g.Index("not_analyzed")
                                                                                           .IncludeInAll(false)))))))
```
