### PR TITLE
added constructors to QueryPathBase

### DIFF
--- a/src/Nest/DSL/CountDescriptor.cs
+++ b/src/Nest/DSL/CountDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
@@ -28,6 +29,12 @@ namespace Nest
 	
 	public partial class CountRequest : QueryPathBase<CountRequestParameters>, ICountRequest
 	{
+		public CountRequest() {}
+
+		public CountRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+		public CountRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
 		public IQueryContainer Query { get; set; }
 
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<CountRequestParameters> pathInfo)
@@ -39,6 +46,12 @@ namespace Nest
 	public partial class CountRequest<T> : QueryPathBase<CountRequestParameters, T>, ICountRequest
 		where T : class
 	{
+		public CountRequest() {}
+
+		public CountRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+		public CountRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
 		public IQueryContainer Query { get; set; }
 
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<CountRequestParameters> pathInfo)

--- a/src/Nest/DSL/DeleteByQueryDescriptor.cs
+++ b/src/Nest/DSL/DeleteByQueryDescriptor.cs
@@ -33,31 +33,14 @@ namespace Nest
 
 	public partial class DeleteByQueryRequest : QueryPathBase<DeleteByQueryRequestParameters>, IDeleteByQueryRequest
 	{
+		public DeleteByQueryRequest() {}
+
+		public DeleteByQueryRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+		public DeleteByQueryRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
 		public IQueryContainer Query { get; set; }
 
-		/// <summary>
-		/// Sents a delete query to _all indices
-		/// </summary>
-		public DeleteByQueryRequest()
-		{
-			this.AllIndices = true;
-			this.AllTypes = true;
-		}
-	
-		public DeleteByQueryRequest(IndexNameMarker index, TypeNameMarker type = null)
-		{
-			this.Indices = new [] { index };
-			if (type != null)
-				this.Types = new[] { type };
-			else this.AllTypes = true;
-		}
-
-		public DeleteByQueryRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null)
-		{
-			this.Indices = indices;
-			this.AllTypes = !types.HasAny();
-			this.Types = types;
-		}
 
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<DeleteByQueryRequestParameters> pathInfo)
 		{
@@ -68,6 +51,12 @@ namespace Nest
 
 	public partial class DeleteByQueryRequest<T> : QueryPathBase<DeleteByQueryRequestParameters, T>, IDeleteByQueryRequest where T : class
 	{
+		public DeleteByQueryRequest() {}
+
+		public DeleteByQueryRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+		public DeleteByQueryRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
 		public IQueryContainer Query { get; set; }
 
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<DeleteByQueryRequestParameters> pathInfo)

--- a/src/Nest/DSL/Paths/QueryPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/QueryPathDescriptor.cs
@@ -77,6 +77,26 @@ namespace Nest
 	public abstract class QueryPathBase<TParameters> : BasePathRequest<TParameters>, IQueryPath<TParameters>
 		where TParameters : IRequestParameters, new()
 	{
+		protected QueryPathBase()
+		{
+			this.AllTypes = true;
+		}
+
+		protected QueryPathBase(IndexNameMarker index, TypeNameMarker type = null)
+		{
+			this.Indices = new [] { index };
+			if (type != null)
+				this.Types = new[] { type };
+			else this.AllTypes = true;
+		}
+
+		protected QueryPathBase(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null)
+		{
+			this.Indices = indices;
+			this.AllTypes = !types.HasAny();
+			this.Types = types;
+		}
+
 
 		protected override void SetRouteParameters(IConnectionSettingsValues settings, ElasticsearchPathInfo<TParameters> pathInfo)
 		{
@@ -94,6 +114,24 @@ namespace Nest
 		where TParameters : IRequestParameters, new()
 		where T : class
 	{
+		protected QueryPathBase()
+		{
+			this.AllIndices = false;
+			this.AllTypes = false;
+		}
+		
+		protected QueryPathBase(IndexNameMarker index, TypeNameMarker type = null)
+		{
+			this.Indices = new [] { index };
+			if (type != null)
+				this.Types = new[] { type };
+		}
+
+		protected QueryPathBase(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null)
+		{
+			this.Indices = indices;
+			this.Types = types;
+		}
 
 		protected override void SetRouteParameters(IConnectionSettingsValues settings, ElasticsearchPathInfo<TParameters> pathInfo)
 		{

--- a/src/Nest/DSL/SearchDescriptor.cs
+++ b/src/Nest/DSL/SearchDescriptor.cs
@@ -127,6 +127,12 @@ namespace Nest
 	
 	public partial class SearchRequest : QueryPathBase<SearchRequestParameters>, ISearchRequest
 	{
+		public SearchRequest() {}
+
+		public SearchRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+		public SearchRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
 		private Type _clrType { get; set; }
 		Type ISearchRequest.ClrType { get { return _clrType; } }
 
@@ -186,6 +192,12 @@ namespace Nest
 	public partial class SearchRequest<T> : QueryPathBase<SearchRequestParameters, T>, ISearchRequest
 		where T : class
 	{
+		public SearchRequest() {}
+
+		public SearchRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+		public SearchRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<SearchRequestParameters> pathInfo)
 		{
 			SearchPathInfo.Update(settings,pathInfo, this);

--- a/src/Nest/DSL/SearchShardsDescriptor.cs
+++ b/src/Nest/DSL/SearchShardsDescriptor.cs
@@ -27,6 +27,12 @@ namespace Nest
 	
 	public partial class SearchShardsRequest : QueryPathBase<SearchShardsRequestParameters>, ISearchShardsRequest
 	{
+		public SearchShardsRequest() {}
+
+		public SearchShardsRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+		public SearchShardsRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<SearchShardsRequestParameters> pathInfo)
 		{
 			SearchShardsPathInfo.Update(settings, pathInfo, this);
@@ -36,6 +42,12 @@ namespace Nest
 	public partial class SearchShardsRequest<T> : QueryPathBase<SearchShardsRequestParameters, T>, ISearchShardsRequest
 		where T : class
 	{
+		public SearchShardsRequest() {}
+
+		public SearchShardsRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+		public SearchShardsRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<SearchShardsRequestParameters> pathInfo)
 		{
 			SearchShardsPathInfo.Update(settings,pathInfo, this);

--- a/src/Nest/DSL/ValidateQueryDescriptor.cs
+++ b/src/Nest/DSL/ValidateQueryDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
@@ -29,7 +30,13 @@ namespace Nest
 
     public partial class ValidateQueryRequest : QueryPathBase<ValidateQueryRequestParameters>, IValidateQueryRequest
     {
-        public IQueryContainer Query { get; set; }
+		public ValidateQueryRequest() {}
+
+	    public ValidateQueryRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+	    public ValidateQueryRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
+	    public IQueryContainer Query { get; set; }
 
         protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<ValidateQueryRequestParameters> pathInfo)
         {
@@ -40,7 +47,14 @@ namespace Nest
     public partial class ValidateQueryRequest<T> : QueryPathBase<ValidateQueryRequestParameters, T>, IValidateQueryRequest<T>
         where T : class
     {
-        public IQueryContainer Query { get; set; }
+
+		public ValidateQueryRequest() {}
+
+	    public ValidateQueryRequest(IndexNameMarker index, TypeNameMarker type = null) : base(index, type) { }
+
+	    public ValidateQueryRequest(IEnumerable<IndexNameMarker> indices, IEnumerable<TypeNameMarker> types = null) : base(indices, types) { }
+
+	    public IQueryContainer Query { get; set; }
 
         protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<ValidateQueryRequestParameters> pathInfo)
         {

--- a/src/Nest/ExposedInternals/ElasticInferrer.cs
+++ b/src/Nest/ExposedInternals/ElasticInferrer.cs
@@ -39,7 +39,8 @@ namespace Nest
 		{
 			get
 			{
-				return (this._connectionSettings == null) ? string.Empty : this._connectionSettings.DefaultIndex;
+				var index = (this._connectionSettings == null) ? string.Empty : this._connectionSettings.DefaultIndex;
+				return index.IsNullOrEmpty() ? "_all" : index;
 			}
 		}
 

--- a/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -89,6 +89,7 @@
     <Compile Include="..\..\Elasticsearch.Net\Extensions\TypeExtensions.cs">
       <Link>LinkedExtensions\TypeExtensions.cs</Link>
     </Compile>
+    <Compile Include="Aggregations\CombinationTests.cs" />
     <Compile Include="Aggregations\NestedBucketAggregationTests.cs" />
     <Compile Include="Aggregations\BucketAggregationTests.cs" />
     <Compile Include="Aggregations\SingleBucketAggregationTests.cs" />

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestTests.cs
@@ -30,6 +30,7 @@ namespace Nest.Tests.Unit.ObjectInitializer.DeleteByQuery
 
 			var request = new DeleteByQueryRequest()
 			{
+				AllIndices = true,
 				AllowNoIndices = true,
 				ExpandWildcards = ExpandWildcards.Closed,
 				Query = query,

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestUrlTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestUrlTests.cs
@@ -17,7 +17,7 @@ namespace Nest.Tests.Unit.ObjectInitializer.DeleteByQuery
 			var status = this._client.DeleteByQuery(new DeleteByQueryRequest())
 				.ConnectionStatus;
 
-			status.RequestUrl.Should().EndWith("/_all/_query");
+			status.RequestUrl.Should().EndWith("/nest_test_data/_query");
 			status.RequestMethod.Should().Be("DELETE");
 		}
 	


### PR DESCRIPTION
Added constructors to QueryPathBase and its subclasses to be more inlinewith other OIS classes, deleteby query untyped OIS parameterless constructor no longer defaults to _all index to be more inline with search requests defaulting to the default index.
