### PR TITLE
Skip over doc_count_error_upper_bound when deserializing aggregations

### DIFF
--- a/src/Nest/Resolvers/Converters/Aggregations/AggregationConverter.cs
+++ b/src/Nest/Resolvers/Converters/Aggregations/AggregationConverter.cs
@@ -36,6 +36,13 @@ namespace Nest.Resolvers.Converters.Aggregations
 			if (_numeric.IsMatch(property))
 				return GetPercentilesMetricAggregation(reader, serializer, oldFormat: true);
 
+			if (property == "doc_count_error_upper_bound")
+			{
+				reader.Read();
+				reader.Read();
+				property = reader.Value as string;
+			}
+
 			switch (property)
 			{
 				case "values":


### PR DESCRIPTION
Deserializing a search response with bucket aggregations in it fails because the `doc_count_error_upper_bound` is unexpected. Take this response snippet for example:

`... "aggregations":{"myBucket":{"doc_count_error_upper_bound":105322,"buckets":[{"key":"00000000-1111-1111-0000-070000000000","doc_count":202391...`

This commit skips over this value and lets the method continue as intended. This has been tested on `elasticsearch 1.4.0.beta1`.

Without this change I'm unable to use bucket aggregations. 
