### PR TITLE
Prevent object type from being skipped during deserialization

### DIFF
--- a/src/Nest/Resolvers/Converters/ElasticTypeConverter.cs
+++ b/src/Nest/Resolvers/Converters/ElasticTypeConverter.cs
@@ -21,50 +21,58 @@ namespace Nest.Resolvers.Converters
 		private IElasticType GetTypeFromJObject(JObject po, JsonSerializer serializer)
 		{
 			JToken typeToken;
+			JToken propertiesToken;
 			JToken fieldsToken;
+			var type = string.Empty;
+
+			var hasType = po.TryGetValue("type", out typeToken);
+			if (hasType)
+				type = typeToken.Value<string>().ToLowerInvariant();
+			else if (po.TryGetValue("properties", out propertiesToken))
+				type = "object";
+
+			var originalType = type;
+			var hasFields = po.TryGetValue("fields", out fieldsToken);
+			if (hasFields)
+				type = "multi_field";
+
 			serializer.TypeNameHandling = TypeNameHandling.None;
-			if (po.TryGetValue("type", out typeToken))
+
+			switch (type)
 			{
-				var type = typeToken.Value<string>().ToLowerInvariant();
-				var originalType = type;
-				var hasFields = po.TryGetValue("fields", out fieldsToken);
-				if (hasFields)
-					type = "multi_field";
-				switch (type)
-				{
-					case "string":
-						return serializer.Deserialize(po.CreateReader(), typeof(StringMapping)) as StringMapping;
-					case "float":
-					case "double":
-					case "byte":
-					case "short":
-					case "integer":
-					case "long":
-						return serializer.Deserialize(po.CreateReader(), typeof(NumberMapping)) as NumberMapping;
-					case "date":
-						return serializer.Deserialize(po.CreateReader(), typeof(DateMapping)) as DateMapping;
-					case "boolean":
-						return serializer.Deserialize(po.CreateReader(), typeof(BooleanMapping)) as BooleanMapping;
-					case "binary":
-						return serializer.Deserialize(po.CreateReader(), typeof(BinaryMapping)) as BinaryMapping;
-					case "object":
-						return serializer.Deserialize(po.CreateReader(), typeof(ObjectMapping)) as ObjectMapping;
-					case "nested":
-						return serializer.Deserialize(po.CreateReader(), typeof(NestedObjectMapping)) as NestedObjectMapping;
-					case "multi_field":
-						var m =serializer.Deserialize(po.CreateReader(), typeof(MultiFieldMapping)) as MultiFieldMapping;
-						m.Type = originalType;
-						return m;
-					case "ip":
-						return serializer.Deserialize(po.CreateReader(), typeof(IPMapping)) as IPMapping;
-					case "geo_point":
-						return serializer.Deserialize(po.CreateReader(), typeof(GeoPointMapping)) as GeoPointMapping;
-					case "geo_shape":
-						return serializer.Deserialize(po.CreateReader(), typeof(GeoShapeMapping)) as GeoShapeMapping;
-					case "attachment":
-						return serializer.Deserialize(po.CreateReader(), typeof(AttachmentMapping)) as AttachmentMapping;
-				}
+				case "string":
+					return serializer.Deserialize(po.CreateReader(), typeof(StringMapping)) as StringMapping;
+				case "float":
+				case "double":
+				case "byte":
+				case "short":
+				case "integer":
+				case "long":
+					return serializer.Deserialize(po.CreateReader(), typeof(NumberMapping)) as NumberMapping;
+				case "date":
+					return serializer.Deserialize(po.CreateReader(), typeof(DateMapping)) as DateMapping;
+				case "boolean":
+					return serializer.Deserialize(po.CreateReader(), typeof(BooleanMapping)) as BooleanMapping;
+				case "binary":
+					return serializer.Deserialize(po.CreateReader(), typeof(BinaryMapping)) as BinaryMapping;
+				case "object":
+					return serializer.Deserialize(po.CreateReader(), typeof(ObjectMapping)) as ObjectMapping;
+				case "nested":
+					return serializer.Deserialize(po.CreateReader(), typeof(NestedObjectMapping)) as NestedObjectMapping;
+				case "multi_field":
+					var m =serializer.Deserialize(po.CreateReader(), typeof(MultiFieldMapping)) as MultiFieldMapping;
+					m.Type = originalType;
+					return m;
+				case "ip":
+					return serializer.Deserialize(po.CreateReader(), typeof(IPMapping)) as IPMapping;
+				case "geo_point":
+					return serializer.Deserialize(po.CreateReader(), typeof(GeoPointMapping)) as GeoPointMapping;
+				case "geo_shape":
+					return serializer.Deserialize(po.CreateReader(), typeof(GeoShapeMapping)) as GeoShapeMapping;
+				case "attachment":
+					return serializer.Deserialize(po.CreateReader(), typeof(AttachmentMapping)) as AttachmentMapping;
 			}
+
 			return null;
 		}
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue,

--- a/src/Tests/Nest.Tests.Integration/Mapping/MapTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Mapping/MapTests.cs
@@ -24,28 +24,17 @@ namespace Nest.Tests.Integration.Mapping
 			Assert.AreEqual("float", typeMapping.Properties["floatValue"].Type.Name);
 			Assert.AreEqual("integer", typeMapping.Properties["id"].Type.Name);
 			Assert.AreEqual("integer", typeMapping.Properties["loc"].Type.Name);
