### PR TITLE
use DefaultPropertyNameInferrer from settings when resolving property na...

### DIFF
--- a/src/Nest/Resolvers/PropertyNameResolver.cs
+++ b/src/Nest/Resolvers/PropertyNameResolver.cs
@@ -77,7 +77,7 @@ namespace Nest.Resolvers
 				return null;
 
 			var name = info.Name;
-			var resolvedName = name.ToCamelCase();
+			var resolvedName = _settings.DefaultPropertyNameInferrer(name);
 			var att = ElasticAttributes.Property(info);
 			if (att != null && !att.Name.IsNullOrEmpty())
 				resolvedName = att.Name;


### PR DESCRIPTION
PropertyNameResolver was defaulting to camel case instead of using the DefaultPropertyNameInferrer when not taking the ExpressionVisitor route.

Closes #697
