### PR TITLE
Support for supplying index settings on restore #1362

### DIFF
--- a/src/Nest/DSL/RestoreDescriptor.cs
+++ b/src/Nest/DSL/RestoreDescriptor.cs
@@ -111,9 +111,10 @@ namespace Nest
 			return this;
 		}
 
-		public RestoreDescriptor IndexSettings(Func<UpdateSettingsDescriptor, UpdateSettingsDescriptor> settings)
+		public RestoreDescriptor IndexSettings(Func<UpdateSettingsDescriptor, UpdateSettingsDescriptor> settingsSelector)
 		{
-			Self.IndexSettings = settings(new UpdateSettingsDescriptor());
+			settingsSelector.ThrowIfNull("settings");
+			Self.IndexSettings = settingsSelector(new UpdateSettingsDescriptor());
 			return this;
 		}
 

--- a/src/Nest/DSL/RestoreDescriptor.cs
+++ b/src/Nest/DSL/RestoreDescriptor.cs
@@ -19,7 +19,10 @@ namespace Nest
 		string RenamePattern { get; set; }
 		[JsonProperty("rename_replacement")]
 		string RenameReplacement { get; set; }
-		
+		[JsonProperty("index_settings")]
+		IUpdateSettingsRequest IndexSettings { get; set; }
+		[JsonProperty("ignore_index_settings")]
+		List<string> IgnoreIndexSettings { get; set; }
 	}
 
 	internal static class RestorePathInfo
@@ -43,6 +46,8 @@ namespace Nest
 		public string RenamePattern { get; set; }
 		
 		public string RenameReplacement { get; set; }
+		public IUpdateSettingsRequest IndexSettings { get; set; }
+		public List<string> IgnoreIndexSettings { get; set; }
 
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<RestoreRequestParameters> pathInfo)
 		{
@@ -61,7 +66,9 @@ namespace Nest
 		bool? IRestoreRequest.IncludeGlobalState { get; set; }
 		string IRestoreRequest.RenamePattern { get; set; }
 		string IRestoreRequest.RenameReplacement { get; set; }
-		
+		IUpdateSettingsRequest IRestoreRequest.IndexSettings { get; set; }
+		List<string> IRestoreRequest.IgnoreIndexSettings { get; set; }
+
 		public RestoreDescriptor Index(string index)
 		{
 			return this.Indices(index);
@@ -104,10 +111,29 @@ namespace Nest
 			return this;
 		}
 
+		public RestoreDescriptor IndexSettings(Func<UpdateSettingsDescriptor, UpdateSettingsDescriptor> settings)
+		{
+			Self.IndexSettings = settings(new UpdateSettingsDescriptor());
+			return this;
+		}
+
+		public RestoreDescriptor IgnoreIndexSettings(List<string> ignoreIndexSettings)
+		{
+			ignoreIndexSettings.ThrowIfNull("ignoreIndexSettings");
+			Self.IgnoreIndexSettings = ignoreIndexSettings;
+			return this;
+		}
+
+		public RestoreDescriptor IgnoreIndexSettings(params string[] ignoreIndexSettings)
+		{
+			ignoreIndexSettings.ThrowIfNull("ignoreIndexSettings");
+			this.IgnoreIndexSettings(ignoreIndexSettings.ToList());
+			return this;
+		}
+
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<RestoreRequestParameters> pathInfo)
 		{
 			RestorePathInfo.Update(pathInfo, this);
 		}
-
 	}
 }

