### PR TITLE
Do not retry when timeout is hit

### DIFF
--- a/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
@@ -61,6 +61,9 @@ namespace Elasticsearch.Net.Connection
 		private int? _maxDeadTimeout;
 		int? IConnectionConfigurationValues.MaxDeadTimeout { get{ return _maxDeadTimeout; } }
 	
+		private TimeSpan? _maxRetryTimeout;
+		TimeSpan? IConnectionConfigurationValues.MaxRetryTimeout { get{ return _maxRetryTimeout; } }
+	
 		private string _proxyUsername;
 		string IConnectionConfigurationValues.ProxyUsername { get{ return _proxyUsername; } }
 		
@@ -278,6 +281,19 @@ namespace Elasticsearch.Net.Connection
 			this._maxDeadTimeout = timeout;
 			return (T) this;
 		}
+		
+		/// <summary>
+		/// Limits the total runtime including retries separately from <see cref="Timeout"/>
+		/// <pre>
+		/// When not specified defaults to <see cref="Timeout"/> which itself defaults to 60seconds
+		/// </pre>
+		/// </summary>
+		public T SetMaxRetryTimeout(TimeSpan maxRetryTimeout)
+		{
+			this._maxRetryTimeout = maxRetryTimeout;
+			return (T) this;
+		}
+		
 		/// <summary>
 		/// Semaphore asynchronous connections automatically by giving
 		/// it a maximum concurrent connections. 

--- a/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
@@ -6,6 +6,8 @@ using Elasticsearch.Net.Connection.Security;
 
 namespace Elasticsearch.Net.Connection
 {
+	//TODO change timeouts to TimeSpans in 2.0?
+
 	public interface IConnectionConfigurationValues
 	{
 		/// <summary>
@@ -26,7 +28,7 @@ namespace Elasticsearch.Net.Connection
 		int Timeout { get; }
 
 		/// <summary>
-		/// The timeout to use for ping calls that are issues to check whether a node is up or not.
+		/// The timeout in milliseconds to use for ping calls that are issues to check whether a node is up or not.
 		/// </summary>
 		int? PingTimeout { get; }
 		
@@ -45,6 +47,14 @@ namespace Elasticsearch.Net.Connection
 		/// amount of times we should retry the call to elasticsearch
 		/// </summary>
 		int? MaxRetries { get; }
+
+		/// <summary>
+		/// Limits the total runtime including retries separately from <see cref="Timeout"/>
+		/// <pre>
+		/// When not specified defaults to <see cref="Timeout"/> which itself defaults to 60seconds
+		/// </pre>
+		/// </summary>
+		TimeSpan? MaxRetryTimeout { get; }
 
 		/// <summary>
 		/// This signals that we do not want to send initial pings to unknown/previously dead nodes

--- a/src/Elasticsearch.Net/Connection/ITransportDelegator.cs
+++ b/src/Elasticsearch.Net/Connection/ITransportDelegator.cs
@@ -26,6 +26,13 @@ namespace Elasticsearch.Net.Connection
 
 		bool SniffingDisabled(IRequestConfiguration requestConfiguration);
 		bool SniffOnFaultDiscoveredMoreNodes(ITransportRequestState requestState, int retried, ElasticsearchResponse<Stream> streamResponse);
+		
+		/// <summary>
+		/// Returns whether the current delegation over nodes took too long and we should quit.
+		/// if <see cref="ConnectionSettings.SetMaxRetryTimeout"/> is set we'll use that timeout otherwise we default to th value of 
+		/// <see cref="ConnectionSettings.SetTimeout"/> which itself defaults to 60 seconds
+		/// </summary>
+		bool TookTooLongToRetry(ITransportRequestState requestState);
 
 		/// <summary>
 		/// Selects next node uri on request state

--- a/src/Elasticsearch.Net/Connection/RequestState/ITransportRequestState.cs
+++ b/src/Elasticsearch.Net/Connection/RequestState/ITransportRequestState.cs
@@ -11,6 +11,7 @@ namespace Elasticsearch.Net.Connection.RequestState
 		Uri CreatePathOnCurrentNode(string path);
 		IRequestConfiguration RequestConfiguration { get; }
 		int Retried { get; }
+		DateTime StartedOn { get; }
 		bool SniffedOnConnectionFailure { get; set; }
 		int? Seed { get; set; }
 		Uri CurrentNode { get; set; }

--- a/src/Tests/Elasticsearch.Net.Tests.Unit/ConnectionPools/SniffingConnectionPoolTests.cs
+++ b/src/Tests/Elasticsearch.Net.Tests.Unit/ConnectionPools/SniffingConnectionPoolTests.cs
@@ -184,7 +184,7 @@ namespace Elasticsearch.Net.Tests.Unit.ConnectionPools
 				Assert.Throws<MaxRetryException>(()=>client1.Info()); //info call 5
 
 				sniffCall.MustHaveHappened(Repeated.Exactly.Once);
-				nowCall.MustHaveHappened(Repeated.Exactly.Times(8));
+				nowCall.MustHaveHappened(Repeated.Exactly.Times(10));
 
 			}
 		}

