### PR TITLE
BasicAuthorization should be BasicAuthentication!

### DIFF
--- a/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
@@ -352,9 +352,18 @@ namespace Elasticsearch.Net.Connection
         }
 
 		/// <summary>
-		/// Basic access authorization credentials to specify with all requests.
+		/// Basic access authentication credentials to specify with all requests.
 		/// </summary>
+		[Obsolete("Scheduled to be removed in 2.0.  Use SetBasicAuthentication() instead.")]
 		public T SetBasicAuthorization(string userName, string password)
+		{
+			return this.SetBasicAuthentication(userName, password);
+		}
+
+		/// <summary>
+		/// Basic access authentication credentials to specify with all requests.
+		/// </summary>
+		public T SetBasicAuthentication(string userName, string password)
 		{
 			if (this._basicAuthCredentials == null)
 				this._basicAuthCredentials = new BasicAuthorizationCredentials();

--- a/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
@@ -149,6 +149,7 @@ namespace Elasticsearch.Net.Connection
 		/// <summary>
 		/// Basic access authorization credentials to specify with all requests.
 		/// </summary>
+		/// TODO: Rename to BasicAuthenticationCredentials in 2.0
 		BasicAuthorizationCredentials BasicAuthorizationCredentials { get; } 
 	}
 }

--- a/src/Elasticsearch.Net/Connection/Configuration/IRequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IRequestConfiguration.cs
@@ -53,6 +53,7 @@ namespace Elasticsearch.Net.Connection.Configuration
 		/// Basic access authorization credentials to specify with this request.
 		/// Overrides any credentials that are set at the global IConnectionSettings level.
 		/// </summary>
+		/// TODO: rename to BasicAuthenticationCredentials in 2.0
 		BasicAuthorizationCredentials BasicAuthorizationCredentials { get; set; }
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Connection/Configuration/RequestConfigurationDescriptor.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/RequestConfigurationDescriptor.cs
@@ -81,7 +81,13 @@ namespace Elasticsearch.Net.Connection.Configuration
 			return this;
 		}
 
+		[Obsolete("Scheduled to be removed in 2.0.  Use BasicAuthentication() instead.")]
 		public RequestConfigurationDescriptor BasicAuthorization(string userName, string password)
+		{
+			return this.BasicAuthentication(userName, password);
+		}
+
+		public RequestConfigurationDescriptor BasicAuthentication(string userName, string password)
 		{
 			if (Self.BasicAuthorizationCredentials == null)
 				Self.BasicAuthorizationCredentials = new BasicAuthorizationCredentials();

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -141,7 +141,7 @@ namespace Elasticsearch.Net.Connection
 		protected virtual HttpWebRequest CreateHttpWebRequest(Uri uri, string method, byte[] data, IRequestConfiguration requestSpecificConfig)
 		{
 			var request = this.CreateWebRequest(uri, method, data, requestSpecificConfig);
-			this.SetBasicAuthorizationIfNeeded(uri, request, requestSpecificConfig);
+			this.SetBasicAuthenticationIfNeeded(uri, request, requestSpecificConfig);
 			this.SetProxyIfNeeded(request);
 			return request;
 		}
@@ -164,7 +164,7 @@ namespace Elasticsearch.Net.Connection
             }
 		}
 
