### PR TITLE
Fix terms filter serialization of numeric terms

### DIFF
--- a/src/Nest/DSL/Filter/FilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/FilterDescriptor.cs
@@ -684,7 +684,7 @@ namespace Nest
 		{
 			ITermsFilter filter = new TermsFilterDescriptor();
 			filter.Field = fieldDescriptor;
-			filter.Terms = terms.Cast<object>();
+			filter.Terms = (terms != null) ? terms.Cast<object>() : null;
 			filter.Execution = Execution;
 			return this.New(filter, f=>f.Terms = filter);
 		}	

--- a/src/Nest/DSL/Filter/TermsFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/TermsFilterDescriptor.cs
@@ -43,7 +43,7 @@ namespace Nest
 			{
 				return ((ITermsBaseFilter)this).Field.IsConditionless()
 					   || !((ITermsFilter)this).Terms.HasAny()
-					   || ((ITermsFilter)this).Terms.OfType<string>().All(s => s.IsNullOrEmpty())
+					   || ((ITermsFilter)this).Terms.All(t => t is string && ((string)t).IsNullOrEmpty())
 					   || ((ITermsFilter)this).Terms.All(t => t == null);
 			}
 		}

--- a/src/Tests/Nest.Tests.Unit/Search/Filter/Singles/TermsFilterJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Filter/Singles/TermsFilterJson.cs
@@ -124,5 +124,52 @@ namespace Nest.Tests.Unit.Search.Filter.Singles
 			}";
 			Assert.True(json.JsonEquals(expected), json);
 		}
+
+		[Test]
+		public void TermsFilterWithNumericTerms()
+		{
+			var query = Query<ElasticsearchProject>.Filtered(filtered => filtered
+				.Filter(f =>
+					f.Terms(t => t.LongValue, new long[] { 1, 2, 3 })
+				)
+				.Query(q => q.MatchAll())
+			);
+
+			var json = TestElasticClient.Serialize(query);
+			var expected = @"{ 
+							  filtered: {
+							  query: {
+							    match_all: {}
+							  },
+							  filter: {
+								terms: {
+								  longValue: [1, 2, 3 ]
+								}
+							  }
+							}
+						  }";
+			Assert.True(json.JsonEquals(expected), json);
+		}
+
+		[Test]
+		public void TermsFilterWithNullTerms()
+		{
+			var query = Query<ElasticsearchProject>.Filtered(filtered => filtered
+				.Filter(f =>
+					f.Terms(t => t.Name, null)
+				)
+				.Query(q => q.MatchAll())
+			);
+			var json = TestElasticClient.Serialize(query);
+			var expected = @"{ 
+							  filtered: {
+							  query: {
+							    match_all: {}
+							  },
+							  filter: {}
+							}
+						  }";
+			Assert.True(json.JsonEquals(expected), json);
+		}
 	}
 }


### PR DESCRIPTION
Serialization was being skipped when numeric terms were passed to terms
filter due to incorrect IsConditionless() logic.  This commit also fixes
a NRE that was being thrown when passing a null terms value.  An empty
filter is now created instead.

Closes #843.
