### PR TITLE
Add ability to configure id properties in code

### DIFF
--- a/src/Nest/Domain/Connection/IConnectionSettingsValues.cs
+++ b/src/Nest/Domain/Connection/IConnectionSettingsValues.cs
@@ -11,6 +11,7 @@ namespace Nest
 		ElasticInferrer Inferrer { get; }
 		FluentDictionary<Type, string> DefaultIndices { get; }
 		FluentDictionary<Type, string> DefaultTypeNames { get; }
+		FluentDictionary<Type, string> IdProperties { get; }
 		FluentDictionary<MemberInfo, PropertyMapping> PropertyMappings { get; }
 		string DefaultIndex { get; }
 		Func<string, string> DefaultPropertyNameInferrer { get; }

--- a/src/Nest/ExposedInternals/ElasticInferrer.cs
+++ b/src/Nest/ExposedInternals/ElasticInferrer.cs
@@ -127,6 +127,12 @@ namespace Nest
 		public string Id<T>(T obj) where T : class
 		{
 			if (obj == null) return null;
+			
+			string idProperty;
+			this._connectionSettings.IdProperties.TryGetValue(typeof(T), out idProperty);
+			if (!idProperty.IsNullOrEmpty())
+				return this.IdResolver.GetIdFor(obj, idProperty);
+			
 			return this.IdResolver.GetIdFor(obj);
 		}
 

--- a/src/Nest/Resolvers/IdResolver.cs
+++ b/src/Nest/Resolvers/IdResolver.cs
@@ -24,6 +24,23 @@ namespace Nest.Resolvers
 			return t => f(t);
 		}
 
