### PR TITLE
Check null arg in PropertyNameResolver

### DIFF
--- a/src/Nest/Resolvers/PropertyNameResolver.cs
+++ b/src/Nest/Resolvers/PropertyNameResolver.cs
@@ -59,6 +59,8 @@ namespace Nest.Resolvers
 		private readonly IConnectionSettingsValues _settings;
 		public PropertyNameResolver(IConnectionSettingsValues settings)
 		{
+			if (settings == null)
+				throw new ArgumentNullException("settings");
 			_settings = settings;
 		}
 


### PR DESCRIPTION
Otherwise you get a NullReferenceException in Resolve(), harder to debug.
