### PR TITLE
Add string/double Fluent Dictionary Option to MultiMatchQuery

### DIFF
--- a/src/Nest/DSL/Query/MultiMatchQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MultiMatchQueryDescriptor.cs
@@ -140,6 +140,13 @@ namespace Nest
 			((IMultiMatchQuery)this).Fields = d.Select(o => PropertyPathMarker.Create(o.Key, o.Value));
 			return this;
 		}
+		public MultiMatchQueryDescriptor<T> OnFieldsWithBoost(Action<FluentDictionary<string, double?>> boostableSelector)
+		{
+			var d = new FluentDictionary<string, double?>();
+			boostableSelector(d);
+			((IMultiMatchQuery)this).Fields = d.Select(o => PropertyPathMarker.Create(o.Key, o.Value));
+			return this;
+		}
 
 		public MultiMatchQueryDescriptor<T> Query(string query)
 		{

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -886,6 +886,9 @@
     <None Include="Search\Query\Singles\GeoShape\GeoShapePolygon.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Search\Query\Singles\MultiMatch\TestMultiMatchOnFieldsWithBoost.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Search\Query\Singles\MultiMatch\TestMultiMatchJson.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MultiMatch/MultiMatchJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MultiMatch/MultiMatchJson.cs
@@ -26,5 +26,20 @@ namespace Nest.Tests.Unit.Search.Query.Singles.MultiMatch
 				);
 			this.JsonEquals(s, MethodInfo.GetCurrentMethod());
 		}
+
+		[Test]
+		public void TestMultiMatchOnFieldsWithBoost()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.Query(q => q
+					.MultiMatch(m => m
+						.OnFieldsWithBoost(f=>f.Add("field1", 1.2).Add("field2",.9))
+						.Query("this is a query")
+					)
+				);
+			this.JsonEquals(s, MethodInfo.GetCurrentMethod());
+		}
 	}
 }

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MultiMatch/TestMultiMatchOnFieldsWithBoost.json
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MultiMatch/TestMultiMatchOnFieldsWithBoost.json
@@ -1,0 +1,13 @@
+  {
+  "from": 0,
+  "size": 10,
+  "query": {
+    "multi_match": {
+      "query": "this is a query",
+      "fields": [
+        "field1^1.2",
+        "field2^0.9"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- For the MultiMatchQuery, this adds an override to OnFieldsWithBoost to
  allow one to specify a list of fields and boost values with string
  values instead of fluent values.
  *\* This adds parity to QueryStringQuery.OnFieldsWithBoost

This is useful in the case of multifields where you have no fluent
equivalent of the field name you want to query and boost on.
