### PR TITLE
Fix OIS class for ConstantScoreQuery

### DIFF
--- a/src/Nest/DSL/Query/ConstantScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/ConstantScoreQueryDescriptor.cs
@@ -22,11 +22,11 @@ namespace Nest
 		double? Boost { get; set; }
 	}
 
-	public class ConstantScoreQuery : PlainQuery, ICustomScoreQuery
+	public class ConstantScoreQuery : PlainQuery, IConstantScoreQuery
 	{
 		protected override void WrapInContainer(IQueryContainer container)
 		{
-			container.CustomScore = this;
+			container.ConstantScore = this;
 		}
 
 		public bool IsConditionless { get { return false; } }
@@ -34,6 +34,8 @@ namespace Nest
 		public string Script { get; set; }
 		public Dictionary<string, object> Params { get; set; }
 		public IQueryContainer Query { get; set; }
+		public IFilterContainer Filter { get; set; }
+		public double? Boost { get; set; }
 	}
 
 	public class ConstantScoreQueryDescriptor<T> : IConstantScoreQuery where T : class


### PR DESCRIPTION
The OIS class for ConstantScoreQuery currently implements the interface for ICustomScoreQuery instead of IConstantScoreQuery causing the wrong json to be sent to the server.
