### PR TITLE
add support for multiple geo points while sorting fix #1104

### DIFF
--- a/src/Nest/Domain/Geo/GeoLocation.cs
+++ b/src/Nest/Domain/Geo/GeoLocation.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+/*
+ * Taken from SolrNet https://github.com/mausch/SolrNet/blob/master/SolrNet/Location.cs
+ */
+
+namespace Nest
+{
+
+	/// <summary>
+	/// Represents a Latitude/Longitude as a 2 dimensional point. 
+	/// </summary>
+	public class GeoLocation : IEquatable<GeoLocation>, IFormattable
+	{
+		/// <summary>
+		/// Latitude
+		/// </summary>
+		public double Latitude { get { return _latitude; } }
+		private readonly double _latitude;
+
+		/// <summary>
+		/// Longitude
+		/// </summary>
+		public double Longtitude { get { return _longitude; } }
+		private readonly double _longitude;
+
+		/// <summary>
+		/// Represents a Latitude/Longitude as a 2 dimensional point. 
+		/// </summary>
+		/// <param name="latitude">Value between -90 and 90</param>
+		/// <param name="longitude">Value between -180 and 180</param>
+		/// <exception cref="ArgumentOutOfRangeException">If <paramref name="latitude"/> or <paramref name="longitude"/> are invalid</exception>
+		public GeoLocation(double latitude, double longitude)
+		{
+			if (!IsValidLatitude(latitude))
+				throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture,
+					"Invalid latitude '{0}'. Valid values are between -90 and 90", latitude));
+			if (!IsValidLongitude(longitude))
+				throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture,
+					"Invalid longitude '{0}'. Valid values are between -180 and 180", longitude));
+			_latitude = latitude;
+			_longitude = longitude;
+		}
+
+		/// <summary>
+		/// True if <paramref name="latitude"/> is a valid latitude. Otherwise false.
+		/// </summary>
+		/// <param name="latitude"></param>
+		/// <returns></returns>
+		public static bool IsValidLatitude(double latitude)
+		{
+			return latitude >= -90 && latitude <= 90;
+		}
+
+		/// <summary>
+		/// True if <paramref name="longitude"/> is a valid longitude. Otherwise false.
+		/// </summary>
+		/// <param name="longitude"></param>
+		/// <returns></returns>
+		public static bool IsValidLongitude(double longitude)
+		{
+			return longitude >= -180 && longitude <= 180;
+		}
+
+		/// <summary>
+		/// Try to create a <see cref="GeoLocation"/>. 
+		/// Return <value>null</value> if either <paramref name="latitude"/> or <paramref name="longitude"/> are invalid.
+		/// </summary>
+		/// <param name="latitude">Value between -90 and 90</param>
+		/// <param name="longitude">Value between -180 and 180</param>
+		/// <returns></returns>
+		public static GeoLocation TryCreate(double latitude, double longitude)
+		{
+			if (IsValidLatitude(latitude) && IsValidLongitude(longitude))
+				return new GeoLocation(latitude, longitude);
+			return null;
+		}
+
+		public override string ToString()
+		{
+			return string.Format(CultureInfo.InvariantCulture, "{0},{1}", _latitude, _longitude);
+		}
+
+		public bool Equals(GeoLocation other)
+		{
+			if (ReferenceEquals(null, other))
+				return false;
+			if (ReferenceEquals(this, other))
+				return true;
+			return _latitude.Equals(other._latitude) && _longitude.Equals(other._longitude);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj))
+				return false;
+			if (ReferenceEquals(this, obj))
+				return true;
+			if (obj.GetType() != this.GetType())
+				return false;
+			return Equals((GeoLocation) obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return (_latitude.GetHashCode()*397) ^ _longitude.GetHashCode();
+			}
+		}
+
+		public string ToString(string format, IFormatProvider formatProvider)
+		{
+			return ToString();
+		}
+	}
+}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Domain\Cat\CatRecoveryRecord.cs" />
     <Compile Include="Domain\Cat\CatPluginsRecord.cs" />
     <Compile Include="Domain\Cat\CatPendingTasksRecord.cs" />
+    <Compile Include="Domain\Geo\GeoLocation.cs" />
     <Compile Include="Domain\Hit\ExplainGet.cs" />
     <Compile Include="Domain\Mapping\PropertyMapping.cs" />
     <Compile Include="Domain\Mapping\Descriptors\FieldDataFilterDescriptor.cs" />

