### PR TITLE
fix #599 thrift connection implementation does not failover 

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -10,13 +11,15 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elasticsearch.Net.Connection.Thrift.Protocol;
 using Elasticsearch.Net.Connection.Thrift.Transport;
+using Elasticsearch.Net.ConnectionPool;
 using Elasticsearch.Net.Providers;
 
 namespace Elasticsearch.Net.Connection.Thrift
 {
 	public class ThriftConnection : IConnection, IDisposable
 	{
-		private readonly ConcurrentQueue<Rest.Client> _clients = new ConcurrentQueue<Rest.Client>();
+		private readonly ConcurrentDictionary<Uri, ConcurrentQueue<Rest.Client>> _clients =
+			new ConcurrentDictionary<Uri, ConcurrentQueue<Rest.Client>>();
 		private readonly Semaphore _resourceLock;
 		private readonly int _timeout;
 		private readonly int _poolSize;
@@ -27,20 +30,36 @@ namespace Elasticsearch.Net.Connection.Thrift
 		{
 			this._connectionSettings = connectionSettings;
 			this._timeout = connectionSettings.Timeout;
-			this._poolSize = Math.Max(1, connectionSettings.MaximumAsyncConnections);
-
+			var connectionPool = this._connectionSettings.ConnectionPool;
+			var maximumConnections = Math.Max(1, connectionSettings.MaximumAsyncConnections);
+			var maximumUrls = connectionPool.MaxRetries + 1;
+			this._poolSize = maximumConnections;
 			this._resourceLock = new Semaphore(_poolSize, _poolSize);
-			int seed; bool shouldPingHint;
-			for (var i = 0; i <= connectionSettings.MaximumAsyncConnections; i++)
+
+			int seed; int initialSeed = 0; bool shouldPingHint;
+
+			for (var i = 0; i < maximumUrls; i++)
 			{
-				var uri = this._connectionSettings.ConnectionPool.GetNext(null, out seed, out shouldPingHint);
-				var host = uri.Host;
-				var port = uri.Port;
-				var tsocket = new TSocket(host, port);
-				var transport = new TBufferedTransport(tsocket, 1024);
-				var protocol = new TBinaryProtocol(transport);
-				var client = new Rest.Client(protocol);
-				_clients.Enqueue(client);
+				var uri = connectionPool.GetNext(initialSeed, out seed, out shouldPingHint);
+				var queue = new ConcurrentQueue<Rest.Client>();
+				for (var c = 0; c < maximumConnections; c++)
+				{
+					var host = uri.Host;
+					var port = uri.Port;
+					var tsocket = new TSocket(host, port);
+					var transport = new TBufferedTransport(tsocket, 1024);
+					var protocol = new TBinaryProtocol(transport);
+					var client = new Rest.Client(protocol);
+					tsocket.Timeout = this._connectionSettings.Timeout;
+					tsocket.TcpClient.SendTimeout = this._connectionSettings.Timeout;
+					tsocket.TcpClient.ReceiveTimeout = this._connectionSettings.Timeout;
+					//tsocket.TcpClient.NoDelay = true;
+
+					queue.Enqueue(client);
+
+					initialSeed = seed;
+				}
+				_clients.TryAdd(uri, queue);
 			}
 		}
 
@@ -59,7 +78,7 @@ namespace Elasticsearch.Net.Connection.Thrift
 				return this.Execute(restRequest, deserializationState);
 			});
 		}