--- a/src/Tests/Elasticsearch.Net.Tests.Unit/Elasticsearch.Net.Tests.Unit.csproj
+++ b/src/Tests/Elasticsearch.Net.Tests.Unit/Elasticsearch.Net.Tests.Unit.csproj
@@ -63,6 +63,8 @@
     <Compile Include="Failover\Concurrent\ConcurrencyTestConnection.cs" />
     <Compile Include="Failover\Retries\ClientExceptionsUsingPoolingTests.cs" />
     <Compile Include="Failover\Retries\ClientExceptionsWithoutPoolingTests.cs" />
+    <Compile Include="Failover\Timeout\DontRetryAfterMaxRetryTimeoutTests.cs" />
+    <Compile Include="Failover\Timeout\DontRetryAfterDefaultTimeoutTests.cs" />
     <Compile Include="Memory\Helpers\AsyncMemorySetup.cs" />
     <Compile Include="Memory\Helpers\IMemorySetup.cs" />
     <Compile Include="Memory\ResponseAsyncCodePathsMemoryTests.cs" />

--- a/src/Tests/Elasticsearch.Net.Tests.Unit/Failover/Timeout/DontRetryAfterDefaultTimeoutTests.cs
+++ b/src/Tests/Elasticsearch.Net.Tests.Unit/Failover/Timeout/DontRetryAfterDefaultTimeoutTests.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using Autofac.Extras.FakeItEasy;
+using Elasticsearch.Net.Connection;
+using Elasticsearch.Net.Connection.Configuration;
+using Elasticsearch.Net.ConnectionPool;
+using Elasticsearch.Net.Exceptions;
+using Elasticsearch.Net.Providers;
+using Elasticsearch.Net.Tests.Unit.Stubs;
+using FakeItEasy;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Elasticsearch.Net.Tests.Unit.Failover.Timeout
+{
+	[TestFixture]
+	public class DontRetryAfterDefaultTimeoutTests
+	{
+		[Test]
+		public void FailEarlyIfTimeoutIsExhausted()
+		{
+			using (var fake = new AutoFake())
+			{
+				var dateTimeProvider = ProvideDateTimeProvider(fake);
+				var config = ProvideConfiguration(dateTimeProvider);
+				var connection = ProvideConnection(fake, config, dateTimeProvider);
+
+				var getCall = FakeCalls.GetSyncCall(fake);
+				var ok = FakeResponse.Ok(config);
+				var bad = FakeResponse.Bad(config);
+				getCall.ReturnsNextFromSequence(
+					bad,  //info 1 - 9204
+					bad, //info 2 - 9203 DEAD
+					ok  //info 2 retry - 9202
+				);
+				
+				var seenNodes = new List<Uri>();
+				getCall.Invokes((Uri u, IRequestConfiguration o) => seenNodes.Add(u));
+
+				var pingCall = FakeCalls.PingAtConnectionLevel(fake);
+				pingCall.Returns(ok);
+
+				var client1 = fake.Resolve<ElasticsearchClient>();
+				
+				//event though the third node should have returned ok, the first 2 calls took a minute
+				var e = Assert.Throws<MaxRetryException>(() => client1.Info());
+				e.Message.Should()
+					.StartWith("Retry timeout 00:01:00 was hit after retrying 1 times:");
+
+				IElasticsearchResponse response = null;
+				Assert.DoesNotThrow(() => response = client1.Info() );
+				response.Should().NotBeNull();
+				response.Success.Should().BeTrue();
+
+			}
+		}
+
+		[Test]
+		public void FailEarlyIfTimeoutIsExhausted_Async()
+		{
+			using (var fake = new AutoFake())
+			{
+				var dateTimeProvider = ProvideDateTimeProvider(fake);
+				var config = ProvideConfiguration(dateTimeProvider);
+				var connection = ProvideConnection(fake, config, dateTimeProvider);
+				
+				var getCall = FakeCalls.GetCall(fake);
+				var ok = Task.FromResult(FakeResponse.Ok(config));
+				var bad = Task.FromResult(FakeResponse.Bad(config));
+				getCall.ReturnsNextFromSequence(
+					bad,  
+					bad,  
+					ok 
+				);
+				
+				var seenNodes = new List<Uri>();
+				getCall.Invokes((Uri u, IRequestConfiguration o) => seenNodes.Add(u));
+
+				var pingCall = FakeCalls.PingAtConnectionLevelAsync(fake);
+				pingCall.Returns(ok);
+
+				var client1 = fake.Resolve<ElasticsearchClient>();
+				//event though the third node should have returned ok, the first 2 calls took a minute
+				var e = Assert.Throws<MaxRetryException>(async () => await client1.InfoAsync());
+				e.Message.Should()
+					.StartWith("Retry timeout 00:01:00 was hit after retrying 1 times:");
+
+				IElasticsearchResponse response = null;
+				Assert.DoesNotThrow(async () => response = await client1.InfoAsync() );
+				response.Should().NotBeNull();
+				response.Success.Should().BeTrue();
+			}
+		}
+		
+		private static IConnection ProvideConnection(AutoFake fake, ConnectionConfiguration config, IDateTimeProvider dateTimeProvider)
+		{
+			fake.Provide<IConnectionConfigurationValues>(config);
+			var param = new TypedParameter(typeof(IDateTimeProvider), dateTimeProvider);
+			var transport = fake.Provide<ITransport, Transport>(param);
+			var connection = fake.Resolve<IConnection>();
+			return connection;
+		}
+
+		private static ConnectionConfiguration ProvideConfiguration(IDateTimeProvider dateTimeProvider)
+		{
+			var connectionPool = new StaticConnectionPool(new[]
+			{
+				new Uri("http://localhost:9204"),
+				new Uri("http://localhost:9203"),
+				new Uri("http://localhost:9202"),
+				new Uri("http://localhost:9201")
+			}, randomizeOnStartup: false, dateTimeProvider: dateTimeProvider);
+			var config = new ConnectionConfiguration(connectionPool).EnableMetrics();
+			return config;
+		}
+
+		private static IDateTimeProvider ProvideDateTimeProvider(AutoFake fake)
+		{
+			var now = DateTime.UtcNow;
+			var dateTimeProvider = fake.Resolve<IDateTimeProvider>();
+			var nowCall = A.CallTo(() => dateTimeProvider.Now());
+			nowCall.ReturnsNextFromSequence(
+				now, //initital sniff now from constructor
+				now, //pool select next node
+				now.AddSeconds(30), //info 1 took to long? 
+				now.AddSeconds(30), //pool select next node? 
+				now.AddMinutes(1) //info 2 took to long? 
+			);
+			A.CallTo(() => dateTimeProvider.AliveTime(A<Uri>._, A<int>._)).Returns(new DateTime());
+			//dead time will return a fixed timeout of 1 minute
+			A.CallTo(() => dateTimeProvider.DeadTime(A<Uri>._, A<int>._, A<int?>._, A<int?>._))
+				.Returns(DateTime.UtcNow.AddMinutes(1));
+			//make sure the transport layer uses a different datetimeprovider
+			fake.Provide<IDateTimeProvider>(new DateTimeProvider());
+			return dateTimeProvider;
+		}
+	}
+}

