### PR TITLE
Changed type of _version in IBulkOperation from System.String to long?

### DIFF
--- a/src/Nest/DSL/Bulk/BulkCreateDescriptor.cs
+++ b/src/Nest/DSL/Bulk/BulkCreateDescriptor.cs
@@ -111,7 +111,7 @@ namespace Nest
 		}
 
 
-		public BulkCreateDescriptor<T> Version(string version)
+        public BulkCreateDescriptor<T> Version(long? version)
 		{
 			Self.Version = version; 
 			return this;

--- a/src/Nest/DSL/Bulk/BulkDeleteDescriptor.cs
+++ b/src/Nest/DSL/Bulk/BulkDeleteDescriptor.cs
@@ -114,7 +114,7 @@ namespace Nest
 		}
 
 
-		public BulkDeleteDescriptor<T> Version(string version)
+        public BulkDeleteDescriptor<T> Version(long? version)
 		{
 			Self.Version = version; 
 			return this;

--- a/src/Nest/DSL/Bulk/BulkIndexDescriptor.cs
+++ b/src/Nest/DSL/Bulk/BulkIndexDescriptor.cs
@@ -113,7 +113,7 @@ namespace Nest
 		}
 
 
-		public BulkIndexDescriptor<T> Version(string version)
+        public BulkIndexDescriptor<T> Version(long version)
 		{
 			Self.Version = version; 
 			return this;

--- a/src/Nest/DSL/Bulk/BulkOperationBase.cs
+++ b/src/Nest/DSL/Bulk/BulkOperationBase.cs
@@ -10,7 +10,7 @@ namespace Nest
 		public IndexNameMarker Index { get; set; }
 		public TypeNameMarker Type { get; set; }
 		public string Id { get; set; }
-		public string Version { get; set; }
+        public long? Version { get; set; }
 		public VersionType? VersionType { get; set; }
 		public string Routing { get; set; }
 		public string Parent { get; set; }

--- a/src/Nest/DSL/Bulk/BulkUpdateDescriptor.cs
+++ b/src/Nest/DSL/Bulk/BulkUpdateDescriptor.cs
@@ -232,7 +232,7 @@ namespace Nest
 			return this;
 		}
 
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> Version(string version)
+        public BulkUpdateDescriptor<TDocument, TPartialDocument> Version(long version)
 		{
 			Self.Version = version; 
 			return this;

--- a/src/Nest/Domain/Bulk/BulkOperationDescriptorBase.cs
+++ b/src/Nest/Domain/Bulk/BulkOperationDescriptorBase.cs
@@ -19,7 +19,7 @@ namespace Nest
 
 		string IBulkOperation.Id { get; set; }
 
-		string IBulkOperation.Version { get; set; }
+		long? IBulkOperation.Version { get; set; }
 
 		VersionType? IBulkOperation.VersionType { get; set; }
 

--- a/src/Nest/Domain/Bulk/IBulkOperation.cs
+++ b/src/Nest/Domain/Bulk/IBulkOperation.cs
@@ -21,7 +21,7 @@ namespace Nest
 		string Id { get; set; }
 
 		[JsonProperty(PropertyName = "_version")]
-		string Version { get; set; }
+		long? Version { get; set; }
 
 		[JsonProperty(PropertyName = "_version_type")]
 		[JsonConverter(typeof(StringEnumConverter))]


### PR DESCRIPTION
this commit fixes #968
