### PR TITLE
this adds support for passing in documents to termvector and mtervector

### DIFF
--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mtermvectors.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mtermvectors.json
@@ -1,6 +1,7 @@
+
 {
   "mtermvectors" : {
-    "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html",
+    "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
       "path" : "/_mtermvectors",
@@ -13,11 +14,7 @@
         "type" : {
           "type" : "string",
           "description" : "The type of the document."
-        },
-        "id" : {
-           "type" : "string",
-           "description" : "The id of the document."
-         }
+        }
       },
       "params" : {
         "ids" : {
@@ -74,11 +71,16 @@
           "type" : "string",
           "description" : "Parent id of documents. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "required" : false
+        },
+        "realtime": {
+           "type" : "boolean",
+           "description" : "Specifies if requests are real-time as opposed to near-real-time (default: true).",
+           "required" : false
         }
       }
     },
     "body" : {
-        "description" : "Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.",
+        "description" : "Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.",
         "required" : false
 
     }

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/termvector.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/termvector.json
@@ -1,10 +1,10 @@
 {
   "termvector" : {
-    "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html",
+    "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
-      "path" : "/{index}/{type}/{id}/_termvector",
-      "paths" : ["/{index}/{type}/{id}/_termvector"],
+      "path" : "/{index}/{type}/_termvector",
+      "paths" : ["/{index}/{type}/_termvector", "/{index}/{type}/{id}/_termvector"],
       "parts" : {
         "index" : {
          "type" : "string",
@@ -18,8 +18,7 @@
         },
         "id" : {
            "type" : "string",
-           "description" : "The id of the document.",
-           "required" : true
+           "description" : "The id of the document, when not specified a doc param should be supplied."
          }
       },
       "params": {
@@ -72,11 +71,16 @@
           "type" : "string",
           "description" : "Parent id of documents.",
           "required" : false
+        },
+        "realtime": {
+          "type" : "boolean",
+          "description" : "Specifies if request is real-time as opposed to near-real-time (default: true).",
+          "required" : false
         }
       }
     },
     "body": {
-      "description" : "Define parameters. See documentation.",
+      "description" : "Define parameters and or supply a document to get termvectors for. See documentation.",
       "required" : false
     }
   }

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -4725,7 +4725,7 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for MtermvectorsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html
+	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html
 	///</pre>
 	///</summary>
 	public class MultiTermVectorsRequestParameters : FluentRequestParameters<MultiTermVectorsRequestParameters> 
@@ -4817,6 +4817,16 @@ namespace Elasticsearch.Net
 		{
 			this._parent = parent;
 			this.AddQueryString("parent", this._parent);
+			return this;
+		}
+		
+		
+		internal bool _realtime { get; set; }
+		///<summary>Specifies if requests are real-time as opposed to near-real-time (default: true).</summary>
+		public MultiTermVectorsRequestParameters Realtime(bool realtime)
+		{
+			this._realtime = realtime;
+			this.AddQueryString("realtime", this._realtime);
 			return this;
 		}
 		
@@ -5955,7 +5965,7 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for TermvectorGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html
+	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html
 	///</pre>
 	///</summary>
 	public class TermvectorRequestParameters : FluentRequestParameters<TermvectorRequestParameters> 
@@ -6047,6 +6057,16 @@ namespace Elasticsearch.Net
 		{
 			this._parent = parent;
 			this.AddQueryString("parent", this._parent);
+			return this;
+		}
+		
+		
+		internal bool _realtime { get; set; }
+		///<summary>Specifies if request is real-time as opposed to near-real-time (default: true).</summary>
+		public TermvectorRequestParameters Realtime(bool realtime)
+		{
+			this._realtime = realtime;
+			this.AddQueryString("realtime", this._realtime);
 			return this;
 		}
 		

--- a/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
@@ -28073,7 +28073,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28105,7 +28105,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28138,7 +28138,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28172,7 +28172,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28205,7 +28205,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -28239,7 +28239,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -28274,7 +28274,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -28310,7 +28310,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -28345,7 +28345,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28381,7 +28381,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28418,7 +28418,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28456,7 +28456,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28493,9 +28493,9 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28526,9 +28526,9 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28560,9 +28560,9 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28595,9 +28595,9 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28629,10 +28629,10 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28664,10 +28664,10 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28700,10 +28700,10 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28737,10 +28737,10 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28773,11 +28773,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28810,11 +28810,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28848,11 +28848,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -28887,11 +28887,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -38885,15 +38885,163 @@ namespace Elasticsearch.Net
 			));
 		}
 		
