### PR TITLE
Keep exceptions stack trace in NEST ElasticClient Async calls

### DIFF
--- a/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerAsync.cs
+++ b/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerAsync.cs
@@ -204,7 +204,7 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 
 			//If we are not using any pooling and we see an exception we rethrow
 			if (!requestState.UsingPooling && t.IsFaulted && t.Exception != null && maxRetries == 0)
-				throw t.Exception;
+				t.Exception.RethrowKeepingStackTrace();
 
 
 			var retried = requestState.Retried;
@@ -215,7 +215,7 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 
 			// If the response never recieved a status code and has a caught exception make sure we throw it
 			if (streamResponse.HttpStatusCode.GetValueOrDefault(-1) <= 0 && streamResponse.OriginalException != null)
-				throw streamResponse.OriginalException;
+				streamResponse.OriginalException.RethrowKeepingStackTrace();
 
 			// If the user explicitly wants a stream return the undisposed stream
 			if (typeof(Stream).IsAssignableFrom(typeof(T)))

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Domain\Response\ElasticsearchServerError.cs" />
     <Compile Include="Exceptions\OneToOneServerException.cs" />
     <Compile Include="Exceptions\ElasticsearchAuthException.cs" />
+    <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="IElasticsearchClient.cs" />
     <Compile Include="Obsolete\RequestParameters\FlushRequestParametersObsoleteExtensions.cs" />
     <Compile Include="Obsolete\IndicesDeleteAlias.cs" />

--- a/src/Elasticsearch.Net/Extensions/ExceptionExtensions.cs
+++ b/src/Elasticsearch.Net/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+
+namespace Elasticsearch.Net
+{
+	internal static class ExceptionExtensions
+	{
+		private static readonly Lazy<MethodInfo> preserveStackTraceMethodInfo = new Lazy<MethodInfo>(() =>
+			typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic)
+		);
+
+		public static void RethrowKeepingStackTrace(this Exception exception)
+		{
+			// In .Net 4.5 it would be simple : ExceptionDispatchInfo.Capture(exception).Throw();
+			// But as NEST target .Net 4.0 the old internal method must be used
+			if (preserveStackTraceMethodInfo.Value != null)
+			{
+				preserveStackTraceMethodInfo.Value.Invoke(exception, null);
+			}
+			throw exception;
+		}
+	}
+}

--- a/src/Nest/ElasticClient.cs
+++ b/src/Nest/ElasticClient.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Connection;
@@ -126,21 +125,6 @@ namespace Nest
 			return this.DispatchAsync<D, Q, R, I>(descriptor, dispatch);
 		}
 
-		private static readonly Lazy<MethodInfo> preserveStackTraceMethodInfo = new Lazy<MethodInfo>(() => 
-			typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic)
-		);
-
-		private static void RethrowKeepingStackTrace(Exception exception)
-		{
-			// In .Net 4.5 it would be simple : ExceptionDispatchInfo.Capture(exception).Throw();
-			// But as NEST target .Net 4.0 the old internal method must be used
-			if (preserveStackTraceMethodInfo.Value != null)
-			{
-				preserveStackTraceMethodInfo.Value.Invoke(exception, null);
-			}
-			throw exception;
-		}
-
 		private Task<I> DispatchAsync<D, Q, R, I>(
 			D descriptor
 			, Func<ElasticsearchPathInfo<Q>, D, Task<ElasticsearchResponse<R>>> dispatch
@@ -158,13 +142,13 @@ namespace Nest
 					{
 						var mr = r.Exception.InnerException as MaxRetryException;
 						if (mr != null)
-							RethrowKeepingStackTrace(mr);
+							mr.RethrowKeepingStackTrace();
 
 						var ae = r.Exception.Flatten();
 						if (ae.InnerException != null)
-							RethrowKeepingStackTrace(ae.InnerException);
+							ae.InnerException.RethrowKeepingStackTrace();
 
-						RethrowKeepingStackTrace(ae);
+						ae.RethrowKeepingStackTrace();
 					}
 					return ResultsSelector<D, Q, R>(r.Result, descriptor);
 				});

--- a/src/Nest/Extensions/ExceptionExtensions.cs
+++ b/src/Nest/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+
+namespace Elasticsearch.Net
+{
+    internal static class ExceptionExtensions
+    {
+        private static readonly Lazy<MethodInfo> preserveStackTraceMethodInfo = new Lazy<MethodInfo>(() =>
+            typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic)
+        );
+
+        public static void RethrowKeepingStackTrace(this Exception exception)
+        {
+            // In .Net 4.5 it would be simple : ExceptionDispatchInfo.Capture(exception).Throw();
+            // But as NEST target .Net 4.0 the old internal method must be used
+            if (preserveStackTraceMethodInfo.Value != null)
+            {
+                preserveStackTraceMethodInfo.Value.Invoke(exception, null);
+            }
+            throw exception;
+        }
+    }
+}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -410,6 +410,7 @@
     <Compile Include="Exception\SnapshotException.cs" />
     <Compile Include="ExposedInternals\NestSerializer.cs" />
     <Compile Include="Enums\GeoDistance.cs" />
+    <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Obsolete\Obsolete.cs" />
     <Compile Include="Resolvers\Converters\Aggregations\FiltersAggregatorConverter.cs" />
     <Compile Include="Resolvers\Converters\Aggregations\FilterAggregatorConverter.cs" />

--- a/src/Tests/Nest.Tests.Integration/Exceptions/ElasticsearchExceptionTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Exceptions/ElasticsearchExceptionTests.cs
@@ -48,6 +48,19 @@ namespace Nest.Tests.Integration.Exceptions
 				.ThrowOnElasticsearchServerExceptions());
 			Assert.Throws<WebException>(async () => await client.RootNodeInfoAsync());
 		}
+
+		[Test]
+		public void ConnectionException_WithThrowingClient_Async_PreserveStacktrace()
+		{
+			var uri = ElasticsearchConfiguration.CreateBaseUri(9494);
+			var client = new ElasticClient(new ConnectionSettings(uri)
+				.SetTimeout(500)
+				.ThrowOnElasticsearchServerExceptions());
+			var exception = Assert.Throws<WebException>(async () => await client.RootNodeInfoAsync());
+
+			var elasticClientType = typeof (ElasticClient);
+			Assert.That(exception.StackTrace, Is.Not.StringStarting(string.Format("   at {0}.{1}", elasticClientType.Namespace, elasticClientType.Name)));
+		}
 		
 		[Test]
 		public void ServerError_Is_Set_ClientThat_DoesNotThow_AndDoesNotExposeRawResponse_Async()


### PR DESCRIPTION
This pull request aim to fix #1399 by using the internal `InternalPreserveStackTrace` method of `Exception`.

There is a clean non-reflection way to do in in .Net 4.5 using `ExceptionDispatchInfo` (See [this blog](http://blogs.microsoft.co.il/sasha/2011/10/19/capture-transfer-and-rethrow-exceptions-with-exceptiondispatchinfo-net-45/)) but it would require changing the target version.

The unit test wouldn't catch all causes of exception callstack being erased, only a direct regression.