### PR TITLE
Support for `min_score` parameter on function score query #1344

### DIFF
--- a/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
@@ -40,6 +40,9 @@ namespace Nest
 
 		[JsonProperty(PropertyName = "weight")]
 		double? WeightAsDouble { get; set; }
+
+		[JsonProperty(PropertyName = "min_score")]
+		float? MinScore { get; set; }
 	}
 
 	public class FunctionScoreQuery : PlainQuery, IFunctionScoreQuery
@@ -67,6 +70,7 @@ namespace Nest
 		}
 
 		public double? WeightAsDouble { get; set; }
+		public float? MinScore { get; set; }
 	}
 
 	public class FunctionScoreQueryDescriptor<T> : IFunctionScoreQuery where T : class
@@ -95,6 +99,7 @@ namespace Nest
 
 		// TODO: Remove in 2.0 and change Weight to double
 		double? IFunctionScoreQuery.WeightAsDouble { get; set; }
+		float? IFunctionScoreQuery.MinScore { get; set; }
 
 		string IQuery.Name { get; set; }
 
@@ -200,6 +205,12 @@ namespace Nest
 		public FunctionScoreQueryDescriptor<T> Weight(long weight)
 		{
 			Self.Weight = weight;
+			return this;
+		}
+
+		public FunctionScoreQueryDescriptor<T> MinScore(float minScore)
+		{
+			Self.MinScore = minScore;
 			return this;
 		}
 	}

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/FunctionScoreQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/FunctionScoreQueryTests.cs
@@ -16,6 +16,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 				f=>f.FunctionScore(fq=>fq
 					.BoostMode(FunctionBoostMode.Average)
 					.MaxBoost(0.95f)
+					.MinScore(1.1f)
 					.Functions(
 						ff => ff.Gauss(x => x.StartedOn, d => d.Scale("42w")).Weight(1),
 						ff => ff.Linear(x => x.FloatValue, d => d.Scale("0.3")).Filter(lff=>Filter2).Weight(2),
@@ -36,6 +37,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 
 			q.BoostMode.Should().Be(FunctionBoostMode.Average);
 			q.MaxBoost.Should().Be(0.95f);
+			q.MinScore.Should().Be(1.1f);
 			q.RandomScore.Should().NotBeNull();
 			q.RandomScore.Seed.Should().Be(1337);
 			q.ScoreMode.Should().Be(FunctionScoreMode.First);

--- a/src/Tests/Nest.Tests.Unit/Search/Sorting/FunctionScoreTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Sorting/FunctionScoreTests.cs
@@ -288,5 +288,46 @@ namespace Nest.Tests.Unit.Search.Sorting
 							}";
 			Assert.IsTrue(json.JsonEquals(expected), json);
 		}
+
+		[Test]
+		public void TestMinScore()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.Query(q => q
+					.FunctionScore(fs => fs
+						.MinScore(1.1f)
+						.Functions(
+							f => f
+								.BoostFactor(2)
+								.Filter(
+									filter => filter.Term("term1", "termValue")
+								)
+								.Weight(0.5)
+						)
+					)
+
+				);
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"{
+                          query: {
+                            function_score: {
+                              functions : [
+                                {
+                                    boost_factor: 2.0,
+                                    filter:{
+                                        term : {
+                                            ""term1"":""termValue""
+                                        }
+                                    },
+                                    weight: 0.5
+                                }
+                              ],
+                              min_score: 1.1
+                            }
+                          }
+                        }";
+
+			Assert.True(json.JsonEquals(expected), json);
+		}
 	}
 }


### PR DESCRIPTION
PR for https://github.com/elastic/elasticsearch-net/issues/1344 issue.