+		///<summary>Represents a GET on /{index}/{type}/_termvector
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> TermvectorGet<T>(string index, string type, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			type.ThrowIfNullOrEmpty("type");
+			var url = "{0}/{1}/_termvector".F(Encoded(index), Encoded(type));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new TermvectorRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/{type}/_termvector
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> TermvectorGetAsync<T>(string index, string type, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			type.ThrowIfNullOrEmpty("type");
+			var url = "{0}/{1}/_termvector".F(Encoded(index), Encoded(type));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new TermvectorRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/{type}/_termvector
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> TermvectorGet(string index, string type, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			type.ThrowIfNullOrEmpty("type");
+			var url = "{0}/{1}/_termvector".F(Encoded(index), Encoded(type));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new TermvectorRequestParameters());
+			}
+				
+
+
+			return ElasticsearchResponse.Wrap(this.DoRequest<Dictionary<string, object>>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			));
+		}
+		
+		///<summary>Represents a GET on /{index}/{type}/_termvector
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> TermvectorGetAsync(string index, string type, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			type.ThrowIfNullOrEmpty("type");
+			var url = "{0}/{1}/_termvector".F(Encoded(index), Encoded(type));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new TermvectorRequestParameters());
+			}
+				
+
+
+			return ElasticsearchResponse.WrapAsync(this.DoRequestAsync<Dictionary<string, object>>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			));
+		}
+		
 		///<summary>Represents a GET on /{index}/{type}/{id}/_termvector
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -38927,11 +39075,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -38966,11 +39114,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39006,11 +39154,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39041,16 +39189,168 @@ namespace Elasticsearch.Net
 			));
 		}
 		
+		///<summary>Represents a POST on /{index}/{type}/_termvector
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> Termvector<T>(string index, string type, object body, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			type.ThrowIfNullOrEmpty("type");
+			var url = "{0}/{1}/_termvector".F(Encoded(index), Encoded(type));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new TermvectorRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"POST", url, body, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/{type}/_termvector
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> TermvectorAsync<T>(string index, string type, object body, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			type.ThrowIfNullOrEmpty("type");
+			var url = "{0}/{1}/_termvector".F(Encoded(index), Encoded(type));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new TermvectorRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"POST", url, body, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/{type}/_termvector
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> Termvector(string index, string type, object body, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			type.ThrowIfNullOrEmpty("type");
+			var url = "{0}/{1}/_termvector".F(Encoded(index), Encoded(type));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new TermvectorRequestParameters());
+			}
+				
+
+
+			return ElasticsearchResponse.Wrap(this.DoRequest<Dictionary<string, object>>(
+				"POST", url, body, 
+				requestParameters: requestParams
+			));
+		}
+		
+		///<summary>Represents a POST on /{index}/{type}/_termvector
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> TermvectorAsync(string index, string type, object body, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			type.ThrowIfNullOrEmpty("type");
+			var url = "{0}/{1}/_termvector".F(Encoded(index), Encoded(type));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new TermvectorRequestParameters());
+			}
+				
+
+
+			return ElasticsearchResponse.WrapAsync(this.DoRequestAsync<Dictionary<string, object>>(
+				"POST", url, body, 
+				requestParameters: requestParams
+			));
+		}
+		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_termvector
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
-		///<param name="body">Define parameters. See documentation.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39084,12 +39384,12 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
-		///<param name="body">Define parameters. See documentation.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39124,12 +39424,12 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
-		///<param name="body">Define parameters. See documentation.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39165,12 +39465,12 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
-		///<param name="body">Define parameters. See documentation.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>

--- a/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
@@ -14980,7 +14980,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14997,7 +14997,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15015,7 +15015,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15034,7 +15034,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15052,7 +15052,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -15070,7 +15070,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -15089,7 +15089,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -15109,7 +15109,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -15128,7 +15128,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15147,7 +15147,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15167,7 +15167,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15188,7 +15188,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15208,9 +15208,9 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15226,9 +15226,9 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15245,9 +15245,9 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15265,9 +15265,9 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15284,10 +15284,10 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15303,10 +15303,10 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15323,10 +15323,10 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15344,10 +15344,10 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15364,11 +15364,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15384,11 +15384,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15405,11 +15405,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -15427,11 +15427,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
+		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20816,15 +20816,95 @@ namespace Elasticsearch.Net
 		
 		Task<ElasticsearchResponse<DynamicDictionary>> SuggestGetAsync(string index, Func<SuggestRequestParameters, SuggestRequestParameters> requestParameters = null);
 		
