### PR TITLE
Refactored SearchDescriptor to allow adding Sort objects.

### DIFF
--- a/src/Nest/DSL/Search/SortFieldDescriptor.cs
+++ b/src/Nest/DSL/Search/SortFieldDescriptor.cs
@@ -34,6 +34,8 @@ namespace Nest
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public interface ISort
 	{
+		PropertyPathMarker SortKey { get; }
+
 		[JsonProperty("missing")]
 		string Missing { get; set; }
 
@@ -67,6 +69,13 @@ namespace Nest
 		public FilterContainer NestedFilter { get; set; }
 		public PropertyPathMarker NestedPath { get; set; }
 		public bool? IgnoreUnmappedFields { get; set; }
+		PropertyPathMarker ISort.SortKey
+		{
+			get
+			{
+				return Field;
+			}
+		}
 	}
 
 	public class SortFieldDescriptor<T> : IFieldSort where T : class
@@ -190,6 +199,14 @@ namespace Nest
 		{
 			Self.NestedPath = objectPath;
 			return this;
+		}
+
+		PropertyPathMarker ISort.SortKey
+		{
+			get
+			{
+				return Self.Field;
+			}
 		}
 	}
 }

--- a/src/Nest/DSL/Search/SortGeoDistanceDescriptor.cs
+++ b/src/Nest/DSL/Search/SortGeoDistanceDescriptor.cs
@@ -36,6 +36,14 @@ namespace Nest
 				{ "unit", this.GeoUnit }
 			};
 		}
+
+		PropertyPathMarker ISort.SortKey
+		{
+			get
+			{
+				return "_geo_distance";
+			}
+		}
 	}
 
 	public class SortGeoDistanceDescriptor<T> : IGeoDistanceSort where T : class
@@ -134,6 +142,14 @@ namespace Nest
 				{ "order", Self.Order },
 				{ "unit", Self.GeoUnit }
 			};
+		}
+
+		PropertyPathMarker ISort.SortKey
+		{
+			get
+			{
+				return "_geo_distance";
+			}
 		}
 	}
 }

--- a/src/Nest/DSL/Search/SortScriptDescriptor.cs
+++ b/src/Nest/DSL/Search/SortScriptDescriptor.cs
@@ -26,6 +26,14 @@ namespace Nest.DSL.Descriptors
 		public string Type { get; set; }
 		public string Script { get; set; }
 		public Dictionary<string, object> Params { get; set; }
+
+		PropertyPathMarker ISort.SortKey
+		{
+			get
+			{
+				return "_script";
+			}
+		}
 	}
 
 	public class SortScriptDescriptor<T> : IScriptSort
@@ -105,6 +113,14 @@ namespace Nest.DSL.Descriptors
 		{
 			Self.Mode = mode;
 			return this;
+		}
+
+		PropertyPathMarker ISort.SortKey
+		{
+			get
+			{
+				return "_script";
+			}
 		}
 	}
 }

--- a/src/Nest/Resolvers/Converters/SortCollectionConverter.cs
+++ b/src/Nest/Resolvers/Converters/SortCollectionConverter.cs
@@ -10,7 +10,7 @@ namespace Nest.Resolvers.Converters
 	{
 		public override bool CanConvert(Type objectType)
 		{
-			return typeof(IList<KeyValuePair<PropertyPathMarker, ISort>>).IsAssignableFrom(objectType);
+			return typeof(IList<ISort>).IsAssignableFrom(objectType);
 		}
 
 		public override bool CanRead
@@ -26,14 +26,14 @@ namespace Nest.Resolvers.Converters
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
 			writer.WriteStartArray();
-			var sortItems = value as IList<KeyValuePair<PropertyPathMarker, ISort>>;
-			foreach (var item in sortItems)
+			var sorts = value as IList<ISort>;
+			foreach (var sort in sorts)
 			{
 				writer.WriteStartObject();
 				var contract = serializer.ContractResolver as SettingsContractResolver;
-				var fieldName = contract.Infer.PropertyPath(item.Key);
+				var fieldName = contract.Infer.PropertyPath(sort.SortKey);
 				writer.WritePropertyName(fieldName);
-				serializer.Serialize(writer, item.Value);
+				serializer.Serialize(writer, sort);
 				writer.WriteEndObject();
 			}
 			writer.WriteEndArray();

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MoreLikeThis/MoreLikeThisRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MoreLikeThis/MoreLikeThisRequestTests.cs
@@ -42,9 +42,9 @@ namespace Nest.Tests.Unit.ObjectInitializer.MoreLikeThis
 				}),
 				TrackScores = true,
 				Explain = true,