-		private void SetBasicAuthorizationIfNeeded(Uri uri, HttpWebRequest request, IRequestConfiguration requestSpecificConfig)
+		private void SetBasicAuthenticationIfNeeded(Uri uri, HttpWebRequest request, IRequestConfiguration requestSpecificConfig)
 		{
 			// Basic auth credentials take the following precedence (highest -> lowest):
 			// 1 - Specified on the request (highest precedence)

--- a/src/Elasticsearch.Net/Connection/Security/BasicAuthorizationCredentials.cs
+++ b/src/Elasticsearch.Net/Connection/Security/BasicAuthorizationCredentials.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace Elasticsearch.Net.Connection.Security
 {
+	// TODO: Rename to BasicAuthenticationCredentials in 2.0
 	public class BasicAuthorizationCredentials
 	{
 		public string UserName { get; set; }

--- a/src/Tests/Nest.Tests.Integration/Connection/Security/BasicAuthenticationTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Connection/Security/BasicAuthenticationTests.cs
@@ -11,7 +11,7 @@ namespace Tests.Integration.Security.BasicAuthTests
 {
 	[TestFixture]
 	[Ignore]
-	public class BasicAuthorizationTests
+	public class BasicAuthenticationTests
 	{
 		[Test]
 		public void No_Credentials_Result_In_401()
@@ -27,7 +27,7 @@ namespace Tests.Integration.Security.BasicAuthTests
 		public void Invalid_Credentials_Result_In_401()
 		{
 			var settings = new ConnectionSettings(new Uri("http://localhost:9200"))
-				.SetBasicAuthorization("nestuser", "incorrectpassword");
+				.SetBasicAuthentication("nestuser", "incorrectpassword");
 			var client = new ElasticClient(settings);
 			var response = client.RootNodeInfo();
 			response.IsValid.Should().BeFalse();
@@ -38,7 +38,7 @@ namespace Tests.Integration.Security.BasicAuthTests
 		public void Valid_Credentials_Result_In_200()
 		{
 			var settings = new ConnectionSettings(new Uri("http://localhost:9200"))
-				.SetBasicAuthorization("nestuser", "elastic");
+				.SetBasicAuthentication("nestuser", "elastic");
 			var client = new ElasticClient(settings);
 			var response = client.RootNodeInfo();
 			response.IsValid.Should().BeTrue();
@@ -66,7 +66,7 @@ namespace Tests.Integration.Security.BasicAuthTests
 		public void ConnectionSettings_Overrides_URI()
 		{
 			var settings = new ConnectionSettings(new Uri("http://invalid:user@localhost:9200"))
-				.SetBasicAuthorization("nestuser", "elastic");
+				.SetBasicAuthentication("nestuser", "elastic");
 			var client = new ElasticClient(settings);
 			var response = client.RootNodeInfo();
 			response.IsValid.Should().BeTrue();
@@ -76,11 +76,11 @@ namespace Tests.Integration.Security.BasicAuthTests
 		public void RequestConfiguration_Overrides_ConnectionSettings()
 		{
 			var settings = new ConnectionSettings(new Uri("http://localhost:9200"))
-				.SetBasicAuthorization("invalid", "user");
+				.SetBasicAuthentication("invalid", "user");
 			var client = new ElasticClient(settings);
 			var response = client.RootNodeInfo(c => c
 				.RequestConfiguration(rc => rc
-					.BasicAuthorization("nestuser", "elastic")
+					.BasicAuthentication("nestuser", "elastic")
 				)
 			);
 			response.IsValid.Should().BeTrue();

--- a/src/Tests/Nest.Tests.Integration/ElasticsearchConfiguration.cs
+++ b/src/Tests/Nest.Tests.Integration/ElasticsearchConfiguration.cs
@@ -46,7 +46,7 @@ namespace Nest.Tests.Integration
 				.DisableAutomaticProxyDetection(false)
 				.UsePrettyResponses()
 				.ExposeRawResponse()
-				.SetBasicAuthorization("nestuser", "elastic");
+				.SetBasicAuthentication("nestuser", "elastic");
 		}
 
 		public static readonly Lazy<ElasticClient> Client = new Lazy<ElasticClient>(()=> new ElasticClient(Settings()));

--- a/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -105,7 +105,7 @@
     <Compile Include="Cluster\StatsTest.cs" />
     <Compile Include="Connection\Failover\SniffTests.cs" />
     <Compile Include="Connection\HttpClient\HttpClientTests.cs" />
-    <Compile Include="Connection\Security\BasicAuthorizationTests.cs" />
+    <Compile Include="Connection\Security\BasicAuthenticationTests.cs" />
     <Compile Include="Connection\Security\UnauthorizedRequestTests.cs" />
     <Compile Include="Connection\Thrift\ThiftBugReportTests.cs" />
     <Compile Include="Core\Analyze\AnalyzeTests.cs" />


### PR DESCRIPTION
_There are only two hard things in Computer Science: cache invalidation and naming things. -Phil Karlton_

It's HTTP basic authentication not authorization. :)

Marked all references to BasicAuthorization obsolete in favor of BasicAuthentication. Also added a few TODOs where we need to actually rename properties/classes for 2.0.
