### PR TITLE
Add support for standard deviation bounds to extended stats

### DIFF
--- a/src/Nest/Domain/Aggregations/ExtendedStatsMetric.cs
+++ b/src/Nest/Domain/Aggregations/ExtendedStatsMetric.cs
@@ -10,5 +10,12 @@
 		public double? SumOfSquares { get; set; }
 		public double? Variance { get; set; }
 		public double? StdDeviation { get; set; }
+		public StandardDeviationBounds StdDeviationBounds { get; set; }
+	}
+
+	public class StandardDeviationBounds
+	{
+		public double? Upper { get; set; }
+		public double? Lower { get; set; }
 	}
 }

--- a/src/Nest/Resolvers/Converters/Aggregations/AggregationConverter.cs
+++ b/src/Nest/Resolvers/Converters/Aggregations/AggregationConverter.cs
@@ -184,18 +184,39 @@ namespace Nest.Resolvers.Converters.Aggregations
 			reader.Read(); reader.Read();
 			var variance = (reader.Value as double?);
 			reader.Read(); reader.Read();
-			var stdVariation = (reader.Value as double?);
+			var stdDeviation = (reader.Value as double?);
 			reader.Read();
+
+			StandardDeviationBounds stdDeviationBounds = null;
+			if (reader.TokenType != JsonToken.EndObject)
+			{
+				stdDeviationBounds = new StandardDeviationBounds();
+				reader.Read();
+				reader.Read();
+				if ((reader.Value as string) == "upper")
+				{
+					reader.Read();
+					stdDeviationBounds.Upper = reader.Value as double?;
+				}
+				reader.Read();
+				if ((reader.Value as string) == "lower")
+				{
+					reader.Read();
+					stdDeviationBounds.Lower = reader.Value as double?;
+				}
+			}
+
 			return new ExtendedStatsMetric()
 			{
 				Average = average,
 				Count = count,
 				Max = max,
 				Min = min,
-				StdDeviation = stdVariation,
+				StdDeviation = stdDeviation,
 				Sum = sum,
 				SumOfSquares = sumOfSquares,
-				Variance = variance
+				Variance = variance,
+				StdDeviationBounds = stdDeviationBounds
 			};
 		}
 

--- a/src/Tests/Nest.Tests.Integration/Aggregations/StatsAggregationTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Aggregations/StatsAggregationTests.cs
@@ -81,7 +81,27 @@ namespace Nest.Tests.Integration.Aggregations
 	        statsBucket.Should().NotBeNull();
 	        statsBucket.Count.Should().BeGreaterThan(1);
 	        statsBucket.StdDeviation.Should().BeGreaterThan(1);
-        }	
+        }
+
+		[Test]
+		[SkipVersion("0 - 1.4.2", "Standard deviation bounds added in 1.4.3")]
+		public void ExtendedStatsWithStandardDeviationBounds()
+		{
+			var results = this.Client.Search<ElasticsearchProject>(s => s
+				.Size(0)
+				.Aggregations(a => a
+					.ExtendedStats("stats_agg", t => t.Field(p => p.LOC))
+				)
+			);
+			results.IsValid.Should().BeTrue();
+			var statsBucket = results.Aggs.ExtendedStats("stats_agg");
+			statsBucket.Should().NotBeNull();
+			statsBucket.Count.Should().BeGreaterThan(1);
+			statsBucket.StdDeviation.Should().BeGreaterThan(1);
+			statsBucket.StdDeviationBounds.Should().NotBeNull();
+			statsBucket.StdDeviationBounds.Upper.Should().NotBe(0);
+			statsBucket.StdDeviationBounds.Lower.Should().NotBe(0);
+		}
 		
     }
 }


### PR DESCRIPTION
Added in ES 1.4.3.  This consequently fixes a deserialization
exception that occurs when running against an ES version earlier
than 1.4.3.

Closes #1281