### PR TITLE
Get rid of some unused variables

### DIFF
--- a/src/Tests/Nest.Tests.Integration/Exceptions/ElasticsearchExceptionTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Exceptions/ElasticsearchExceptionTests.cs
@@ -186,7 +186,7 @@ namespace Nest.Tests.Integration.Exceptions
 				var result = await client.SearchAsync<ElasticsearchProject>(s => s.MatchAll());
 				result.IsValid.Should().BeFalse();
 			}
-			catch (MaxRetryException e)
+			catch (MaxRetryException)
 			{
 				Assert.Pass("MaxRetryException caught");
 			}
@@ -242,7 +242,7 @@ namespace Nest.Tests.Integration.Exceptions
 				var close = await client.CloseIndexAsync(i=>i.Index(index));
 				var result = await client.SearchAsync<ElasticsearchProject>(s => s.Index(index));
 			}
-			catch (ElasticsearchServerException e)
+			catch (ElasticsearchServerException)
 			{
 				Assert.Pass("ElasticearchServerException caught");
 			}

--- a/src/Tests/Nest.Tests.Integration/IntegrationSetup.cs
+++ b/src/Tests/Nest.Tests.Integration/IntegrationSetup.cs
@@ -59,7 +59,7 @@ namespace Nest.Tests.Integration
 					.Refresh()
 				);
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
 
 				throw;


### PR DESCRIPTION
These are causing warnings. Might as well not have them until someone needs them.
