### PR TITLE
Fix fielddata fields on search and inner hits

### DIFF
--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/SearchDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/SearchDescriptorOverrides.cs
@@ -27,7 +27,8 @@ namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
 					"_source_include",
 					"_source_exclude",
 					"track_scores",
-					"terminate_after"
+					"terminate_after",
+					"fielddata_fields"
 				};
 			}
 		}

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -5451,16 +5451,6 @@ namespace Elasticsearch.Net
 		}
 		
 		
-		internal IEnumerable<object> _fielddata_fields { get; set; }
-		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
-		public SearchRequestParameters FielddataFields(params string[] fielddata_fields)
-		{
-			this._fielddata_fields = fielddata_fields.Select(f=>(object)f);
-			this.AddQueryString("fielddata_fields", this._fielddata_fields);
-			return this;
-		}
-		
-		
 		internal bool _ignore_unavailable { get; set; }
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public SearchRequestParameters IgnoreUnavailable(bool ignore_unavailable)

--- a/src/Nest/DSL/Search/IGlobalInnerHit.cs
+++ b/src/Nest/DSL/Search/IGlobalInnerHit.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using System.Linq.Expressions;
 
 namespace Nest
 {
@@ -35,7 +36,7 @@ namespace Nest
 		bool? IInnerHits.Explain { get; set; }
 		ISourceFilter IInnerHits.Source { get; set; }
 		bool? IInnerHits.Version { get; set; }
-		IEnumerable<string> IInnerHits.FielddataFields { get; set; }
+		IList<PropertyPathMarker> IInnerHits.FielddataFields { get; set; }
 		IDictionary<string, IScriptFilter> IInnerHits.ScriptFields { get; set; }
 
 		public GlobalInnerHitDescriptor<T> Query(Func<QueryDescriptor<T>, IQueryContainer> querySelector)
@@ -89,13 +90,17 @@ namespace Nest
 
 		public GlobalInnerHitDescriptor<T> FielddataFields(params string[] fielddataFields)
 		{
-			Self.FielddataFields = fielddataFields;
+			if (fielddataFields.HasAny())
+				return this;
+			Self.FielddataFields = fielddataFields.Select(f => (PropertyPathMarker)f).ToList();
 			return this;
 		}
 
-		public GlobalInnerHitDescriptor<T> FielddataFields(IEnumerable<string> fielddataFields)
+		public GlobalInnerHitDescriptor<T> FielddataFields(params Expression<Func<T, object>>[] fielddataFields)
 		{
-			Self.FielddataFields = fielddataFields;
+			if (!fielddataFields.HasAny())
+				return this;
+			Self.FielddataFields = fielddataFields.Select(e => (PropertyPathMarker)e).ToList();
 			return this;
 		}
 

--- a/src/Nest/DSL/Search/InnerHitsDescriptor.cs
+++ b/src/Nest/DSL/Search/InnerHitsDescriptor.cs
@@ -36,7 +36,7 @@ namespace Nest
 		bool? Version { get; set; }
 
 		[JsonProperty(PropertyName = "fielddata_fields")]
-		IEnumerable<string> FielddataFields { get; set; }
+		IList<PropertyPathMarker> FielddataFields { get; set; }
 
 		[JsonProperty(PropertyName = "script_fields")]
 		[JsonConverter(typeof (DictionaryKeysAreNotPropertyNamesJsonConverter))]
@@ -62,7 +62,7 @@ namespace Nest
 
 		public bool? Version { get; set; }
 
-		public IEnumerable<string> FielddataFields { get; set; }
+		public IList<PropertyPathMarker> FielddataFields { get; set; }
 
 		public IDictionary<string, IScriptFilter> ScriptFields { get; set; }
 	}
@@ -79,7 +79,7 @@ namespace Nest
 		bool? IInnerHits.Explain { get; set; }
 		ISourceFilter IInnerHits.Source { get; set; }
 		bool? IInnerHits.Version { get; set; }
-		IEnumerable<string> IInnerHits.FielddataFields { get; set; }
+		IList<PropertyPathMarker> IInnerHits.FielddataFields { get; set; }
 		IDictionary<string, IScriptFilter> IInnerHits.ScriptFields { get; set; }
 
 		public InnerHitsDescriptor<T> From(int? from)
