### PR TITLE
Has child/top children: support for min score type and min/max_children

### DIFF
--- a/src/Nest/DSL/Query/HasChildQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/HasChildQueryDescriptor.cs
@@ -18,6 +18,12 @@ namespace Nest
 		[JsonConverter(typeof (StringEnumConverter))]
 		ChildScoreType? ScoreType { get; set; }
 
+		[JsonProperty("min_children")]
+		int? MinChildren { get; set; }
+
+		[JsonProperty("max_children")]
+		int? MaxChildren { get; set; }
+
 		[JsonProperty("query")]
 		[JsonConverter(typeof(CompositeJsonConverter<ReadAsTypeConverter<QueryDescriptor<object>>, CustomJsonConverter>))]
 		IQueryContainer Query { get; set; }
@@ -39,6 +45,8 @@ namespace Nest
 		bool IQuery.IsConditionless { get { return false; } }
 		public TypeNameMarker Type { get; set; }
 		public ChildScoreType? ScoreType { get; set; }
+		public int? MinChildren { get; set; }
+		public int? MaxChildren { get; set; }
 		public IQueryContainer Query { get; set; }
 		public IInnerHits InnerHits { get; set; }
 	}
@@ -50,6 +58,10 @@ namespace Nest
 		TypeNameMarker IHasChildQuery.Type { get; set; }
 
 		ChildScoreType? IHasChildQuery.ScoreType { get; set; }
+
+		int? IHasChildQuery.MinChildren { get; set; }
+
+		int? IHasChildQuery.MaxChildren { get; set; }
 
 		IQueryContainer IHasChildQuery.Query { get; set; }
 
@@ -92,6 +104,18 @@ namespace Nest
 		public HasChildQueryDescriptor<T> Score(ChildScoreType? scoreType)
 		{
 			Self.ScoreType = scoreType;
+			return this;
+		}
+
+		public HasChildQueryDescriptor<T> MinChildren(int minChildren)
+		{
+			Self.MinChildren = minChildren;
+			return this;
+		}
+
+		public HasChildQueryDescriptor<T> MaxChildren(int maxChildren)
+		{
+			Self.MaxChildren = maxChildren;
 			return this;
 		}
 

--- a/src/Nest/Domain/DSL/ChildScoreType.cs
+++ b/src/Nest/Domain/DSL/ChildScoreType.cs
@@ -17,6 +17,8 @@ namespace Nest
 		[EnumMember(Value = "sum")]
 		Sum,
 		[EnumMember(Value = "max")]
-		Max
+		Max,
+		[EnumMember(Value = "min")]
+		Min
 	}
 }

--- a/src/Nest/Enums/TopChildrenScore.cs
+++ b/src/Nest/Enums/TopChildrenScore.cs
@@ -15,8 +15,8 @@ namespace Nest
 		[EnumMember(Value = "sum")]
 		Sum,
 		[EnumMember(Value = "avg")]
-		Average
+		Average,
+		[EnumMember(Value = "min")]
+		Min
 	}
-
-	
 }

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/HasChildQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/HasChildQueryTests.cs
@@ -16,12 +16,16 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 				f=>f.HasChild<Person>(hq=>hq
 					.Query(qq=>Query2)
 					.Score(ChildScoreType.Average)
+					.MinChildren(2)
+					.MaxChildren(10)
 					.InnerHits()
 				)
 			);
 			q.Type.Should().Be("person");
 			q.ScoreType.Should().Be(ChildScoreType.Average);
 			q.InnerHits.Should().NotBeNull();
+			q.MinChildren.Should().Be(2);
+			q.MaxChildren.Should().Be(10);
 			AssertIsTermQuery(q.Query, Query2);
 		}
 	}


### PR DESCRIPTION
While adding `min` score type, also discovered that we were missing the `min_children` and `max_children` parameters on `has child`.

Closes #1360