### PR TITLE
fix #693 can now instruct the HTTP client to accept gzip, deflated respo...

### DIFF
--- a/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
@@ -106,6 +106,9 @@ namespace Elasticsearch.Net.Connection
 		private TimeSpan? _sniffLifeSpan;
 		TimeSpan? IConnectionConfigurationValues.SniffInformationLifeSpan { get{ return _sniffLifeSpan; } }
 
+		private bool _compressionEnabled;
+		bool IConnectionConfigurationValues.EnableCompressedResponses { get{ return _compressionEnabled; } }
+
 		private bool _traceEnabled;
 		bool IConnectionConfigurationValues.TraceEnabled { get{ return _traceEnabled; } }
 
@@ -157,6 +160,16 @@ namespace Elasticsearch.Net.Connection
 		{
 			this._sniffLifeSpan = sniffTimeSpan;
 			return (T)this;
+		}
+
+		/// <summary>
+		/// Enable compressed responses from elasticsearch (NOTE that that nodes need to be configured to allow this)
+		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html
+		/// </summary>
+		public T EnableCompressedResponses(bool enabled = true)
+		{
+			this._compressionEnabled = enabled;
+			return (T) this;
 		}
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfiguration.cs
@@ -13,6 +13,12 @@ namespace Elasticsearch.Net.Connection
 		where T : IConnectionConfiguration<T>
 	{
 
+		/// <summary>
+		/// Enable compressed responses from elasticsearch (NOTE that that nodes need to be configured to allow this)
+		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html
+		/// </summary>
+		T EnableCompressedResponses(bool enabled = true);
+		
 	
 		/// <summary>
 		/// Enable Trace signals to the IConnection that it should put debug information on the Trace.

--- a/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
@@ -16,6 +16,7 @@ namespace Elasticsearch.Net.Connection
 		int? MaxDeadTimeout { get; }
 		int? MaxRetries { get; }
 		bool DisablePings { get; }
+		bool EnableCompressedResponses { get; }
 		
 		string ProxyAddress { get; }
 		string ProxyUsername { get; }

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
@@ -170,9 +171,13 @@ namespace Elasticsearch.Net.Connection
 			//var url = this._CreateUriString(path);
 
 			var myReq = (HttpWebRequest)WebRequest.Create(uri);
-
 			myReq.Accept = "application/json";
 			myReq.ContentType = "application/json";
+			if (this.ConnectionSettings.EnableCompressedResponses)
+			{
+				myReq.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+				myReq.Headers.Add("Accept-Encoding", "gzip,deflate");
+			}
 			if (requestSpecificConfig != null && !string.IsNullOrWhiteSpace(requestSpecificConfig.ContentType))
 			{
 				myReq.Accept = requestSpecificConfig.ContentType;

--- a/src/Tests/Nest.Tests.Integration/ElasticsearchConfiguration.cs
+++ b/src/Tests/Nest.Tests.Integration/ElasticsearchConfiguration.cs
@@ -39,7 +39,7 @@ namespace Nest.Tests.Integration
 				.ExposeRawResponse();
 		}
 
-		public static readonly ElasticClient Client = new ElasticClient(Settings());
+		public static readonly ElasticClient Client = new ElasticClient(Settings().EnableCompressedResponses());
 		public static readonly ElasticClient ClientNoRawResponse = new ElasticClient(Settings().ExposeRawResponse(false));
 		public static readonly ElasticClient ClientThatTrows = new ElasticClient(Settings().ThrowOnElasticsearchServerExceptions());
 		public static readonly ElasticClient ThriftClient = new ElasticClient(Settings(9500), new ThriftConnection(Settings(9500)));

--- a/src/Tests/Nest.Tests.Integration/Reproduce/Reproduce325Tests.cs
+++ b/src/Tests/Nest.Tests.Integration/Reproduce/Reproduce325Tests.cs
@@ -44,6 +44,7 @@ namespace Nest.Tests.Integration.Reproduce
 				})
 				.AddMapping<TechnicalProduct>(m => MapTechnicalProduct(m, indexName)));
 
+			var index = this._client.GetIndexSettings(i=>i.Index(indexName));
 		}
 
 


### PR DESCRIPTION
...nses (elasticsearch node needs to be properly configureed to allow this as well

This is now implemented, you can specify `new ConnectionSettings().EnableCompressedResponses()` and it will start to accept gzip, deflated responses
