### PR TITLE
fix #1105 add default and ignore_missing to timestamp mappings

### DIFF
--- a/src/Nest/Domain/Mapping/SpecialFields/TimestampFieldMapping.cs
+++ b/src/Nest/Domain/Mapping/SpecialFields/TimestampFieldMapping.cs
@@ -16,6 +16,12 @@ namespace Nest
 
 		[JsonProperty("format")]
 		string Format { get; set; }
+
+		[JsonProperty("default")]
+		string Default { get; set; }
+
+		[JsonProperty("ignore_missing")]
+		bool? IgnoreMissing { get; set; }
 	}
 
 	public class TimestampFieldMapping : ITimestampFieldMapping
@@ -25,6 +31,8 @@ namespace Nest
 		public PropertyPathMarker Path { get; set; }
 
 		public string Format { get; set; }
+		public string Default { get; set; }
+		public bool? IgnoreMissing { get; set; }
 	}
 
 
@@ -37,6 +45,8 @@ namespace Nest
 		PropertyPathMarker ITimestampFieldMapping.Path { get; set;}
 
 		string ITimestampFieldMapping.Format { get; set; }
+		string ITimestampFieldMapping.Default { get; set; }
+		bool? ITimestampFieldMapping.IgnoreMissing { get; set; }
 
 		public TimestampFieldMappingDescriptor<T> Enabled(bool enabled = true)
 		{
@@ -54,9 +64,22 @@ namespace Nest
 			Self.Path = objectPath;
 			return this;
 		}
+
 		public TimestampFieldMappingDescriptor<T> Format(string format)
 		{
 			Self.Format = format;
+			return this;
+		}
+
+		public TimestampFieldMappingDescriptor<T> Default(string defaultValue)
+		{
+			Self.Default = defaultValue;
+			return this;
+		}
+
+		public TimestampFieldMappingDescriptor<T> IgnoreMissing(bool ignoreMissing = true)
+		{
+			Self.IgnoreMissing = ignoreMissing;
 			return this;
 		}
 


### PR DESCRIPTION
See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.5/mapping-timestamp-field.html#mapping-timestamp-field-default