### PR TITLE
Adding key to a date range aggregation

### DIFF
--- a/src/Nest/DSL/Facets/DateExpressionRange.cs
+++ b/src/Nest/DSL/Facets/DateExpressionRange.cs
@@ -11,6 +11,9 @@ namespace Nest
 		[JsonProperty(PropertyName = "to")]
 		internal string _To { get; set; }
 
+        [JsonProperty(PropertyName = "key")]
+        internal string _Key { get; set; }
+
 		public DateExpressionRange From(string value)
 		{
 			this._From = value;
@@ -21,5 +24,10 @@ namespace Nest
 			this._To = value;
 			return this;
 		}
-	}
+        public DateExpressionRange Key(string key)
+        {
+            this._Key = key;
+            return this;
+        }
+    }
 }


### PR DESCRIPTION
I was doing a date range aggregation with a series of date ranges, but ES returns them in descending count order, not how I submitted them.  Without the key, I didn't have a decent way of telling the aggregations apart to display to the end user.