+		///<summary>Represents a GET on /{index}/{type}/_termvector
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> TermvectorGet<T>(string index, string type, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/{type}/_termvector
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> TermvectorGetAsync<T>(string index, string type, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/{type}/_termvector
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> TermvectorGet(string index, string type, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/{type}/_termvector
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> TermvectorGetAsync(string index, string type, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
+		
 		///<summary>Represents a GET on /{index}/{type}/{id}/_termvector
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20840,11 +20920,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20861,11 +20941,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20883,11 +20963,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20900,16 +20980,100 @@ namespace Elasticsearch.Net
 		
 		Task<ElasticsearchResponse<DynamicDictionary>> TermvectorGetAsync(string index, string type, string id, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
 		
+		///<summary>Represents a POST on /{index}/{type}/_termvector
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> Termvector<T>(string index, string type, object body, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/{type}/_termvector
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> TermvectorAsync<T>(string index, string type, object body, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/{type}/_termvector
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> Termvector(string index, string type, object body, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/{type}/_termvector
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///</summary>
+		///<param name="index">The index in which the document resides.</param>
+		///<param name="type">The type of the document.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> TermvectorAsync(string index, string type, object body, Func<TermvectorRequestParameters, TermvectorRequestParameters> requestParameters = null);
+		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_termvector
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
-		///<param name="body">Define parameters. See documentation.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20925,12 +21089,12 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
-		///<param name="body">Define parameters. See documentation.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20947,12 +21111,12 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
-		///<param name="body">Define parameters. See documentation.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20970,12 +21134,12 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html</para>	
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document.</param>
-		///<param name="body">Define parameters. See documentation.</param>
+		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>

--- a/src/Nest/DSL/TermVector/MultiTermVectorDocumentDescriptor.cs
+++ b/src/Nest/DSL/TermVector/MultiTermVectorDocumentDescriptor.cs
@@ -19,6 +19,7 @@ namespace Nest
 			IMultiTermVectorDocumentDescriptor d = this;
 			if (d.Document == null) d.Document = new MultiTermVectorDocument();
 			d.Document.Id = Self.Id;
+			d.Document.Document = d.Document.Document;
 			d.Document.Type = Self.Type;
 			d.Document.Index = Self.Index;
 			return d.Document;
@@ -30,6 +31,12 @@ namespace Nest
 			if (d.Document == null) d.Document = new MultiTermVectorDocument();
 			setter(d);
 			return this;
+		}
+
+		public MultiTermVectorDocumentDescriptor<T> Document<TDocument>(TDocument document)
+			where TDocument : class
+		{
+			return this.SetDocValue(d => d.Document.Document = document);
 		}
 
 		public MultiTermVectorDocumentDescriptor<T> Fields(params string[] fields)

--- a/src/Nest/DSL/TermVectorDescriptor.cs
+++ b/src/Nest/DSL/TermVectorDescriptor.cs
@@ -2,52 +2,74 @@
 using System.Collections.Generic;
 using System.Linq;
 using Elasticsearch.Net;
+using Newtonsoft.Json;
 
 namespace Nest
 {
-    public interface ITermvectorRequest : IDocumentOptionalPath<TermvectorRequestParameters> { }
-
-    public interface ITermvectorRequest<T> : ITermvectorRequest where T : class { }
-
-    internal static class TermvectorPathInfo
-    {
-        public static void Update(IConnectionSettingsValues settings, ElasticsearchPathInfo<TermvectorRequestParameters> pathInfo)
-        {
-            pathInfo.HttpMethod = PathInfoHttpMethod.GET;
-        }
-    }
-
-    public partial class TermvectorRequest : DocumentPathBase<TermvectorRequestParameters>, ITermvectorRequest
-    {
-	    public TermvectorRequest(IndexNameMarker indexName, TypeNameMarker typeName, string id) : base(indexName, typeName, id) { }
-
-	    protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<TermvectorRequestParameters> pathInfo)
-        {
-            TermvectorPathInfo.Update(settings, pathInfo);
-        }
-    }
-
-    public partial class TermvectorRequest<T> : DocumentPathBase<TermvectorRequestParameters, T>, ITermvectorRequest<T>
-        where T : class
-    {
-	    public TermvectorRequest(string id) : base(id) { }
-
-	    public TermvectorRequest(long id) : base(id) { }
-
-	    public TermvectorRequest(T document) : base(document) { }
-
-	    protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<TermvectorRequestParameters> pathInfo)
-        {
-            TermvectorPathInfo.Update(settings, pathInfo);
-        }
-    }
-
-	public partial class TermvectorDescriptor<T> : DocumentPathDescriptor<TermvectorDescriptor<T>, TermvectorRequestParameters, T>
-		where T : class
+	public interface ITermvectorRequest : IDocumentOptionalPath<TermvectorRequestParameters>
 	{
+		/// <summary>
+		/// An optional document to get termvectors for instead of using an already indexed document
+		/// </summary>
+		[JsonProperty("doc")]
+		object Document { get; set; }
+	}
+
+	public interface ITermvectorRequest<T> : ITermvectorRequest where T : class { }
+
+	internal static class TermvectorPathInfo
+	{
+		public static void Update(IConnectionSettingsValues settings, ElasticsearchPathInfo<TermvectorRequestParameters> pathInfo, ITermvectorRequest request)
+		{
+			pathInfo.HttpMethod = request.Document == null ? PathInfoHttpMethod.GET : PathInfoHttpMethod.POST;
+		}
+	}
+
+	public partial class TermvectorRequest : DocumentOptionalPathBase<TermvectorRequestParameters>, ITermvectorRequest
+	{
+		public TermvectorRequest(IndexNameMarker indexName, TypeNameMarker typeName, string id) : base(indexName, typeName, id) { }
+
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<TermvectorRequestParameters> pathInfo)
 		{
-            TermvectorPathInfo.Update(settings, pathInfo);
+			TermvectorPathInfo.Update(settings, pathInfo, this);
 		}
+
+		public object Document { get; set; }
+	}
+
+	public partial class TermvectorRequest<T> : DocumentOptionalPathBase<TermvectorRequestParameters, T>, ITermvectorRequest<T>
+		where T : class
+	{
+		object ITermvectorRequest.Document { get; set; }
+
+		public TermvectorRequest(string id) : base(id) { }
+
+		public TermvectorRequest(long id) : base(id) { }
+
+		public TermvectorRequest(T document) : base(document) { }
+
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<TermvectorRequestParameters> pathInfo)
+		{
+			TermvectorPathInfo.Update(settings, pathInfo, this);
+		}
+	}
+
+	public partial class TermvectorDescriptor<T> : DocumentOptionalPathDescriptor<TermvectorDescriptor<T>, TermvectorRequestParameters, T>
+		, ITermvectorRequest
+		where T : class
+	{
+		object ITermvectorRequest.Document { get; set; }
+
+		public TermvectorDescriptor<T> Document<TDocument>(TDocument document) where TDocument : class
+		{
+			((ITermvectorRequest) this).Document = document;
+			return this;
+		}
+
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<TermvectorRequestParameters> pathInfo)
+		{
+			TermvectorPathInfo.Update(settings, pathInfo, this);
+		}
+
 	}
 }

--- a/src/Nest/DSL/_Descriptors.generated.cs
+++ b/src/Nest/DSL/_Descriptors.generated.cs
@@ -4407,7 +4407,7 @@ namespace Nest
 	
 	///<summary>descriptor for MtermvectorsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html
+	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html
 	///</pre>
 	///</summary>
 	public partial class MultiTermVectorsDescriptor<T> 
@@ -4494,6 +4494,14 @@ namespace Nest
 		public MultiTermVectorsDescriptor<T> Parent(string parent)
 		{
 			this.Request.RequestParameters.Parent(parent);
+			return this;
+		}
+		
+
+		///<summary>Specifies if requests are real-time as opposed to near-real-time (default: true).</summary>
+		public MultiTermVectorsDescriptor<T> Realtime(bool realtime = true)
+		{
+			this.Request.RequestParameters.Realtime(realtime);
 			return this;
 		}
 		
@@ -5559,7 +5567,7 @@ namespace Nest
 	
 	///<summary>descriptor for TermvectorGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html
+	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html
 	///</pre>
 	///</summary>
 	public partial class TermvectorDescriptor<T> 
@@ -5646,6 +5654,14 @@ namespace Nest
 		public TermvectorDescriptor<T> Parent(string parent)
 		{
 			this.Request.RequestParameters.Parent(parent);
+			return this;
+		}
+		
+
+		///<summary>Specifies if request is real-time as opposed to near-real-time (default: true).</summary>
+		public TermvectorDescriptor<T> Realtime(bool realtime = true)
+		{
+			this.Request.RequestParameters.Realtime(realtime);
 			return this;
 		}
 		

--- a/src/Nest/DSL/_Requests.generated.cs
+++ b/src/Nest/DSL/_Requests.generated.cs
@@ -3976,7 +3976,7 @@ namespace Nest
 		
 	///<summary>Request parameters for MtermvectorsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-multi-termvectors.html
+	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html
 	///</pre>
 	///</summary>
 	public partial class MultiTermVectorsRequest 
@@ -4051,6 +4051,14 @@ namespace Nest
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<string>("parent"); } 
 			set { this.Request.RequestParameters.AddQueryString("parent", value); }
+		}
+		
+		
+		///<summary>Specifies if requests are real-time as opposed to near-real-time (default: true).</summary>
+		public bool Realtime 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("realtime"); } 
+			set { this.Request.RequestParameters.AddQueryString("realtime", value); }
 		}
 		
 	}