--- a/src/Tests/Nest.Tests.Integration/Mapping/GetMultipleMappingTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Mapping/GetMultipleMappingTests.cs
@@ -107,7 +107,7 @@ namespace Nest.Tests.Integration.Mapping
 
 			x = this.Client.CreateIndex(indices.Last(), s => s
 				.AddMapping<ElasticsearchProject>(m => m.MapFromAttributes())
-				.AddMapping<GeoLocation>(m => m.MapFromAttributes())
+				.AddMapping<MockData.Domain.CustomGeoLocation>(m => m.MapFromAttributes())
 			);
 			Assert.IsTrue(x.Acknowledged, x.ConnectionStatus.ToString());
 

--- a/src/Tests/Nest.Tests.MockData/DataSources/GeoLocationSource.cs
+++ b/src/Tests/Nest.Tests.MockData/DataSources/GeoLocationSource.cs
@@ -6,12 +6,12 @@ using Nest.Tests.MockData.Domain;
 
 namespace Nest.Tests.MockData.DataSources
 {
-	public class GeoLocationSource : DatasourceBase<GeoLocation>
+	public class GeoLocationSource : DatasourceBase<Domain.CustomGeoLocation>
 	{
 		private Random mRandom = new Random(1337);
-		public override GeoLocation Next(IGenerationSession session)
+		public override Domain.CustomGeoLocation Next(IGenerationSession session)
 		{
-			return session.Single<GeoLocation>().Get();
+			return session.Single<Domain.CustomGeoLocation>().Get();
 		}
 
 	}

--- a/src/Tests/Nest.Tests.MockData/Domain/CustomGeoLocation.cs
+++ b/src/Tests/Nest.Tests.MockData/Domain/CustomGeoLocation.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Nest.Tests.MockData.Domain
 {
-	public class GeoLocation
+	public class CustomGeoLocation
 	{
 		public float lat { get; set; }
 		public float lon { get; set; }

--- a/src/Tests/Nest.Tests.MockData/Domain/ElasticsearchProject.cs
+++ b/src/Tests/Nest.Tests.MockData/Domain/ElasticsearchProject.cs
@@ -26,7 +26,7 @@ namespace Nest.Tests.MockData.Domain
 		public List<Person> NestedFollowers { get; set; }
 
 		[ElasticProperty(Type=FieldType.GeoPoint)]
-		public GeoLocation Origin { get; set; }
+		public CustomGeoLocation Origin { get; set; }
 		public DateTime StartedOn { get; set; }
 
 		[ElasticProperty(Type=FieldType.Ip)]

--- a/src/Tests/Nest.Tests.MockData/Domain/Person.cs
+++ b/src/Tests/Nest.Tests.MockData/Domain/Person.cs
@@ -16,6 +16,6 @@ namespace Nest.Tests.MockData.Domain
 		public string Email { get; set; }
 		public DateTime DateOfBirth { get; set; }
 		[ElasticProperty(Type = FieldType.GeoPoint)]
-		public GeoLocation PlaceOfBirth { get; set; }
+		public CustomGeoLocation PlaceOfBirth { get; set; }
 	}
 }

--- a/src/Tests/Nest.Tests.MockData/Nest.Tests.MockData.csproj
+++ b/src/Tests/Nest.Tests.MockData/Nest.Tests.MockData.csproj
@@ -100,7 +100,7 @@
     <Compile Include="Domain\BoolTerm.cs" />
     <Compile Include="Domain\GeoShape.cs" />
     <Compile Include="Domain\ElasticsearchProject.cs" />
-    <Compile Include="Domain\GeoLocation.cs" />
+    <Compile Include="Domain\CustomGeoLocation.cs" />
     <Compile Include="Domain\Person.cs" />
     <Compile Include="Domain\Product.cs" />
     <Compile Include="NestTestData.cs" />

--- a/src/Tests/Nest.Tests.MockData/NestTestData.cs
+++ b/src/Tests/Nest.Tests.MockData/NestTestData.cs
@@ -30,7 +30,7 @@ namespace Nest.Tests.MockData
 
 					});
 					x.AddFromAssemblyContainingType<Person>();
