### PR TITLE
Missing fuzzy_transpositions support in MatchQuery #1333

### DIFF
--- a/src/Nest/DSL/Query/MatchQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MatchQueryDescriptor.cs
@@ -29,6 +29,9 @@ namespace Nest
 		[JsonProperty(PropertyName = "fuzziness")]
 		double? Fuzziness { get; set; }
 
+		[JsonProperty(PropertyName = "fuzzy_transpositions")]
+		bool? FuzzyTranspositions { get; set; }
+
 		[JsonProperty(PropertyName = "cutoff_frequency")]
 		double? CutoffFrequency { get; set; }
 
@@ -82,6 +85,7 @@ namespace Nest
 		public string Analyzer { get; set; }
 		public RewriteMultiTerm? Rewrite { get; set; }
 		public double? Fuzziness { get; set; }
+		public bool? FuzzyTranspositions { get; set; }
 		public double? CutoffFrequency { get; set; }
 		public int? PrefixLength { get; set; }
 		public int? MaxExpansions { get; set; }
@@ -112,6 +116,7 @@ namespace Nest
 		RewriteMultiTerm? IMatchQuery.Rewrite { get; set; }
 
 		double? IMatchQuery.Fuzziness { get; set; }
+		bool? IMatchQuery.FuzzyTranspositions { get; set; }
 
 		double? IMatchQuery.CutoffFrequency { get; set; }
 
@@ -187,7 +192,13 @@ namespace Nest
 			Self.Fuzziness = fuzziness;
 			return this;
 		}
-		
+
+		public MatchQueryDescriptor<T> FuzzyTranspositions(bool fuzzyTranspositions = true)
+		{
+			Self.FuzzyTranspositions = fuzzyTranspositions;
+			return this;
+		}
+
 		public MatchQueryDescriptor<T> CutoffFrequency(double cutoffFrequency)
 		{
 			Self.CutoffFrequency = cutoffFrequency;

--- a/src/Nest/Resolvers/Converters/Queries/MatchQueryJsonConverter.cs
+++ b/src/Nest/Resolvers/Converters/Queries/MatchQueryJsonConverter.cs
@@ -45,6 +45,7 @@ namespace Nest
 			fq.Analyzer = GetPropValue<string>(jo, "analyzer");
 			fq.CutoffFrequency = GetPropValue<double?>(jo, "cutoff_frequency");
 			fq.Fuzziness = GetPropValue<double?>(jo, "fuzziness");
+			fq.FuzzyTranspositions = GetPropValue<bool?>(jo, "fuzzy_transpositions");
 			fq.Lenient = GetPropValue<bool?>(jo, "lenient");
 			fq.MaxExpansions = GetPropValue<int?>(jo, "max_expansions");
 			fq.PrefixLength = GetPropValue<int?>(jo, "prefix_length");

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MatchQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MatchQueryTests.cs
@@ -33,6 +33,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Boost.Should().Be(2.1);
 			q.CutoffFrequency.Should().Be(1.31);
 			q.Fuzziness.Should().Be(2.3);
+			q.FuzzyTranspositions.Should().Be(null);
 			q.Lenient.Should().BeTrue();
 			q.MaxExpansions.Should().Be(2);
 			q.Field.Should().Be("name");
@@ -54,6 +55,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 					.Boost(2.1)
 					.CutoffFrequency(1.31)
 					.Fuzziness(2.3)
+					.FuzzyTranspositions(false)
 					.Lenient()
 					.MaxExpansions(2)
 					.Operator(Operator.And)
@@ -68,6 +70,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Boost.Should().Be(2.1);
 			q.CutoffFrequency.Should().Be(1.31);
 			q.Fuzziness.Should().Be(2.3);
+			q.FuzzyTranspositions.Should().Be(false);
 			q.Lenient.Should().BeTrue();
 			q.MaxExpansions.Should().Be(2);
 			q.Field.Should().Be("name");
@@ -89,6 +92,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 					.Boost(2.1)
 					.CutoffFrequency(1.31)
 					.Fuzziness(2.3)
+					.FuzzyTranspositions()
 					.Lenient()
 					.MaxExpansions(2)
 					.Operator(Operator.And)
@@ -103,6 +107,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Boost.Should().Be(2.1);
 			q.CutoffFrequency.Should().Be(1.31);
 			q.Fuzziness.Should().Be(2.3);
+			q.FuzzyTranspositions.Should().Be(true);
 			q.Lenient.Should().BeTrue();
 			q.MaxExpansions.Should().Be(2);
 			q.Field.Should().Be("name");

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MatchQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MatchQueryJson.cs
@@ -35,6 +35,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 					}
 				}
 			}";
+
 			Assert.True(json.JsonEquals(expected), json);		
 		}
 		
@@ -66,6 +67,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 					}
 				}
 			}";
+
 			Assert.True(json.JsonEquals(expected), json);		
 		}
 
@@ -79,7 +81,6 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 					.Match(t => t
 						.OnField(f => f.Name)
 						.Query("this is a test")
-						
 						.Fuzziness(1.0)
 						.Analyzer("my_analyzer")
 						.CutoffFrequency(0.3)
@@ -103,8 +104,10 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 					}
 				}
 			}";
+
 			Assert.True(json.JsonEquals(expected), json);
 		}
+
 		[Test]
 		public void MatchQueryFuzzyTranspositions()
 		{
@@ -140,6 +143,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 					}
 				}
 			}";
+
 			Assert.True(json.JsonEquals(expected), json);
 		}
 	}

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MatchQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MatchQueryJson.cs
@@ -68,6 +68,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 			}";
 			Assert.True(json.JsonEquals(expected), json);		
 		}
+
 		[Test]
 		public void MatchQuerySomeOptions()
 		{
@@ -96,6 +97,43 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 							analyzer : ""my_analyzer"",
 							rewrite: ""constant_score_filter"",
 							fuzziness: 1.0,
+							cutoff_frequency: 0.3,
+							prefix_length: 2
+						}
+					}
+				}
+			}";
+			Assert.True(json.JsonEquals(expected), json);
+		}
+		[Test]
+		public void MatchQueryFuzzyTranspositions()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.Query(q => q
+					.Match(t => t
+						.OnField(f => f.Name)
+						.Query("this is a test")
+						.Fuzziness(1.0)
+						.FuzzyTranspositions()
+						.Analyzer("my_analyzer")
+						.CutoffFrequency(0.3)
+						.Rewrite(RewriteMultiTerm.ConstantScoreFilter)
+						.PrefixLength(2)
+					)
+			);
+
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"{ from: 0, size: 10, 
+				query : {
+					match: {
+						name : { 
+							query : ""this is a test"",
+							analyzer : ""my_analyzer"",
+							rewrite: ""constant_score_filter"",
+							fuzziness: 1.0,
+							fuzzy_transpositions : true,
 							cutoff_frequency: 0.3,
 							prefix_length: 2
 						}


### PR DESCRIPTION
PR for https://github.com/elastic/elasticsearch-net/issues/1333.

Looks like [fuzzy_transpositions](https://github.com/elastic/elasticsearch/pull/6300) parameter is available since 1.1.3 ES version. Would be great to prepare hot fix for previous versions of NEST? I'm not quite sure if I have such skill to do this.