@@ -5006,7 +5014,7 @@ namespace Nest
 		
 	///<summary>Request parameters for TermvectorGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html
+	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html
 	///</pre>
 	///</summary>
 	public partial class TermvectorRequest<T> 
@@ -5081,6 +5089,14 @@ namespace Nest
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<string>("parent"); } 
 			set { this.Request.RequestParameters.AddQueryString("parent", value); }
+		}
+		
+		
+		///<summary>Specifies if request is real-time as opposed to near-real-time (default: true).</summary>
+		public bool Realtime 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("realtime"); } 
+			set { this.Request.RequestParameters.AddQueryString("realtime", value); }
 		}
 		
 	}
@@ -6599,7 +6615,7 @@ namespace Nest
 		
 	///<summary>Request parameters for TermvectorGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/docs-termvectors.html
+	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html
 	///</pre>
 	///</summary>
 	public partial class TermvectorRequest 
@@ -6674,6 +6690,14 @@ namespace Nest
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<string>("parent"); } 
 			set { this.Request.RequestParameters.AddQueryString("parent", value); }
+		}
+		
+		
+		///<summary>Specifies if request is real-time as opposed to near-real-time (default: true).</summary>
+		public bool Realtime 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("realtime"); } 
+			set { this.Request.RequestParameters.AddQueryString("realtime", value); }
 		}
 		
 	}

