### PR TITLE
ConditionlessWhen on function_score query

### DIFF
--- a/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
@@ -98,16 +98,25 @@ namespace Nest
 
 		string IQuery.Name { get; set; }
 
+		private bool _forcedConditionless = false;
+
 		bool IQuery.IsConditionless
 		{
 			get
 			{
-				return (Self.Query == null || Self.Query.IsConditionless)
+				return _forcedConditionless || ((Self.Query == null || Self.Query.IsConditionless)
 					&& Self.RandomScore == null 
 					&& Self.ScriptScore == null 
-					&& !Self.Functions.HasAny();
+					&& !Self.Functions.HasAny());
 			}
 		}
+
+		public FunctionScoreQueryDescriptor<T> ConditionlessWhen(bool isConditionless)
+		{
+			this._forcedConditionless = isConditionless;
+			return this;
+		}
+
 
 		public FunctionScoreQueryDescriptor<T> Name(string name)
 		{


### PR DESCRIPTION
Allows you to specify e.g: `.ConditionlessWhen(string.IsNullOrEmpty(query))` on a function score query to prevent functions to be applied in case of an empty query or fixed references inside the functions