### PR TITLE
fix #1100 add new throttling related properties to indexing stats

### DIFF
--- a/src/Nest/Domain/Responses/NodeStatsResponse.cs
+++ b/src/Nest/Domain/Responses/NodeStatsResponse.cs
@@ -5,24 +5,24 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-    public interface INodeStatsResponse : IResponse
-    {
-        string ClusterName { get; }
-        Dictionary<string, NodeStats> Nodes { get; }
-    }
+	public interface INodeStatsResponse : IResponse
+	{
+		string ClusterName { get; }
+		Dictionary<string, NodeStats> Nodes { get; }
+	}
 
-    [JsonObject]
-    public class NodeStatsResponse : BaseResponse, INodeStatsResponse
-    {
-        public NodeStatsResponse()
-        {
-            this.IsValid = true;
-        }
+	[JsonObject]
+	public class NodeStatsResponse : BaseResponse, INodeStatsResponse
+	{
+		public NodeStatsResponse()
+		{
+			this.IsValid = true;
+		}
 
-        [JsonProperty(PropertyName = "cluster_name")]
-        public string ClusterName { get; internal set; }
-        [JsonProperty(PropertyName = "nodes")]
+		[JsonProperty(PropertyName = "cluster_name")]
+		public string ClusterName { get; internal set; }
+		[JsonProperty(PropertyName = "nodes")]
 		[JsonConverter(typeof(DictionaryKeysAreNotPropertyNamesJsonConverter))]
 		public Dictionary<string, NodeStats> Nodes { get; set; }
-    }
+	}
 }

--- a/src/Nest/Domain/Stats/IndexingStats.cs
+++ b/src/Nest/Domain/Stats/IndexingStats.cs
@@ -22,8 +22,22 @@ namespace Nest
 		public string DeleteTime { get; set; }
 		[JsonProperty(PropertyName = "delete_time_in_millis")]
 		public double DeleteTimeInMilliseconds { get; set; }
+
 		[JsonProperty(PropertyName = "delete_current")]
 		public long DeleteCurrent { get; set; }
+		
+		[JsonProperty(PropertyName = "noop_update_total")]
+		public long NoopUpdateTotal { get; set; }
+		
+		[JsonProperty(PropertyName = "is_throttled")]
+		public bool IsThrottled { get; set; }
+		
+		[JsonProperty(PropertyName = "throttle_time_in_millis")]
+		public long ThrottleTimeInMilliseconds { get; set; }
+		
+		[JsonProperty(PropertyName = "throttle_time")]
+		public string ThrottleTime { get; set; }
+		
 		[JsonProperty(PropertyName = "types")]
 		[JsonConverter(typeof(DictionaryKeysAreNotPropertyNamesJsonConverter))]
 		public Dictionary<string, TypeStats> Types { get; set; }


### PR DESCRIPTION
Relevant bits in elasticsearch core here:

https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java#L275-L278