--- a/src/Nest/Domain/TermVector/MultiTermVectorDocument.cs
+++ b/src/Nest/Domain/TermVector/MultiTermVectorDocument.cs
@@ -11,6 +11,8 @@ namespace Nest
 		public TypeNameMarker Type { get; set; }
 		[JsonProperty("_id")]
 		public string Id { get; set; }
+		[JsonProperty("doc")]
+		public object Document { get; set; }
 		[JsonProperty("fields")]
 		public IEnumerable<PropertyPathMarker> Fields { get; set; }
 		[JsonProperty("offsets")]

--- a/src/Nest/RawDispatch.generated.cs
+++ b/src/Nest/RawDispatch.generated.cs
@@ -4098,16 +4098,22 @@ namespace Nest
 					//GET /{index}/{type}/{id}/_termvector
 					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty() && !pathInfo.Id.IsNullOrEmpty())
 						return this.Raw.TermvectorGet<T>(pathInfo.Index,pathInfo.Type,pathInfo.Id,u => pathInfo.RequestParameters);
+					//GET /{index}/{type}/_termvector
+					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty())
+						return this.Raw.TermvectorGet<T>(pathInfo.Index,pathInfo.Type,u => pathInfo.RequestParameters);
 					break;
 
 				case PathInfoHttpMethod.POST:
 					//POST /{index}/{type}/{id}/_termvector
 					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty() && !pathInfo.Id.IsNullOrEmpty() && body != null)
 						return this.Raw.Termvector<T>(pathInfo.Index,pathInfo.Type,pathInfo.Id,body,u => pathInfo.RequestParameters);