-			var mapping = typeMapping.Properties["country"] as StringMapping;
-			Assert.NotNull(mapping);
-			Assert.AreEqual(FieldIndexOption.NotAnalyzed, mapping.Index);
-			//Assert.AreEqual("elasticsearchprojects", typeMapping.Parent.Type);
-
 			Assert.AreEqual("geo_point", typeMapping.Properties["origin"].Type.Name);
+			Assert.AreEqual("object", typeMapping.Properties["product"].Type.Name);
 
-			//Assert.IsTrue(typeMapping.Properties["origin"].Dynamic);
-			//Assert.AreEqual("double", typeMapping.Properties["origin"].Properties["lat"].Type);
-			//Assert.AreEqual("double", typeMapping.Properties["origin"].Properties["lon"].Type);
+			var productMapping = typeMapping.Properties["product"] as ObjectMapping;
+			Assert.NotNull(productMapping);
+			Assert.AreEqual("string", productMapping.Properties["name"].Type.Name);
+			Assert.AreEqual("string", productMapping.Properties["id"].Type.Name);
 
-			//Assert.IsTrue(typeMapping.Properties["followers"].Dynamic);
-			//Assert.AreEqual("long", typeMapping.Properties["followers"].Properties["age"].Type);
-			//Assert.AreEqual("date", typeMapping.Properties["followers"].Properties["dateOfBirth"].Type);
-			//Assert.AreEqual("string", typeMapping.Properties["followers"].Properties["email"].Type);
-			//Assert.AreEqual("string", typeMapping.Properties["followers"].Properties["firstName"].Type);
-			//Assert.AreEqual("long", typeMapping.Properties["followers"].Properties["id"].Type);
-			//Assert.AreEqual("string", typeMapping.Properties["followers"].Properties["lastName"].Type);
-
-			//Assert.IsTrue(typeMapping.Properties["followers"].Properties["placeOfBirth"].Dynamic);
-			//Assert.AreEqual("double", typeMapping.Properties["followers"].Properties["placeOfBirth"].Properties["lat"].Type);
-			//Assert.AreEqual("double", typeMapping.Properties["followers"].Properties["placeOfBirth"].Properties["lon"].Type);
+			var countryMapping = typeMapping.Properties["country"] as StringMapping;
+			Assert.NotNull(countryMapping);
+			Assert.AreEqual(FieldIndexOption.NotAnalyzed, countryMapping.Index);
 		}
 
 		[Test]

--- a/src/Tests/Nest.Tests.Integration/Search/FieldTests/FieldsTest.cs
+++ b/src/Tests/Nest.Tests.Integration/Search/FieldTests/FieldsTest.cs
@@ -23,7 +23,7 @@ namespace Nest.Tests.Integration.Search.FieldTests
 			// Left in followers + contributors will cause a leaf node exception, so good test victims
 			var fields = typeof (ElasticsearchProject).GetProperties()
 				.Select(x => x.Name.ToCamelCase())
-				.Except(new List<string> {"followers", "contributors", "nestedFollowers", "myGeoShape"}).ToList();
+				.Except(new List<string> {"followers", "contributors", "product", "nestedFollowers", "myGeoShape"}).ToList();
 
 			var queryResults = _client.Search<ElasticsearchProject>(s =>
 					s.Skip(0)
@@ -35,7 +35,7 @@ namespace Nest.Tests.Integration.Search.FieldTests
 
 			queryResults.Documents.Should().BeEmpty();
 			
-			foreach (var doc in queryResults.FieldSelections)
+			foreach (var doc in queryResults.FieldSelections)	
 			{
 				// "content" is a string
 				var content = doc.FieldValues(p => p.Content).First();

--- a/src/Tests/Nest.Tests.MockData/Domain/ElasticsearchProject.cs
+++ b/src/Tests/Nest.Tests.MockData/Domain/ElasticsearchProject.cs
@@ -53,5 +53,7 @@ namespace Nest.Tests.MockData.Domain
 
 		public string MyBinaryField { get; set; }
 
+		[ElasticProperty(Type=FieldType.Object)]
+		public Product Product { get; set; }
 	}
 }

--- a/src/Tests/Nest.Tests.Unit/Search/SearchOptions/SearchOptionTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/SearchOptions/SearchOptionTests.cs
@@ -200,7 +200,8 @@ namespace Nest.Tests.Unit.Search.SearchOptions
 			""locScriptField"",
 			""stupidIntIWantAsLong"",
 			""myAttachment"",
-			""myBinaryField""
+			""myBinaryField"",
+			""product""
 		  ]
 		}";
 		  Assert.True(json.JsonEquals(expected));


### PR DESCRIPTION
This PR addresses the issue pointed out here: http://stackoverflow.com/questions/24557919/nest-ignoring-complex-properties-when-retrieving-mappings?noredirect=1#comment38054528_24557919

Object type mappings do not contain a `type` property and thus were getting skipped during deserialization.  I've verified this in ES all the way back to 0.90.13.  We can get around this by checking for `properties` (which all objects will have) if `type` is missing.
