### PR TITLE
IncludeInParent elastic property in NEST #1307

### DIFF
--- a/src/Nest/Domain/Mapping/Attributes/ElasticPropertyAttribute.cs
+++ b/src/Nest/Domain/Mapping/Attributes/ElasticPropertyAttribute.cs
@@ -30,6 +30,7 @@ namespace Nest
 		public bool OmitNorms { get; set; }
 		public bool OmitTermFrequencyAndPositions { get; set; }
 		public bool IncludeInAll { get; set; }
+		public bool IncludeInParent { get; set; }
 		public bool Store { get; set; }
 
 		/// <summary>

--- a/src/Nest/Domain/Mapping/Attributes/IElasticPropertyAttribute.cs
+++ b/src/Nest/Domain/Mapping/Attributes/IElasticPropertyAttribute.cs
@@ -20,6 +20,7 @@
         bool OmitNorms { get; set; }
         bool OmitTermFrequencyAndPositions { get; set; }
         bool IncludeInAll { get; set; }
+		bool IncludeInParent { get; set; }
         bool Store { get; set; }
 
         bool DocValues { get; set; }

--- a/src/Nest/Resolvers/Writers/WritePropertiesFromAttributeVisitor.cs
+++ b/src/Nest/Resolvers/Writers/WritePropertiesFromAttributeVisitor.cs
@@ -102,6 +102,11 @@ namespace Nest.Resolvers.Writers {
                 this._jsonWriter.WritePropertyName("include_in_all");
                 this._jsonWriter.WriteValue("false");
             }
+	        if (att.IncludeInParent)
+	        {
+				this._jsonWriter.WritePropertyName("include_in_parent");
+				this._jsonWriter.WriteValue(true);
+			}
             if (att.Store)
             {
                 this._jsonWriter.WritePropertyName("store");

--- a/src/Tests/Nest.Tests.Integration/Mapping/MapFromAttributeTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Mapping/MapFromAttributeTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nest.Tests.MockData.Domain;
+using NUnit.Framework;
+
+namespace Nest.Tests.Integration.Mapping
+{
+	[TestFixture]
+	public class MapFromAttributeTests : IntegrationTests
+	{
+		class MapFromAttributeObject
+		{
+			public string Name { get; set; }
+			[ElasticProperty(Type = FieldType.Nested, IncludeInParent = true)]
+			public List<NestedObject> NestedObjects { get; set; }
+			[ElasticProperty(Type = FieldType.Nested)]
+			public List<NestedObject> NestedObjectsDontIncludeInParent { get; set; }
+		}
+
+		class NestedObject
+		{
+			public string Name { get; set; }
+		}
+
+		[Test]
+		public void InlcudeInParent()
+		{
+			var indicesResponse = this.Client.Map<MapFromAttributeObject>(m => m.MapFromAttributes());
+
+			indicesResponse.IsValid.Should().BeTrue();
+
+			var typeMapping = this.Client.GetMapping<MapFromAttributeObject>(i => i.Type("mapfromattributeobject"));
+			typeMapping.Should().NotBeNull();
+
+			typeMapping.Mapping.Properties["nestedObjects"].Type.Name.Should().Be("nested");
+			typeMapping.Mapping.Properties["nestedObjectsDontIncludeInParent"].Type.Name.Should().Be("nested");
+			var nestedObject = typeMapping.Mapping.Properties["nestedObjects"] as NestedObjectMapping;
+			var nestedObjectDontincludeInParent = typeMapping.Mapping.Properties["nestedObjectsDontIncludeInParent"] as NestedObjectMapping;
+			nestedObject.Should().NotBeNull();
+			nestedObjectDontincludeInParent.Should().NotBeNull();
+			nestedObject.IncludeInParent.Should().BeTrue();
+			nestedObjectDontincludeInParent.IncludeInParent.Should().NotHaveValue();
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Core\Exists\IndexExistsTests.cs" />
     <Compile Include="Indices\StatsTests.cs" />
     <Compile Include="Core\AsyncTests.cs" />
+    <Compile Include="Mapping\MapFromAttributeTests.cs" />
     <Compile Include="Mapping\MappingVisitorTests.cs" />
     <Compile Include="Mapping\GetMultipleMappingTests.cs" />
     <Compile Include="Reproduce\Reproduce1181Tests.cs" />

--- a/src/Tests/Nest.Tests.Unit/Core/AttributeBasedMap/IncludeInParentTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/AttributeBasedMap/IncludeInParentTests.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+
+namespace Nest.Tests.Unit.Core.AttributeBasedMap
+{
+	[TestFixture]
+	public class IncludeInParentTests : BaseAttributeMappingTests
+	{
+		private class SimpleNestedMapParent
+		{
+			public string Name { get; set; }
+			[ElasticProperty(Type = FieldType.Nested, IncludeInParent = true)]
+			public SimpleNestedMapChild SimpleNestedMapChild { get; set; }
+			[ElasticProperty(Type = FieldType.Nested)]
+			public SimpleNestedMapChild SimpleNestedMapChildDontIncludeInParent { get; set; }
+		}
+
+		private class SimpleNestedMapChild
+		{
+			public string Name { get; set; }
+		}
+
+		[Test]
+		public void TestIncludeInParent()
+		{
+			var json = this.CreateMapFor<SimpleNestedMapParent>();
+			this.JsonEquals(json, System.Reflection.MethodInfo.GetCurrentMethod());
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Unit/Core/AttributeBasedMap/TestIncludeInParent.json
+++ b/src/Tests/Nest.Tests.Unit/Core/AttributeBasedMap/TestIncludeInParent.json
@@ -1,0 +1,26 @@
+﻿{
+  "simplenestedmapparent": {
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "simpleNestedMapChild": {
+        "type": "nested",
+        "include_in_parent": true,
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "simpleNestedMapChildDontIncludeInParent": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Cluster\NodeTests.cs" />
     <Compile Include="Cluster\Reroute\RerouteTests.cs" />
     <Compile Include="Cluster\State\StateTests.cs" />
+    <Compile Include="Core\AttributeBasedMap\IncludeInParentTests.cs" />
     <Compile Include="Core\Bulk\BulkTests.cs" />
     <Compile Include="Core\Bulk\BulkUrlTests.cs" />
     <Compile Include="Core\Indices\Alias\AliasTests.cs" />
@@ -116,6 +117,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Cluster\Reroute\ClusterReroute.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Core\AttributeBasedMap\TestIncludeInParent.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Core\Bulk\BulkIndexDetailsFixedPath.json">


### PR DESCRIPTION
PR contains fix for https://github.com/elastic/elasticsearch-net/issues/1307.

I modified `IElasticPropertyAttribute` and `WritePropertiesFromAttributeVisitor` to handle missing property. 