+					//POST /{index}/{type}/_termvector
+					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty() && body != null)
+						return this.Raw.Termvector<T>(pathInfo.Index,pathInfo.Type,body,u => pathInfo.RequestParameters);
 					break;
 
 			}
-			throw new DispatchException("Could not dispatch IElasticClient.Termvector() into any of the following paths: \r\n - /{index}/{type}/{id}/_termvector");
+			throw new DispatchException("Could not dispatch IElasticClient.Termvector() into any of the following paths: \r\n - /{index}/{type}/_termvector\r\n - /{index}/{type}/{id}/_termvector");
 		}
 		
 		
@@ -4119,16 +4125,22 @@ namespace Nest
 					//GET /{index}/{type}/{id}/_termvector
 					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty() && !pathInfo.Id.IsNullOrEmpty())
 						return this.Raw.TermvectorGetAsync<T>(pathInfo.Index,pathInfo.Type,pathInfo.Id,u => pathInfo.RequestParameters);
+					//GET /{index}/{type}/_termvector
+					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty())
+						return this.Raw.TermvectorGetAsync<T>(pathInfo.Index,pathInfo.Type,u => pathInfo.RequestParameters);
 					break;
 
 				case PathInfoHttpMethod.POST:
 					//POST /{index}/{type}/{id}/_termvector
 					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty() && !pathInfo.Id.IsNullOrEmpty() && body != null)
 						return this.Raw.TermvectorAsync<T>(pathInfo.Index,pathInfo.Type,pathInfo.Id,body,u => pathInfo.RequestParameters);
+					//POST /{index}/{type}/_termvector
+					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty() && body != null)
+						return this.Raw.TermvectorAsync<T>(pathInfo.Index,pathInfo.Type,body,u => pathInfo.RequestParameters);
 					break;
 
 			}
-			throw new DispatchException("Could not dispatch IElasticClient.Termvector() into any of the following paths: \r\n - /{index}/{type}/{id}/_termvector");
+			throw new DispatchException("Could not dispatch IElasticClient.Termvector() into any of the following paths: \r\n - /{index}/{type}/_termvector\r\n - /{index}/{type}/{id}/_termvector");
 		}
 		
 		

--- a/src/Tests/Nest.Tests.Integration/Core/TermVectors/TermVectorTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/TermVectors/TermVectorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using Nest.Tests.MockData;
 using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 
@@ -17,6 +18,21 @@ namespace Nest.Tests.Integration.Core.TermVectors
 				.Id("1")
 				.Fields(ep => ep.Content));
 