+		public string GetIdFor<T>(T @object, string idProperty)
+		{
+			try
+			{
+				var value = @object
+					.GetType()
+					.GetProperty(idProperty)
+					.GetValue(@object, null);
+
+				return value.ToString();
+			}
+			catch
+			{
+				return null;
+			}
+		}
+
 		public string GetIdFor<T>(T @object)
 		{
 			if (@object == null)

--- a/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapIdPropertyForTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapIdPropertyForTests.cs
@@ -1,0 +1,123 @@
+﻿using FluentAssertions;
+using Elasticsearch.Net.Connection;
+using Nest.Tests.MockData.Domain;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nest.Tests.Unit.Internals.Inferno
+{
+	[TestFixture]
+	public class MapIdPropertyForTests : BaseJsonTests
+	{
+		[Test]
+		public void MapNumericIdProperty()
+		{
+			var settings = new ConnectionSettings()
+				.MapIdPropertyFor<ElasticsearchProject>(p => p.LongValue);
+
+			var client = new ElasticClient(settings, connection: new InMemoryConnection());
+
+			var project = new ElasticsearchProject { LongValue = 123 };
+
+			Assert.AreEqual(project.LongValue.ToString(), client.Infer.Id<ElasticsearchProject>(project));
+		}
+
+		[Test]
+		public void MapStringIdProperty()
+		{
+			var settings = new ConnectionSettings()
+				.MapIdPropertyFor<ElasticsearchProject>(p => p.Name);
+
+			var client = new ElasticClient(settings, connection: new InMemoryConnection());
+
+			var project = new ElasticsearchProject { Name = "foo" };
+
+			Assert.AreEqual(project.Name, client.Infer.Id<ElasticsearchProject>(project));
+		}
+
+		[Test]
+		public void MapIdPropertiesForMultipleTypes()
+		{
+			var settings = new ConnectionSettings()
+				.MapIdPropertyFor<ElasticsearchProject>(p => p.LongValue)
+				.MapIdPropertyFor<Person>(p => p.Id)
+				.MapIdPropertyFor<Product>(p => p.Name);
+
+			var client = new ElasticClient(settings, connection: new InMemoryConnection());
+
+			var project = new ElasticsearchProject { LongValue = 1 };
+			Assert.AreEqual(project.LongValue.ToString(), client.Infer.Id<ElasticsearchProject>(project));
+
+			var person = new Person { Id = 2 };
+			Assert.AreEqual(person.Id.ToString(), client.Infer.Id<Person>(person));
+
+			var product = new Product { Name = "foo" };
+			Assert.AreEqual(product.Name, client.Infer.Id<Product>(product));
+		}
+
+		[Test]
+		public void IdPropertyNotMapped_IdIsInferred()
+		{
+			var settings = new ConnectionSettings();
+			var client = new ElasticClient(settings, connection: new InMemoryConnection());
+			var project = new ElasticsearchProject { Id = 123 };
+
+			Assert.AreEqual(project.Id.ToString(), client.Infer.Id<ElasticsearchProject>(project));
+		}
+
+		[Test]
+		public void DifferentIdPropertyMappedTwice_ThrowsException()
+		{
+			var e = Assert.Throws<ArgumentException>(() =>
+			{
+				var settings = new ConnectionSettings()
+					.MapIdPropertyFor<ElasticsearchProject>(p => p.Id)
+					.MapIdPropertyFor<ElasticsearchProject>(p => p.Name);
+			});
+
+			e.Message
+				.Should()
+				.Be("Cannot map 'Name' as the id property for type 'ElasticsearchProject': it already has 'Id' mapped.");
+		}
+
+		[Test]
+		public void SameIdPropertyMappedTwice_DoesNotThrowException()
+		{
+			Assert.DoesNotThrow(() =>
+			{
+				var settings = new ConnectionSettings()
+					.MapIdPropertyFor<ElasticsearchProject>(p => p.Id)
+					.MapIdPropertyFor<ElasticsearchProject>(p => p.Id);
+			});
+		}
+
+
+		[ElasticType(IdProperty = "Name")]
+		public class IdPropertyTestWithAttribute
+		{
+			public string Id { get; set; }
+			public string Name { get; set; }
+		}
+
+		[Test]
+		public void IdPropertyMapped_And_TypeHasIdPropertyAttribute_MappingTakesPrecedence()
+		{
+			var settings = new ConnectionSettings()
+				.MapIdPropertyFor<IdPropertyTestWithAttribute>(o => o.Id);
+
+			var client = new ElasticClient(settings, connection: new InMemoryConnection());
+
+			var doc = new IdPropertyTestWithAttribute
+			{
+				Id = "should-be-the-id",
+				Name = "should-not-be-the-id"
+			};
+
+			Assert.AreEqual(doc.Id, client.Infer.Id<IdPropertyTestWithAttribute>(doc));
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Internals\Exceptions\BadQueryServerExceptionTests.cs" />
     <Compile Include="Internals\Inferno\EscapedFormatTests.cs" />
     <Compile Include="Internals\Inferno\HostNameWithPathTests.cs" />
+    <Compile Include="Internals\Inferno\MapIdPropertyForTests.cs" />
     <Compile Include="Internals\Inferno\MapPropertyIgnoreTests.cs" />
     <Compile Include="Internals\Inferno\MapTypeNamesTests.cs" />
     <Compile Include="Internals\Inferno\MapPropertyNamesForTests.cs" />


### PR DESCRIPTION
Previously, the only way to specify an id property was to use the  `ElasticTypeAttribute`:

`[ElasticType(IdProperty="AlternateId"]`

This PR introduces an alternative way to configure id properties, via code:

```
var settings = new ConnectionSettings()
    .MapIdPropertyFor<Foo>(o => o.AlternateId);
```

**Note:** Mapping two different id properties on the same type is an error:

```
var settings = new ConnectionSettings()
    .MapIdPropertyFor<Foo>(o => o.AlternateId)
    .MapIdPropertyFor<Foo>(o => o.AnotherId);
```

and will cause an `ArgumentException` to be thrown.

**Question:**  How should we treat the case where a type has an Id property set via `ElasticTypeAttribute` and an id property is mapped in code?  [Currently, the code mapping will take precedence](https://github.com/elasticsearch/elasticsearch-net/blob/feature/idproperty-in-code/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapIdPropertyForTests.cs#L107), but I wonder if this should be an error instead?

Closes #407
