### PR TITLE
Added overload to DismaxQueryDescriptor's Queries method to take QueryContainer[]

### DIFF
--- a/src/Nest/DSL/Query/DismaxQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/DismaxQueryDescriptor.cs
@@ -74,11 +74,25 @@ namespace Nest
 			return this;
 		}
 
+		public DisMaxQueryDescriptor<T> Queries(params QueryContainer[] queries)
+		{
+			var descriptors = new List<QueryContainer>();
+			foreach (var q in queries)
+			{
+				if (q.IsConditionless)
+					continue;
+				descriptors.Add(q);
+			}
+			((IDisMaxQuery)this).Queries = descriptors.HasAny() ? descriptors : null;
+			return this;
+		}
+
 		public DisMaxQueryDescriptor<T> Boost(double boost)
 		{
 			Self.Boost = boost;
 			return this;
 		}
+
 		public DisMaxQueryDescriptor<T> TieBreaker(double tieBreaker)
 		{
 			Self.TieBreaker = tieBreaker;


### PR DESCRIPTION
This allows it to act like other descriptors that get formatted into an array, such as Bool Query's Should, if you've already composed your QueryContainers elsewhere.