@@ -102,13 +102,17 @@ namespace Nest
 
 		public InnerHitsDescriptor<T> FielddataFields(params string[] fielddataFields)
 		{
-			Self.FielddataFields = fielddataFields;
+			if (fielddataFields.HasAny())
+				return this;
+			Self.FielddataFields = fielddataFields.Select(f => (PropertyPathMarker)f).ToList();
 			return this;
 		}
 
-		public InnerHitsDescriptor<T> FielddataFields(IEnumerable<string> fielddataFields)
+		public InnerHitsDescriptor<T> FielddataFields(params Expression<Func<T, object>>[] fielddataFields)
 		{
-			Self.FielddataFields = fielddataFields;
+			if (!fielddataFields.HasAny())
+				return this;
+			Self.FielddataFields = fielddataFields.Select(e => (PropertyPathMarker)e).ToList();
 			return this;
 		}
 

--- a/src/Nest/DSL/SearchDescriptor.cs
+++ b/src/Nest/DSL/SearchDescriptor.cs
@@ -63,6 +63,9 @@ namespace Nest
 		[JsonProperty(PropertyName = "fields")]
 		IList<PropertyPathMarker> Fields { get; set; }
 
+		[JsonProperty(PropertyName = "fielddata_fields")]
+		IList<PropertyPathMarker> FielddataFields { get; set; }
+
 		[JsonProperty(PropertyName = "script_fields")]
 		[JsonConverter(typeof (DictionaryKeysAreNotPropertyNamesJsonConverter))]
 		IDictionary<string, IScriptFilter> ScriptFields { get; set; }
@@ -155,6 +158,7 @@ namespace Nest
 		public double? MinScore { get; set; }
 		public long? TerminateAfter { get; set; }
 		public IList<PropertyPathMarker> Fields { get; set; }
+		public IList<PropertyPathMarker> FielddataFields { get; set; }
 		public IDictionary<string, IScriptFilter> ScriptFields { get; set; }
 		public ISourceFilter Source { get; set; }
 		public IList<KeyValuePair<PropertyPathMarker, ISort>> Sort { get; set; }
@@ -237,6 +241,7 @@ namespace Nest
 		public IHighlightRequest Highlight { get; set; }
 		public IRescore Rescore { get; set; }
 		public IList<PropertyPathMarker> Fields { get; set; }
+		public IList<PropertyPathMarker> FielddataFields { get; set; }
 		public IDictionary<string, IScriptFilter> ScriptFields { get; set; }
 		public ISourceFilter Source { get; set; }
 		public IDictionary<string, IInnerHitsContainer> InnerHits { get; set; }
@@ -349,6 +354,8 @@ namespace Nest
 		IFilterContainer ISearchRequest.Filter { get; set; }
 
 		IList<PropertyPathMarker> ISearchRequest.Fields { get; set; }
+
+		IList<PropertyPathMarker> ISearchRequest.FielddataFields { get; set; }
 
 		IDictionary<string, IScriptFilter> ISearchRequest.ScriptFields { get; set; }
 
@@ -614,6 +621,28 @@ namespace Nest
 		public SearchDescriptor<T> Fields(params string[] fields)
 		{
 			Self.Fields = fields.Select(f => (PropertyPathMarker)f).ToList();
+			return this;
+		}
+
+		///<summary>
+		///A comma-separated list of fields to return as the field data representation of a field for each hit
+		///</summary>
+		public SearchDescriptor<T> FielddataFields(params string[] fielddataFields)
+		{
+			if (fielddataFields.HasAny())
+				return this;
+			Self.FielddataFields = fielddataFields.Select(f => (PropertyPathMarker)f).ToList();
+			return this;
+		}
+
+		///<summary>
+		///A comma-separated list of fields to return as the field data representation of a field for each hit
+		///</summary>
+		public SearchDescriptor<T> FielddataFields(params Expression<Func<T, object>>[] fielddataFields)
+		{
+			if (!fielddataFields.HasAny())
+				return this;
+			Self.FielddataFields = fielddataFields.Select(f => (PropertyPathMarker)f).ToList();
 			return this;
 		}
 

--- a/src/Nest/DSL/_Descriptors.generated.cs
+++ b/src/Nest/DSL/_Descriptors.generated.cs
@@ -5079,25 +5079,6 @@ namespace Nest
 		}
 		
 
