### PR TITLE
Add connection setting to enable/disable HTTP pipelining

### DIFF
--- a/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
@@ -112,6 +112,9 @@ namespace Elasticsearch.Net.Connection
 		private bool _traceEnabled;
 		bool IConnectionConfigurationValues.TraceEnabled { get{ return _traceEnabled; } }
 
+		private bool _httpPipeliningEnabled;
+		bool IConnectionConfigurationValues.HttpPipeliningEnabled { get { return _httpPipeliningEnabled; } }
+
 		private bool _throwOnServerExceptions;
 		bool IConnectionConfigurationValues.ThrowOnElasticsearchServerExceptions { get{ return _throwOnServerExceptions; } }
 
@@ -325,9 +328,18 @@ namespace Elasticsearch.Net.Connection
         {
             handler.ThrowIfNull("handler");
             this._connectionStatusHandler = handler;
-            return (T)this;
+			return (T)this;
         }
 
+		/// <summary>
+		/// Allows for requests to be pipelined. http://en.wikipedia.org/wiki/HTTP_pipelining
+		/// <para>Note: HTTP pipelining must also be enabled in Elasticsearch for this to work properly.</para>
+		/// </summary>
+		public T HttpPipeliningEnabled(bool enabled = true)
+		{
+			this._httpPipeliningEnabled = enabled;
+			return (T)this;
+		}
 	}
 }
 

--- a/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
@@ -26,7 +26,8 @@ namespace Elasticsearch.Net.Connection
 		bool MetricsEnabled { get; }
 		bool UsesPrettyResponses { get; }
 		bool KeepRawResponse { get; }
-        bool DisableAutomaticProxyDetection { get; }
+		bool DisableAutomaticProxyDetection { get; }
+		bool HttpPipeliningEnabled { get; }
 
 		/// <summary>
 		/// Instead of following a c/go like error checking on response.IsValid always throw an ElasticsearchServerException

--- a/src/Elasticsearch.Net/Connection/Configuration/IRequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IRequestConfiguration.cs
@@ -48,6 +48,10 @@ namespace Elasticsearch.Net.Connection.Configuration
 		/// </summary>
 		IEnumerable<int> AllowedStatusCodes { get; set; }
 
-
+		/// <summary>
+		/// Whether or not this request should be pipelined. http://en.wikipedia.org/wiki/HTTP_pipelining
+		/// <para>Note: HTTP pipelining must also be enabled in Elasticsearch for this to work properly.</para>
+		/// </summary>
+		bool EnableHttpPipelining { get; set; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/RequestConfiguration.cs
@@ -13,5 +13,6 @@ namespace Elasticsearch.Net.Connection.Configuration
 		public bool? DisableSniff { get; set; }
 		public bool? DisablePing { get; set; }
 		public IEnumerable<int> AllowedStatusCodes { get; set; }
+		public bool EnableHttpPipelining { get; set; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/Configuration/RequestConfigurationDescriptor.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/RequestConfigurationDescriptor.cs
@@ -23,6 +23,8 @@ namespace Elasticsearch.Net.Connection.Configuration
 		
 		IEnumerable<int> IRequestConfiguration.AllowedStatusCodes { get; set; }
 
+		bool IRequestConfiguration.EnableHttpPipelining { get; set; }
+
 		public RequestConfigurationDescriptor RequestTimeout(int requestTimeoutInMilliseconds)
 		{
 			Self.RequestTimeout = requestTimeoutInMilliseconds;
@@ -73,6 +75,12 @@ namespace Elasticsearch.Net.Connection.Configuration
 		public RequestConfigurationDescriptor MaxRetries(int retry)
 		{
 			Self.MaxRetries = retry;
+			return this;
+		}
+
+		public RequestConfigurationDescriptor EnableHttpPipelining(bool enable = true)
+		{
+			Self.EnableHttpPipelining = enable;
 			return this;
 		}
 	}


### PR DESCRIPTION
Previously, pipelining was explicitly disabled since elasticsearch did not support it.  Support has just been added (https://github.com/elasticsearch/elasticsearch/pull/8299) and so this PR adds a connection setting to enable/disable pipelining on the client as well.

Pipelining can be turned on at a global/connection level via `IConnectionConfigurationValues` or per request via `IRequestConfiguration`.  The default is to disable pipelining (might make sense to default to enabled in `2.0`).