-				Sort = new List<KeyValuePair<PropertyPathMarker, ISort>>()
+				Sort = new List<ISort>()
 				{
-					new KeyValuePair<PropertyPathMarker, ISort>("field", new Sort { Order = SortOrder.Ascending, Missing = "_first"})
+					new Sort { Field="field", Order = SortOrder.Ascending, Missing = "_first"}
 				}
 			};
 			var request = new MoreLikeThisRequest("some-index", "the-type","document-id-21")

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Search/SearchRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Search/SearchRequestTests.cs
@@ -39,9 +39,9 @@ namespace Nest.Tests.Unit.ObjectInitializer.Search
 				{
 					{ Infer.Index<ElasticsearchProject>(), 2.3 }
 				},
-				Sort = new List<KeyValuePair<PropertyPathMarker, ISort>>()
+				Sort = new List<ISort>()
 				{
-					new KeyValuePair<PropertyPathMarker, ISort>("field", new Sort { Order = SortOrder.Ascending, Missing = "_first"})
+					new Sort { Field = "field", Order = SortOrder.Ascending, Missing = "_first"}
 				},
 				Facets = new Dictionary<PropertyPathMarker, IFacetContainer>()
 				{

--- a/src/Tests/Nest.Tests.Unit/Search/InitializerSyntax/InitializerExample.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/InitializerSyntax/InitializerExample.cs
@@ -69,9 +69,9 @@ namespace Nest.Tests.Unit.Search.InitializerSyntax
 							{"multiplier", 4}
 						}
 					}),
-				Sort = new List<KeyValuePair<PropertyPathMarker, ISort>>()
+				Sort = new List<ISort>()
 				{
-					new KeyValuePair<PropertyPathMarker, ISort>("field", new Sort { Order = SortOrder.Ascending, Missing = "_first"})
+					new Sort { Field="field", Order = SortOrder.Ascending, Missing = "_first"}
 				},
 				Source = new SourceFilter
 				{

--- a/src/Tests/Nest.Tests.Unit/Search/Sorting/SortTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Sorting/SortTests.cs
@@ -329,5 +329,49 @@ namespace Nest.Tests.Unit.Search.Sorting
 			);
 			this.JsonEquals(s, MethodInfo.GetCurrentMethod());
 		}
+
+		[Test]
+		public void TestSortAdd()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.Sort(new Sort
+				{
+					Field = "field",
+					Order = SortOrder.Descending,
+					Mode = SortMode.Min
+				})
+				.Sort(new GeoDistanceSort()
+				{
+					Field = "geo_field",
+					PinLocation = "40, -70",
+					Mode = SortMode.Max,
+					GeoUnit = GeoUnit.Kilometers
+				})
+				;
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"
+				{
+				  from: 0,
+				  size: 10,
+				  sort: [
+					{
+					  field: {
+						order: ""desc"",
+						mode: ""min"",
+					  }
+					},
+					{
+					  _geo_distance: {
+						geo_field: ""40, -70"",
+						mode: ""max"",
+						unit: ""km""
+					  }
+					}
+				  ]
+				}";
+			Assert.True(json.JsonEquals(expected), json);
+        }
 	}
 }


### PR DESCRIPTION
I changed the ISearchRequest Sort property to be an IList of
ISort, and not KeyValuePairs. I also modified ISort so that it
requires an ISort to know what its key is in a Sort object. These
two changes allow adding Sort objects directly to a
SearchDescriptor without specifying the key, and means that an
ISort object always carries the data required to serialize it along
with it.
