### PR TITLE
fixes enums being skipped when calling MapFromAttributes()

### DIFF
--- a/src/Nest/DSL/PutMappingDescriptor.cs
+++ b/src/Nest/DSL/PutMappingDescriptor.cs
@@ -99,11 +99,11 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Convenience method to map from most of the object from the attributes/properties.
-		/// Later calls can override whatever is set is by this call. 
-		/// This helps mapping all the ints as ints, floats as floats etcetera withouth having to be overly verbose in your fluent mapping
+		/// Convenience method to map as much as it can based on ElasticType attributes set on the type.
+		/// <pre>This method also automatically sets up mappings for known values types (int, long, double, datetime, etcetera)</pre>
+		/// <pre>Class types default to object and Enums to int</pre>
+		/// <pre>Later calls can override whatever is set is by this call.</pre>
 		/// </summary>
-		/// <returns></returns>
 		public PutMappingDescriptor<T> MapFromAttributes(int maxRecursion = 0)
 		{
 			//TODO no longer needed when we have an IPutMappingRequest

--- a/src/Nest/Resolvers/Writers/TypeMappingWriter.cs
+++ b/src/Nest/Resolvers/Writers/TypeMappingWriter.cs
@@ -136,7 +136,7 @@ namespace Nest.Resolvers.Writers
 
 				var propertyName = this.Infer.PropertyName(p);
 				var type = GetElasticSearchType(att, p);
-				
+
 				if (type == null) //could not get type from attribute or infer from CLR type.
 					continue;
 
@@ -234,8 +234,8 @@ namespace Nest.Resolvers.Writers
 					return "boolean";
 				case FieldType.Completion:
 					return "completion";
-        case FieldType.Nested:
-          return "nested";
+				case FieldType.Nested:
+					return "nested";
 				case FieldType.Object:
 					return "object";
 				default:
@@ -254,6 +254,9 @@ namespace Nest.Resolvers.Writers
 
 			if (propertyType == typeof(string))
 				return FieldType.String;
+
+			if (propertyType.IsEnum)
+				return FieldType.Integer;
 
 			if (propertyType.IsValueType)
 			{
@@ -284,7 +287,7 @@ namespace Nest.Resolvers.Writers
 			if (type.IsArray)
 				return type.GetElementType();
 
-            if (type.IsGenericType && type.GetGenericArguments().Length == 1 && (type.GetInterface("IEnumerable") != null || Nullable.GetUnderlyingType(type) != null))
+			if (type.IsGenericType && type.GetGenericArguments().Length == 1 && (type.GetInterface("IEnumerable") != null || Nullable.GetUnderlyingType(type) != null))
 				return type.GetGenericArguments()[0];
 
 			return type;

--- a/src/Nest/Resolvers/Writers/TypeMappingWriter.cs
+++ b/src/Nest/Resolvers/Writers/TypeMappingWriter.cs
@@ -15,6 +15,10 @@ namespace Nest.Resolvers.Writers
 		private readonly Type _type;
 		private readonly IConnectionSettingsValues _connectionSettings;
 		private readonly NestSerializer _elasticSerializer;
+
+		private readonly static string _noFieldTypeMessage =
+			"Property {0} on type {1} has an ElasticProperty attribute but its FieldType (Type = ) can not be inferred and is not set explicitly while calling MapFromAttributes";
+
 		private ElasticInferrer Infer { get; set; }
 
 		private int MaxRecursion { get; set; }
@@ -194,6 +198,11 @@ namespace Nest.Resolvers.Writers
 			if (fieldType == null || fieldType == FieldType.None)
 			{
 				fieldType = this.GetFieldTypeFromType(p.PropertyType);
+				if (fieldType == null && att != null)
+				{
+					var message = _noFieldTypeMessage.F(p.Name, this._type.Name);
+					throw new DslException(message);
+				}
 			}
 
 			return this.GetElasticSearchTypeFromFieldType(fieldType);

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Enums/EnumCanBeOverriddenAfterMapFromAttributes.json
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Enums/EnumCanBeOverriddenAfterMapFromAttributes.json
@@ -1,0 +1,10 @@
+{
+  "myclass": {
+    "properties": {
+      "myEnum": {
+        "index": "not_analyzed",
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Enums/EnumMappingTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Enums/EnumMappingTests.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nest.Tests.Unit.Core.Map.Enums
+{
+	[TestFixture]
+	public class EnumMappingTests : BaseJsonTests
+	{
+		private class MyClass
+		{
+			public MyEnum MyEnum { get; set; }
+		}
+
+		private enum MyEnum
+		{
+			Value1,
+			Value2
+		}
+
+		[Test]
+		public void EnumShouldMapToIntByDefault()
+		{
+			var result = this._client.Map<MyClass>(m => m.MapFromAttributes());
+			this.JsonEquals(result.ConnectionStatus.Request, MethodBase.GetCurrentMethod());
+		}
+
+		[Test]
+		public void EnumCanBeOverriddenAfterMapFromAttributes()
+		{
+			var result = this._client.Map<MyClass>(m => m
+				.MapFromAttributes()
+				.Properties(props=>props
+					.String(s=>s
+						.Name(p=>p.MyEnum)
+						.Index(FieldIndexOption.NotAnalyzed)
+					)
+				)
+			);
+			this.JsonEquals(result.ConnectionStatus.Request, MethodBase.GetCurrentMethod());
+		}
+
+	}
+
+}

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Enums/EnumShouldMapToIntByDefault.json
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Enums/EnumShouldMapToIntByDefault.json
@@ -1,0 +1,9 @@
+{
+  "myclass": {
+    "properties": {
+      "myEnum": {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Structs/EnumMappingTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Structs/EnumMappingTests.cs
@@ -1,0 +1,62 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Nest.Tests.Unit.Core.Map.Structs
+{
+	[TestFixture]
+	public class StructMappingTests : BaseJsonTests
+	{
+		private class MyClass
+		{
+			public MyStruct Struct { get; set; }
+		}
+
+		private class MyClass2
+		{
+			[ElasticProperty(Analyzer = "default")]
+			public MyStruct StructProperty { get; set; }
+		}
+
+		private struct MyStruct
+		{
+			public string Object { get; set; }
+		}
+
+		[Test]
+		public void StructWithNoAttributeSetIsIgnored()
+		{
+			//unknow value types are not handled by default by MapFromAttributes()
+			var result = this._client.Map<MyClass>(m => m.MapFromAttributes());
+			this.JsonEquals(result.ConnectionStatus.Request, MethodBase.GetCurrentMethod());
+		}
+
+		[Test]
+		public void StructWithAttributeButNoTypeInformationThrows()
+		{
+			//unknown value types with missing FieldType information in the attribute should throw an exception
+			
+			//example
+
+			//Nest.DslException : Property Struct on type MyClass2 <continued>
+			//has an ElasticProperty attribute but its FieldType (Type = ) can not be inferred <continued>
+			//and is not set explicitly while calling MapFromAttributes
+
+			var e = Assert.Throws<DslException>(() =>
+			{
+				var result = this._client.Map<MyClass2>(m => m.MapFromAttributes());
+				this.JsonEquals(result.ConnectionStatus.Request, MethodBase.GetCurrentMethod());
+			});
+
+			e.Message.Should().EndWith("while calling MapFromAttributes");
+			e.Message.Should().Contain("StructProperty");
+		}
+
+	}
+
+}

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Structs/StructWithAttributeButNoTypeInformationThrows.json
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Structs/StructWithAttributeButNoTypeInformationThrows.json
@@ -1,0 +1,6 @@
+{
+  "myclass2": {
+    "properties": {
+    }
+  }
+}

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Structs/StructWithNoAttributeSetIsIgnored.json
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Structs/StructWithNoAttributeSetIsIgnored.json
@@ -1,0 +1,6 @@
+{
+  "myclass": {
+    "properties": {
+    }
+  }
+}

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Core\Indices\Analysis\TokenFilters\TokenFilterTests.cs" />
     <Compile Include="Core\Indices\Similarity\SimilarityTests.cs" />
     <Compile Include="Core\Map\CustomMapping\ImagePluginMappingTests.cs" />
+    <Compile Include="Core\Map\Enums\EnumMappingTests.cs" />
     <Compile Include="Core\Map\GenericTypes\GenericTypeMappingTests.cs" />
     <Compile Include="Core\Map\GeoShape\GeoShapeMappingTests.cs" />
     <Compile Include="Core\Map\GetMappingSerializationTests.cs" />
@@ -174,6 +175,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Core\Map\CustomMapping\RepresentUnknowImageMappingPlugin.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Core\Map\Enums\EnumCanBeOverriddenAfterMapFromAttributes.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Core\Map\Enums\EnumShouldMapToIntByDefault.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Core\Map\GenericTypes\GenericTypeMapping.json">
@@ -392,7 +399,7 @@
     <Compile Include="Reproduce\Reproduce1146Tests.cs" />
     <Compile Include="Reproduce\Reproduce629Tests.cs" />
     <Compile Include="Reproduce\Reproduce1187Tests.cs" />
-    <Compile Include="Reproduce\Reproduce991Tests.cs" />
+    <Compile Include="Reproduce\Reproduce901Tests.cs" />
     <Compile Include="Reproduce\Reproduce990Tests.cs" />
     <Compile Include="Reproduce\Reproduce974Tests.cs" />
     <Compile Include="Reproduce\Reproduce928Tests.cs" />
@@ -817,6 +824,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Reproduce\Issue1199Mapping.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Reproduce\EnumQueryDefaultsToInt.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Reproduce\Issue928.json">

--- a/src/Tests/Nest.Tests.Unit/Reproduce/Reproduce901Tests.cs
+++ b/src/Tests/Nest.Tests.Unit/Reproduce/Reproduce901Tests.cs
@@ -12,7 +12,7 @@ namespace Nest.Tests.Unit.Reproduce
 	/// tests to reproduce reported errors
 	/// </summary>
 	[TestFixture]
-	public class Reproduce991Tests : BaseJsonTests
+	public class Reproduce901Tests : BaseJsonTests
 	{
 		private class MyClass
 		{
@@ -32,5 +32,6 @@ namespace Nest.Tests.Unit.Reproduce
 				.Query(q => q.Term(p => p.MyEnum, MyEnum.Value2));
 			this.JsonEquals(query, MethodBase.GetCurrentMethod());
 		}
+
 	}
 }


### PR DESCRIPTION
They are now mapped to integers by default (as per json.net defaults). 

You can still remap them to (not_analyzed) strings after a `MapFromAttributes()` call.

fixes #901 