-					x.Include<GeoLocation>()
+					x.Include<CustomGeoLocation>()
 						.Setup(c => c.lat).Use<FloatSource>()
 						.Setup(c => c.lon).Use<FloatSource>();
 					x.Include<BoolTerm>()

--- a/src/Tests/Nest.Tests.Unit/Search/Sorting/SortTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Sorting/SortTests.cs
@@ -37,17 +37,17 @@ namespace Nest.Tests.Unit.Search.Sorting
 			Assert.True(json.JsonEquals(expected), json);
 		}
 
-	    [Test]
-	    public void TestSortWithUnmappedType()
-	    {
-            var s = new SearchDescriptor<ElasticsearchProject>()
-                .From(0)
-                .Size(10)
-                .Sort(sort => sort
-                    .OnField(e => e.DoubleValue)
-                    .UnmappedType(FieldType.Long)
-                );
-            var expected = @"
+		[Test]
+		public void TestSortWithUnmappedType()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.Sort(sort => sort
+					.OnField(e => e.DoubleValue)
+					.UnmappedType(FieldType.Long)
+				);
+			var expected = @"
                 {
                   from: 0,
                   size: 10,
@@ -57,9 +57,9 @@ namespace Nest.Tests.Unit.Search.Sorting
                     }
                   ]
                 }";
-            var json = TestElasticClient.Serialize(s);
-            Assert.True(json.JsonEquals(expected), json);
-	    }
+			var json = TestElasticClient.Serialize(s);
+			Assert.True(json.JsonEquals(expected), json);
+		}
 
 		[Test]
 		public void TestSortOnSortField()
@@ -91,19 +91,19 @@ namespace Nest.Tests.Unit.Search.Sorting
 			Assert.True(json.JsonEquals(expected), json);
 		}
 
-        [Test]
-        public void TestSortOnNestedField()
-        {
-            var s = new SearchDescriptor<ElasticsearchProject>()
-                .From(0)
-                .Size(10)
-                .Sort(sort => sort
-                    .OnField(e => e.Contributors.Suffix("age")) // Sort projects by oldest contributor
-                    .NestedMax()
-                    .Descending()
-                );
-            var json = TestElasticClient.Serialize(s);
-            var expected = @"
+		[Test]
+		public void TestSortOnNestedField()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.Sort(sort => sort
+					.OnField(e => e.Contributors.Suffix("age")) // Sort projects by oldest contributor
+					.NestedMax()
+					.Descending()
+				);
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"
                 {
                   from: 0,
                   size: 10,
@@ -116,8 +116,8 @@ namespace Nest.Tests.Unit.Search.Sorting
 					}
                   ]
                 }";
-            Assert.True(json.JsonEquals(expected), json);
-        }
+			Assert.True(json.JsonEquals(expected), json);
+		}
 
 		[Test]
 		public void TestSortAscending()
@@ -222,6 +222,40 @@ namespace Nest.Tests.Unit.Search.Sorting
 						 mode: ""max"",
 						 order: ""desc"",
 						 unit: ""km""
+					  }
+					}
+                  ]
+                }";
+			Assert.True(json.JsonEquals(expected), json);
+		}
+
+		[Test]
+		public void TestSortGeoMultiple()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.SortGeoDistance(sort => sort
+					.OnField(e => e.Origin)
+					.MissingLast()
+					.Descending()
+					.PinTo(GeoLocation.TryCreate(40, -70),GeoLocation.TryCreate(30.21, 1.21))
+					.Unit(GeoUnit.Miles)
+					.Mode(SortMode.Average)
+				);
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"
+                {
+                  from: 0,
+                  size: 10,
+                  sort: [
+					{
+					  _geo_distance: {
+					   ""origin"": [""40,-70"",""30.21,1.21""],
+						 missing: ""_last"",
+						 mode: ""avg"",
+						 order: ""desc"",
+						 unit: ""mi""
 					  }
 					}
                   ]


### PR DESCRIPTION
This utilizes the `Location` class from SolrNet to encode lat lon. 

origin: https://github.com/mausch/SolrNet/blob/master/SolrNet/Location.cs
ours: https://github.com/elasticsearch/elasticsearch-net/blob/1f8db7b8c72cc88ccedbc00bd9681f8e0f5c93d4/src/Nest/Domain/Geo/GeoLocation.cs

@mausch are you ok with us making us of it ?
