### PR TITLE
Fixed the syntax of QueryRaw as it didn't work

### DIFF
--- a/docs/contents/nest/writing-queries.markdown
+++ b/docs/contents/nest/writing-queries.markdown
@@ -28,8 +28,8 @@ Or if using the object initializer syntax:
 ## Raw Strings
 Although not preferred, many folks like to build their own JSON strings and just pass that along:
 
-    .QueryRaw("\"match_all\" : { }")
-    .FilterRaw("\"match_all\" : { }")
+    .QueryRaw(@"{""match_all"": {} }")
+    .FilterRaw(@"{""match_all"": {} }")
 
 NEST does not modify this in anyway and just writes this straight into the JSON output. 
 


### PR DESCRIPTION
//When I try this 
var response = client.Search(func);

//This worked if the definition of func was
Func<SearchDescriptor<dynamic>, SearchDescriptor<dynamic>> func = s => s
               .AllTypes()
               .From(0)
               .Size(5)
               .QueryRaw(@"{""match_all"": {} }")
               ;

//This didn't work if the definition of func was
            Func<SearchDescriptor<dynamic>, SearchDescriptor<dynamic>> func = s => s
                .AllTypes()
                .From(0)
                .Size(10)
                .QueryRaw("\"match_all\" : { }")
);
