### PR TITLE
Lowercased TextQueryType enum members

### DIFF
--- a/src/Nest/Enums/TextQueryType.cs
+++ b/src/Nest/Enums/TextQueryType.cs
@@ -4,11 +4,11 @@ namespace Nest
 {
     public enum TextQueryType
     {
-        BEST_FIELDS,
-        MOST_FIELDS,
-        CROSS_FIELDS,
-        PHRASE,
-        PHRASE_PREFIX
+        best_fields,
+        most_fields,
+        cross_fields,
+        phrase,
+        phrase_prefix
     }
 }
 // ReSharper restore CheckNamespace

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MultiMatchQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MultiMatchQueryTests.cs
@@ -24,7 +24,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 					.Rewrite(RewriteMultiTerm.top_terms_N)
 					.Slop(2)
 					.TieBreaker(2.0)
-					.Type(TextQueryType.BEST_FIELDS)
+					.Type(TextQueryType.best_fields)
 					)
 				);
 			q.Analyzer.Should().Be("my-analyzer");
@@ -39,7 +39,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Rewrite.Should().Be(RewriteMultiTerm.top_terms_N);
 			q.Slop.Should().Be(2);
 			q.TieBreaker.Should().Be(2.0);
-			q.Type.Should().Be(TextQueryType.BEST_FIELDS);
+			q.Type.Should().Be(TextQueryType.best_fields);
 		}
 	}
 }


### PR DESCRIPTION
Mind, this is a breaking change for consumers. Yet I don't get the upper-casing to begin with since all other resembling enumerations have lower-cased members. Of course the real reason for doing this is issue #739.