--- a/src/Nest/DSL/UpdateSettingsDescriptor.cs
+++ b/src/Nest/DSL/UpdateSettingsDescriptor.cs
@@ -1,116 +1,154 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest
-{
+{ 
+	public class SettingNames
+	{
+		public const string NumberOfReplicas = "index.number_of_replicas";
+		public const string AutoExpandReplicas = "index.auto_expand_replicas";
+		public const string BlocksReadOnly = "index.blocks.read_only";
+		public const string BlocksRead = "index.blocks.read";
+		public const string BlocksWrite = "index.blocks.write";
+		public const string BlocksMetadata = "index.blocks.metadata";
+		public const string RefreshInterval = "index.refresh_interval";
+		public const string IndexConcurrency = "index.index_concurrency";
+		public const string Codec = "index.codec";
+		public const string CodecBloomLoad = "index.codec.bloom.load";
+		public const string FailOnMergeFailure = "index.fail_on_merge_failure";
+		public const string TranslogFlushTreshHoldOps = "index.translog.flush_threshold_ops";
+		public const string TranslogFlushThresholdSize = "index.translog.flush_threshold_size";
+		public const string TranslogFlushThresholdPeriod = "index.translog.flush_threshold_period";
+		public const string TranslogDisableFlush = "index.translog.disable_flush";
+		public const string CacheFilterMaxSize = "index.cache.filter.max_size";
+		public const string CacheFilterExpire = "index.cache.filter.expire";
+		public const string CacheQueryEnable = "index.cache.query.enable";
+		public const string GatewaySnapshotInterval = "index.gateway.snapshot_interval";
+		public const string RoutingAllocationInclude = "index.routing.allocation.include";
+		public const string RoutingAllocationExclude = "index.routing.allocation.exclude";
+		public const string RoutingAllocationRequire = "index.routing.allocation.require";
+		public const string RoutingAllocationEnable = "index.routing.allocation.enable";
+		public const string RoutingAllocationDisableAllication = "index.routing.allocation.disable_allocation";
+		public const string RoutingAllocationDisableNewAllocation = "index.routing.allocation.disable_new_allocation";
+		public const string RoutingAllocationDisableReplicaAllocation = "index.routing.allocation.disable_replica_allocation";
+		public const string RoutingAllocationTotalShardsPerNode = "index.routing.allocation.total_shards_per_node";
+		public const string RecoveryInitialShards = "index.recovery.initial_shards";
+		public const string GcDeletes = "index.gc_deletes";
+		public const string TtlDisablePurge = "index.ttl.disable_purge";
+		public const string TranslogFsType = "index.translog.fs.type";
+		public const string CompoundFormat = "index.compound_format";
+		public const string CompoundOnFlush = "index.compound_on_flush";
+		public const string WarmersEnabled = "index.warmer.enabled";
+		public const string Analysis = "analysis";
+	}
+
 	public interface IUpdateSettingsRequest : IIndexOptionalPath<UpdateSettingsRequestParameters>
 	{
-		[JsonProperty("index.number_of_replicas")]
+		[JsonProperty(SettingNames.NumberOfReplicas)]
 		int? NumberOfReplicas { get; set; }
 
-		[JsonProperty("index.auto_expand_replicas")]
+		[JsonProperty(SettingNames.AutoExpandReplicas)]
 		object AutoExpandReplicas { get; set; }
 
-		[JsonProperty("index.blocks.read_only")]
+		[JsonProperty(SettingNames.BlocksReadOnly)]
 		bool? BlocksReadOnly { get; set; }
 
-		[JsonProperty("index.blocks.read")]
+		[JsonProperty(SettingNames.BlocksRead)]
 		bool? BlocksRead { get; set; }
 
-		[JsonProperty("index.blocks.write")]
+		[JsonProperty(SettingNames.BlocksWrite)]
 		bool? BlocksWrite { get; set; }
 
-		[JsonProperty("index.blocks.metadata")]
+		[JsonProperty(SettingNames.BlocksMetadata)]
 		bool? BlocksMetadata { get; set; }
 
-		[JsonProperty("index.refresh_interval")]
+		[JsonProperty(SettingNames.RefreshInterval)]
 		string RefreshInterval { get; set; }
 
-		[JsonProperty("index.index_concurrency")]
+		[JsonProperty(SettingNames.IndexConcurrency)]
 		int? IndexConcurrency { get; set; }
 
-		[JsonProperty("index.codec")]
+		[JsonProperty(SettingNames.Codec)]
 		string Codec { get; set; }
 
-		[JsonProperty("index.codec.bloom.load")]
+		[JsonProperty(SettingNames.CodecBloomLoad)]
 		bool? CodecBloomLoad { get; set; }
 
-		[JsonProperty("index.fail_on_merge_failure")]
+		[JsonProperty(SettingNames.FailOnMergeFailure)]
 		bool? FailOnMergeFailure { get; set; }
 
-		[JsonProperty("index.translog.flush_threshold_ops")]
+		[JsonProperty(SettingNames.TranslogFlushTreshHoldOps)]
 		string TranslogFlushTreshHoldOps { get; set; }
 
-		[JsonProperty("index.translog.flush_threshold_size")]
+		[JsonProperty(SettingNames.TranslogFlushThresholdSize)]
 		string TranslogFlushThresholdSize { get; set; }
 
-		[JsonProperty("index.translog.flush_threshold_period")]
+		[JsonProperty(SettingNames.TranslogFlushThresholdPeriod)]
 		string TranslogFlushThresholdPeriod { get; set; }
 
-		[JsonProperty("index.translog.disable_flush")]
+		[JsonProperty(SettingNames.TranslogDisableFlush)]
 		bool? TranslogDisableFlush { get; set; }
 
-		[JsonProperty("index.cache.filter.max_size")]
+		[JsonProperty(SettingNames.CacheFilterMaxSize)]
 		string CacheFilterMaxSize { get; set; }
 
-		[JsonProperty("index.cache.filter.expire")]
+		[JsonProperty(SettingNames.CacheFilterExpire)]
 		string CacheFilterExpire { get; set; }
 
-		[JsonProperty("index.cache.query.enable")]
+		[JsonProperty(SettingNames.CacheQueryEnable)]
 		bool? CacheQueryEnable { get; set; }
 
-		[JsonProperty("index.gateway.snapshot_interval")]
+		[JsonProperty(SettingNames.GatewaySnapshotInterval)]
 		string GatewaySnapshotInterval { get; set; }
 
-		[JsonProperty("index.routing.allocation.include")]
+		[JsonProperty(SettingNames.RoutingAllocationInclude)]
 		IDictionary<string, object> RoutingAllocationInclude { get; set; }
 
-		[JsonProperty("index.routing.allocation.exclude")]
+		[JsonProperty(SettingNames.RoutingAllocationExclude)]
 		IDictionary<string, object> RoutingAllocationExclude { get; set; }
 
-		[JsonProperty("index.routing.allocation.require")]
+		[JsonProperty(SettingNames.RoutingAllocationRequire)]
 		IDictionary<string, object> RoutingAllocationRequire { get; set; }
 
-		[JsonProperty("index.routing.allocation.enable")]
+		[JsonProperty(SettingNames.RoutingAllocationEnable)]
 		RoutingAllocationEnableOption? RoutingAllocationEnable { get; set; }
 
-		[JsonProperty("index.routing.allocation.disable_allocation")]
+		[JsonProperty(SettingNames.RoutingAllocationDisableAllication)]
 		bool? RoutingAllocationDisableAllication { get; set; }
 
-		[JsonProperty("index.routing.allocation.disable_new_allocation")]
+		[JsonProperty(SettingNames.RoutingAllocationDisableNewAllocation)]
 		bool? RoutingAllocationDisableNewAllocation { get; set; }
 
-		[JsonProperty("index.routing.allocation.disable_replica_allocation")]
+		[JsonProperty(SettingNames.RoutingAllocationDisableReplicaAllocation)]
 		bool? RoutingAllocationDisableReplicaAllocation { get; set; }
 
-		[JsonProperty("index.routing.allocation.total_shards_per_node")]
+		[JsonProperty(SettingNames.RoutingAllocationTotalShardsPerNode)]
 		int? RoutingAllocationTotalShardsPerNode { get; set; }
 
-		[JsonProperty("index.recovery.initial_shards")]
+		[JsonProperty(SettingNames.RecoveryInitialShards)]
 		string RecoveryInitialShards { get; set; }
 
-		[JsonProperty("index.gc_deletes")]
+		[JsonProperty(SettingNames.GcDeletes)]
 		bool? GcDeletes { get; set; }
 
-		[JsonProperty("index.ttl.disable_purge")]
+		[JsonProperty(SettingNames.TtlDisablePurge)]
 		bool? TtlDisablePurge { get; set; }
 
-		[JsonProperty("index.translog.fs.type")]
+		[JsonProperty(SettingNames.TranslogFsType)]
 		string TranslogFsType { get; set; }
 
-		[JsonProperty("index.compound_format")]
+		[JsonProperty(SettingNames.CompoundFormat)]
 		bool? CompoundFormat { get; set; }
 
-		[JsonProperty("index.compound_on_flush")]
+		[JsonProperty(SettingNames.CompoundOnFlush)]
 		bool? CompoundOnFlush { get; set; }
 
-		[JsonProperty("index.warmer.enabled")]
+		[JsonProperty(SettingNames.WarmersEnabled)]
 		bool? WarmersEnabled { get; set; }
 
-		[JsonProperty("analysis")]
+		[JsonProperty(SettingNames.Analysis)]
 		AnalysisSettings Analysis { get; set; }
 	}
 

--- a/src/Nest/DSL/UpdateSettingsDescriptor.cs
+++ b/src/Nest/DSL/UpdateSettingsDescriptor.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 { 
-	public class SettingNames
+	public class UpdatableSettings
 	{
 		public const string NumberOfReplicas = "index.number_of_replicas";
 		public const string AutoExpandReplicas = "index.auto_expand_replicas";
@@ -46,109 +46,109 @@ namespace Nest
 
 	public interface IUpdateSettingsRequest : IIndexOptionalPath<UpdateSettingsRequestParameters>
 	{
-		[JsonProperty(SettingNames.NumberOfReplicas)]
+		[JsonProperty(UpdatableSettings.NumberOfReplicas)]
 		int? NumberOfReplicas { get; set; }
 
-		[JsonProperty(SettingNames.AutoExpandReplicas)]
+		[JsonProperty(UpdatableSettings.AutoExpandReplicas)]
 		object AutoExpandReplicas { get; set; }
 
-		[JsonProperty(SettingNames.BlocksReadOnly)]
+		[JsonProperty(UpdatableSettings.BlocksReadOnly)]
 		bool? BlocksReadOnly { get; set; }
 
-		[JsonProperty(SettingNames.BlocksRead)]
+		[JsonProperty(UpdatableSettings.BlocksRead)]
 		bool? BlocksRead { get; set; }
 
-		[JsonProperty(SettingNames.BlocksWrite)]
+		[JsonProperty(UpdatableSettings.BlocksWrite)]
 		bool? BlocksWrite { get; set; }
 
-		[JsonProperty(SettingNames.BlocksMetadata)]
+		[JsonProperty(UpdatableSettings.BlocksMetadata)]
 		bool? BlocksMetadata { get; set; }
 
-		[JsonProperty(SettingNames.RefreshInterval)]
+		[JsonProperty(UpdatableSettings.RefreshInterval)]
 		string RefreshInterval { get; set; }
 
-		[JsonProperty(SettingNames.IndexConcurrency)]
+		[JsonProperty(UpdatableSettings.IndexConcurrency)]
 		int? IndexConcurrency { get; set; }
 
-		[JsonProperty(SettingNames.Codec)]
+		[JsonProperty(UpdatableSettings.Codec)]
 		string Codec { get; set; }
 
-		[JsonProperty(SettingNames.CodecBloomLoad)]
+		[JsonProperty(UpdatableSettings.CodecBloomLoad)]
 		bool? CodecBloomLoad { get; set; }
 
-		[JsonProperty(SettingNames.FailOnMergeFailure)]
+		[JsonProperty(UpdatableSettings.FailOnMergeFailure)]
 		bool? FailOnMergeFailure { get; set; }
 
-		[JsonProperty(SettingNames.TranslogFlushTreshHoldOps)]
+		[JsonProperty(UpdatableSettings.TranslogFlushTreshHoldOps)]
 		string TranslogFlushTreshHoldOps { get; set; }
 
-		[JsonProperty(SettingNames.TranslogFlushThresholdSize)]
+		[JsonProperty(UpdatableSettings.TranslogFlushThresholdSize)]
 		string TranslogFlushThresholdSize { get; set; }
 
-		[JsonProperty(SettingNames.TranslogFlushThresholdPeriod)]
+		[JsonProperty(UpdatableSettings.TranslogFlushThresholdPeriod)]
 		string TranslogFlushThresholdPeriod { get; set; }
 
-		[JsonProperty(SettingNames.TranslogDisableFlush)]
+		[JsonProperty(UpdatableSettings.TranslogDisableFlush)]
 		bool? TranslogDisableFlush { get; set; }
 
-		[JsonProperty(SettingNames.CacheFilterMaxSize)]
+		[JsonProperty(UpdatableSettings.CacheFilterMaxSize)]
 		string CacheFilterMaxSize { get; set; }
 
-		[JsonProperty(SettingNames.CacheFilterExpire)]
+		[JsonProperty(UpdatableSettings.CacheFilterExpire)]
 		string CacheFilterExpire { get; set; }
 
-		[JsonProperty(SettingNames.CacheQueryEnable)]
+		[JsonProperty(UpdatableSettings.CacheQueryEnable)]
 		bool? CacheQueryEnable { get; set; }
 
-		[JsonProperty(SettingNames.GatewaySnapshotInterval)]
+		[JsonProperty(UpdatableSettings.GatewaySnapshotInterval)]
 		string GatewaySnapshotInterval { get; set; }
 
-		[JsonProperty(SettingNames.RoutingAllocationInclude)]
+		[JsonProperty(UpdatableSettings.RoutingAllocationInclude)]
 		IDictionary<string, object> RoutingAllocationInclude { get; set; }
 
-		[JsonProperty(SettingNames.RoutingAllocationExclude)]
+		[JsonProperty(UpdatableSettings.RoutingAllocationExclude)]
 		IDictionary<string, object> RoutingAllocationExclude { get; set; }
 
-		[JsonProperty(SettingNames.RoutingAllocationRequire)]
+		[JsonProperty(UpdatableSettings.RoutingAllocationRequire)]
 		IDictionary<string, object> RoutingAllocationRequire { get; set; }
 
-		[JsonProperty(SettingNames.RoutingAllocationEnable)]
+		[JsonProperty(UpdatableSettings.RoutingAllocationEnable)]
 		RoutingAllocationEnableOption? RoutingAllocationEnable { get; set; }
 
-		[JsonProperty(SettingNames.RoutingAllocationDisableAllication)]
+		[JsonProperty(UpdatableSettings.RoutingAllocationDisableAllication)]
 		bool? RoutingAllocationDisableAllication { get; set; }
 
-		[JsonProperty(SettingNames.RoutingAllocationDisableNewAllocation)]
+		[JsonProperty(UpdatableSettings.RoutingAllocationDisableNewAllocation)]
 		bool? RoutingAllocationDisableNewAllocation { get; set; }
 
-		[JsonProperty(SettingNames.RoutingAllocationDisableReplicaAllocation)]
+		[JsonProperty(UpdatableSettings.RoutingAllocationDisableReplicaAllocation)]
 		bool? RoutingAllocationDisableReplicaAllocation { get; set; }
 
-		[JsonProperty(SettingNames.RoutingAllocationTotalShardsPerNode)]
+		[JsonProperty(UpdatableSettings.RoutingAllocationTotalShardsPerNode)]
 		int? RoutingAllocationTotalShardsPerNode { get; set; }
 
-		[JsonProperty(SettingNames.RecoveryInitialShards)]
+		[JsonProperty(UpdatableSettings.RecoveryInitialShards)]
 		string RecoveryInitialShards { get; set; }
 
-		[JsonProperty(SettingNames.GcDeletes)]
+		[JsonProperty(UpdatableSettings.GcDeletes)]
 		bool? GcDeletes { get; set; }
 
-		[JsonProperty(SettingNames.TtlDisablePurge)]
+		[JsonProperty(UpdatableSettings.TtlDisablePurge)]
 		bool? TtlDisablePurge { get; set; }
 
-		[JsonProperty(SettingNames.TranslogFsType)]
+		[JsonProperty(UpdatableSettings.TranslogFsType)]
 		string TranslogFsType { get; set; }
 
-		[JsonProperty(SettingNames.CompoundFormat)]
+		[JsonProperty(UpdatableSettings.CompoundFormat)]
 		bool? CompoundFormat { get; set; }
 
-		[JsonProperty(SettingNames.CompoundOnFlush)]
+		[JsonProperty(UpdatableSettings.CompoundOnFlush)]
 		bool? CompoundOnFlush { get; set; }
 
-		[JsonProperty(SettingNames.WarmersEnabled)]
+		[JsonProperty(UpdatableSettings.WarmersEnabled)]
 		bool? WarmersEnabled { get; set; }
 
-		[JsonProperty(SettingNames.Analysis)]
+		[JsonProperty(UpdatableSettings.Analysis)]
 		AnalysisSettings Analysis { get; set; }
 	}
 

--- a/src/Tests/Nest.Tests.Integration/Core/Repository/RestoreTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/Repository/RestoreTests.cs
@@ -122,7 +122,7 @@ namespace Nest.Tests.Integration.Core.Repository
 				.IgnoreUnavailable(true)
 				.IndexSettings(descriptor => descriptor
 					.RefreshInterval("123s"))
-				.IgnoreIndexSettings(SettingNames.BlocksWrite));
+				.IgnoreIndexSettings(UpdatableSettings.BlocksWrite));
 
 			restoreResponse.IsValid.Should().BeTrue();
 			_restoredIndexName = _indexName.Replace(d + "_", d + "_restored_");
@@ -132,8 +132,8 @@ namespace Nest.Tests.Integration.Core.Repository
 
 			var indexSettingsResponse = this.Client.GetIndexSettings(descriptor => descriptor.Index(_restoredIndexName));
 			indexSettingsResponse.IsValid.Should().BeTrue();
-			indexSettingsResponse.IndexSettings.Settings[SettingNames.RefreshInterval].Should().Be("123s");
-			indexSettingsResponse.IndexSettings.Settings[SettingNames.BlocksWrite].Should().BeNull();
+			indexSettingsResponse.IndexSettings.Settings[UpdatableSettings.RefreshInterval].Should().Be("123s");
+			indexSettingsResponse.IndexSettings.Settings[UpdatableSettings.BlocksWrite].Should().BeNull();
 		}
 
 		[Test]

--- a/src/Tests/Nest.Tests.Integration/Core/Repository/RestoreTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/Repository/RestoreTests.cs
@@ -100,7 +100,7 @@ namespace Nest.Tests.Integration.Core.Repository
 		}
 
 		[Test]
