### PR TITLE
Use IList<string> for TypeTable in WordDelimiterTokenFilter

### DIFF
--- a/src/Nest/Domain/Analysis/TokenFilter/WordDelimiterTokenFilter.cs
+++ b/src/Nest/Domain/Analysis/TokenFilter/WordDelimiterTokenFilter.cs
@@ -48,7 +48,7 @@ namespace Nest
         public string ProtectedWordsPath { get; set; }
 
         [JsonProperty("type_table")]
-        public string TypeTable { get; set; }
+        public IList<string> TypeTable { get; set; }
 
         [JsonProperty("type_table_path")]
         public string TypeTablePath { get; set; }


### PR DESCRIPTION
Using the REST interface I can specify an array of mappings for the type_table for a word_delimiter filter, e.g.

```
curl -XPUT 'http://localhost:9200/test_index' -d '{
    "settings" : {
        "analysis" : {
            "filter" : {
                "tweet_filter" : {
                    "type" : "word_delimiter",
                    "type_table": ["# => ALPHA", "@ => ALPHA"]
                }   
            },
            "analyzer" : {
                "tweet_analyzer" : {
                    "type" : "custom",
                    "tokenizer" : "whitespace",
                    "filter" : ["lowercase", "tweet_filter"]
                }
            }
        }
    },
    "mappings" : {
        "test_type" : {
            "properties" : {
                "title" : {
                    "type" : "string",
                    "analyzer" : "tweet_analyzer"
                }
            }
        }
    }
}'
```

but the .Net interface is only accepting a single string, like this:

```
            var tweetFilter = new WordDelimiterTokenFilter
            {
                TypeTable = "# => ALPHA"
            };
```

This change should allow this instead:

```
            var tweetFilter = new WordDelimiterTokenFilter
            {
                TypeTable = new string[] { "# => ALPHA", "@ => ALPHA" }
            };
```