-	
+
 		public Task<ElasticsearchResponse<Stream>> Head(Uri uri, IRequestConnectionConfiguration deserializationState = null)
 		{
 			var restRequest = new RestRequest();
@@ -68,7 +87,7 @@ namespace Elasticsearch.Net.Connection.Thrift
 
 			restRequest.Headers = new Dictionary<string, string>();
 			restRequest.Headers.Add("Content-Type", "application/json");
-			return Task.Factory.StartNew<ElasticsearchResponse<Stream>>(()=> 
+			return Task.Factory.StartNew<ElasticsearchResponse<Stream>>(() =>
 			{
 				return this.Execute(restRequest, deserializationState);
 			});
@@ -219,15 +238,13 @@ namespace Elasticsearch.Net.Connection.Thrift
 		protected virtual void Dispose(bool disposing)
 		{
 			if (_disposed)
-			{
 				return;
-			}
 
-			foreach (var c in this._clients)
+			foreach (var c in this._clients.SelectMany(c=>c.Value))
 			{
-				if (c != null 
-					&& c.InputProtocol != null 
-					&& c.InputProtocol.Transport != null 
+				if (c != null
+					&& c.InputProtocol != null
+					&& c.InputProtocol.Transport != null
 					&& c.InputProtocol.Transport.IsOpen)
 					c.InputProtocol.Transport.Close();
 			}
@@ -249,8 +266,10 @@ namespace Elasticsearch.Net.Connection.Thrift
 		{
 			//RestResponse result = GetClient().execute(restRequest);
 			//
-			var method = Enum.GetName(typeof (Method), restRequest.Method);
-			var path = restRequest.Uri.ToString();
+			var method = Enum.GetName(typeof(Method), restRequest.Method);
+			var uri = restRequest.Uri;
+			var path = uri.ToString();
+			var baseUri = new Uri(string.Format("{0}://{1}:{2}", uri.Scheme, uri.Host, uri.Port));
 			var requestData = restRequest.Body;
 			if (!this._resourceLock.WaitOne(this._timeout))
 			{
@@ -259,8 +278,17 @@ namespace Elasticsearch.Net.Connection.Thrift
 			}
 			try
 			{
-				Rest.Client client = null;
-				if (!this._clients.TryDequeue(out client))
+				ConcurrentQueue<Rest.Client> queue;
+				if (!this._clients.TryGetValue(baseUri,out queue))
+				{
+					var m = string.Format("Could dequeue a thrift client from internal socket pool of size {0}", this._poolSize);
+					var status = ElasticsearchResponse<Stream>.CreateError(this._connectionSettings, new Exception(m), method, path, requestData);
+					return status;
+				}
+
+
+				Rest.Client client;
+				if (!queue.TryDequeue(out client))
 				{
 					var m = string.Format("Could dequeue a thrift client from internal socket pool of size {0}", this._poolSize);
 					var status = ElasticsearchResponse<Stream>.CreateError(this._connectionSettings, new Exception(m), method, path, requestData);
@@ -298,7 +326,8 @@ namespace Elasticsearch.Net.Connection.Thrift
 				finally
 				{
 					//make sure we make the client available again.
-					this._clients.Enqueue(client);
+					if (queue != null && client != null)
+						queue.Enqueue(client);
 				}
 
 			}

--- a/src/Elasticsearch.Net/Connection/Transport.cs
+++ b/src/Elasticsearch.Net/Connection/Transport.cs
@@ -204,7 +204,7 @@ namespace Elasticsearch.Net.Connection
 				if (maxRetries == 0 && retried == 0)
 					throw;
 				seenError = true;
-				return RetryRequest<T>(requestState, uri, retried, e);
+				return RetryRequest<T>(requestState, baseUri, retried, e);
 			}
 			finally
 			{
@@ -212,7 +212,7 @@ namespace Elasticsearch.Net.Connection
 				if (!seenError && response != null && response.SuccessOrKnownError)
 					this._connectionPool.MarkAlive(baseUri);
 			}
-			return RetryRequest<T>(requestState, uri, retried);
+			return RetryRequest<T>(requestState, baseUri, retried);
 		}
 
 		private Uri GetNextBaseUri<T>(TransportRequestState<T> requestState, out int initialSeed, out bool shouldPingHint)
@@ -233,6 +233,7 @@ namespace Elasticsearch.Net.Connection
 			var exceptionMessage = MaxRetryExceptionMessage.F(requestState.Method, requestState.Path.IsNullOrEmpty() ? "/" : "", retried);
 
 			this._connectionPool.MarkDead(baseUri, this._configurationValues.DeadTimeout, this._configurationValues.MaxDeadTimeout);
+
 			if (!SniffingDisabled(requestState.RequestConfiguration)
 				&& this._configurationValues.SniffsOnConnectionFault 
 				&& retried == 0)

--- a/src/Elasticsearch.Net/ConnectionPool/StaticConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/StaticConnectionPool.cs
@@ -34,7 +34,7 @@ namespace Elasticsearch.Net.ConnectionPool
 			_dateTimeProvider = dateTimeProvider ?? new DateTimeProvider();
 			var rnd = new Random();
 			uris.ThrowIfEmpty("uris");
-			_nodeUris = uris.ToList();
+			_nodeUris = uris.Distinct().ToList();
 			if (randomizeOnStartup)
 				_nodeUris = _nodeUris.OrderBy((item) => rnd.Next()).ToList();
 			_uriLookup = _nodeUris.ToDictionary(k=>k, v=> new EndpointState());

--- a/src/Nest/Domain/Connection/ConnectionSettings.cs
+++ b/src/Nest/Domain/Connection/ConnectionSettings.cs
@@ -85,7 +85,7 @@ namespace Nest
 		private ReadOnlyCollection<Func<Type, JsonConverter>> _contractConverters;
 		ReadOnlyCollection<Func<Type, JsonConverter>> IConnectionSettingsValues.ContractConverters { get { return _contractConverters; } }
 
-		public ConnectionSettings(IConnectionPool uri, string defaultIndex) : base(uri)
+		public ConnectionSettings(IConnectionPool connectionPool, string defaultIndex) : base(connectionPool)
 		{
 			if (!defaultIndex.IsNullOrEmpty())
 				this.SetDefaultIndex(defaultIndex);

--- a/src/Tests/Nest.Tests.Integration/Connection/Thrift/ThiftBugReportTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Connection/Thrift/ThiftBugReportTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using Elasticsearch.Net.Connection.Thrift;
+using Elasticsearch.Net.ConnectionPool;
 using FluentAssertions;
 using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
@@ -36,6 +38,30 @@ namespace Nest.Tests.Integration.Core.Bulk
 			var result = this._thriftClient.Connection.HeadSync(ElasticsearchConfiguration.CreateBaseUri(9500));
 			result.Success.Should().BeTrue();
 			result.OriginalException.Should().BeNull();
+		}
+
+		[Test]
+		public void ShouldFailoverOnThriftConnections()
+		{
+			var uris = new []
+			{
+				new Uri("http://INVALID_HOST"),
+				new Uri("http://INVALID_HOST2"),
+				new Uri("http://localhost:9500")
+			};
+			var connectionPool = new StaticConnectionPool(uris, randomizeOnStartup: false);
+			var settings = new ConnectionSettings(connectionPool, ElasticsearchConfiguration.DefaultIndex)
+				.ExposeRawResponse()
+				.SetTimeout(2000);
+			var client = new ElasticClient(settings, new ThriftConnection(settings));
+
+			var results = client.Search<dynamic>(s => s.MatchAll());
+			results.IsValid.Should().BeTrue("{0}", results.ConnectionStatus.ToString());
+			results.ConnectionStatus.NumberOfRetries.Should().Be(2);
+
+			results = client.Search<dynamic>(s => s.MatchAll());
+			results.IsValid.Should().BeTrue("{0}", results.ConnectionStatus.ToString());
+			results.ConnectionStatus.NumberOfRetries.Should().Be(0);
 		}
 	}
 }

--- a/src/Tests/Nest.Tests.Integration/Core/Bulk/BulkTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/Bulk/BulkTests.cs
@@ -48,8 +48,8 @@ namespace Nest.Tests.Integration.Core.Bulk
 		public void DoubleCreateReturnsOneError()
 		{
 			var result = this._client.Bulk(b => b
-				.Create<ElasticsearchProject>(i => i.Object(new ElasticsearchProject { Id = 123123 }))
-				.Create<ElasticsearchProject>(i => i.Object(new ElasticsearchProject { Id = 123123 }))
+				.Create<ElasticsearchProject>(i => i.Object(new ElasticsearchProject { Id = 12315555 }))
+				.Create<ElasticsearchProject>(i => i.Object(new ElasticsearchProject { Id = 12315555 }))
 			);
 
 			result.IsValid.Should().BeFalse();


### PR DESCRIPTION
Since it has an internal pool of connections. 

The pool is now a dict<baseUri, queue> and the thrift implementation now tries to dequeue from the proper baseUri queue.

https://github.com/elasticsearch/elasticsearch-net/issues/599 