-		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
-		public SearchDescriptor<T> FielddataFields(params string[] fielddata_fields)
-		{
-			this.Request.RequestParameters.FielddataFields(fielddata_fields);
-			return this;
-		}
-		
-			
-		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
-		public SearchDescriptor<T> FielddataFields(params Expression<Func<T, object>>[] typedPathLookups) 
-		{
-			if (!typedPathLookups.HasAny())
-				return this;
-
-			this.Request.RequestParameters._FielddataFields(typedPathLookups);
-			return this;
-		}
-			
-
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public SearchDescriptor<T> IgnoreUnavailable(bool ignore_unavailable = true)
 		{

--- a/src/Nest/DSL/_Requests.generated.cs
+++ b/src/Nest/DSL/_Requests.generated.cs
@@ -4572,14 +4572,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
-		public IList<PropertyPathMarker> FielddataFields 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<IList<PropertyPathMarker>>("fielddata_fields"); } 
-			set { this.Request.RequestParameters.AddQueryString("fielddata_fields", value); }
-		}
-		
-		
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public bool IgnoreUnavailable 
 		{ 
@@ -6478,14 +6470,6 @@ namespace Nest
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<string>("df"); } 
 			set { this.Request.RequestParameters.AddQueryString("df", value); }
-		}
-		
-		
-		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
-		public IList<PropertyPathMarker> FielddataFields 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<IList<PropertyPathMarker>>("fielddata_fields"); } 
-			set { this.Request.RequestParameters.AddQueryString("fielddata_fields", value); }
 		}
 		
 		

--- a/src/Nest/Domain/RequestParametersExtensions.Generated.cs
+++ b/src/Nest/Domain/RequestParametersExtensions.Generated.cs
@@ -281,18 +281,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
-			internal static SearchRequestParameters _FielddataFields<T>(
-				this SearchRequestParameters qs,
-				IEnumerable<Expression<Func<T, object>>>  fielddata_fields)
-			where T : class
-		{
-			var _fielddata_fields = fielddata_fields.Select(e=>(PropertyPathMarker)e);
-			qs.AddQueryString("fielddata_fields", _fielddata_fields);
-			return qs;
-		}
-		
-		
 		///<summary>Specify which field to use for suggestions</summary>
 			internal static SearchRequestParameters _SuggestField<T>(
 				this SearchRequestParameters qs,

--- a/src/Tests/Nest.Tests.Integration/Search/FieldTests/FieldsTest.cs
+++ b/src/Tests/Nest.Tests.Integration/Search/FieldTests/FieldsTest.cs
@@ -54,5 +54,21 @@ namespace Nest.Tests.Integration.Search.FieldTests
 			}
 
 		}
+
+		[Test]
+		public void FielddataFieldsTest()
+		{
+			var result = this.Client.Search<ElasticsearchProject>(s => s
+				.FielddataFields(p => p.Name)
+			);
+
+			result.IsValid.Should().BeTrue();
+			
+			foreach(var hit in result.Hits)
+			{
+				var fieldValues = hit.Fields.FieldValues<string[]>("name");
+				fieldValues.Should().NotBeEmpty();
+			}
+		}
 	}
 }

--- a/src/Tests/Nest.Tests.Integration/Search/InnerHitsTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Search/InnerHitsTests.cs
@@ -122,6 +122,7 @@ namespace Nest.Tests.Integration.Search
 							.InnerHits(innerInnerHits => innerInnerHits
 								.Add("barons", iii => iii.Type<Baron>())
 							)
+							.FielddataFields(p => p.Name)
 						)
 					)
 					.Add("princes", i => i.Type<Prince>())
@@ -136,6 +137,8 @@ namespace Nest.Tests.Integration.Search
 				var earlHits = hit.InnerHits["earls"].Hits;
 				earlHits.Total.Should().BeGreaterThan(0);
 				earlHits.Hits.Should().NotBeEmpty().And.HaveCount(5);
+				foreach(var earlHit in earlHits.Hits)
+					earlHit.Fields.FieldValues<string[]>("name").Should().NotBeEmpty();
 				var earls = earlHits.Documents<Earl>();
 				earls.Should().NotBeEmpty().And.OnlyContain(earl => !earl.Name.IsNullOrEmpty());
 				foreach (var earlHit in earlHits.Hits)


### PR DESCRIPTION
This was largely implemented already but with a few issues.  I had to modify the code gen to skip the fielddata_fields param in order to work around https://github.com/elastic/elasticsearch/issues/11025.

Also modified the implementation on inner hits to be more consistent with search (i.e. `IList<PropertyPathMarker>` vs `IEnumerable<string>` and added an overload that accepts property path expressions).

Closes #1366