### PR TITLE
Fix issues with deserializing mappings

### DIFF
--- a/src/Nest/Domain/Mapping/SpecialFields/AnalyzerFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/AnalyzerFieldMapping.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<AnalyzerFieldMapping>))]
 	public interface IAnalyzerFieldMapping : ISpecialField
 	{
 		[JsonProperty("index"), JsonConverter(typeof(YesNoBoolConverter))]

--- a/src/Nest/Domain/Mapping/SpecialFields/BoostFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/BoostFieldMapping.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
+using Nest.Resolvers.Converters;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<BoostFieldMapping>))]
 	public interface IBoostFieldMapping : ISpecialField
 	{
 		[JsonProperty("name")]

--- a/src/Nest/Domain/Mapping/SpecialFields/IdFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/IdFieldMapping.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<IdFieldMapping>))]
 	public interface IIdFieldMapping : ISpecialField
 	{
 		[JsonProperty("path")]

--- a/src/Nest/Domain/Mapping/SpecialFields/IndexFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/IndexFieldMapping.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<IndexFieldMapping>))]
 	public interface IIndexFieldMapping : ISpecialField
 	{
 		[JsonProperty("enabled")]

--- a/src/Nest/Domain/Mapping/SpecialFields/RoutingFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/RoutingFieldMapping.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using Newtonsoft.Json;
 using System.Linq.Expressions;
+using Nest.Resolvers.Converters;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<RoutingFieldMapping>))]
 	public interface IRoutingFieldMapping : ISpecialField
 	{
 		[JsonProperty("required")]

--- a/src/Nest/Domain/Mapping/SpecialFields/SizeFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/SizeFieldMapping.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<SizeFieldMapping>))]
 	public interface ISizeFieldMapping : ISpecialField
 	{
 		[JsonProperty("enabled")]

--- a/src/Nest/Domain/Mapping/SpecialFields/SourceFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/SourceFieldMapping.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using Nest.Resolvers.Converters;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<SourceFieldMapping>))]
 	public interface ISourceFieldMapping : ISpecialField
 	{
 		[JsonProperty("enabled")]

--- a/src/Nest/Domain/Mapping/SpecialFields/TimestampFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/TimestampFieldMapping.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using Newtonsoft.Json;
 using System.Linq.Expressions;
+using Nest.Resolvers.Converters;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<TimestampFieldMapping>))]
 	public interface ITimestampFieldMapping : ISpecialField
 	{
 		[JsonProperty("enabled")]

--- a/src/Nest/Domain/Mapping/SpecialFields/TtlFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/TtlFieldMapping.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<TtlFieldMapping>))]
 	public interface ITtlFieldMapping : ISpecialField
 	{
 		[JsonProperty("enabled")]

--- a/src/Nest/Domain/Mapping/SpecialFields/TypeFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/TypeFieldMapping.cs
@@ -1,8 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ReadAsTypeConverter<TypeFieldMapping>))]
 	public interface ITypeFieldMapping : ISpecialField
 	{
 		[JsonProperty("index"), JsonConverter(typeof(StringEnumConverter))]

--- a/src/Tests/Nest.Tests.Unit/Core/Map/GetMappingSerializationTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/GetMappingSerializationTests.cs
@@ -1,0 +1,104 @@
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nest.Tests.Unit.Core.Map
+{
+	class GetMappingSerializationTests : BaseJsonTests
+	{
+		/// <summary>
+		/// Verify that we can serialize/deserialize a populated root mapping.
+		/// If we can round trip a full root mapping, we're in a pretty good place.
+		/// </summary>
+		[Test]
+		public void CanDeserializeRootMapping()
+		{
+			var rootMapping = new RootObjectMapping()
+			{
+				AllFieldMapping = new AllFieldMapping()
+				{
+					Enabled = true,
+					IndexAnalyzer = "index_analyzer"
+				},
+				SourceFieldMappingDescriptor = new SourceFieldMapping()
+				{
+					Compress = false,
+					Excludes = new[] { "excluded" }
+				},
+				RoutingFieldMapping = new RoutingFieldMapping()
+				{
+					Path = "routing_path"
+				},
+				SizeFieldMapping = new SizeFieldMapping()
+				{
+					Enabled = true,
+				},
+				TtlFieldMappingDescriptor = new TtlFieldMapping()
+				{
+					Enabled = true,
+				},
+				IdFieldMappingDescriptor = new IdFieldMapping()
+				{
+					Index = "not_analyzed",
+					Store = false,
+					Path = "id_field",
+				},
+				TimestampFieldMapping = new TimestampFieldMapping()
+				{
+					Enabled = true,
+					Format = "YYY-MM-dd",
+					Path = "the_timestamp",
+				},
+				IndexFieldMapping = new IndexFieldMapping()
+				{
+					Enabled = true,
+				},
+				AnalyzerFieldMapping = new AnalyzerFieldMapping()
+				{
+					Path = "index_path",
+				},
+				BoostFieldMapping = new BoostFieldMapping()
+				{
+					Name = "boost",
+					NullValue = 2.0,
+				},
+				Parent = new ParentTypeMapping()
+				{
+					Type = "type"
+				},
+				TypeFieldMappingDescriptor = new TypeFieldMapping()
+				{
+					Index = NonStringIndexOption.NotAnalyzed, 
+					Store = false,
+				}
+			};
+			var json = TestElasticClient.Serialize(rootMapping);
+
+			var mapping = TestElasticClient.Deserialize<RootObjectMapping>(json);
+			TestElasticClient.Serialize(mapping).JsonEquals(json);
+		}
+
+		/// <summary>
+		/// Verify that we can serialize/deserialize an empty root mapping. One of the
+		/// failure modes of serialization/deserialization is handling data that's not there.
+		/// </summary>
+		[Test]
+		public void CanDeserializeEmptyRootMapping()
+		{
+			var rootMapping = new RootObjectMapping()
+			{
+			};
+			var json = TestElasticClient.Serialize(rootMapping);
+
+			var mapping = TestElasticClient.Deserialize<RootObjectMapping>(json);
+			TestElasticClient.Serialize(mapping).JsonEquals(json);
+		}
+		
+	}
+}

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Core\Indices\Analysis\Analyzers\AnalyzerTests.cs" />
     <Compile Include="Core\Indices\Similarity\SimilarityTests.cs" />
     <Compile Include="Core\Map\CustomMapping\ImagePluginMappingTests.cs" />
+    <Compile Include="Core\Map\GetMappingSerializationTests.cs" />
     <Compile Include="Core\Map\MappingBehaviourTests.cs" />
     <None Include="Cluster\PutSettings\PutSettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -1216,7 +1217,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Tests/Nest.Tests.Unit/TestElasticClient.cs
+++ b/src/Tests/Nest.Tests.Unit/TestElasticClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -15,9 +16,15 @@ namespace Nest.Tests.Unit
 
 			Client = new ElasticClient(Settings);
 		}
+
 		public static string Serialize<T>(T obj) where T : class
 		{
 			return Encoding.UTF8.GetString(Client.Serializer.Serialize(obj));
+		}
+
+		public static T Deserialize<T>(string json) where T : class
+		{
+			return Client.Serializer.Deserialize<T>(new MemoryStream(Encoding.UTF8.GetBytes(json)));
 		}
 	}
 }


### PR DESCRIPTION
We need to make sure that we can deserialize the interfaces on the
RootObjectMapping, which requires specifying ResolveAsTypeConverter
on all the appropriate interfaces. I added a test as well, though I'm
not sure it's in the right place, and I added a Deserialize function
on TestElasticClient to make it easier to roundtrip the serialization.

I'm not sure if that was the right place to put the test, or the right approach, but it seemed like a good idea to have tests for whether we can serialize/deserialize RootObjectMapping.
