### PR TITLE
Fix bad nuspec output path for .NET 4.0 nuget packages

### DIFF
--- a/build/Elasticsearch.Net.Connection.Thrift.nuspec
+++ b/build/Elasticsearch.Net.Connection.Thrift.nuspec
@@ -18,6 +18,10 @@
 		<tags>elasticsearch elastic search lucene thrift nest</tags>
 	</metadata>
 	<files>
+    <file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.dll" target="lib"/>
+    <file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.pdb" target="lib"/>
+    <file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.XML" target="lib"/>
+    
 		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.dll" target="lib\net40"/>
 		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.pdb" target="lib\net40"/>
 		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.XML" target="lib\net40"/>

--- a/build/Elasticsearch.Net.Connection.Thrift.nuspec
+++ b/build/Elasticsearch.Net.Connection.Thrift.nuspec
@@ -18,9 +18,9 @@
 		<tags>elasticsearch elastic search lucene thrift nest</tags>
 	</metadata>
 	<files>
-		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.dll" target="lib"/>
-		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.pdb" target="lib"/>
-		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.XML" target="lib"/>
+		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.dll" target="lib\net40"/>
+		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.pdb" target="lib\net40"/>
+		<file src="output\Elasticsearch.Net.Connection.Thrift\net40\Elasticsearch.Net.Connection.Thrift.XML" target="lib\net40"/>
 		
 		<file src="output\Elasticsearch.Net.Connection.Thrift\net45\Elasticsearch.Net.Connection.Thrift.dll" target="lib\net45"/>
 		<file src="output\Elasticsearch.Net.Connection.Thrift\net45\Elasticsearch.Net.Connection.Thrift.pdb" target="lib\net45"/>

--- a/build/Elasticsearch.Net.JsonNET.nuspec
+++ b/build/Elasticsearch.Net.JsonNET.nuspec
@@ -19,6 +19,10 @@
 		<tags>elasticsearch elastic search lucene thrift nest</tags>
 	</metadata>
 	<files>
+    <file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.dll" target="lib"/>
+    <file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.pdb" target="lib"/>
+    <file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.XML" target="lib"/>
+    
 		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.dll" target="lib\net40"/>
 		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.pdb" target="lib\net40"/>
 		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.XML" target="lib\net40"/>

--- a/build/Elasticsearch.Net.JsonNET.nuspec
+++ b/build/Elasticsearch.Net.JsonNET.nuspec
@@ -19,9 +19,9 @@
 		<tags>elasticsearch elastic search lucene thrift nest</tags>
 	</metadata>
 	<files>
-		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.dll" target="lib"/>
-		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.pdb" target="lib"/>
-		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.XML" target="lib"/>
+		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.dll" target="lib\net40"/>
+		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.pdb" target="lib\net40"/>
+		<file src="output\Elasticsearch.Net.JsonNET\net40\Elasticsearch.Net.JsonNET.XML" target="lib\net40"/>
 		
 		<file src="output\Elasticsearch.Net.JsonNET\net45\Elasticsearch.Net.JsonNET.dll" target="lib\net45"/>
 		<file src="output\Elasticsearch.Net.JsonNET\net45\Elasticsearch.Net.JsonNET.pdb" target="lib\net45"/>

--- a/build/Elasticsearch.Net.nuspec
+++ b/build/Elasticsearch.Net.nuspec
@@ -19,9 +19,9 @@
 		<tags>elasticsearch elastic search lucene nest</tags>
 	</metadata>
 	<files>
-		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.dll" target="lib"/>
-		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.pdb" target="lib"/>
-		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.XML" target="lib"/>
+		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.dll" target="lib\net40"/>
+		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.pdb" target="lib\net40"/>
+		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.XML" target="lib\net40"/>
 		
 		<file src="output\Elasticsearch.Net\net45\Elasticsearch.Net.dll" target="lib\net45"/>
 		<file src="output\Elasticsearch.Net\net45\Elasticsearch.Net.pdb" target="lib\net45"/>

--- a/build/Elasticsearch.Net.nuspec
+++ b/build/Elasticsearch.Net.nuspec
@@ -19,6 +19,10 @@
 		<tags>elasticsearch elastic search lucene nest</tags>
 	</metadata>
 	<files>
+    <file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.dll" target="lib"/>
+    <file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.pdb" target="lib"/>
+    <file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.XML" target="lib"/>
+    
 		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.dll" target="lib\net40"/>
 		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.pdb" target="lib\net40"/>
 		<file src="output\Elasticsearch.Net\net40\Elasticsearch.Net.XML" target="lib\net40"/>

--- a/build/NEST.nuspec
+++ b/build/NEST.nuspec
@@ -19,6 +19,10 @@
 		<tags>elasticsearch elastic search lucene nest</tags>
 	</metadata>
 	<files>
+    <file src="output\Nest\net40\Nest.dll" target="lib"/>
+		<file src="output\Nest\net40\Nest.pdb" target="lib"/>
+		<file src="output\Nest\net40\Nest.XML" target="lib"/>
+    
 		<file src="output\Nest\net40\Nest.dll" target="lib\net40"/>
 		<file src="output\Nest\net40\Nest.pdb" target="lib\net40"/>
 		<file src="output\Nest\net40\Nest.XML" target="lib\net40"/>

--- a/build/NEST.nuspec
+++ b/build/NEST.nuspec
@@ -19,9 +19,9 @@
 		<tags>elasticsearch elastic search lucene nest</tags>
 	</metadata>
 	<files>
-		<file src="output\Nest\net40\Nest.dll" target="lib"/>
-		<file src="output\Nest\net40\Nest.pdb" target="lib"/>
-		<file src="output\Nest\net40\Nest.XML" target="lib"/>
+		<file src="output\Nest\net40\Nest.dll" target="lib\net40"/>
+		<file src="output\Nest\net40\Nest.pdb" target="lib\net40"/>
+		<file src="output\Nest\net40\Nest.XML" target="lib\net40"/>
 		
 		<file src="output\Nest\net45\Nest.dll" target="lib\net45"/>
 		<file src="output\Nest\net45\Nest.pdb" target="lib\net45"/>


### PR DESCRIPTION
resolve #1346 NEST and Elasticsearch.NET bad nuspec files that makes the package not usable in .NET 4.0