### PR TITLE
Mtermvectors descriptor can now accept a collection of documents

### DIFF
--- a/src/Nest/DSL/MultiTermVectorsDescriptor.cs
+++ b/src/Nest/DSL/MultiTermVectorsDescriptor.cs
@@ -21,7 +21,13 @@ namespace Nest
 			this._Documents = documentSelectors.Select(s => s(new MultiTermVectorDocumentDescriptor<T>()).GetDocument()).Where(d=>d!= null).ToList();
 			return this;
 		}
-		
+
+		public MultiTermVectorsDescriptor<T> Documents(IEnumerable<MultiTermVectorDocument> documents)
+		{
+			this._Documents = documents;
+			return this;
+		}
+
 		ElasticsearchPathInfo<MultiTermVectorsRequestParameters> IPathInfo<MultiTermVectorsRequestParameters>.ToPathInfo(IConnectionSettingsValues settings)
 		{
 			var pathInfo = base.ToPathInfo(settings, this._QueryString);


### PR DESCRIPTION
Pretty self-explanatory.  Provides more flexibility for adding docs to the request body.