-		[SkipVersion("0 - 1.5.0", "Requires index_settings and ignore_index_settings parameters which have been added in ES 1.5.0")]
+		[SkipVersion("0 - 1.4.9", "Requires index_settings and ignore_index_settings parameters which have been added in ES 1.5.0")]
 		public void SnapshotRestore_IndexSettings()
 		{
 			var updateSettingsResponse = this.Client.UpdateSettings(descriptor => descriptor.BlocksWrite());

--- a/src/Tests/Nest.Tests.Unit/Core/Repository/Restore.json
+++ b/src/Tests/Nest.Tests.Unit/Core/Repository/Restore.json
@@ -1,0 +1,13 @@
+﻿{
+  "indices": [
+    "index"
+  ],
+  "index_settings": {
+    "index.number_of_replicas": 0,
+    "index.blocks.read": true
+  },
+  "ignore_index_settings": [
+    "index.refresh_interval",
+    "index.auto_expand_replicas"
+  ]
+}

--- a/src/Tests/Nest.Tests.Unit/Core/Repository/RestoreTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Repository/RestoreTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nest.Tests.Unit.Core.Repository
+{
+	public class RestoreTests : BaseJsonTests
+	{
+		[Test]
+		public void Restore()
+		{
+			var restoreResponse = _client.Restore("repository", "snapshotName",
+				descriptor => descriptor
+					.Index("index")
+					.IndexSettings(settingsDescriptor => settingsDescriptor
+						.NumberOfReplicas(0)
+						.BlocksRead())
+					.IgnoreIndexSettings(SettingNames.RefreshInterval, SettingNames.AutoExpandReplicas));
+
+			restoreResponse.ConnectionStatus.RequestUrl.Should().Be("http://localhost:9200/_snapshot/repository/snapshotName/_restore");
+			this.JsonEquals(restoreResponse.ConnectionStatus.Request, MethodInfo.GetCurrentMethod());
+		}
+
+		[Test]
+		[ExpectedException]
+		public void Null_IgnoreIndexSettings_ThorwException()
+		{
+			List<string> ignoreIndexSettings = null;
+			_client.Restore("repository", "snapshotName",
+				descriptor => descriptor
+					.IgnoreIndexSettings(ignoreIndexSettings));
+		}
+
+		[Test]
+		[ExpectedException]
+		public void Null_IndexSettings_ThorwException()
+		{
+			Func<UpdateSettingsDescriptor, UpdateSettingsDescriptor> settings = null;
+
+			var restoreResponse = _client.Restore("repository", "snapshotName",
+				descriptor => descriptor
+					.IndexSettings(settings));
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Unit/Core/Repository/RestoreTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Repository/RestoreTests.cs
@@ -22,7 +22,7 @@ namespace Nest.Tests.Unit.Core.Repository
 					.IndexSettings(settingsDescriptor => settingsDescriptor
 						.NumberOfReplicas(0)
 						.BlocksRead())
-					.IgnoreIndexSettings(SettingNames.RefreshInterval, SettingNames.AutoExpandReplicas));
+					.IgnoreIndexSettings(UpdatableSettings.RefreshInterval, UpdatableSettings.AutoExpandReplicas));
 
 			restoreResponse.ConnectionStatus.RequestUrl.Should().Be("http://localhost:9200/_snapshot/repository/snapshotName/_restore");
 			this.JsonEquals(restoreResponse.ConnectionStatus.Request, MethodInfo.GetCurrentMethod());

--- a/src/Tests/Nest.Tests.Unit/Core/Repository/RestoreTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Repository/RestoreTests.cs
@@ -29,24 +29,26 @@ namespace Nest.Tests.Unit.Core.Repository
 		}
 
 		[Test]
-		[ExpectedException]
+		[ExpectedException(typeof(ArgumentNullException))]
 		public void Null_IgnoreIndexSettings_ThorwException()
 		{
 			List<string> ignoreIndexSettings = null;
 			_client.Restore("repository", "snapshotName",
 				descriptor => descriptor
+					.Index("index")
 					.IgnoreIndexSettings(ignoreIndexSettings));
 		}
 
 		[Test]
-		[ExpectedException]
+		[ExpectedException(typeof(ArgumentNullException))]
 		public void Null_IndexSettings_ThorwException()
 		{
-			Func<UpdateSettingsDescriptor, UpdateSettingsDescriptor> settings = null;
+			Func<UpdateSettingsDescriptor, UpdateSettingsDescriptor> settingsSelector = null;
 
 			var restoreResponse = _client.Restore("repository", "snapshotName",
 				descriptor => descriptor
-					.IndexSettings(settings));
+					.Index("index")
+					.IndexSettings(settingsSelector));
 		}
 	}
 }

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -201,6 +201,7 @@
     </None>
     <Compile Include="Core\MultiPercolate\MultiPercolateTests.cs" />
     <Compile Include="Core\Map\Transform\MappingTansformTests.cs" />
+    <Compile Include="Core\Repository\RestoreTests.cs" />
     <Compile Include="Core\Script\DeleteScriptRequestTests.cs" />
     <Compile Include="Core\Script\GetScriptRequestTests.cs" />
     <Compile Include="Core\Script\PutScriptRequestTests.cs" />
@@ -681,6 +682,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Core\MultiPercolate\MultiPercolateJson.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Core\Repository\Restore.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Core\Script\PutScript.json">


### PR DESCRIPTION
PR for https://github.com/elastic/elasticsearch-net/issues/1362 issue.

For `IndexSettings` property on `IRrestoreDescriptor` I reused `IUpdateSettingsRequest`, but I'm not sure if this name fits in this context. Way how we can combine `RestoreDescriptor` with `UpdateSettingsDescriptor` is really nice.

Moreover, I've extracted all setting names to separate class. Avoiding googling for each plain index setting is really convenient.

Any thoughts? Let me know.
Thanks.