### PR TITLE
Code cleanup. Removed not used namespaces/using

### DIFF
--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Allow404/ApiEndpointsThatAllow404.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Allow404/ApiEndpointsThatAllow404.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Runtime.InteropServices;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.LowLevelClient.Overrides.Allow404
 {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/ClearCacheDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/ClearCacheDescriptorOverrides.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
 {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/DeleteWarmerDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/DeleteWarmerDescriptorOverrides.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
 {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/MultiTermVectorsDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/MultiTermVectorsDescriptorOverrides.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
 {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/NodesHotThreadsDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/NodesHotThreadsDescriptorOverrides.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
 {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/PutTemplateDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/PutTemplateDescriptorOverrides.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
 {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/ScrollDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/ScrollDescriptorOverrides.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
 {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/SearchDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/SearchDescriptorOverrides.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
 {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Program.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Program.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace CodeGeneration.LowLevelClient
 {

--- a/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Domain/TestSuite.cs
+++ b/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Domain/TestSuite.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using CsQuery.ExtensionMethods.Internal;
 

--- a/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Domain/YamlDefinition.cs
+++ b/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Domain/YamlDefinition.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.YamlTestsRunner.Domain
 {

--- a/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Domain/YamlSpecification.cs
+++ b/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Domain/YamlSpecification.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace CodeGeneration.YamlTestsRunner.Domain
 {

--- a/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Extensions.cs
+++ b/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Extensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Program.cs
+++ b/src/CodeGeneration/CodeGeneration.YamlTestsRunner/Program.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CodeGeneration.YamlTestsRunner
+﻿namespace CodeGeneration.YamlTestsRunner
 {
 	class Program
 	{

--- a/src/CodeGeneration/CodeGeneration.YamlTestsRunner/YamlTestsGenerator.cs
+++ b/src/CodeGeneration/CodeGeneration.YamlTestsRunner/YamlTestsGenerator.cs
@@ -5,19 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using CodeGeneration.YamlTestsRunner.Domain;
 using CsQuery;
 using CsQuery.ExtensionMethods.Internal;
-using FubuCore.Util;
 using FubuCsProjFile;
 using ShellProgressBar;
 using Xipton.Razor;
-using YamlDotNet;
-using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
 
 namespace CodeGeneration.YamlTestsRunner
@@ -25,14 +19,14 @@ namespace CodeGeneration.YamlTestsRunner
 	using YamlTestSuite = Dictionary<string, object>;
 	public static class YamlTestsGenerator
 	{
-		private readonly static string _listingUrl = "https://github.com/elasticsearch/elasticsearch/tree/v1.3.2/rest-api-spec/test";
-		private readonly static string _rawUrlPrefix = "https://raw.github.com/elasticsearch/elasticsearch/v1.3.2/rest-api-spec/test/";
-		private readonly static string _testProjectFolder = @"..\..\..\..\..\src\Tests\Elasticsearch.Net.Integration.Yaml\";
-		private readonly static string _rawClientInterface = @"..\..\..\..\..\src\Elasticsearch.Net\IElasticsearchClient.generated.cs";
-		private readonly static string _viewFolder = @"..\..\Views\";
-		private readonly static string _cacheFolder = @"..\..\YamlCache\";
-		
-		private static readonly RazorMachine _razorMachine;
+	    private const string _listingUrl = "https://github.com/elasticsearch/elasticsearch/tree/v1.3.2/rest-api-spec/test";
+	    private const string _rawUrlPrefix = "https://raw.github.com/elasticsearch/elasticsearch/v1.3.2/rest-api-spec/test/";
+	    private const string _testProjectFolder = @"..\..\..\..\..\src\Tests\Elasticsearch.Net.Integration.Yaml\";
+	    private const string _rawClientInterface = @"..\..\..\..\..\src\Elasticsearch.Net\IElasticsearchClient.generated.cs";
+	    private const string _viewFolder = @"..\..\Views\";
+	    private const string _cacheFolder = @"..\..\YamlCache\";
+
+	    private static readonly RazorMachine _razorMachine;
 		private static readonly Assembly _assembly;
 		public static IEnumerable<string> RawElasticCalls;
 

--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TSocketSettings.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TSocketSettings.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Elasticsearch.Net.Connection.Thrift.Transport
+﻿namespace Elasticsearch.Net.Connection.Thrift.Transport
 {
 	public class TSocketSettings
 	{

--- a/src/Elasticsearch.Net/Extensions/DateExtensions.cs
+++ b/src/Elasticsearch.Net/Extensions/DateExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Elasticsearch.Net
 {

--- a/src/Elasticsearch.Net/Extensions/NameValueCollectionExtensions.cs
+++ b/src/Elasticsearch.Net/Extensions/NameValueCollectionExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Text;
 using Elasticsearch.Net.Serialization;
 
 namespace Elasticsearch.Net

--- a/src/Elasticsearch.Net/Extensions/TypeExtensions.cs
+++ b/src/Elasticsearch.Net/Extensions/TypeExtensions.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using Elasticsearch.Net.Connection;
 
 namespace Elasticsearch.Net
 {

--- a/src/Nest/ConvenienceExtensions/AliasExtensions.cs
+++ b/src/Nest/ConvenienceExtensions/AliasExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/Nest/ConvenienceExtensions/DeleteIndexExtensions.cs
+++ b/src/Nest/ConvenienceExtensions/DeleteIndexExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nest

--- a/src/Nest/ConvenienceExtensions/SerializerExtensions.cs
+++ b/src/Nest/ConvenienceExtensions/SerializerExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
 
 namespace Nest.SerializationExtensions

--- a/src/Nest/DSL/Aggregations/AverageAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/AverageAggregationDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Aggregations/BucketAggregationBaseDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/BucketAggregationBaseDescriptor.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Aggregations/CardinalityAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/CardinalityAggregationDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Aggregations/ChildrenAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/ChildrenAggregationDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Aggregations/GeoBoundsAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/GeoBoundsAggregationDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Aggregations/GeoHashAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/GeoHashAggregationDescriptor.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Aggregations/MaxAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/MaxAggregationDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Aggregations/MetricAggregationBaseDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/MetricAggregationBaseDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Aggregations/MinAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/MinAggregationDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Aggregations/MissingAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/MissingAggregationDescriptor.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Aggregations/PercentileRanksAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/PercentileRanksAggregationDescriptor.cs
@@ -1,9 +1,6 @@
 ﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Aggregations/ReverseNestedAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/ReverseNestedAggregationDescriptor.cs
@@ -1,10 +1,7 @@
 ﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Aggregations/ScriptedMetricAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/ScriptedMetricAggregationDescriptor.cs
@@ -2,8 +2,6 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Aggregations/StatsAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/StatsAggregationDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Aggregations/SumAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/SumAggregationDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Aggregations/TopHitsAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/TopHitsAggregationDescriptor.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Aggregations/ValueCountAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/ValueCountAggregationDescriptor.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/AliasDescriptor.cs
+++ b/src/Nest/DSL/AliasDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/AliasExistsDescriptor.cs
+++ b/src/Nest/DSL/AliasExistsDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/AnalyzeDescriptor.cs
+++ b/src/Nest/DSL/AnalyzeDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/CatAliasesDescriptor.cs
+++ b/src/Nest/DSL/CatAliasesDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatAllocationDescriptor.cs
+++ b/src/Nest/DSL/CatAllocationDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatCountDescriptor.cs
+++ b/src/Nest/DSL/CatCountDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatFielddataDescriptor.cs
+++ b/src/Nest/DSL/CatFielddataDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatHealthDescriptor.cs
+++ b/src/Nest/DSL/CatHealthDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatIndicesDescriptor.cs
+++ b/src/Nest/DSL/CatIndicesDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatMasterDescriptor.cs
+++ b/src/Nest/DSL/CatMasterDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatNodesDescriptor.cs
+++ b/src/Nest/DSL/CatNodesDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatPendingTasksDescriptor.cs
+++ b/src/Nest/DSL/CatPendingTasksDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatPluginsDescriptor.cs
+++ b/src/Nest/DSL/CatPluginsDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatRecoveryDescriptor.cs
+++ b/src/Nest/DSL/CatRecoveryDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatShardsDescriptor.cs
+++ b/src/Nest/DSL/CatShardsDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CatThreadPoolDescriptor.cs
+++ b/src/Nest/DSL/CatThreadPoolDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/ClearCacheDescriptor.cs
+++ b/src/Nest/DSL/ClearCacheDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/ClearScrollDescriptor.cs
+++ b/src/Nest/DSL/ClearScrollDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/CloseIndexDescriptor.cs
+++ b/src/Nest/DSL/CloseIndexDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Cluster/AllocateClusterRerouteCommand.cs
+++ b/src/Nest/DSL/Cluster/AllocateClusterRerouteCommand.cs
@@ -1,9 +1,4 @@
-﻿using Nest.Resolvers.Converters;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Cluster/AllocateClusterRerouteCommandDescriptor.cs
+++ b/src/Nest/DSL/Cluster/AllocateClusterRerouteCommandDescriptor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public class AllocateClusterRerouteCommandDescriptor
 	{

--- a/src/Nest/DSL/Cluster/CancelClusterRerouteCommand.cs
+++ b/src/Nest/DSL/Cluster/CancelClusterRerouteCommand.cs
@@ -1,9 +1,4 @@
-﻿using Nest.Resolvers.Converters;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Cluster/CancelClusterRerouteCommandDescriptor.cs
+++ b/src/Nest/DSL/Cluster/CancelClusterRerouteCommandDescriptor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public class CancelClusterRerouteCommandDescriptor
 	{

--- a/src/Nest/DSL/Cluster/IClusterRerouteCommand.cs
+++ b/src/Nest/DSL/Cluster/IClusterRerouteCommand.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IClusterRerouteCommand
 	{

--- a/src/Nest/DSL/Cluster/MoveClusterRerouteCommand.cs
+++ b/src/Nest/DSL/Cluster/MoveClusterRerouteCommand.cs
@@ -1,9 +1,4 @@
-﻿using Nest.Resolvers.Converters;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Cluster/MoveClusterRerouteCommandDescriptor.cs
+++ b/src/Nest/DSL/Cluster/MoveClusterRerouteCommandDescriptor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public class MoveClusterRerouteCommandDescriptor
 	{

--- a/src/Nest/DSL/ClusterGetSettingsDescriptor.cs
+++ b/src/Nest/DSL/ClusterGetSettingsDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/ClusterHealthDescriptor.cs
+++ b/src/Nest/DSL/ClusterHealthDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/ClusterPendingTasksDescriptor.cs
+++ b/src/Nest/DSL/ClusterPendingTasksDescriptor.cs
@@ -1,8 +1,4 @@
 ﻿using Elasticsearch.Net;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/ClusterRerouteDescriptor.cs
+++ b/src/Nest/DSL/ClusterRerouteDescriptor.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/ClusterSettingsDescriptor.cs
+++ b/src/Nest/DSL/ClusterSettingsDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/ClusterStatsDescriptor.cs
+++ b/src/Nest/DSL/ClusterStatsDescriptor.cs
@@ -1,8 +1,4 @@
 ﻿using Elasticsearch.Net;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/CreateIndexDescriptor.cs
+++ b/src/Nest/DSL/CreateIndexDescriptor.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/CreateRepositoryDescriptor.cs
+++ b/src/Nest/DSL/CreateRepositoryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/DeleteAliasDescriptor.cs
+++ b/src/Nest/DSL/DeleteAliasDescriptor.cs
@@ -1,8 +1,4 @@
 ﻿using Elasticsearch.Net;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/DeleteByQueryDescriptor.cs
+++ b/src/Nest/DSL/DeleteByQueryDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/DeleteDescriptor.cs
+++ b/src/Nest/DSL/DeleteDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/DeleteIndexDescriptor.cs
+++ b/src/Nest/DSL/DeleteIndexDescriptor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/DeleteMappingDescriptor.cs
+++ b/src/Nest/DSL/DeleteMappingDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/DeleteRepositoryDescriptor.cs
+++ b/src/Nest/DSL/DeleteRepositoryDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/DeleteScriptDescriptor.cs
+++ b/src/Nest/DSL/DeleteScriptDescriptor.cs
@@ -1,4 +1,3 @@
-using System;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/DeleteSearchTemplateDescriptor.cs
+++ b/src/Nest/DSL/DeleteSearchTemplateDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/DeleteSnapshotDescriptor.cs
+++ b/src/Nest/DSL/DeleteSnapshotDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/DeleteTemplateDescriptor.cs
+++ b/src/Nest/DSL/DeleteTemplateDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/DeleteWarmerDescriptor.cs
+++ b/src/Nest/DSL/DeleteWarmerDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/DocumentExistsDescriptor.cs
+++ b/src/Nest/DSL/DocumentExistsDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Facets/BaseFacetDescriptor.cs
+++ b/src/Nest/DSL/Facets/BaseFacetDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Nest

--- a/src/Nest/DSL/Facets/DateExpressionRange.cs
+++ b/src/Nest/DSL/Facets/DateExpressionRange.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Facets/DateHistogramFacetDescriptor.cs
+++ b/src/Nest/DSL/Facets/DateHistogramFacetDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Facets/DateInterval.cs
+++ b/src/Nest/DSL/Facets/DateInterval.cs
@@ -1,7 +1,4 @@
-﻿
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/DSL/Facets/DateRounding.cs
+++ b/src/Nest/DSL/Facets/DateRounding.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/DSL/Facets/FacetContainer.cs
+++ b/src/Nest/DSL/Facets/FacetContainer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Facets/GeoDistanceFacetDescriptor.cs
+++ b/src/Nest/DSL/Facets/GeoDistanceFacetDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using System.Linq.Expressions;
 using System.Globalization;

--- a/src/Nest/DSL/Facets/HistogramFacetDescriptor.cs
+++ b/src/Nest/DSL/Facets/HistogramFacetDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Facets/Ip4Range.cs
+++ b/src/Nest/DSL/Facets/Ip4Range.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Facets/Range.cs
+++ b/src/Nest/DSL/Facets/Range.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Facets/RangeFacetDescriptor.cs
+++ b/src/Nest/DSL/Facets/RangeFacetDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using System.Linq.Expressions;
 

--- a/src/Nest/DSL/Facets/TermsOrder.cs
+++ b/src/Nest/DSL/Facets/TermsOrder.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/DSL/Facets/TermsStatsFacetDescriptor.cs
+++ b/src/Nest/DSL/Facets/TermsStatsFacetDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;

--- a/src/Nest/DSL/Facets/TermsStatsOrder.cs
+++ b/src/Nest/DSL/Facets/TermsStatsOrder.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/DSL/Filter/AndFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/AndFilterDescriptor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Nest.Resolvers.Converters;

--- a/src/Nest/DSL/Filter/ConditionlessFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/ConditionlessFilterDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/ExistsFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/ExistsFilterDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/FilterBase.cs
+++ b/src/Nest/DSL/Filter/FilterBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/GeoBoundingBoxFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoBoundingBoxFilterDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/GeoDistanceFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoDistanceFilterDescriptor.cs
@@ -1,9 +1,5 @@
-﻿//using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System.Globalization;
-using System;
 using Newtonsoft.Json.Converters;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/GeoDistanceRangeFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoDistanceRangeFilterDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System.Globalization;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/GeoIndexedShapeFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoIndexedShapeFilterDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Filter/GeoPolygonFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoPolygonFilterDescriptor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Filter/GeoShapeCircleFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoShapeCircleFilterDescriptor.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest.Resolvers;
-using Nest.Resolvers.Converters;
-using Nest.Resolvers.Converters.Filters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/GeoShapeEnvelopeFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoShapeEnvelopeFilterDescriptor.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest.Resolvers;
-using Nest.Resolvers.Converters;
-using Nest.Resolvers.Converters.Filters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/GeoShapeLineStringFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoShapeLineStringFilterDescriptor.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest.Resolvers;
-using Nest.Resolvers.Converters;
-using Nest.Resolvers.Converters.Filters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/GeoShapeMultiLineStringFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoShapeMultiLineStringFilterDescriptor.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest.Resolvers;
-using Nest.Resolvers.Converters;
-using Nest.Resolvers.Converters.Filters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/GeoShapeMultiPointFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoShapeMultiPointFilterDescriptor.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest.Resolvers;
-using Nest.Resolvers.Converters;
-using Nest.Resolvers.Converters.Filters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/GeoShapeMultiPolygonFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoShapeMultiPolygonFilterDescriptor.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest.Resolvers;
-using Nest.Resolvers.Converters;
-using Nest.Resolvers.Converters.Filters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/GeoShapePointFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoShapePointFilterDescriptor.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest.Resolvers;
-using Nest.Resolvers.Converters;
-using Nest.Resolvers.Converters.Filters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/GeoShapePolygonFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/GeoShapePolygonFilterDescriptor.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Nest.Resolvers;
-using Nest.Resolvers.Converters;
-using Nest.Resolvers.Converters.Filters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/HasChildFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/HasChildFilterDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Filter/HasParentFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/HasParentFilterDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Filter/IFilterContainer.cs
+++ b/src/Nest/DSL/Filter/IFilterContainer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Nest.DSL.Visitor;
+﻿using Nest.DSL.Visitor;
 using Nest.Resolvers.Converters;
 using Nest.Resolvers.Converters.Filters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Filter/INotFilter.cs
+++ b/src/Nest/DSL/Filter/INotFilter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Nest.Resolvers.Converters;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/IdsFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/IdsFilterDescriptor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Filter/IndicesFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/IndicesFilterDescriptor.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 
 namespace Nest

--- a/src/Nest/DSL/Filter/LimitFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/LimitFilterDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/MatchAllFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/MatchAllFilterDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/MissingFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/MissingFilterDescriptor.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/NestedFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/NestedFilterDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Filter/OrFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/OrFilterDescriptor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Nest.Resolvers.Converters;

--- a/src/Nest/DSL/Filter/PrefixFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/PrefixFilterDescriptor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/QueryFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/QueryFilterDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Nest.Resolvers.Converters;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/RangeFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/RangeFilterDescriptor.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Filter/RawFilter.cs
+++ b/src/Nest/DSL/Filter/RawFilter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Nest.Resolvers.Converters;
 
 namespace Nest

--- a/src/Nest/DSL/Filter/RegexpFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/RegexpFilterDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using System.Linq.Expressions;
 

--- a/src/Nest/DSL/Filter/ScriptFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/ScriptFilterDescriptor.cs
@@ -1,7 +1,5 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Filter/TermFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/TermFilterDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Filter/TermsFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/TermsFilterDescriptor.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nest.Resolvers.Converters.Filters;

--- a/src/Nest/DSL/Filter/TermsLookupFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/TermsLookupFilterDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Filter/TypeFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/TypeFilterDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/FlushDescriptor.cs
+++ b/src/Nest/DSL/FlushDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetAliasDescriptor.cs
+++ b/src/Nest/DSL/GetAliasDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetAliasesDescriptor.cs
+++ b/src/Nest/DSL/GetAliasesDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetDescriptor.cs
+++ b/src/Nest/DSL/GetDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetFieldMappingDescriptor.cs
+++ b/src/Nest/DSL/GetFieldMappingDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Elasticsearch.Net;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/GetIndexDescriptor.cs
+++ b/src/Nest/DSL/GetIndexDescriptor.cs
@@ -1,7 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/GetIndexSettingsDescriptor.cs
+++ b/src/Nest/DSL/GetIndexSettingsDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetMappingDescriptor.cs
+++ b/src/Nest/DSL/GetMappingDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetRepositoryDescriptor.cs
+++ b/src/Nest/DSL/GetRepositoryDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetSearchTemplateDescriptor.cs
+++ b/src/Nest/DSL/GetSearchTemplateDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/GetSnapshotDescriptor.cs
+++ b/src/Nest/DSL/GetSnapshotDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetTemplateDescriptor.cs
+++ b/src/Nest/DSL/GetTemplateDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/GetWarmerDescriptor.cs
+++ b/src/Nest/DSL/GetWarmerDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/IndexDescriptor.cs
+++ b/src/Nest/DSL/IndexDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/IndexExistsDescriptor.cs
+++ b/src/Nest/DSL/IndexExistsDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/IndicesStatusDescriptor.cs
+++ b/src/Nest/DSL/IndicesStatusDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/InfoDescriptor.cs
+++ b/src/Nest/DSL/InfoDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Mapping/AnalysisDescriptor.cs
+++ b/src/Nest/DSL/Mapping/AnalysisDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/DSL/MoreLikeThisDescriptor.cs
+++ b/src/Nest/DSL/MoreLikeThisDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/MultiPercolate/IPercolateOperation.cs
+++ b/src/Nest/DSL/MultiPercolate/IPercolateOperation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/MultiPercolateDescriptor.cs
+++ b/src/Nest/DSL/MultiPercolateDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/MultiSearchDescriptor.cs
+++ b/src/Nest/DSL/MultiSearchDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/NodesHotThreadsDescriptor.cs
+++ b/src/Nest/DSL/NodesHotThreadsDescriptor.cs
@@ -1,10 +1,4 @@
-﻿
-using Elasticsearch.Net;
-using Elasticsearch.Net.Serialization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/NodesShutdownDescriptor.cs
+++ b/src/Nest/DSL/NodesShutdownDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/OpenIndexDescriptor.cs
+++ b/src/Nest/DSL/OpenIndexDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/OptimizeDescriptor.cs
+++ b/src/Nest/DSL/OptimizeDescriptor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Paths/DocumentOptionalPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/DocumentOptionalPathDescriptor.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Elasticsearch.Net;
 
 namespace Nest

--- a/src/Nest/DSL/Paths/DocumentPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/DocumentPathDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Paths/FixedIndexTypePathDescriptor.cs
+++ b/src/Nest/DSL/Paths/FixedIndexTypePathDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 
 namespace Nest

--- a/src/Nest/DSL/Paths/IndexNamePathDescriptor.cs
+++ b/src/Nest/DSL/Paths/IndexNamePathDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 
 namespace Nest

--- a/src/Nest/DSL/Paths/IndexOptionalNamePathDescriptor.cs
+++ b/src/Nest/DSL/Paths/IndexOptionalNamePathDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 
 namespace Nest

--- a/src/Nest/DSL/Paths/IndexOptionalPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/IndexOptionalPathDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 
 namespace Nest

--- a/src/Nest/DSL/Paths/IndexPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/IndexPathDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 
 namespace Nest

--- a/src/Nest/DSL/Paths/IndexTypePathDescriptor.cs
+++ b/src/Nest/DSL/Paths/IndexTypePathDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 
 namespace Nest

--- a/src/Nest/DSL/Paths/IndicesOptionalTypesOptionalFieldPathDecriptor.cs
+++ b/src/Nest/DSL/Paths/IndicesOptionalTypesOptionalFieldPathDecriptor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Elasticsearch.Net;
-using Nest.Resolvers;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Paths/NamePathDescriptor.cs
+++ b/src/Nest/DSL/Paths/NamePathDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Paths/NodeIdOptionalDescriptor.cs
+++ b/src/Nest/DSL/Paths/NodeIdOptionalDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Paths/RepositoryOptionalPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/RepositoryOptionalPathDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Paths/RepositoryPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/RepositoryPathDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Paths/RepositorySnapshotOptionalPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/RepositorySnapshotOptionalPathDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Paths/RepositorySnapshotPathDescriptor.cs
+++ b/src/Nest/DSL/Paths/RepositorySnapshotPathDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/PercolateCountDescriptor.cs
+++ b/src/Nest/DSL/PercolateCountDescriptor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using Elasticsearch.Net;
 using Nest.DSL.Descriptors;

--- a/src/Nest/DSL/PercolateDescriptor.cs
+++ b/src/Nest/DSL/PercolateDescriptor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using Elasticsearch.Net;
 using Nest.DSL.Descriptors;

--- a/src/Nest/DSL/PingDescriptor.cs
+++ b/src/Nest/DSL/PingDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/PutAliasDescriptor.cs
+++ b/src/Nest/DSL/PutAliasDescriptor.cs
@@ -1,9 +1,6 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/PutScriptDescriptor.cs
+++ b/src/Nest/DSL/PutScriptDescriptor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/PutSearchTemplateDescriptor.cs
+++ b/src/Nest/DSL/PutSearchTemplateDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/PutTemplateDescriptor.cs
+++ b/src/Nest/DSL/PutTemplateDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/PutWarmerDescriptor.cs
+++ b/src/Nest/DSL/PutWarmerDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Query/BoostingQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/BoostingQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Query/CommonTermsQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/CommonTermsQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Query/ConditionlessQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/ConditionlessQueryDescriptor.cs
@@ -1,7 +1,4 @@
-﻿
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/ConstantScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/ConstantScoreQueryDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Query/CustomBoostFactorQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/CustomBoostFactorQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Query/CustomFiltersScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/CustomFiltersScoreQueryDescriptor.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using Nest.DSL.Query;

--- a/src/Nest/DSL/Query/CustomScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/CustomScoreQueryDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Query/FilterScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FilterScoreQueryDescriptor.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest.DSL.Query
 {

--- a/src/Nest/DSL/Query/FilteredQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FilteredQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;

--- a/src/Nest/DSL/Query/Functions/FieldValueFactorDescriptor.cs
+++ b/src/Nest/DSL/Query/Functions/FieldValueFactorDescriptor.cs
@@ -1,10 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/Functions/FunctionScoreFunctionsDescriptor.cs
+++ b/src/Nest/DSL/Query/Functions/FunctionScoreFunctionsDescriptor.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/Functions/RandomScoreFunction.cs
+++ b/src/Nest/DSL/Query/Functions/RandomScoreFunction.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Query/FuzzyDateQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FuzzyDateQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Query/FuzzyNumericQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FuzzyNumericQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Query/FuzzyQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FuzzyQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Query/GeoShapeCircleQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/GeoShapeCircleQueryDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Query/GeoShapeEnvelopeQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/GeoShapeEnvelopeQueryDescriptor.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using Nest.DSL.Query.Behaviour;
-using Nest.Resolvers;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/GeoShapeLineStringQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/GeoShapeLineStringQueryDescriptor.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using Nest.DSL.Query.Behaviour;
-using Nest.Resolvers;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/GeoShapeMultiLineStringQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/GeoShapeMultiLineStringQueryDescriptor.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using Nest.DSL.Query.Behaviour;
-using Nest.Resolvers;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/GeoShapeMultiPointQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/GeoShapeMultiPointQueryDescriptor.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using Nest.DSL.Query.Behaviour;
-using Nest.Resolvers;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/GeoShapeMultiPolygonQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/GeoShapeMultiPolygonQueryDescriptor.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using Nest.DSL.Query.Behaviour;
-using Nest.Resolvers;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/GeoShapePointQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/GeoShapePointQueryDescriptor.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using Nest.DSL.Query.Behaviour;
-using Nest.Resolvers;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/GeoShapePolygonQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/GeoShapePolygonQueryDescriptor.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using Nest.DSL.Query.Behaviour;
-using Nest.Resolvers;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/HasChildQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/HasChildQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;

--- a/src/Nest/DSL/Query/HasParentQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/HasParentQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;

--- a/src/Nest/DSL/Query/IQuery.cs
+++ b/src/Nest/DSL/Query/IQuery.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IQuery
 	{

--- a/src/Nest/DSL/Query/IdsQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/IdsQueryDescriptor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Query/IndicesQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/IndicesQueryDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;

--- a/src/Nest/DSL/Query/MatchAllQuery.cs
+++ b/src/Nest/DSL/Query/MatchAllQuery.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Query/MatchPhrasePrefixQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MatchPhrasePrefixQueryDescriptor.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// A Query that matches documents containing a particular sequence of terms.

--- a/src/Nest/DSL/Query/MatchPhraseQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MatchPhraseQueryDescriptor.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// A Query that matches documents containing a particular sequence of terms. A PhraseQuery is built by QueryParser for input like "new york".

--- a/src/Nest/DSL/Query/MatchQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MatchQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.DSL.Query.Behaviour;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Query/NestedQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/NestedQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Query/PrefixQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/PrefixQueryDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.DSL.Query.Behaviour;
+﻿using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/DSL/Query/QueryContainer.cs
+++ b/src/Nest/DSL/Query/QueryContainer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using Nest.DSL.Visitor;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Query/QueryDescriptor.cs
+++ b/src/Nest/DSL/Query/QueryDescriptor.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using System.Linq.Expressions;
 

--- a/src/Nest/DSL/Query/RangeQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/RangeQueryDescriptor.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Query/RegexpQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/RegexpQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;
 using System.Linq.Expressions;

--- a/src/Nest/DSL/Query/SpanFirstQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/SpanFirstQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Query/SpanMultiTermQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/SpanMultiTermQueryDescriptor.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Query/SpanNotQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/SpanNotQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Query/SpanQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/SpanQueryDescriptor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Nest.Resolvers.Converters;

--- a/src/Nest/DSL/Query/SpanTermQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/SpanTermQueryDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.DSL.Query.Behaviour;
+﻿using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/Query/SubDescriptors/ExternalFieldDeclaration.cs
+++ b/src/Nest/DSL/Query/SubDescriptors/ExternalFieldDeclaration.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
-
-namespace Nest
+﻿namespace Nest
 {
 	public class ExternalFieldDeclaration : IExternalFieldDeclaration
 	{

--- a/src/Nest/DSL/Query/TermQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/TermQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Query/TopChildrenQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/TopChildrenQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;

--- a/src/Nest/DSL/Query/WildcardQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/WildcardQueryDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Nest.DSL.Query.Behaviour;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/RecoveryStatusDescriptor.cs
+++ b/src/Nest/DSL/RecoveryStatusDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/RefreshDescriptor.cs
+++ b/src/Nest/DSL/RefreshDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/RegisterPercolatorDescriptor.cs
+++ b/src/Nest/DSL/RegisterPercolatorDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Reindex/ReindexDescriptor.cs
+++ b/src/Nest/DSL/Reindex/ReindexDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 namespace Nest
 {
 	public class ReindexDescriptor<T> where T : class

--- a/src/Nest/DSL/Repository/AzureRepositoryDescriptor.cs
+++ b/src/Nest/DSL/Repository/AzureRepositoryDescriptor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Repository/FileSystemRepositoryDescriptor.cs
+++ b/src/Nest/DSL/Repository/FileSystemRepositoryDescriptor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Repository/HdfsRepositoryDescriptor.cs
+++ b/src/Nest/DSL/Repository/HdfsRepositoryDescriptor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Repository/S3RepositoryDescriptor.cs
+++ b/src/Nest/DSL/Repository/S3RepositoryDescriptor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Rescore/RescoreDescriptor.cs
+++ b/src/Nest/DSL/Rescore/RescoreDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/ScrollDescriptor.cs
+++ b/src/Nest/DSL/ScrollDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Search/HighlightDescriptor.cs
+++ b/src/Nest/DSL/Search/HighlightDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/Search/SortFieldDescriptor.cs
+++ b/src/Nest/DSL/Search/SortFieldDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
 using System.Linq.Expressions;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/Search/SortScriptDescriptor.cs
+++ b/src/Nest/DSL/Search/SortScriptDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest.DSL.Descriptors

--- a/src/Nest/DSL/SearchExistsDescriptor.cs
+++ b/src/Nest/DSL/SearchExistsDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/SearchShardsDescriptor.cs
+++ b/src/Nest/DSL/SearchShardsDescriptor.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
-using Nest.Resolvers.Converters;
-using System.Linq.Expressions;
-using Nest.DSL.Descriptors;
 
 namespace Nest
 {

--- a/src/Nest/DSL/SearchTemplateDescriptor.cs
+++ b/src/Nest/DSL/SearchTemplateDescriptor.cs
@@ -1,12 +1,8 @@
 ﻿using Elasticsearch.Net;
-using Nest.DSL.Descriptors;
-using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/SegmentsDescriptor.cs
+++ b/src/Nest/DSL/SegmentsDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/SimilarityDescriptor.cs
+++ b/src/Nest/DSL/SimilarityDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/DSL/SnapshotStatusDescriptor.cs
+++ b/src/Nest/DSL/SnapshotStatusDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/SourceDescriptor.cs
+++ b/src/Nest/DSL/SourceDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Suggest/CompletionSuggestDescriptor.cs
+++ b/src/Nest/DSL/Suggest/CompletionSuggestDescriptor.cs
@@ -1,7 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Nest

--- a/src/Nest/DSL/Suggest/Context/CategorySuggestDescriptor.cs
+++ b/src/Nest/DSL/Suggest/Context/CategorySuggestDescriptor.cs
@@ -1,9 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Suggest/Context/GeoLocationSuggestDescriptor.cs
+++ b/src/Nest/DSL/Suggest/Context/GeoLocationSuggestDescriptor.cs
@@ -1,9 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Suggest/Context/ISuggestContext.cs
+++ b/src/Nest/DSL/Suggest/Context/ISuggestContext.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Suggest/FuzzySuggestDescriptor.cs
+++ b/src/Nest/DSL/Suggest/FuzzySuggestDescriptor.cs
@@ -1,8 +1,5 @@
 ﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Suggest/PhraseSuggestCollateDescriptor.cs
+++ b/src/Nest/DSL/Suggest/PhraseSuggestCollateDescriptor.cs
@@ -1,8 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/Suggest/PhraseSuggestHighlightDescriptor.cs
+++ b/src/Nest/DSL/Suggest/PhraseSuggestHighlightDescriptor.cs
@@ -1,9 +1,4 @@
-﻿using Nest.Resolvers.Converters;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/DSL/SuggestDescriptor.cs
+++ b/src/Nest/DSL/SuggestDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/TemplateExistsDescriptor.cs
+++ b/src/Nest/DSL/TemplateExistsDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/TermVectorDescriptor.cs
+++ b/src/Nest/DSL/TermVectorDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/TypeExistsDescriptor.cs
+++ b/src/Nest/DSL/TypeExistsDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/DSL/UnregisterPercolatorDescriptor.cs
+++ b/src/Nest/DSL/UnregisterPercolatorDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/DSL/UpdateDescriptor.cs
+++ b/src/Nest/DSL/UpdateDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Elasticsearch.Net;
 using Newtonsoft.Json;

--- a/src/Nest/DSL/UpdateSettingsDescriptor.cs
+++ b/src/Nest/DSL/UpdateSettingsDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/DSL/UpgradeDescriptor.cs
+++ b/src/Nest/DSL/UpgradeDescriptor.cs
@@ -1,10 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace Nest
 {
 	internal static class UpgradePathInfo

--- a/src/Nest/DSL/UpgradeStatusDescriptor.cs
+++ b/src/Nest/DSL/UpgradeStatusDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/DSL/VerifyRepositoryDescriptor.cs
+++ b/src/Nest/DSL/VerifyRepositoryDescriptor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Aggregations/FiltersBucket.cs
+++ b/src/Nest/Domain/Aggregations/FiltersBucket.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Aggregations/GeoBoundsMetric.cs
+++ b/src/Nest/Domain/Aggregations/GeoBoundsMetric.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public class GeoBoundsMetric : IMetricAggregation
 	{

--- a/src/Nest/Domain/Aggregations/IAggration.cs
+++ b/src/Nest/Domain/Aggregations/IAggration.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IAggregation
 	{

--- a/src/Nest/Domain/Aggregations/ISignificantTermsHeuristic.cs
+++ b/src/Nest/Domain/Aggregations/ISignificantTermsHeuristic.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Aggregations/ScriptedValueMetric.cs
+++ b/src/Nest/Domain/Aggregations/ScriptedValueMetric.cs
@@ -1,9 +1,4 @@
-﻿
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Aggregations/TopHitsMetric.cs
+++ b/src/Nest/Domain/Aggregations/TopHitsMetric.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Domain/Alias/IAliasAction.cs
+++ b/src/Nest/Domain/Alias/IAliasAction.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// Marker interface for alias operation

--- a/src/Nest/Domain/Analysis/Analyzers/AnalyzerBase.cs
+++ b/src/Nest/Domain/Analysis/Analyzers/AnalyzerBase.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Analyzers/CustomAnalyzer.cs
+++ b/src/Nest/Domain/Analysis/Analyzers/CustomAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Analysis/Analyzers/KeywordAnalyzer.cs
+++ b/src/Nest/Domain/Analysis/Analyzers/KeywordAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// An analyzer of type keyword that “tokenizes” an entire stream as a single token. This is useful for data like zip codes, ids and so on. 

--- a/src/Nest/Domain/Analysis/Analyzers/PatternAnalyzer.cs
+++ b/src/Nest/Domain/Analysis/Analyzers/PatternAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Analyzers/SimpleAnalyzer.cs
+++ b/src/Nest/Domain/Analysis/Analyzers/SimpleAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// An analyzer of type simple that is built using a Lower Case Tokenizer.

--- a/src/Nest/Domain/Analysis/Analyzers/WhitespaceAnalyzer.cs
+++ b/src/Nest/Domain/Analysis/Analyzers/WhitespaceAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// An analyzer of type whitespace that is built using a Whitespace Tokenizer.

--- a/src/Nest/Domain/Analysis/CharFilter/HtmlStripCharFilter.cs
+++ b/src/Nest/Domain/Analysis/CharFilter/HtmlStripCharFilter.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// A char filter of type html_strip stripping out HTML elements from an analyzed text.
@@ -12,7 +10,5 @@ namespace Nest
 		{
 
 		}
-
 	}
-
 }

--- a/src/Nest/Domain/Analysis/TokenFilter/AsciiFoldingTokenFilter.cs
+++ b/src/Nest/Domain/Analysis/TokenFilter/AsciiFoldingTokenFilter.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/TokenFilter/DelimitedPayloadTokenFilter.cs
+++ b/src/Nest/Domain/Analysis/TokenFilter/DelimitedPayloadTokenFilter.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/TokenFilter/TruncateTokenFilter.cs
+++ b/src/Nest/Domain/Analysis/TokenFilter/TruncateTokenFilter.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/TokenFilter/UniqueTokenFilter.cs
+++ b/src/Nest/Domain/Analysis/TokenFilter/UniqueTokenFilter.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Tokenizer/KeywordTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/KeywordTokenizer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Tokenizer/LetterTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/LetterTokenizer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// A tokenizer of type letter that divides text at non-letters. That’s to say, it defines tokens as maximal strings of adjacent letters. 

--- a/src/Nest/Domain/Analysis/Tokenizer/LowercaseTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/LowercaseTokenizer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// A tokenizer of type lowercase that performs the function of Letter Tokenizer and Lower Case Token Filter together. 

--- a/src/Nest/Domain/Analysis/Tokenizer/PathHierarchyTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/PathHierarchyTokenizer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Tokenizer/PatternTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/PatternTokenizer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Tokenizer/StandardTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/StandardTokenizer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Tokenizer/TokenizerBase.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/TokenizerBase.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Tokenizer/UaxEmailUrlTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/UaxEmailUrlTokenizer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Analysis/Tokenizer/WhitespaceTokenizer.cs
+++ b/src/Nest/Domain/Analysis/Tokenizer/WhitespaceTokenizer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nest
+﻿namespace Nest
 {
 	/// <summary>
 	/// A tokenizer of type whitespace that divides text at whitespace.

--- a/src/Nest/Domain/Cat/CatFielddataRecord.cs
+++ b/src/Nest/Domain/Cat/CatFielddataRecord.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/Domain/Cluster/ClusterRerouteDecision.cs
+++ b/src/Nest/Domain/Cluster/ClusterRerouteDecision.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Cluster/ClusterRerouteExplanation.cs
+++ b/src/Nest/Domain/Cluster/ClusterRerouteExplanation.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Cluster/ClusterRerouteParameters.cs
+++ b/src/Nest/Domain/Cluster/ClusterRerouteParameters.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Cluster/ClusterRerouteState.cs
+++ b/src/Nest/Domain/Cluster/ClusterRerouteState.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/DSL/ChildScoreType.cs
+++ b/src/Nest/Domain/DSL/ChildScoreType.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/Domain/DSL/ParentScoreType.cs
+++ b/src/Nest/Domain/DSL/ParentScoreType.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/Domain/DSL/Query.cs
+++ b/src/Nest/Domain/DSL/Query.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Nest

--- a/src/Nest/Domain/Geo/CircleGeoShape.cs
+++ b/src/Nest/Domain/Geo/CircleGeoShape.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Geo/EnvelopeGeoShape.cs
+++ b/src/Nest/Domain/Geo/EnvelopeGeoShape.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Geo/GeoLocation.cs
+++ b/src/Nest/Domain/Geo/GeoLocation.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 
 /*
  * Taken from SolrNet https://github.com/mausch/SolrNet/blob/master/SolrNet/Location.cs

--- a/src/Nest/Domain/Geo/GeoShape.cs
+++ b/src/Nest/Domain/Geo/GeoShape.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Geo/LineStringGeoShape.cs
+++ b/src/Nest/Domain/Geo/LineStringGeoShape.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Geo/MultiLineStringGeoShape.cs
+++ b/src/Nest/Domain/Geo/MultiLineStringGeoShape.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Geo/MultiPointGeoShape.cs
+++ b/src/Nest/Domain/Geo/MultiPointGeoShape.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Geo/MultiPolygonGeoShape.cs
+++ b/src/Nest/Domain/Geo/MultiPolygonGeoShape.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Geo/PointGeoShape.cs
+++ b/src/Nest/Domain/Geo/PointGeoShape.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Geo/PolygonGeoShape.cs
+++ b/src/Nest/Domain/Geo/PolygonGeoShape.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Hit/AnalyzeToken.cs
+++ b/src/Nest/Domain/Hit/AnalyzeToken.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Hit/ExplainGet.cs
+++ b/src/Nest/Domain/Hit/ExplainGet.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Domain;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Hit/Explanation.cs
+++ b/src/Nest/Domain/Hit/Explanation.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Hit/ExplanationDetail.cs
+++ b/src/Nest/Domain/Hit/ExplanationDetail.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Hit/HighlightCollection.cs
+++ b/src/Nest/Domain/Hit/HighlightCollection.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Hit/Hit.cs
+++ b/src/Nest/Domain/Hit/Hit.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Nest.Domain;
 using Newtonsoft.Json;

--- a/src/Nest/Domain/Hit/MultiGetHit.cs
+++ b/src/Nest/Domain/Hit/MultiGetHit.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Nest.Domain;
 
 namespace Nest

--- a/src/Nest/Domain/Hit/MultiHit.cs
+++ b/src/Nest/Domain/Hit/MultiHit.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Hit/Segment.cs
+++ b/src/Nest/Domain/Hit/Segment.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Hit/ShardSegmentRouting.cs
+++ b/src/Nest/Domain/Hit/ShardSegmentRouting.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Hit/ShardsMetaData.cs
+++ b/src/Nest/Domain/Hit/ShardsMetaData.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Hit/ValidationExplanation.cs
+++ b/src/Nest/Domain/Hit/ValidationExplanation.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Attributes/ElasticTypeAttribute.cs
+++ b/src/Nest/Domain/Mapping/Attributes/ElasticTypeAttribute.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Descriptors/CompletionMappingDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/CompletionMappingDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Nest

--- a/src/Nest/Domain/Mapping/Descriptors/FieldDataFilterDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/FieldDataFilterDescriptor.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Descriptors/FieldDataFrequencyFilterDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/FieldDataFrequencyFilterDescriptor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public class FieldDataFrequencyFilterDescriptor
 	{

--- a/src/Nest/Domain/Mapping/Descriptors/FieldDataNonStringMappingDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/FieldDataNonStringMappingDescriptor.cs
@@ -1,8 +1,4 @@
-﻿
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Descriptors/FieldDataRegexFilterDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/FieldDataRegexFilterDescriptor.cs
@@ -1,10 +1,4 @@
-﻿
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public class FieldDataRegexFilterDescriptor
 	{

--- a/src/Nest/Domain/Mapping/Descriptors/FieldDataStringMappingDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/FieldDataStringMappingDescriptor.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Descriptors/MappingTransformDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/MappingTransformDescriptor.cs
@@ -1,8 +1,4 @@
-﻿
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Descriptors/SingleMappingDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/SingleMappingDescriptor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Descriptors/SuggestContextMappingDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/SuggestContextMappingDescriptor.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/PropertyMapping.cs
+++ b/src/Nest/Domain/Mapping/PropertyMapping.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
-using System.Reflection.Emit;
-using Nest.Resolvers;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataFilter.cs
+++ b/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataFilter.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataFrequencyFilter.cs
+++ b/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataFrequencyFilter.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataMapping.cs
+++ b/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataMapping.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataNonStringMapping.cs
+++ b/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataNonStringMapping.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataRegexFilter.cs
+++ b/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataRegexFilter.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataStringMapping.cs
+++ b/src/Nest/Domain/Mapping/SubMappings/FieldData/FieldDataStringMapping.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/SubMappings/MappingTransform.cs
+++ b/src/Nest/Domain/Mapping/SubMappings/MappingTransform.cs
@@ -1,9 +1,5 @@
-﻿using Nest.Resolvers.Converters;
-using Newtonsoft.Json;
-using System;
+﻿using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/SubMappings/NormsMapping.cs
+++ b/src/Nest/Domain/Mapping/SubMappings/NormsMapping.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
 using System;
 using Newtonsoft.Json.Converters;

--- a/src/Nest/Domain/Mapping/Types/AttachmentMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/AttachmentMapping.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Types/BinaryMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/BinaryMapping.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using System;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Types/BooleanMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/BooleanMapping.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using System;
 using Newtonsoft.Json.Converters;
 
 namespace Nest

--- a/src/Nest/Domain/Mapping/Types/CompletionMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/CompletionMapping.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Types/DateMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/DateMapping.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
 using System;
 using Newtonsoft.Json.Converters;

--- a/src/Nest/Domain/Mapping/Types/GenericMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/GenericMapping.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Mapping/Types/GeoPointMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/GeoPointMapping.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
-using System;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Types/GeoShapeMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/GeoShapeMapping.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
-using System;
 using Newtonsoft.Json.Converters;
 
 namespace Nest

--- a/src/Nest/Domain/Mapping/Types/IElasticCoreType.cs
+++ b/src/Nest/Domain/Mapping/Types/IElasticCoreType.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IElasticCoreType : IElasticType
 	{

--- a/src/Nest/Domain/Mapping/Types/IElasticType.cs
+++ b/src/Nest/Domain/Mapping/Types/IElasticType.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IElasticType : IFieldMapping
 	{

--- a/src/Nest/Domain/Mapping/Types/IPMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/IPMapping.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Types/MultiFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/MultiFieldMapping.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Types/NestedObjectMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/NestedObjectMapping.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Mapping/Types/NumberMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/NumberMapping.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
-using System;
 using Newtonsoft.Json.Converters;
 
 namespace Nest

--- a/src/Nest/Domain/Mapping/Types/ObjectMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/ObjectMapping.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Types/RootObjectMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/RootObjectMapping.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Mapping/Types/StringMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/StringMapping.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using System;
 using Newtonsoft.Json.Converters;
 
 namespace Nest

--- a/src/Nest/Domain/Observers/RestoreObservable.cs
+++ b/src/Nest/Domain/Observers/RestoreObservable.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/Nest/Domain/Observers/SnapshotObservable.cs
+++ b/src/Nest/Domain/Observers/SnapshotObservable.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;

--- a/src/Nest/Domain/Repository/SnapshotRestore.cs
+++ b/src/Nest/Domain/Repository/SnapshotRestore.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Repository/SnapshotShardFailure.cs
+++ b/src/Nest/Domain/Repository/SnapshotShardFailure.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/BaseResponse.cs
+++ b/src/Nest/Domain/Responses/BaseResponse.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/CatResponse.cs
+++ b/src/Nest/Domain/Responses/CatResponse.cs
@@ -1,9 +1,6 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/ClusterPendingTasksResponse.cs
+++ b/src/Nest/Domain/Responses/ClusterPendingTasksResponse.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/ClusterRerouteResponse.cs
+++ b/src/Nest/Domain/Responses/ClusterRerouteResponse.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/ClusterStatsResponse.cs
+++ b/src/Nest/Domain/Responses/ClusterStatsResponse.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/DeleteAliasResponse.cs
+++ b/src/Nest/Domain/Responses/DeleteAliasResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IDeleteAliasResponse : IResponse
 	{

--- a/src/Nest/Domain/Responses/DeleteSearchTemplateResponse.cs
+++ b/src/Nest/Domain/Responses/DeleteSearchTemplateResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IDeleteSearchTemplateResponse : IResponse
 	{

--- a/src/Nest/Domain/Responses/ElasticSearchVersionInfo.cs
+++ b/src/Nest/Domain/Responses/ElasticSearchVersionInfo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/EmptyResponse.cs
+++ b/src/Nest/Domain/Responses/EmptyResponse.cs
@@ -1,6 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/ExplainResponse.cs
+++ b/src/Nest/Domain/Responses/ExplainResponse.cs
@@ -1,8 +1,5 @@
-﻿using System.Security.Cryptography.X509Certificates;
-using Nest.Domain;
+﻿using Nest.Domain;
 using Newtonsoft.Json;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/GetFieldMappingResponse.cs
+++ b/src/Nest/Domain/Responses/GetFieldMappingResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using System.Linq.Expressions;
 using Elasticsearch.Net;

--- a/src/Nest/Domain/Responses/GetRepositoryResponse.cs
+++ b/src/Nest/Domain/Responses/GetRepositoryResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 

--- a/src/Nest/Domain/Responses/GetSearchTemplateResponse.cs
+++ b/src/Nest/Domain/Responses/GetSearchTemplateResponse.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/GetSnapshotResponse.cs
+++ b/src/Nest/Domain/Responses/GetSnapshotResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/HealthResponse.cs
+++ b/src/Nest/Domain/Responses/HealthResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/MultiPercolateResponse.cs
+++ b/src/Nest/Domain/Responses/MultiPercolateResponse.cs
@@ -1,7 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using Nest.Domain;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/MultiTermVectorResponse.cs
+++ b/src/Nest/Domain/Responses/MultiTermVectorResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/NodeInfoResponse.cs
+++ b/src/Nest/Domain/Responses/NodeInfoResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/NodeStatsResponse.cs
+++ b/src/Nest/Domain/Responses/NodeStatsResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/NodesHotThreadsResponse.cs
+++ b/src/Nest/Domain/Responses/NodesHotThreadsResponse.cs
@@ -1,9 +1,4 @@
-﻿using Nest.Resolvers.Converters;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/NodesShutDownResponse.cs
+++ b/src/Nest/Domain/Responses/NodesShutDownResponse.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/PingResponse.cs
+++ b/src/Nest/Domain/Responses/PingResponse.cs
@@ -1,9 +1,4 @@
-﻿using Elasticsearch.Net;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/PutAliasResponse.cs
+++ b/src/Nest/Domain/Responses/PutAliasResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IPutAliasResponse : IResponse
 	{

--- a/src/Nest/Domain/Responses/PutScriptResponse.cs
+++ b/src/Nest/Domain/Responses/PutScriptResponse.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/PutSearchTemplateResponse.cs
+++ b/src/Nest/Domain/Responses/PutSearchTemplateResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Nest
+﻿namespace Nest
 {
 	public interface IPutSearchTemplateResponse : IResponse
 	{

--- a/src/Nest/Domain/Responses/RecoveryStatusResponse.cs
+++ b/src/Nest/Domain/Responses/RecoveryStatusResponse.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/ReindexResponse.cs
+++ b/src/Nest/Domain/Responses/ReindexResponse.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/RestoreResponse.cs
+++ b/src/Nest/Domain/Responses/RestoreResponse.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/SearchShardsResponse.cs
+++ b/src/Nest/Domain/Responses/SearchShardsResponse.cs
@@ -1,9 +1,5 @@
-﻿using Nest.Domain;
-using Newtonsoft.Json;
-using System;
+﻿using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/SnapshotResponse.cs
+++ b/src/Nest/Domain/Responses/SnapshotResponse.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/SnapshotStatusResponse.cs
+++ b/src/Nest/Domain/Responses/SnapshotStatusResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/StatusResponse.cs
+++ b/src/Nest/Domain/Responses/StatusResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/SuggestResponse.cs
+++ b/src/Nest/Domain/Responses/SuggestResponse.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/TermVectorResponse.cs
+++ b/src/Nest/Domain/Responses/TermVectorResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Responses/UpgradeResponse.cs
+++ b/src/Nest/Domain/Responses/UpgradeResponse.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/UpgradeStatusResponse.cs
+++ b/src/Nest/Domain/Responses/UpgradeStatusResponse.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/ValidateResponse.cs
+++ b/src/Nest/Domain/Responses/ValidateResponse.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Responses/VerifyRepositoryResponse.cs
+++ b/src/Nest/Domain/Responses/VerifyRepositoryResponse.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Settings/IndexSettings.cs
+++ b/src/Nest/Domain/Settings/IndexSettings.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using System;
 using Nest.Resolvers.Converters;
 
 namespace Nest

--- a/src/Nest/Domain/Similarity/BM25Similarity.cs
+++ b/src/Nest/Domain/Similarity/BM25Similarity.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Similarity/DFRSimilarity.cs
+++ b/src/Nest/Domain/Similarity/DFRSimilarity.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Similarity/DefaultSimilarity.cs
+++ b/src/Nest/Domain/Similarity/DefaultSimilarity.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Similarity/LMDirichletSimilarity.cs
+++ b/src/Nest/Domain/Similarity/LMDirichletSimilarity.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Similarity/LMJelinekSimilarity.cs
+++ b/src/Nest/Domain/Similarity/LMJelinekSimilarity.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Similarity/SimilarityBase.cs
+++ b/src/Nest/Domain/Similarity/SimilarityBase.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Similarity/SimilaritySettings.cs
+++ b/src/Nest/Domain/Similarity/SimilaritySettings.cs
@@ -1,7 +1,5 @@
-﻿
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 
 namespace Nest

--- a/src/Nest/Domain/State/ClusterState.cs
+++ b/src/Nest/Domain/State/ClusterState.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/Domain/Stats/ClusterNodesStas.cs
+++ b/src/Nest/Domain/Stats/ClusterNodesStas.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/CompletionStats.cs
+++ b/src/Nest/Domain/Stats/CompletionStats.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/DocStats.cs
+++ b/src/Nest/Domain/Stats/DocStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/FieldDataStats.cs
+++ b/src/Nest/Domain/Stats/FieldDataStats.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/FilterCacheStats.cs
+++ b/src/Nest/Domain/Stats/FilterCacheStats.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/FlushStats.cs
+++ b/src/Nest/Domain/Stats/FlushStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/GetStats.cs
+++ b/src/Nest/Domain/Stats/GetStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/IdCacheStats.cs
+++ b/src/Nest/Domain/Stats/IdCacheStats.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/IndexDocStats.cs
+++ b/src/Nest/Domain/Stats/IndexDocStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/IndexHealthStats.cs
+++ b/src/Nest/Domain/Stats/IndexHealthStats.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Stats/IndexSizeStats.cs
+++ b/src/Nest/Domain/Stats/IndexSizeStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/IndexingStats.cs
+++ b/src/Nest/Domain/Stats/IndexingStats.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Stats/IndicesStats.cs
+++ b/src/Nest/Domain/Stats/IndicesStats.cs
@@ -1,9 +1,4 @@
-﻿
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/MergesStats.cs
+++ b/src/Nest/Domain/Stats/MergesStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/NodeInfo.cs
+++ b/src/Nest/Domain/Stats/NodeInfo.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 

--- a/src/Nest/Domain/Stats/NodeStats.cs
+++ b/src/Nest/Domain/Stats/NodeStats.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/Domain/Stats/PercolateStats.cs
+++ b/src/Nest/Domain/Stats/PercolateStats.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/PluginStats.cs
+++ b/src/Nest/Domain/Stats/PluginStats.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/RefreshStats.cs
+++ b/src/Nest/Domain/Stats/RefreshStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/SearchStats.cs
+++ b/src/Nest/Domain/Stats/SearchStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/SegmentsStats.cs
+++ b/src/Nest/Domain/Stats/SegmentsStats.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/ShardHealthStats.cs
+++ b/src/Nest/Domain/Stats/ShardHealthStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/Stats.cs
+++ b/src/Nest/Domain/Stats/Stats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/StatsContainer.cs
+++ b/src/Nest/Domain/Stats/StatsContainer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/StoreStats.cs
+++ b/src/Nest/Domain/Stats/StoreStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/TranslogStats.cs
+++ b/src/Nest/Domain/Stats/TranslogStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/Domain/Stats/TypeStats.cs
+++ b/src/Nest/Domain/Stats/TypeStats.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/ElasticClient-Bulk.cs
+++ b/src/Nest/ElasticClient-Bulk.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-ClearCache.cs
+++ b/src/Nest/ElasticClient-ClearCache.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-ClusterHealth.cs
+++ b/src/Nest/ElasticClient-ClusterHealth.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-ClusterPendingTasks.cs
+++ b/src/Nest/ElasticClient-ClusterPendingTasks.cs
@@ -1,8 +1,5 @@
 ﻿using Elasticsearch.Net;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nest

--- a/src/Nest/ElasticClient-ClusterReroute.cs
+++ b/src/Nest/ElasticClient-ClusterReroute.cs
@@ -1,8 +1,5 @@
 ﻿using Elasticsearch.Net;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nest

--- a/src/Nest/ElasticClient-ClusterSettings.cs
+++ b/src/Nest/ElasticClient-ClusterSettings.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-ClusterState.cs
+++ b/src/Nest/ElasticClient-ClusterState.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-ClusterStats.cs
+++ b/src/Nest/ElasticClient-ClusterStats.cs
@@ -1,8 +1,5 @@
 ﻿using Elasticsearch.Net;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nest

--- a/src/Nest/ElasticClient-Count.cs
+++ b/src/Nest/ElasticClient-Count.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Delete.cs
+++ b/src/Nest/ElasticClient-Delete.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-DeleteByQuery.cs
+++ b/src/Nest/ElasticClient-DeleteByQuery.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-DoRequest.cs
+++ b/src/Nest/ElasticClient-DoRequest.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Elasticsearch.Net;
 
 namespace Nest

--- a/src/Nest/ElasticClient-Explain.cs
+++ b/src/Nest/ElasticClient-Explain.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Flush.cs
+++ b/src/Nest/ElasticClient-Flush.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Get.cs
+++ b/src/Nest/ElasticClient-Get.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-GetIndex.cs
+++ b/src/Nest/ElasticClient-GetIndex.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Index.cs
+++ b/src/Nest/ElasticClient-Index.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-IndexSettings.cs
+++ b/src/Nest/ElasticClient-IndexSettings.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-IndicesStats.cs
+++ b/src/Nest/ElasticClient-IndicesStats.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-MappingDelete.cs
+++ b/src/Nest/ElasticClient-MappingDelete.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-MappingGetField.cs
+++ b/src/Nest/ElasticClient-MappingGetField.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-MappingType.cs
+++ b/src/Nest/ElasticClient-MappingType.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-MultiGet.cs
+++ b/src/Nest/ElasticClient-MultiGet.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Nest.Resolvers.Converters;

--- a/src/Nest/ElasticClient-MultiPercolate.cs
+++ b/src/Nest/ElasticClient-MultiPercolate.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-MultiSearch.cs
+++ b/src/Nest/ElasticClient-MultiSearch.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Nest.Resolvers.Converters;

--- a/src/Nest/ElasticClient-MultiTermVectors.cs
+++ b/src/Nest/ElasticClient-MultiTermVectors.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Nodes.cs
+++ b/src/Nest/ElasticClient-Nodes.cs
@@ -1,10 +1,8 @@
 ﻿using Elasticsearch.Net;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Nest

--- a/src/Nest/ElasticClient-Optimize.cs
+++ b/src/Nest/ElasticClient-Optimize.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Ping.cs
+++ b/src/Nest/ElasticClient-Ping.cs
@@ -1,9 +1,6 @@
 ﻿using Elasticsearch.Net;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nest

--- a/src/Nest/ElasticClient-RecoveryStatus.cs
+++ b/src/Nest/ElasticClient-RecoveryStatus.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Refresh.cs
+++ b/src/Nest/ElasticClient-Refresh.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Reindex.cs
+++ b/src/Nest/ElasticClient-Reindex.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Nest
 {

--- a/src/Nest/ElasticClient-Repository.cs
+++ b/src/Nest/ElasticClient-Repository.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-RootNodeInfo.cs
+++ b/src/Nest/ElasticClient-RootNodeInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Search.cs
+++ b/src/Nest/ElasticClient-Search.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Newtonsoft.Json;

--- a/src/Nest/ElasticClient-SearchShards.cs
+++ b/src/Nest/ElasticClient-SearchShards.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
-using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Nest/ElasticClient-SearchTemplate.cs
+++ b/src/Nest/ElasticClient-SearchTemplate.cs
@@ -1,10 +1,7 @@
 ﻿using Elasticsearch.Net;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nest

--- a/src/Nest/ElasticClient-Segments.cs
+++ b/src/Nest/ElasticClient-Segments.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Source.cs
+++ b/src/Nest/ElasticClient-Source.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Status.cs
+++ b/src/Nest/ElasticClient-Status.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Suggest.cs
+++ b/src/Nest/ElasticClient-Suggest.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-TemplateExists.cs
+++ b/src/Nest/ElasticClient-TemplateExists.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-TermVector.cs
+++ b/src/Nest/ElasticClient-TermVector.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Update.cs
+++ b/src/Nest/ElasticClient-Update.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-UpdateSettings.cs
+++ b/src/Nest/ElasticClient-UpdateSettings.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Upgrade.cs
+++ b/src/Nest/ElasticClient-Upgrade.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nest

--- a/src/Nest/ElasticClient-Validate.cs
+++ b/src/Nest/ElasticClient-Validate.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient-Warmers.cs
+++ b/src/Nest/ElasticClient-Warmers.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 

--- a/src/Nest/ElasticClient.cs
+++ b/src/Nest/ElasticClient.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Connection;

--- a/src/Nest/Enums/FieldDataNonStringFormat.cs
+++ b/src/Nest/Enums/FieldDataNonStringFormat.cs
@@ -1,10 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Enums/FieldDataStringFormat.cs
+++ b/src/Nest/Enums/FieldDataStringFormat.cs
@@ -1,10 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Enums/FieldType.cs
+++ b/src/Nest/Enums/FieldType.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/Enums/GeoExecution.cs
+++ b/src/Nest/Enums/GeoExecution.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/Enums/GeoHashPrecision.cs
+++ b/src/Nest/Enums/GeoHashPrecision.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	public enum GeoHashPrecision
 	{

--- a/src/Nest/Enums/GeoOptimizeBBox.cs
+++ b/src/Nest/Enums/GeoOptimizeBBox.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/Enums/GeoShapeRelation.cs
+++ b/src/Nest/Enums/GeoShapeRelation.cs
@@ -1,10 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Enums/HighlighterType.cs
+++ b/src/Nest/Enums/HighlighterType.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
+﻿using System.Runtime.Serialization;
 
 namespace Nest
 {

--- a/src/Nest/Enums/NestedScore.cs
+++ b/src/Nest/Enums/NestedScore.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System.Runtime.Serialization;
 using Newtonsoft.Json.Converters;
 

--- a/src/Nest/Enums/RewriteMultiTerm.cs
+++ b/src/Nest/Enums/RewriteMultiTerm.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Runtime.Serialization;

--- a/src/Nest/Enums/RoutingAllocationEnableOption.cs
+++ b/src/Nest/Enums/RoutingAllocationEnableOption.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
 
 namespace Nest

--- a/src/Nest/Enums/TermVectorOption.cs
+++ b/src/Nest/Enums/TermVectorOption.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Runtime.Serialization;
 

--- a/src/Nest/Enums/TopChildrenScore.cs
+++ b/src/Nest/Enums/TopChildrenScore.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System.Runtime.Serialization;
 using Newtonsoft.Json.Converters;
 
@@ -16,7 +13,5 @@ namespace Nest
 		Sum,
 		[EnumMember(Value = "avg")]
 		Average
-	}
-
-	
+	}	
 }

--- a/src/Nest/ExposedInternals/INestSerializer.cs
+++ b/src/Nest/ExposedInternals/INestSerializer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using Elasticsearch.Net.Serialization;
 using Newtonsoft.Json;
 

--- a/src/Nest/Extensions/SuffixExtensions.cs
+++ b/src/Nest/Extensions/SuffixExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nest
+﻿namespace Nest
 {
 	public static class SuffixExtensions
 	{

--- a/src/Nest/Extensions/TypeExtensions.cs
+++ b/src/Nest/Extensions/TypeExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/src/Nest/Obsolete/Obsolete.cs
+++ b/src/Nest/Obsolete/Obsolete.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/RawDispatch.cs
+++ b/src/Nest/RawDispatch.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Nest/Resolvers/Converters/Aggregations/FilterAggregatorConverter.cs
+++ b/src/Nest/Resolvers/Converters/Aggregations/FilterAggregatorConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Converters.Aggregations

--- a/src/Nest/Resolvers/Converters/BulkOperationResponseItemConverter.cs
+++ b/src/Nest/Resolvers/Converters/BulkOperationResponseItemConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Converters

--- a/src/Nest/Resolvers/Converters/CatFielddataRecordConverter.cs
+++ b/src/Nest/Resolvers/Converters/CatFielddataRecordConverter.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/CatThreadPoolRecordConverter.cs
+++ b/src/Nest/Resolvers/Converters/CatThreadPoolRecordConverter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/ClusterRerouteCommandCollectionConverter.cs
+++ b/src/Nest/Resolvers/Converters/ClusterRerouteCommandCollectionConverter.cs
@@ -1,8 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/ConcreteTypeConverter.cs
+++ b/src/Nest/Resolvers/Converters/ConcreteTypeConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Elasticsearch.Net;
 using Nest.Domain;

--- a/src/Nest/Resolvers/Converters/CustomJsonConverter.cs
+++ b/src/Nest/Resolvers/Converters/CustomJsonConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 

--- a/src/Nest/Resolvers/Converters/DynamicMappingOptionConverter.cs
+++ b/src/Nest/Resolvers/Converters/DynamicMappingOptionConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Converters

--- a/src/Nest/Resolvers/Converters/ElasticCoreTypeConverter.cs
+++ b/src/Nest/Resolvers/Converters/ElasticCoreTypeConverter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/ElasticTypeConverter.cs
+++ b/src/Nest/Resolvers/Converters/ElasticTypeConverter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/FacetConverter.cs
+++ b/src/Nest/Resolvers/Converters/FacetConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/Filters/GeoBoundingFilterConverter.cs
+++ b/src/Nest/Resolvers/Converters/Filters/GeoBoundingFilterConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json;

--- a/src/Nest/Resolvers/Converters/Filters/GeoDistanceFilterConverter.cs
+++ b/src/Nest/Resolvers/Converters/Filters/GeoDistanceFilterConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/Filters/GeoDistanceRangeFilterConverter.cs
+++ b/src/Nest/Resolvers/Converters/Filters/GeoDistanceRangeFilterConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/Filters/GeoPolygonFilterJsonReader.cs
+++ b/src/Nest/Resolvers/Converters/Filters/GeoPolygonFilterJsonReader.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/Nest/Resolvers/Converters/Filters/GeoShapeFilterJsonReader.cs
+++ b/src/Nest/Resolvers/Converters/Filters/GeoShapeFilterJsonReader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/Filters/PrefixFilterConverter.cs
+++ b/src/Nest/Resolvers/Converters/Filters/PrefixFilterConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/Filters/RangeFilterJsonReader.cs
+++ b/src/Nest/Resolvers/Converters/Filters/RangeFilterJsonReader.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/Filters/RegexpFilterJsonReader.cs
+++ b/src/Nest/Resolvers/Converters/Filters/RegexpFilterJsonReader.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/Filters/TermFilterConverter.cs
+++ b/src/Nest/Resolvers/Converters/Filters/TermFilterConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/Filters/TermsFilterConverter.cs
+++ b/src/Nest/Resolvers/Converters/Filters/TermsFilterConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/FuzzinessConverter.cs
+++ b/src/Nest/Resolvers/Converters/FuzzinessConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Converters

--- a/src/Nest/Resolvers/Converters/GeoShapeConverterBase.cs
+++ b/src/Nest/Resolvers/Converters/GeoShapeConverterBase.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/GetRepositoryResponseConverter.cs
+++ b/src/Nest/Resolvers/Converters/GetRepositoryResponseConverter.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
-
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/IndexNameMarkerConverter.cs
+++ b/src/Nest/Resolvers/Converters/IndexNameMarkerConverter.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
-
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/IndexSettingsResponseConverter.cs
+++ b/src/Nest/Resolvers/Converters/IndexSettingsResponseConverter.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
-
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/MappingTransformConverter.cs
+++ b/src/Nest/Resolvers/Converters/MappingTransformConverter.cs
@@ -2,8 +2,6 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/PropertyPathMarkerConverter.cs
+++ b/src/Nest/Resolvers/Converters/PropertyPathMarkerConverter.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
-
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/Queries/GeoShapeQueryJsonReader.cs
+++ b/src/Nest/Resolvers/Converters/Queries/GeoShapeQueryJsonReader.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Nest
 {

--- a/src/Nest/Resolvers/Converters/Queries/TermsQueryJsonConverter.cs
+++ b/src/Nest/Resolvers/Converters/Queries/TermsQueryJsonConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/ReadAsTypeConverter.cs
+++ b/src/Nest/Resolvers/Converters/ReadAsTypeConverter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Converters

--- a/src/Nest/Resolvers/Converters/SimilarityCollectionConverter.cs
+++ b/src/Nest/Resolvers/Converters/SimilarityCollectionConverter.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/SimilaritySettingsConverter.cs
+++ b/src/Nest/Resolvers/Converters/SimilaritySettingsConverter.cs
@@ -1,8 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/SortCollectionConverter.cs
+++ b/src/Nest/Resolvers/Converters/SortCollectionConverter.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Nest.Resolvers.Converters
 {

--- a/src/Nest/Resolvers/Converters/SuggestResponseConverter.cs
+++ b/src/Nest/Resolvers/Converters/SuggestResponseConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Nest/Resolvers/Converters/TypeNameMarkerConverter.cs
+++ b/src/Nest/Resolvers/Converters/TypeNameMarkerConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 

--- a/src/Nest/Resolvers/Converters/WarmerMappingConverter.cs
+++ b/src/Nest/Resolvers/Converters/WarmerMappingConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Newtonsoft.Json;
-using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace Nest.Resolvers.Converters

--- a/src/Nest/Resolvers/Converters/YesNoBoolConverter.cs
+++ b/src/Nest/Resolvers/Converters/YesNoBoolConverter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Converters

--- a/src/Nest/Resolvers/ExpressionVisitor.cs
+++ b/src/Nest/Resolvers/ExpressionVisitor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Nest.Resolvers

--- a/src/Nest/Resolvers/IdResolver.cs
+++ b/src/Nest/Resolvers/IdResolver.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Collections.Concurrent;
 using System.Reflection;
 

--- a/src/Nest/Resolvers/IndexNameResolver.cs
+++ b/src/Nest/Resolvers/IndexNameResolver.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest.Resolvers
 {

--- a/src/Nest/Resolvers/SettingsContractResolver.cs
+++ b/src/Nest/Resolvers/SettingsContractResolver.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json.Serialization;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest.Resolvers
 {

--- a/src/Nest/Resolvers/TypeNameResolver.cs
+++ b/src/Nest/Resolvers/TypeNameResolver.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest.Resolvers
 {

--- a/src/Nest/Resolvers/Writers/TypeMappingWriter.cs
+++ b/src/Nest/Resolvers/Writers/TypeMappingWriter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/src/Nest/Resolvers/Writers/WritePropertiesFromAttributeVisitor.cs
+++ b/src/Nest/Resolvers/Writers/WritePropertiesFromAttributeVisitor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Writers {

--- a/src/Profiling/Profiling.Indexing/HttpClientTester.cs
+++ b/src/Profiling/Profiling.Indexing/HttpClientTester.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Elasticsearch.Net.Connection;
+﻿using Elasticsearch.Net.Connection;
 using Nest;
 
 namespace Profiling.Indexing
@@ -13,7 +11,5 @@ namespace Profiling.Indexing
 			var client = new ElasticClient(settings, new HttpClientConnection(settings));
 			return client;
 		}
-		
-
 	}
 }

--- a/src/Profiling/Profiling.Indexing/HttpTester.cs
+++ b/src/Profiling/Profiling.Indexing/HttpTester.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Nest;
+﻿using Nest;
 
 namespace Profiling.Indexing
 {
@@ -11,8 +9,6 @@ namespace Profiling.Indexing
 			var settings = this.CreateSettings(indexName, 9200);
 			var client = new ElasticClient(settings);
 			return client;
-		}
-		
-
+		}	
 	}
 }

--- a/src/Profiling/Profiling.Indexing/Message.cs
+++ b/src/Profiling/Profiling.Indexing/Message.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Profiling.Indexing
 {

--- a/src/Profiling/Profiling.Indexing/Serializer/SsTextNestSerializer.cs
+++ b/src/Profiling/Profiling.Indexing/Serializer/SsTextNestSerializer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nest;
+﻿using Nest;
 
 namespace Profiling.Indexing.Serializer
 {

--- a/src/Profiling/Profiling.Indexing/ThriftTester.cs
+++ b/src/Profiling/Profiling.Indexing/ThriftTester.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Elasticsearch.Net.Connection.Thrift;
+﻿using Elasticsearch.Net.Connection.Thrift;
 using Elasticsearch.Net.Connection.Thrift.Protocol;
 using Nest;
 

--- a/src/Serialization/Elasticsearch.Net.JsonNET/ElasticsearchJsonNetSerializer.cs
+++ b/src/Serialization/Elasticsearch.Net.JsonNET/ElasticsearchJsonNetSerializer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Elasticsearch.Net.Serialization;

--- a/src/Tests/Nest.Tests.Unit/Cluster/NodeTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Cluster/NodeTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/Tests/Nest.Tests.Unit/Cluster/PendingTasksTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Cluster/PendingTasksTests.cs
@@ -1,11 +1,8 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nest.Tests.Unit.Cluster
 {

--- a/src/Tests/Nest.Tests.Unit/Cluster/Reroute/RerouteTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Cluster/Reroute/RerouteTests.cs
@@ -1,10 +1,5 @@
 ﻿using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nest.Tests.Unit.Cluster.Reroute
 {

--- a/src/Tests/Nest.Tests.Unit/Core/Get/GetTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Get/GetTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Index/IndexTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Index/IndexTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using NUnit.Framework;
 using Nest.Tests.MockData.Domain;

--- a/src/Tests/Nest.Tests.Unit/Core/Indices/Alias/AliasTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Indices/Alias/AliasTests.cs
@@ -1,12 +1,6 @@
-﻿using FluentAssertions;
-using Nest.Tests.MockData.Domain;
+﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nest.Tests.Unit.Core.Indices.Alias
 {

--- a/src/Tests/Nest.Tests.Unit/Core/Indices/Analysis/Analyzers/AnalyzerTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Indices/Analysis/Analyzers/AnalyzerTests.cs
@@ -1,8 +1,5 @@
 ﻿using Nest.Tests.Unit.Core.Indices.Analysis.Tokenizers;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Nest.Tests.Unit.Core.Indices.Analysis.Analyzers

--- a/src/Tests/Nest.Tests.Unit/Core/Map/GenericTypes/GenericTypeMappingTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/GenericTypes/GenericTypeMappingTests.cs
@@ -1,10 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nest.Tests.Unit.Core.Map.GenericTypes
 {

--- a/src/Tests/Nest.Tests.Unit/Core/Map/GetMappingSerializationTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/GetMappingSerializationTests.cs
@@ -1,12 +1,4 @@
-﻿using Newtonsoft.Json;
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+﻿using NUnit.Framework;
 
 namespace Nest.Tests.Unit.Core.Map
 {

--- a/src/Tests/Nest.Tests.Unit/Core/Map/IdField/IdFieldTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/IdField/IdFieldTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 using System.Reflection;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Map/MappingBehaviourTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/MappingBehaviourTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Map/PutMappingRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/PutMappingRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Map/RootProperties/MapRootObjectPropertiesTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/RootProperties/MapRootObjectPropertiesTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 using System.Reflection;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Map/SourceField/SourceFieldTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/SourceField/SourceFieldTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 using System.Reflection;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Transform/MappingTansformTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Transform/MappingTansformTests.cs
@@ -1,11 +1,7 @@
 ﻿using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nest.Tests.Unit.Core.Map.Transform
 {

--- a/src/Tests/Nest.Tests.Unit/Core/Map/TypeField/TypeFieldTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/TypeField/TypeFieldTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 using System.Reflection;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Script/DeleteScriptRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Script/DeleteScriptRequestTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using NUnit.Framework;
 
 namespace Nest.Tests.Unit.Core.Script

--- a/src/Tests/Nest.Tests.Unit/Core/Script/GetScriptRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Script/GetScriptRequestTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Reflection;
 using Elasticsearch.Net;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Script/PutScriptRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Script/PutScriptRequestTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Reflection;
 using Elasticsearch.Net;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Snapshot/RestoreObservableTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Snapshot/RestoreObservableTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
-using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Snapshot/SnapshotObservableTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Snapshot/SnapshotObservableTests.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
-using Elasticsearch.Net;
-using FakeItEasy.Core;
 using Moq;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/Core/Snapshot/SnapshotStatusRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Snapshot/SnapshotStatusRequestTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 
 namespace Nest.Tests.Unit.Core.Snapshot

--- a/src/Tests/Nest.Tests.Unit/Core/Template/PutTemplateRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Template/PutTemplateRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using NUnit.Framework;
 
 namespace Nest.Tests.Unit.Core.Template

--- a/src/Tests/Nest.Tests.Unit/Core/Update/UpdateAPIConsistencyTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Update/UpdateAPIConsistencyTests.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Reflection;
 using NUnit.Framework;
-using Nest.Tests.MockData.Domain;
-using NUnit.Framework.Constraints;
 
 namespace Nest.Tests.Unit.Core.Update
 {

--- a/src/Tests/Nest.Tests.Unit/Core/UpdateSettings/UpdateSettingsTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/UpdateSettings/UpdateSettingsTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
+﻿using System.Reflection;
 using NUnit.Framework;
 
 namespace Nest.Tests.Unit.Core.UpdateSettings

--- a/src/Tests/Nest.Tests.Unit/Core/Versioning/VersioningTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Versioning/VersioningTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using NUnit.Framework;
 using Nest.Tests.MockData.Domain;

--- a/src/Tests/Nest.Tests.Unit/Core/Warmers/PutWarmerRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Warmers/PutWarmerRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using NUnit.Framework;
 using Nest.Tests.MockData.Domain;
 

--- a/src/Tests/Nest.Tests.Unit/Internals/Exceptions/BadQueryServerExceptionTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Internals/Exceptions/BadQueryServerExceptionTests.cs
@@ -1,11 +1,7 @@
 ﻿using System.Reflection;
-using Elasticsearch.Net.Connection;
 using FluentAssertions;
 using Nest.Tests.MockData.Domain;
-using Newtonsoft.Json.Converters;
 using NUnit.Framework;
-using System;
-using Elasticsearch.Net;
 
 namespace Nest.Tests.Unit.Internals.Exceptions
 {

--- a/src/Tests/Nest.Tests.Unit/Internals/Inferno/EscapedFormatTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Internals/Inferno/EscapedFormatTests.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using System;
 using Elasticsearch.Net;
 
 namespace Nest.Tests.Unit.Internals.Inferno

--- a/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapIdPropertyForTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapIdPropertyForTests.cs
@@ -3,10 +3,6 @@ using Elasticsearch.Net.Connection;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nest.Tests.Unit.Internals.Inferno
 {

--- a/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapPropertyIgnoreTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapPropertyIgnoreTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Connection;
 using FluentAssertions;
 using NUnit.Framework;
-using System.Linq.Expressions;
 using Newtonsoft.Json;
 
 namespace Nest.Tests.Unit.Internals.Inferno

--- a/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapPropertyNamesForTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Internals/Inferno/MapPropertyNamesForTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Elasticsearch.Net;
 using Elasticsearch.Net.Connection;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/Tests/Nest.Tests.Unit/Internals/Inferno/PropertyNameResolverTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Internals/Inferno/PropertyNameResolverTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Elasticsearch.Net;
-using FluentAssertions;
 using NUnit.Framework;
 using System.Linq.Expressions;
 using Newtonsoft.Json;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/AliasRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/AliasRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/GetAliasMoreUrlTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/GetAliasMoreUrlTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/GetAliasRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/GetAliasRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/GetAliasesMoreUrlTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/GetAliasesMoreUrlTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/GetAliasesRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Aliases/GetAliasesRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Analyze/AnalyzeRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Analyze/AnalyzeRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Resolvers;
 using Nest.Tests.MockData.Domain;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Bulk/BulkRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Bulk/BulkRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClearCache/ClearCacheRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClearCache/ClearCacheRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClusterHealth/ClusterHealthRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClusterHealth/ClusterHealthRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClusterSettings/ClusterGetSettingsRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClusterSettings/ClusterGetSettingsRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClusterSettings/ClusterSettingsRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClusterSettings/ClusterSettingsRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClusterState/ClusterStateRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/ClusterState/ClusterStateRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Count/CountRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Count/CountRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Resolvers;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/CreateIndex/CreateIndexRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/CreateIndex/CreateIndexRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Delete/DeleteRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Delete/DeleteRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Resolvers;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestUrlTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestUrlTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryTypedRequestUrlTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryTypedRequestUrlTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteIndex/DeleteIndexRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteIndex/DeleteIndexRequestTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Tests.MockData.Domain;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Exists/DocumentExistsRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Exists/DocumentExistsRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Exists/IndexExistsRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Exists/IndexExistsRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Flush/FlushRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Flush/FlushRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Get/GetRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Get/GetRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Index/IndexRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Index/IndexRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Tests.MockData.Domain;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/IndicesStats/IndicesStatsRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/IndicesStats/IndicesStatsRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Resolvers;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Mapping/DeleteMappingRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Mapping/DeleteMappingRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Mapping/GetMappingRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Mapping/GetMappingRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Mapping/MapRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Mapping/MapRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MoreLikeThis/MoreLikeThisRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MoreLikeThis/MoreLikeThisRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiGet/MultiGetRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiGet/MultiGetRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiSearch/MultiSearchRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiSearch/MultiSearchRequestTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Elasticsearch.Net;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiTermVectors/MultiTermVectorsRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiTermVectors/MultiTermVectorsRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Elasticsearch.Net;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiTermVectors/MultiTermVectorsWithDocumentRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MultiTermVectors/MultiTermVectorsWithDocumentRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using Elasticsearch.Net;
 using FluentAssertions;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Nodes/NodeStatsRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Nodes/NodeStatsRequestTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Resolvers;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Nodes/NodesHotThreadsRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Nodes/NodesHotThreadsRequestTests.cs
@@ -1,11 +1,6 @@
 ﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nest.Tests.Unit.ObjectInitializer.Nodes
 {

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Nodes/NodesInfoRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Nodes/NodesInfoRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/OpenClose/CloseIndexRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/OpenClose/CloseIndexRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/OpenClose/OpenIndexRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/OpenClose/OpenIndexRequestTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 using FluentAssertions;
 using Nest.Tests.MockData.Domain;
 using NUnit.Framework;


### PR DESCRIPTION
In the code was a lot of not used namespaces. It's minor changes in the code without any kind backward compatibility issues.
