### PR TITLE
Reduce amount we new ElasticInferrer

### DIFF
--- a/src/Nest/DSL/Paths/DocumentOptionalPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/DocumentOptionalPathDescriptor.cs
@@ -31,7 +31,7 @@ namespace Nest
 			ElasticsearchPathInfo<TParameters> pathInfo)
 			where TParameters : IRequestParameters, new()
 		{
-			var inferrer = new ElasticInferrer(settings);
+			var inferrer = settings.Inferrer;
 
 			pathInfo.Index = inferrer.IndexName(path.Index);
 			pathInfo.Type = inferrer.TypeName(path.Type);
@@ -45,7 +45,7 @@ namespace Nest
 			where TParameters : IRequestParameters, new()
 			where T : class
 		{
-			var inferrer = new ElasticInferrer(settings);
+			var inferrer = settings.Inferrer;
 
 			var index = path.Index != null ? inferrer.IndexName(path.Index) : inferrer.IndexName<T>();
 			var type = path.Type != null ? inferrer.TypeName(path.Type) : inferrer.TypeName<T>();

--- a/src/Nest/DSL/Paths/FixedIndexTypePathDescriptor.cs
+++ b/src/Nest/DSL/Paths/FixedIndexTypePathDescriptor.cs
@@ -21,7 +21,7 @@ namespace Nest
 			ElasticsearchPathInfo<TParameters> pathInfo)
 			where TParameters : IRequestParameters, new()
 		{	
-			var inferrer = new ElasticInferrer(settings);
+			var inferrer = settings.Inferrer;
 			var index = inferrer.IndexName(path.Index);
 			var type = inferrer.TypeName(path.Type);
 		

--- a/src/Nest/DSL/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Nest/DSL/Visitor/DslPrettyPrintVisitor.cs
@@ -25,7 +25,7 @@ namespace Nest.DSL.Visitor
 		public DslPrettyPrintVisitor(IConnectionSettingsValues settings)
 		{
 			this._sb = new StringBuilder();
-			this._infer = new ElasticInferrer(settings);
+			this._infer = settings.Inferrer;
 		}
 
 		public virtual int Depth { get; set; }

--- a/src/Nest/Domain/Connection/ConnectionSettings.cs
+++ b/src/Nest/Domain/Connection/ConnectionSettings.cs
@@ -64,6 +64,9 @@ namespace Nest
 			}
 		}
 
+		private ElasticInferrer _inferrer;
+		ElasticInferrer IConnectionSettingsValues.Inferrer { get { return _inferrer; } }
+
 		private Func<Type, string> _defaultTypeNameInferrer;
 		Func<Type, string> IConnectionSettingsValues.DefaultTypeNameInferrer { get { return _defaultTypeNameInferrer; } }
 
@@ -97,6 +100,7 @@ namespace Nest
 
 			this._modifyJsonSerializerSettings = (j) => { };
 			this._contractConverters = Enumerable.Empty<Func<Type, JsonConverter>>().ToList().AsReadOnly();
+			this._inferrer = new ElasticInferrer(this);
 		}
 		public ConnectionSettings(Uri uri, string defaultIndex) 
 			: this(new SingleNodeConnectionPool(uri ?? new Uri("http://localhost:9200")), defaultIndex)

--- a/src/Nest/Domain/Connection/IConnectionSettingsValues.cs
+++ b/src/Nest/Domain/Connection/IConnectionSettingsValues.cs
@@ -7,6 +7,7 @@ namespace Nest
 {
 	public interface IConnectionSettingsValues : IConnectionConfigurationValues
 	{
+		ElasticInferrer Inferrer { get; }
 		FluentDictionary<Type, string> DefaultIndices { get; }
 		FluentDictionary<Type, string> DefaultTypeNames { get; }
 		string DefaultIndex { get; }

--- a/src/Nest/Domain/Paths/FieldSelection.cs
+++ b/src/Nest/Domain/Paths/FieldSelection.cs
@@ -30,7 +30,7 @@ namespace Nest.Domain
 		private ElasticInferrer Infer { get; set; }
 		public FieldSelection(IConnectionSettingsValues settings, IDictionary<string, object> valuesDictionary = null)
 		{
-			this.Infer = new ElasticInferrer(settings);
+			this.Infer = settings.Inferrer;
 			((IFieldSelection<T>)this).FieldValuesDictionary = valuesDictionary;
 		}
 

--- a/src/Nest/Domain/Responses/BaseResponse.cs
+++ b/src/Nest/Domain/Responses/BaseResponse.cs
@@ -72,7 +72,7 @@ namespace Nest
 				var settings = this.Settings;
 				if (settings == null)
 					return null;
-				this._infer = new ElasticInferrer(settings);
+				this._infer = this.Settings.Inferrer;
 				return this._infer;
 			}
 		}

--- a/src/Nest/ElasticClient.cs
+++ b/src/Nest/ElasticClient.cs
@@ -54,7 +54,7 @@ namespace Nest
 				this.Serializer
 			);
 			this.RawDispatch = new RawDispatch(this.Raw);
-			this.Infer = new ElasticInferrer(this._connectionSettings);
+			this.Infer = this._connectionSettings.Inferrer;
 
 		}
 

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Visitor/DslPrettyPrintVisitor.cs
@@ -31,7 +31,7 @@ namespace Nest.Tests.Unit.QueryParsers.Visitor
 		public DslPrettyPrintVisitor(IConnectionSettingsValues settings)
 		{
 			this._sb = new StringBuilder();
-			this._infer = new ElasticInferrer(settings);
+			this._infer = settings.Inferrer;
 		}
 
 		public virtual int Depth { get; set; }


### PR DESCRIPTION
favor an already instantiated instance of ElasticInferer on settings instead of newing one everytime in various places
