### PR TITLE
Also close Thrift connection on TTransportException

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
@@ -323,6 +323,11 @@ namespace Elasticsearch.Net.Connection.Thrift
 					client.InputProtocol.Transport.Close();
 					throw;
 				}
+				catch (TTransportException)
+				{
+					client.InputProtocol.Transport.Close();
+					throw;
+				}
 				finally
 				{
 					//make sure we make the client available again.


### PR DESCRIPTION
This related to issue #565. I should also close the client on TTransportException
