### PR TITLE
Changed index size stats from ints to longs

### DIFF
--- a/src/Nest/Domain/Stats/IndexSizeStats.cs
+++ b/src/Nest/Domain/Stats/IndexSizeStats.cs
@@ -12,13 +12,13 @@ namespace Nest
         public string PrimarySize { get; set; }
 
         [JsonProperty(PropertyName = "primary_size_in_bytes")]
-        public int PrimarySizeInBytes { get; set; }
+        public long PrimarySizeInBytes { get; set; }
 
         [JsonProperty(PropertyName = "size")]
         public string Size { get; set; }
 
         [JsonProperty(PropertyName = "size_in_bytes")]
-        public int SizeInBytes { get; set; }
+        public long SizeInBytes { get; set; }
 
     }
 }


### PR DESCRIPTION
Otherwise deserialization blows up on indices that exceed Int32.MaxValue in bytes, as you would expect.  
This was pointed out here: http://stackoverflow.com/questions/23626384/elasticclient-an-error-when-checking-the-connection-status, which I was able to reproduce.
