### PR TITLE
UrlEncoded username password are not decoded when adding them as basic authentication.

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -174,6 +174,10 @@ namespace Elasticsearch.Net.Connection
 				{
 					userInfo = Uri.UnescapeDataString(userInfo.Substring(0, length)) + ":" + Uri.UnescapeDataString(userInfo.Substring(length + 1));
 				}
+				else
+				{
+					userInfo = Uri.UnescapeDataString(userInfo);
+				}
 				myReq.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userInfo));
 			}
 		}


### PR DESCRIPTION
UrlDecode username/password before converting them to base64-string, otherwise; the authentication will fail if you have special characters (example @) included in the password (@ is encoded as %40).

The encoded value will be included in the base64-characters string instead of the clear-text version (UrlDecoded).