+			AssertContentsVectors(result);
+		}
+
+		[Test]
+		public void TermVectorDocument()
+		{
+			var document = NestTestData.Data.FirstOrDefault(d => d.Id == 1);
+			var result = Client.TermVector<ElasticsearchProject>(s => s
+				.Document(document)
+				.Fields(ep => ep.Content));
+
+			AssertContentsVectors(result);
+		}
+		private static void AssertContentsVectors(ITermVectorResponse result)
+		{
 			result.IsValid.Should().BeTrue();
 			result.Found.Should().BeTrue();
 			result.TermVectors.Count().Should().Be(1);

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -254,6 +254,7 @@
     <Compile Include="ObjectInitializer\Aliases\GetAliasRequestTests.cs" />
     <Compile Include="ObjectInitializer\Aliases\GetAliasesRequestTests.cs" />
     <Compile Include="ObjectInitializer\Aliases\AliasRequestTests.cs" />
+    <Compile Include="ObjectInitializer\MultiTermVectors\MultiTermVectorsWithDocumentRequestTests.cs" />
     <Compile Include="ObjectInitializer\Nodes\NodesHotThreadsRequestTests.cs" />
     <Compile Include="ObjectInitializer\Repository\VerifyRepositoryRequestTests.cs" />
     <Compile Include="ObjectInitializer\Search\SearchRequestUntypedTests.cs" />
@@ -316,6 +317,7 @@
     <Compile Include="ObjectInitializer\Template\DeleteTemplateRequestTests.cs" />
     <Compile Include="ObjectInitializer\Template\GetTemplateRequestTests.cs" />
     <Compile Include="ObjectInitializer\Template\PutTemplateRequestTests.cs" />
+    <Compile Include="ObjectInitializer\TermVector\TermVectorWithDocRequestTests.cs" />
     <Compile Include="ObjectInitializer\TermVector\TermVectorRequestTests.cs" />
     <Compile Include="ObjectInitializer\Update\UpdateRequestTests.cs" />
     <Compile Include="ObjectInitializer\UpdateSettings\UpdateSettingsRequestTests.cs" />
@@ -725,6 +727,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="ObjectInitializer\MoreLikeThis\MoreLikeThisBody.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="ObjectInitializer\MultiTermVectors\MultiTermVectorsWithDocumentBody.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="ObjectInitializer\Snapshot\SnapshotBody.json">

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiTermVectors/MultiTermVectorsWithDocumentBody.json
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiTermVectors/MultiTermVectorsWithDocumentBody.json
@@ -1,0 +1,18 @@
+  {
+  "docs": [
+    {
+      "doc": { "world": "doc"},
+      "field_statistics": true
+    },
+    {
+        "doc": { "world": "doc"},
+      "field_statistics": true
+    },
+    {  "doc": { "world": "doc"},
+      "field_statistics": true
+    },
+    {  "doc": { "world": "doc"},
+      "field_statistics": true
+    }
+  ]
+}

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiTermVectors/MultiTermVectorsWithDocumentRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiTermVectors/MultiTermVectorsWithDocumentRequestTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Elasticsearch.Net;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nest.Tests.Unit.ObjectInitializer.MultiTermVectors
+{
+	[TestFixture]
+	public class MultiTermVectorsWithDocumentRequestTests : BaseJsonTests
+	{
+		private readonly IElasticsearchResponse _status;
+
+		public MultiTermVectorsWithDocumentRequestTests()
+		{
+			var documents = Enumerable.Range(1,4)
+				.Select(i=>new MultiTermVectorDocument { Document = new { world = "doc" }, FieldStatistics = true });
+			var request = new MultiTermVectorsRequest("my-index","zhe-type")
+			{
+				Documents = documents,
+				FieldStatistics = false,
+				Payloads = true,
+				Positions = false,
+				
+			};
+			var response = this._client.MultiTermVectors(request);
+			this._status = response.ConnectionStatus;
+		}
+
+		[Test]
+		public void Url()
+		{
+			this._status.RequestUrl.Should().EndWith("/_mtermvectors?field_statistics=false&payloads=true&positions=false");
+			this._status.RequestMethod.Should().Be("POST");
+		}
+		
+		[Test]
+		public void MultiTermVectorsWithDocumentBody()
+		{
+			this.JsonEquals(this._status.Request.Utf8String(), MethodBase.GetCurrentMethod());
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/TermVector/TermVectorWithDocRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/TermVector/TermVectorWithDocRequestTests.cs
@@ -1,0 +1,40 @@
+﻿using Elasticsearch.Net;
+using FluentAssertions;
+using Nest.Tests.MockData.Domain;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nest.Tests.Unit.ObjectInitializer.TermVector
+{
+	public class TermVectorWithDocRequestTests : BaseJsonTests
+	{
+		private readonly IElasticsearchResponse _status;
+
+		public TermVectorWithDocRequestTests()
+		{
+			var response = this._client.TermVector<ElasticsearchProject>(t=>t
+				.Offsets()
+				.Payloads()
+				.Positions()
+				.TermStatistics()
+				.FieldStatistics()
+				.Document(new { world = "doc doc doc"})
+			);
+			this._status = response.ConnectionStatus;
+		}
+
+		[Test]
+		public void Url()
+		{
+			this._status.RequestUrl.Should().EndWith(
+				"/nest_test_data/elasticsearchprojects/_termvector?offsets=true&payloads=true&positions=true&term_statistics=true&field_statistics=true");
+			this._status.RequestMethod.Should().Be("POST");
+			var req  =this._status.Request.Utf8String();
+			req.JsonEquals(@"{ doc: { world: ""doc doc doc"" } }")
+				.Should().BeTrue("{0}", req);
+
+		}
+	}
+}


### PR DESCRIPTION
As introduced here https://github.com/elasticsearch/elasticsearch/pull/7530

This uses an altered rest-api-spec as pushed back to to elasticsearch here:

https://github.com/elasticsearch/elasticsearch/pull/8869
https://github.com/elasticsearch/elasticsearch/pull/8868

fixes https://github.com/elasticsearch/elasticsearch-net/issues/1101
