### PR TITLE
Fix/trace corrolation

### DIFF
--- a/src/Elasticsearch.Net/Connection/RequestState/TransportRequestState.cs
+++ b/src/Elasticsearch.Net/Connection/RequestState/TransportRequestState.cs
@@ -114,11 +114,10 @@ namespace Elasticsearch.Net.Connection.RequestState
 
 			if (this._traceEnabled)
 			{
-				Trace.TraceInformation("NEST start:{0} {1} {2}:\r\n{3}"
+				Trace.TraceInformation("NEST start:{0} {1} {2}"
 					, this._requestId
 					, _result.RequestMethod
 					, _result.RequestUrl
-					, _result
 				);
 			}
 

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MatchQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MatchQueryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
 namespace Nest.Tests.Unit.QueryParsers.Queries
@@ -9,10 +10,19 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 		[Test]
 		public void Match_Deserializes()
 		{
+			_client.Search<Person>(s => s
+	.Query(q =>
+		q.Term(p => p.FirstName, "martijn")
+	)
+);
+			var x = new ()
+			;
+
+
 			var q = this.SerializeThenDeserialize(
-				f=>f.Match,
-				f=>f.Match(m=>m
-					.OnField(p=>p.Name)
+				f => f.Match,
+				f => f.Match(m => m
+					.OnField(p => p.Name)
 					.Analyzer("my-analyzer")
 					.Boost(2.1)
 					.CutoffFrequency(1.31)
@@ -46,9 +56,9 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 		public void MatchPhrasePhrefix_Deserializes()
 		{
 			var q = this.SerializeThenDeserialize(
-				f=>f.Match,
-				f=>f.MatchPhrasePrefix(m=>m
-					.OnField(p=>p.Name)
+				f => f.Match,
+				f => f.MatchPhrasePrefix(m => m
+					.OnField(p => p.Name)
 					.Analyzer("my-analyzer")
 					.Boost(2.1)
 					.CutoffFrequency(1.31)
@@ -81,9 +91,9 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 		public void MatchPhrase_Deserializes()
 		{
 			var q = this.SerializeThenDeserialize(
-				f=>f.Match,
-				f=>f.MatchPhrase(m=>m
-					.OnField(p=>p.Name)
+				f => f.Match,
+				f => f.MatchPhrase(m => m
+					.OnField(p => p.Name)
 					.Analyzer("my-analyzer")
 					.Boost(2.1)
 					.CutoffFrequency(1.31)

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MatchQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MatchQueryTests.cs
@@ -10,15 +10,6 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 		[Test]
 		public void Match_Deserializes()
 		{
-			_client.Search<Person>(s => s
-	.Query(q =>
-		q.Term(p => p.FirstName, "martijn")
-	)
-);
-			var x = new ()
-			;
-
-
 			var q = this.SerializeThenDeserialize(
 				f => f.Match,
 				f => f.Match(m => m


### PR DESCRIPTION
Right now we only TRACE when requests are wrapped up (succesfull/failure/timeout etcetera).

Whats actually more useful is to TRACE the fact we are beginning a request in addition to when ending one.