--- a/src/Tests/Elasticsearch.Net.Tests.Unit/Failover/Timeout/DontRetryAfterMaxRetryTimeoutTests.cs
+++ b/src/Tests/Elasticsearch.Net.Tests.Unit/Failover/Timeout/DontRetryAfterMaxRetryTimeoutTests.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using Autofac.Extras.FakeItEasy;
+using Elasticsearch.Net.Connection;
+using Elasticsearch.Net.Connection.Configuration;
+using Elasticsearch.Net.ConnectionPool;
+using Elasticsearch.Net.Exceptions;
+using Elasticsearch.Net.Providers;
+using Elasticsearch.Net.Tests.Unit.Stubs;
+using FakeItEasy;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Elasticsearch.Net.Tests.Unit.Failover.Timeout
+{
+	[TestFixture]
+	public class DontRetryAfterMaxRetryTimeoutTests
+	{
+		[Test]
+		public void FailEarlyIfTimeoutIsExhausted()
+		{
+			using (var fake = new AutoFake())
+			{
+				var dateTimeProvider = ProvideDateTimeProvider(fake);
+				var config = ProvideConfiguration(dateTimeProvider);
+				var connection = ProvideConnection(fake, config, dateTimeProvider);
+
+				var getCall = FakeCalls.GetSyncCall(fake);
+				var ok = FakeResponse.Ok(config);
+				var bad = FakeResponse.Bad(config);
+				getCall.ReturnsNextFromSequence(
+					bad,  //info 1 - 9204
+					bad, //info 2 - 9203 DEAD
+					ok  //info 2 retry - 9202
+				);
+				
+				var seenNodes = new List<Uri>();
+				getCall.Invokes((Uri u, IRequestConfiguration o) => seenNodes.Add(u));
+
+				var pingCall = FakeCalls.PingAtConnectionLevel(fake);
+				pingCall.Returns(ok);
+
+				var client1 = fake.Resolve<ElasticsearchClient>();
+				
+				//event though the third node should have returned ok, the first 2 calls took a minute
+				var e = Assert.Throws<MaxRetryException>(() => client1.Info());
+				e.Message.Should()
+					.StartWith("Retry timeout 00:01:20 was hit after retrying 1 times:");
+
+				IElasticsearchResponse response = null;
+				Assert.DoesNotThrow(() => response = client1.Info() );
+				response.Should().NotBeNull();
+				response.Success.Should().BeTrue();
+
+			}
+		}
+
+		[Test]
+		public void FailEarlyIfTimeoutIsExhausted_Async()
+		{
+			using (var fake = new AutoFake())
+			{
+				var dateTimeProvider = ProvideDateTimeProvider(fake);
+				var config = ProvideConfiguration(dateTimeProvider);
+				var connection = ProvideConnection(fake, config, dateTimeProvider);
+				
+				var getCall = FakeCalls.GetCall(fake);
+				var ok = Task.FromResult(FakeResponse.Ok(config));
+				var bad = Task.FromResult(FakeResponse.Bad(config));
+				getCall.ReturnsNextFromSequence(
+					bad,  
+					bad,  
+					ok 
+				);
+				
+				var seenNodes = new List<Uri>();
+				getCall.Invokes((Uri u, IRequestConfiguration o) => seenNodes.Add(u));
+
+				var pingCall = FakeCalls.PingAtConnectionLevelAsync(fake);
+				pingCall.Returns(ok);
+
+				var client1 = fake.Resolve<ElasticsearchClient>();
+				//event though the third node should have returned ok, the first 2 calls took a minute
+				var e = Assert.Throws<MaxRetryException>(async () => await client1.InfoAsync());
+				e.Message.Should()
+					.StartWith("Retry timeout 00:01:20 was hit after retrying 1 times:");
+
+				IElasticsearchResponse response = null;
+				Assert.DoesNotThrow(async () => response = await client1.InfoAsync() );
+				response.Should().NotBeNull();
+				response.Success.Should().BeTrue();
+			}
+		}
+		
+		private static IConnection ProvideConnection(AutoFake fake, ConnectionConfiguration config, IDateTimeProvider dateTimeProvider)
+		{
+			fake.Provide<IConnectionConfigurationValues>(config);
+			var param = new TypedParameter(typeof(IDateTimeProvider), dateTimeProvider);
+			var transport = fake.Provide<ITransport, Transport>(param);
+			var connection = fake.Resolve<IConnection>();
+			return connection;
+		}
+
+		private static ConnectionConfiguration ProvideConfiguration(IDateTimeProvider dateTimeProvider)
+		{
+			var connectionPool = new StaticConnectionPool(new[]
+			{
+				new Uri("http://localhost:9204"),
+				new Uri("http://localhost:9203"),
+				new Uri("http://localhost:9202"),
+				new Uri("http://localhost:9201")
+			}, randomizeOnStartup: false, dateTimeProvider: dateTimeProvider);
+			var config = new ConnectionConfiguration(connectionPool)
+				.SetTimeout(20)
+				.SetMaxRetryTimeout(TimeSpan.FromSeconds(80));
+			return config;
+		}
+
+		private static IDateTimeProvider ProvideDateTimeProvider(AutoFake fake)
+		{
+			var now = DateTime.UtcNow;
+			var dateTimeProvider = fake.Resolve<IDateTimeProvider>();
+			var nowCall = A.CallTo(() => dateTimeProvider.Now());
+			nowCall.ReturnsNextFromSequence(
+				now, //initital sniff now from constructor
+				now, //pool select next node
+				now.AddSeconds(30), //info 1 took to long? 
+				now.AddSeconds(30), //pool select next node? 
+				now.AddSeconds(80) //info 2 took to long? 
+			);
+			A.CallTo(() => dateTimeProvider.AliveTime(A<Uri>._, A<int>._)).Returns(new DateTime());
+			//dead time will return a fixed timeout of 1 minute
+			A.CallTo(() => dateTimeProvider.DeadTime(A<Uri>._, A<int>._, A<int?>._, A<int?>._))
+				.Returns(DateTime.UtcNow.AddMinutes(1));
+			//make sure the transport layer uses a different datetimeprovider
+			fake.Provide<IDateTimeProvider>(new DateTimeProvider());
+			return dateTimeProvider;
+		}
+	}
+}


### PR DESCRIPTION
this PR adds a safeguard for retrying after the timeout is hit as reported on #1080 . 

This prevents:
- a query that took 60seconds on one node to be retried on a second node.
- a query that timed out after 30seconds on 2 nodes to be retried a third time.

By default this listens to `SetTimeout()` which itself defaults to `60 seconds`. The max retry timeout can be configured separately by calling `SetMaxRetryTimeout()`.

The MaxRetryException message itself clearly reflects when its thrown because we exceeded the `MaxRetryTimeout`.
