### PR TITLE
Remove class/interface validation when retrieving type from ElasticType

### DIFF
--- a/src/Nest/Resolvers/PropertyNameResolver.cs
+++ b/src/Nest/Resolvers/PropertyNameResolver.cs
@@ -32,24 +32,11 @@ namespace Nest.Resolvers
 			return null;
 		}
 
-		public static ElasticTypeAttribute Type<T>() where T : class
-		{
-			return _Type(typeof(T));
-		}
-
 		public static ElasticTypeAttribute Type(Type type)
-		{
-			return _Type(type);
-		}
-
-		private static ElasticTypeAttribute _Type(Type type)
 		{
 			ElasticTypeAttribute attr = null;
 			if (CachedTypeLookups.TryGetValue(type, out attr))
 				return attr;
-
-			if (!type.IsClass && !type.IsInterface)
-				throw new ArgumentException("Type is not a class or interface", "type");
 
 			var attributes = type.GetCustomAttributes(typeof(ElasticTypeAttribute), true);
 			if (attributes.HasAny())

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -377,6 +377,7 @@
     <Compile Include="Reproduce\Reproduce860Tests.cs" />
     <Compile Include="Reproduce\Reproduce806Tests.cs" />
     <Compile Include="Reproduce\Reproduce876Tests.cs" />
+    <Compile Include="Reproduce\Reproduce926Tests.cs" />
     <Compile Include="Search\Fields\FieldsTests.cs" />
     <Compile Include="Search\Filter\Modes\ConditionlessFilterJson.cs" />
     <Compile Include="Search\Filter\Modes\FilterModesTests.cs" />

--- a/src/Tests/Nest.Tests.Unit/Reproduce/Reproduce926Tests.cs
+++ b/src/Tests/Nest.Tests.Unit/Reproduce/Reproduce926Tests.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nest.Tests.Unit.Reproduce
+{
+	class SomeClass
+	{
+		public SomeClass()
+		{
+			this.Data = new Dictionary<long, SomeOtherClass>();
+		}
+
+		public long ID { get; set; }
+
+		[ElasticProperty(Type = FieldType.Object)]
+		public Dictionary<long, SomeOtherClass> Data { get; set; }
+	}
+
+	class SomeOtherClass
+	{
+		public string Value1 { get; set; }
+		public string Value2 { get; set; }
+	}
+
+	[TestFixture]
+	public class Reproduce926Tests : BaseJsonTests
+	{
+		[Test]
+		public void ObjectMappingOnDictionaryCausesArgumentException()
+		{
+			var mapResult = this._client.Map<SomeClass>(m => m
+				.MapFromAttributes());
+		}
+	}
+}


### PR DESCRIPTION
Since #731, this was causing an ArgumentException to be thrown when
mapping generic objects with value type parameters (List<int>,
Dictionary<long, string>, etc..).  The check doesn't seem necessary since
ElasticTypeAttribute is already constained to classes at compile time.

Also cleaned up PropertyNameResolver a bit.

Closes #926
