### PR TITLE
Elasticsearch carrot plugin implementation.

### DIFF
--- a/src/Elasticsearch.Net/Connection/ITransport.cs
+++ b/src/Elasticsearch.Net/Connection/ITransport.cs
@@ -16,7 +16,9 @@ namespace Elasticsearch.Net.Connection
 			string method, 
 			string path, 
 			object data = null, 
-			IRequestParameters requestParameters = null);
+			IRequestParameters requestParameters = null,
+            string plugin = "_search"
+            );
 
 		Task<ElasticsearchResponse<T>> DoRequestAsync<T>(
 			string method, 

--- a/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandler.cs
+++ b/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandler.cs
@@ -26,7 +26,7 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 		{
 		}
 
-		public ElasticsearchResponse<T> Request<T>(TransportRequestState<T> requestState, object data = null)
+        public ElasticsearchResponse<T> Request<T>(TransportRequestState<T> requestState, object data = null, string plugin = "_search")
 		{
 			var postData = PostData(data);
 			requestState.TickSerialization(postData);

--- a/src/Elasticsearch.Net/Connection/Transport.cs
+++ b/src/Elasticsearch.Net/Connection/Transport.cs
@@ -336,11 +336,11 @@ namespace Elasticsearch.Net.Connection
 			}
 		}
 
-		public ElasticsearchResponse<T> DoRequest<T>(string method, string path, object data = null, IRequestParameters requestParameters = null)
+        public ElasticsearchResponse<T> DoRequest<T>(string method, string path, object data = null, IRequestParameters requestParameters = null, string plugin = "_search")
 		{
 			using (var requestState = new TransportRequestState<T>(this.Settings, requestParameters, method, path))
 			{
-				return this._requestHandler.Request<T>(requestState, data);
+				return this._requestHandler.Request<T>(requestState, data, plugin);
 			}
 		}
 

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -4599,7 +4599,34 @@ namespace Elasticsearch.Net
 			this.AddQueryString("search_indices", this._search_indices);
 			return this;
 		}
-		
+
+
+        internal string _search_algorithm { get; set; }
+        ///<summary>The search query hint</summary>
+        public MoreLikeThisRequestParameters SearchAlgorithm(string search_algorithm)
+        {
+            this._search_algorithm = search_algorithm;
+            this.AddQueryString("search_algorithm", this._search_algorithm);
+            return this;
+        }
+
+        internal string _search_request { get; set; }
+        ///<summary>The search request</summary>
+        public MoreLikeThisRequestParameters SearchRequest(string search_request)
+        {
+            this._search_request = search_request;
+            this.AddQueryString("search_query_hint", this._search_request);
+            return this;
+        }
+
+        internal string _search_query_hint { get; set; }
+        ///<summary>The search query hint</summary>
+        public MoreLikeThisRequestParameters SearchQueryHint(string search_query_hint)
+        {
+            this._search_query_hint = search_query_hint;
+            this.AddQueryString("search_query_hint", this._search_query_hint);
+            return this;
+        }
 		
 		internal string _search_scroll { get; set; }
 		///<summary>A scroll search request definition</summary>

--- a/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
@@ -32795,9 +32795,9 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> SearchGet<T>(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SearchGet<T>(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null,  string plugin = "_search")
 		{
-			var url = "_search";
+            var url = plugin;
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -32827,9 +32827,9 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> SearchGetAsync<T>(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			var url = "_search";
+        public Task<ElasticsearchResponse<T>> SearchGetAsync<T>(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            var url = plugin;
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -32861,9 +32861,9 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> SearchGet(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			var url = "_search";
+        public ElasticsearchResponse<DynamicDictionary> SearchGet(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            var url = plugin;
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -32895,9 +32895,9 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			var url = "_search";
+        public Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            var url = plugin;
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -32928,10 +32928,10 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> SearchGet<T>(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
+        public ElasticsearchResponse<T> SearchGet<T>(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
 			index.ThrowIfNullOrEmpty("index");
-			var url = "{0}/_search".F(Encoded(index));
+			var url = "{0}/"+plugin.F(Encoded(index));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -32962,10 +32962,10 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> SearchGetAsync<T>(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			var url = "{0}/_search".F(Encoded(index));
+        public Task<ElasticsearchResponse<T>> SearchGetAsync<T>(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            var url = "{0}/" + plugin.F(Encoded(index));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -32998,10 +32998,10 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> SearchGet(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			var url = "{0}/_search".F(Encoded(index));
+        public ElasticsearchResponse<DynamicDictionary> SearchGet(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            var url = "{0}/" + plugin.F(Encoded(index));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33034,10 +33034,10 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			var url = "{0}/_search".F(Encoded(index));
+        public Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            var url = "{0}/" + plugin.F(Encoded(index));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33069,11 +33069,11 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> SearchGet<T>(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			var url = "{0}/{1}/_search".F(Encoded(index), Encoded(type));
+        public ElasticsearchResponse<T> SearchGet<T>(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            var url = "{0}/{1}/" + plugin.F(Encoded(index), Encoded(type));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33105,11 +33105,11 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> SearchGetAsync<T>(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			var url = "{0}/{1}/_search".F(Encoded(index), Encoded(type));
+        public Task<ElasticsearchResponse<T>> SearchGetAsync<T>(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            var url = "{0}/{1}/" + plugin.F(Encoded(index), Encoded(type));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33143,11 +33143,11 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> SearchGet(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			var url = "{0}/{1}/_search".F(Encoded(index), Encoded(type));
+        public ElasticsearchResponse<DynamicDictionary> SearchGet(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            var url = "{0}/{1}/" + plugin.F(Encoded(index), Encoded(type));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33181,11 +33181,11 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			var url = "{0}/{1}/_search".F(Encoded(index), Encoded(type));
+        public Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            var url = "{0}/{1}/" + plugin.F(Encoded(index), Encoded(type));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33216,9 +33216,9 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> Search<T>(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			var url = "_search".F();
+        public ElasticsearchResponse<T> Search<T>(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            var url = plugin.F();
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33249,9 +33249,9 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> SearchAsync<T>(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			var url = "_search".F();
+        public Task<ElasticsearchResponse<T>> SearchAsync<T>(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            var url = plugin.F();
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33284,9 +33284,9 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> Search(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			var url = "_search".F();
+        public ElasticsearchResponse<DynamicDictionary> Search(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            var url = plugin.F();
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33319,9 +33319,9 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			var url = "_search".F();
+        public Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            var url = plugin.F();
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33353,10 +33353,10 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> Search<T>(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			var url = "{0}/_search".F(Encoded(index));
+        public ElasticsearchResponse<T> Search<T>(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            var url = "{0}/" + plugin.F(Encoded(index));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33388,10 +33388,10 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			var url = "{0}/_search".F(Encoded(index));
+        public Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            var url = "{0}/" + plugin.F(Encoded(index));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33425,10 +33425,10 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> Search(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			var url = "{0}/_search".F(Encoded(index));
+        public ElasticsearchResponse<DynamicDictionary> Search(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            var url = "{0}/" + plugin.F(Encoded(index));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33462,10 +33462,10 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			var url = "{0}/_search".F(Encoded(index));
+        public Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            var url = "{0}/" + plugin.F(Encoded(index));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33498,11 +33498,11 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> Search<T>(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			var url = "{0}/{1}/_search".F(Encoded(index), Encoded(type));
+        public ElasticsearchResponse<T> Search<T>(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            var url = string.Format("{0}/{1}/" + plugin, Encoded(index), Encoded(type));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33535,11 +33535,11 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			var url = "{0}/{1}/_search".F(Encoded(index), Encoded(type));
+        public Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            var url = string.Format("{0}/{1}/" + plugin, Encoded(index), Encoded(type));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33574,11 +33574,11 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> Search(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			var url = "{0}/{1}/_search".F(Encoded(index), Encoded(type));
+        public ElasticsearchResponse<DynamicDictionary> Search(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            var url = string.Format("{0}/{1}/" + plugin, Encoded(index), Encoded(type));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
@@ -33613,11 +33613,11 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
-		{
-			index.ThrowIfNullOrEmpty("index");
-			type.ThrowIfNullOrEmpty("type");
-			var url = "{0}/{1}/_search".F(Encoded(index), Encoded(type));
+        public Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search")
+        {
+            index.ThrowIfNullOrEmpty("index");
+            type.ThrowIfNullOrEmpty("type");
+            var url = string.Format("{0}/{1}/" + plugin, Encoded(index), Encoded(type));
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)

--- a/src/Elasticsearch.Net/ElasticsearchClient.cs
+++ b/src/Elasticsearch.Net/ElasticsearchClient.cs
@@ -60,7 +60,7 @@ namespace Elasticsearch.Net
 		/// <param name="data">The body of the request, string and byte[] are posted as is other types will be serialized to JSON</param>
 		/// <param name="requestParameters">Optionally configure request specific timeouts, headers</param>
 		/// <returns>An ElasticsearchResponse of T where T represents the JSON response body</returns>
-		public ElasticsearchResponse<T> DoRequest<T>(string method, string path, object data = null, IRequestParameters requestParameters = null)
+        public ElasticsearchResponse<T> DoRequest<T>(string method, string path, object data = null, IRequestParameters requestParameters = null, string plugin = "_search")
 		{
 			return this.Transport.DoRequest<T>(method, path, data, requestParameters);
 		}

--- a/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
@@ -17566,27 +17566,27 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		ElasticsearchResponse<T> SearchGet<T>(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
-		
-		///<summary>Represents a GET on /_search
-		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
-		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
-		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/search-search.html</para>	
-		///</summary>
-		///<param name="requestParameters">
-		///Optional function to specify any additional request parameters 
-		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
-		///</param>
-		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
-		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
-		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///</returns>
-		
-		Task<ElasticsearchResponse<T>> SearchGetAsync<T>(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<T> SearchGet<T>(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /_search
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/search-search.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+
+        Task<ElasticsearchResponse<T>> SearchGetAsync<T>(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
+		
+		///<summary>Represents a GET on /_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
@@ -17602,8 +17602,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		ElasticsearchResponse<DynamicDictionary> SearchGet(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<DynamicDictionary> SearchGet(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /_search
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -17621,8 +17621,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /{index}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17639,8 +17639,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		ElasticsearchResponse<T> SearchGet<T>(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<T> SearchGet<T>(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /{index}/_search
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17657,8 +17657,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<T>> SearchGetAsync<T>(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<T>> SearchGetAsync<T>(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /{index}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -17677,8 +17677,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		ElasticsearchResponse<DynamicDictionary> SearchGet(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<DynamicDictionary> SearchGet(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /{index}/_search
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -17697,8 +17697,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(string index, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /{index}/{type}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17716,8 +17716,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		ElasticsearchResponse<T> SearchGet<T>(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<T> SearchGet<T>(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /{index}/{type}/_search
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17735,8 +17735,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<T>> SearchGetAsync<T>(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<T>> SearchGetAsync<T>(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /{index}/{type}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -17756,8 +17756,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		ElasticsearchResponse<DynamicDictionary> SearchGet(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<DynamicDictionary> SearchGet(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a GET on /{index}/{type}/_search
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -17777,8 +17777,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<DynamicDictionary>> SearchGetAsync(string index, string type, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17795,8 +17795,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		ElasticsearchResponse<T> Search<T>(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<T> Search<T>(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /_search
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17813,8 +17813,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<T>> SearchAsync<T>(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<T>> SearchAsync<T>(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -17833,8 +17833,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		ElasticsearchResponse<DynamicDictionary> Search(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<DynamicDictionary> Search(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /_search
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -17853,8 +17853,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /{index}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17872,8 +17872,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		ElasticsearchResponse<T> Search<T>(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<T> Search<T>(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /{index}/_search
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17891,8 +17891,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /{index}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -17912,8 +17912,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		ElasticsearchResponse<DynamicDictionary> Search(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<DynamicDictionary> Search(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /{index}/_search
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -17933,8 +17933,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(string index, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /{index}/{type}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17953,8 +17953,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		ElasticsearchResponse<T> Search<T>(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<T> Search<T>(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /{index}/{type}/_search
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -17973,8 +17973,8 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /{index}/{type}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -17995,8 +17995,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		ElasticsearchResponse<DynamicDictionary> Search(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        ElasticsearchResponse<DynamicDictionary> Search(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /{index}/{type}/_search
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -18017,8 +18017,8 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		
-		Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null);
+
+        Task<ElasticsearchResponse<DynamicDictionary>> SearchAsync(string index, string type, object body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, string plugin = "_search");
 		
 		///<summary>Represents a POST on /_search/exists
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.

--- a/src/Elasticsearch.Net/IElasticsearchClient.cs
+++ b/src/Elasticsearch.Net/IElasticsearchClient.cs
@@ -17,7 +17,7 @@ namespace Elasticsearch.Net
 		/// <param name="data">The body of the request, string and byte[] are posted as is other types will be serialized to JSON</param>
 		/// <param name="requestParameters">Optionally configure request specific timeouts, headers</param>
 		/// <returns>An ElasticsearchResponse of T where T represents the JSON response body</returns>
-		ElasticsearchResponse<T> DoRequest<T>(string method, string path, object data = null, IRequestParameters requestParameters = null);
+        ElasticsearchResponse<T> DoRequest<T>(string method, string path, object data = null, IRequestParameters requestParameters = null, string plugin = "_search");
 
 		/// <summary>
 		/// Perform any request you want over the configured IConnection asynchronously while taking advantage of the cluster failover.

--- a/src/Nest/DSL/_Descriptors.generated.cs
+++ b/src/Nest/DSL/_Descriptors.generated.cs
@@ -4282,7 +4282,27 @@ namespace Nest
 			this.Request.RequestParameters.SearchIndices(search_indices);
 			return this;
 		}
-		
+
+        ///<summary>The search request</summary>
+        public MoreLikeThisDescriptor<T> SearchRequest(string search_request)
+        {
+            this.Request.RequestParameters.SearchRequest(search_request);
+            return this;
+        }
+
+        ///<summary>The search query hint</summary>
+        public MoreLikeThisDescriptor<T> SearchQueryHint(string search_query_hint)
+        {
+            this.Request.RequestParameters.SearchQueryHint(search_query_hint);
+            return this;
+        }
+
+        ///<summary>The search algorithm</summary>
+        public MoreLikeThisDescriptor<T> SearchAlgorithm(string search_algorithm)
+        {
+            this.Request.RequestParameters.SearchAlgorithm(search_algorithm);
+            return this;
+        }
 
 		///<summary>A scroll search request definition</summary>
 		public MoreLikeThisDescriptor<T> SearchScroll(string search_scroll)

--- a/src/Nest/DSL/_Requests.generated.cs
+++ b/src/Nest/DSL/_Requests.generated.cs
@@ -3858,7 +3858,28 @@ namespace Nest
 			get { return this.Request.RequestParameters.GetQueryStringValue< string[]>("search_indices"); } 
 			set { this.Request.RequestParameters.AddQueryString("search_indices", value); }
 		}
-		
+
+
+        ///<summary>The search query hint</summary>
+        public string SearchQueryHint
+        {
+            get { return this.Request.RequestParameters.GetQueryStringValue<string>("search_query_hint"); }
+            set { this.Request.RequestParameters.AddQueryString("search_query_hint", value); }
+        }
+
+        ///<summary>The search request</summary>
+        public string SearchRequest
+        {
+            get { return this.Request.RequestParameters.GetQueryStringValue<string>("search_request"); }
+            set { this.Request.RequestParameters.AddQueryString("search_request", value); }
+        }
+
+        ///<summary>The search algorithm</summary>
+        public string SearchAlgorithm
+        {
+            get { return this.Request.RequestParameters.GetQueryStringValue<string>("search_algorithm"); }
+            set { this.Request.RequestParameters.AddQueryString("search_algorithm", value); }
+        }
 		
 		///<summary>A scroll search request definition</summary>
 		public string SearchScroll 
@@ -6197,7 +6218,27 @@ namespace Nest
 			get { return this.Request.RequestParameters.GetQueryStringValue< string[]>("search_indices"); } 
 			set { this.Request.RequestParameters.AddQueryString("search_indices", value); }
 		}
-		
+
+        ///<summary>The search query hint</summary>
+        public string SearchQueryHint
+        {
+            get { return this.Request.RequestParameters.GetQueryStringValue<string>("search_query_hint"); }
+            set { this.Request.RequestParameters.AddQueryString("search_query_hint", value); }
+        }
+
+        ///<summary>The search request</summary>
+        public string SearchRequest
+        {
+            get { return this.Request.RequestParameters.GetQueryStringValue<string>("search_request"); }
+            set { this.Request.RequestParameters.AddQueryString("search_request", value); }
+        }
+
+        ///<summary>The search algorithm</summary>
+        public string SearchAlgorithm
+        {
+            get { return this.Request.RequestParameters.GetQueryStringValue<string>("search_algorithm"); }
+            set { this.Request.RequestParameters.AddQueryString("search_algorithm", value); }
+        }
 		
 		///<summary>A scroll search request definition</summary>
 		public string SearchScroll 

--- a/src/Nest/Domain/Clusters/Clusters.cs
+++ b/src/Nest/Domain/Clusters/Clusters.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Nest.Domain.Clusters
+{
+    //[JsonConverter(typeof(ConcreteTypeConverter))]
+    public interface IClusters
+    {
+        string Id { get; }
+        string Score { get; }
+        string Label { get; }
+        string[] Phrases { get; }
+        string[] Documents { get; }
+    }
+
+    [JsonObject]
+    public class Clusters : IClusters
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "score")]
+        public string Score { get; set; }
+
+        [JsonProperty(PropertyName = "label")]
+        public string Label { get; set; }
+
+        [JsonProperty(PropertyName = "phrases")]
+        public string[] Phrases { get; set; }
+
+        [JsonProperty(PropertyName = "documents")]
+        public string[] Documents { get; set; }
+
+        [JsonProperty(PropertyName = "clusters")]
+        public Clusters[] clusters { get; set; }
+    }
+}

--- a/src/Nest/Domain/FieldMapping/FieldMapping.cs
+++ b/src/Nest/Domain/FieldMapping/FieldMapping.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Collections.Generic;
+using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+    /// <summary>
+    /// Represents a typed container for object paths "field.nested.property";
+    /// </summary>
+    [JsonConverter(typeof(FieldMappingOuterClassConverter))]
+    public class FieldMappingOuterClass : IDictionary<string,string>
+    {
+        public Dictionary<string,string> field_mapping { get; set; }
+
+        //IFieldMappingInner IFieldMappingOuter.field_mapping
+        //{
+        //    get;
+        //    set;
+        //}
+
+        public void Add(string key, string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ContainsKey(string key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICollection<string> Keys
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool Remove(string key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetValue(string key, out string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICollection<string> Values
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public string this[string key]
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public void Add(KeyValuePair<string, string> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(KeyValuePair<string, string> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int Count
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool IsReadOnly
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool Remove(KeyValuePair<string, string> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class FieldMappingInnerClass
+    {
+        public List<string> title { get; set; }
+        public List<string> content { get; set; }
+
+        //IList<string> IFieldMappingInner.title
+        //{
+        //    get;
+        //    set;
+        //}
+
+        //IList<string> IFieldMappingInner.content
+        //{
+        //    get;
+        //    set;
+        //}
+    }
+
+}

--- a/src/Nest/Domain/Info/Info.cs
+++ b/src/Nest/Domain/Info/Info.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Nest.Domain.Info
+{
+    public interface IInfo
+    {
+        string Algorithm { get; }
+
+    }
+
+    [JsonObject]
+    public class Info : IInfo
+    {
+        [JsonProperty(PropertyName = "algorithm")]
+        public string Algorithm { get; set; }
+
+        [JsonProperty(PropertyName = "search-millis")]
+        public string ElapsedSearchTime { get; set; }
+
+        [JsonProperty(PropertyName = "clustering-millis")]
+        public string ElapsedClusteringTime { get; set; }
+
+        [JsonProperty(PropertyName = "total-millis")]
+        public string ElapsedTotalTime { get; set; }
+
+        [JsonProperty(PropertyName = "include-hits")]
+        public string IncludeHits { get; set; }
+
+        [JsonProperty(PropertyName = "max-hits")]
+        public string MaxHits { get; set; }
+
+    }
+}

--- a/src/Nest/Domain/Responses/SearchResponse.cs
+++ b/src/Nest/Domain/Responses/SearchResponse.cs
@@ -4,6 +4,8 @@ using Newtonsoft.Json;
 using System.Linq.Expressions;
 using System;
 using System.Linq;
+using Nest.Domain.Info;
+using Nest.Domain.Clusters;
 
 namespace Nest
 {
@@ -30,6 +32,8 @@ namespace Nest
 		/// </summary>
 		IEnumerable<T> Documents { get; }
 		IEnumerable<IHit<T>> Hits { get; }
+        Clusters[] Clusters { get; }
+        Info Info { get; }
 
 		/// <summary>
 		/// Will return the field selections inside the hits when the search descriptor specified .Fields.
@@ -58,6 +62,12 @@ namespace Nest
 
 		[JsonProperty(PropertyName = "hits")]
 		public HitsMetaData<T> HitsMetaData { get; internal set; }
+
+        [JsonProperty(PropertyName = "clusters")]
+        public Clusters[] Clusters { get; set; }
+
+        [JsonProperty(PropertyName = "info")]
+        public Info Info { get; set; }
 
 		[JsonProperty(PropertyName = "facets")]
 		[JsonConverter(typeof(DictionaryKeysAreNotPropertyNamesJsonConverter))]

--- a/src/Nest/ElasticClient-Search.cs
+++ b/src/Nest/ElasticClient-Search.cs
@@ -11,13 +11,13 @@ namespace Nest
 	public partial class ElasticClient
 	{
 		/// <inheritdoc />
-		public ISearchResponse<T> Search<T>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector) where T : class
+        public ISearchResponse<T> Search<T>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector, string plugin = "_search") where T : class
 		{
-			return this.Search<T, T>(searchSelector);
+            return this.Search<T, T>(searchSelector, plugin);
 		}
 
 		/// <inheritdoc />
-		public ISearchResponse<TResult> Search<T, TResult>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector)
+        public ISearchResponse<TResult> Search<T, TResult>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector, string plugin = "_search")
 			where T : class
 			where TResult : class
 		{
@@ -29,19 +29,19 @@ namespace Nest
 				.ToPathInfo(_connectionSettings)
 				.DeserializationState(this.CreateSearchDeserializer<T, TResult>(descriptor));
 
-			var status = this.RawDispatch.SearchDispatch<SearchResponse<TResult>>(pathInfo, descriptor);
+            var status = this.RawDispatch.SearchDispatch<SearchResponse<TResult>>(pathInfo, descriptor, plugin);
 			return status.Success ? status.Response : CreateInvalidInstance<SearchResponse<TResult>>(status);
 		}
 
 
-		
-		public ISearchResponse<T> Search<T>(ISearchRequest request)
+
+        public ISearchResponse<T> Search<T>(ISearchRequest request, string plugin = "_search")
 			where T : class
 		{
-			return this.Search<T, T>(request);
+            return this.Search<T, T>(request, plugin);
 		}
 
-		public ISearchResponse<TResult> Search<T, TResult>(ISearchRequest request)
+        public ISearchResponse<TResult> Search<T, TResult>(ISearchRequest request, string plugin = "_search")
 			where T : class
 			where TResult : class
 		{
@@ -49,19 +49,19 @@ namespace Nest
 				.ToPathInfo(_connectionSettings)
 				.DeserializationState(this.CreateSearchDeserializer<T, TResult>(request));
 
-			var status = this.RawDispatch.SearchDispatch<SearchResponse<TResult>>(pathInfo, request);
+            var status = this.RawDispatch.SearchDispatch<SearchResponse<TResult>>(pathInfo, request, plugin);
 			return status.Success ? status.Response : CreateInvalidInstance<SearchResponse<TResult>>(status);
 		}
 
 		/// <inheritdoc />
-		public Task<ISearchResponse<T>> SearchAsync<T>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector)
+        public Task<ISearchResponse<T>> SearchAsync<T>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector, string plugin = "_search")
 			where T : class
 		{
-			return this.SearchAsync<T, T>(searchSelector);
+            return this.SearchAsync<T, T>(searchSelector, plugin);
 		}
 
 		/// <inheritdoc />
-		public Task<ISearchResponse<TResult>> SearchAsync<T, TResult>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector)
+        public Task<ISearchResponse<TResult>> SearchAsync<T, TResult>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector, string plugin = "_search")
 			where T : class
 			where TResult : class
 		{
@@ -73,7 +73,7 @@ namespace Nest
 				.ToPathInfo(_connectionSettings)
 				.DeserializationState(CreateSearchDeserializer<T, TResult>(descriptor));
 
-			return this.RawDispatch.SearchDispatchAsync<SearchResponse<TResult>>(pathInfo, descriptor)
+            return this.RawDispatch.SearchDispatchAsync<SearchResponse<TResult>>(pathInfo, descriptor, plugin)
 				.ContinueWith<ISearchResponse<TResult>>(t => {
 					if (t.IsFaulted)
 						throw t.Exception.Flatten().InnerException;
@@ -85,21 +85,21 @@ namespace Nest
 		}
 
 
-		public Task<ISearchResponse<T>> SearchAsync<T>(ISearchRequest request)
+        public Task<ISearchResponse<T>> SearchAsync<T>(ISearchRequest request, string plugin = "_search")
 			where T : class
 		{
-			return this.SearchAsync<T, T>(request);
+            return this.SearchAsync<T, T>(request, plugin);
 		}
 
-		public Task<ISearchResponse<TResult>> SearchAsync<T, TResult>(ISearchRequest request)
+        public Task<ISearchResponse<TResult>> SearchAsync<T, TResult>(ISearchRequest request, string plugin = "_search")
 			where T : class
 			where TResult : class
 		{
 			var pathInfo = request
 				.ToPathInfo(_connectionSettings)
 				.DeserializationState(this.CreateSearchDeserializer<T, TResult>(request));
-			
-			return this.RawDispatch.SearchDispatchAsync<SearchResponse<TResult>>(pathInfo, request)
+
+            return this.RawDispatch.SearchDispatchAsync<SearchResponse<TResult>>(pathInfo, request, plugin)
 				.ContinueWith<ISearchResponse<TResult>>(t => {
 					if (t.IsFaulted)
 						throw t.Exception.Flatten().InnerException;

--- a/src/Nest/IElasticClient.cs
+++ b/src/Nest/IElasticClient.cs
@@ -760,40 +760,40 @@ namespace Nest
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the index and typename as well describe the query strongly typed</typeparam>
 		/// <param name="searchSelector">A descriptor that describes the parameters for the search operation</param>
-		ISearchResponse<T> Search<T>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector)
+        ISearchResponse<T> Search<T>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector, string plugin = "_search")
 			where T : class;
 
 		/// <inheritdoc />
-		ISearchResponse<T> Search<T>(ISearchRequest request)
+        ISearchResponse<T> Search<T>(ISearchRequest request, string plugin = "_search")
 			where T : class;
 
 		/// <inheritdoc />
-		ISearchResponse<TResult> Search<T, TResult>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector)
+        ISearchResponse<TResult> Search<T, TResult>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector, string plugin = "_search")
 			where T : class
 			where TResult : class;
 
 		/// <inheritdoc />
-		ISearchResponse<TResult> Search<T, TResult>(ISearchRequest request)
+        ISearchResponse<TResult> Search<T, TResult>(ISearchRequest request, string plugin = "_search")
 			where T : class
 			where TResult : class;
 
 		/// <inheritdoc />
 		/// <typeparam name="T">The type used to infer the index and typename as well describe the query strongly typed</typeparam>
 		/// <param name="searchSelector">A descriptor that describes the parameters for the search operation</param>
-		Task<ISearchResponse<T>> SearchAsync<T>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector)
+        Task<ISearchResponse<T>> SearchAsync<T>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector, string plugin = "_search")
 			where T : class;
 
 		/// <inheritdoc />
-		Task<ISearchResponse<T>> SearchAsync<T>(ISearchRequest request)
+        Task<ISearchResponse<T>> SearchAsync<T>(ISearchRequest request, string plugin = "_search")
 			where T : class;
 
 		/// <inheritdoc />
-		Task<ISearchResponse<TResult>> SearchAsync<T, TResult>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector)
+        Task<ISearchResponse<TResult>> SearchAsync<T, TResult>(Func<SearchDescriptor<T>, SearchDescriptor<T>> searchSelector, string plugin = "_search")
 			where T : class
 			where TResult : class;
 
 		/// <inheritdoc />
-		Task<ISearchResponse<TResult>> SearchAsync<T, TResult>(ISearchRequest request)
+        Task<ISearchResponse<TResult>> SearchAsync<T, TResult>(ISearchRequest request, string plugin = "_search")
 			where T : class
 			where TResult : class;
 

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Domain\Analysis\TokenFilter\StemmerOverrideTokenFilter.cs" />
     <Compile Include="Domain\Analysis\TokenFilter\UppercaseTokenFilter.cs" />
     <Compile Include="Domain\Bulk\IBulkOperation.cs" />
+    <Compile Include="Domain\Clusters\Clusters.cs" />
     <Compile Include="Domain\Cluster\ClusterRerouteDecision.cs" />
     <Compile Include="Domain\Cluster\ClusterRerouteExplanation.cs" />
     <Compile Include="Domain\Cluster\ClusterRerouteParameters.cs" />
@@ -130,9 +131,11 @@
     <Compile Include="Domain\Cat\CatPluginsRecord.cs" />
     <Compile Include="Domain\Cat\CatPendingTasksRecord.cs" />
     <Compile Include="Domain\DSL\IDocument.cs" />
+    <Compile Include="Domain\FieldMapping\FieldMapping.cs" />
     <Compile Include="Domain\Geo\GeoLocation.cs" />
     <Compile Include="Domain\Geo\GeoPrecision.cs" />
     <Compile Include="Domain\Hit\ExplainGet.cs" />
+    <Compile Include="Domain\Info\Info.cs" />
     <Compile Include="Domain\Mapping\PropertyMapping.cs" />
     <Compile Include="Domain\Mapping\Descriptors\FieldDataFilterDescriptor.cs" />
     <Compile Include="Domain\Mapping\Descriptors\FieldDataFrequencyFilterDescriptor.cs" />

--- a/src/Nest/RawDispatch.generated.cs
+++ b/src/Nest/RawDispatch.generated.cs
@@ -3490,63 +3490,63 @@ namespace Nest
 			}
 			throw new DispatchException("Could not dispatch IElasticClient.Scroll() into any of the following paths: \r\n - /_search/scroll\r\n - /_search/scroll/{scroll_id}");
 		}
-		
-		
-		internal ElasticsearchResponse<T> SearchDispatch<T>(ElasticsearchPathInfo<SearchRequestParameters> pathInfo , object body)
+
+
+        internal ElasticsearchResponse<T> SearchDispatch<T>(ElasticsearchPathInfo<SearchRequestParameters> pathInfo, object body, string plugin = "_search")
 		{
 			switch(pathInfo.HttpMethod)
 			{
 				case PathInfoHttpMethod.GET:
 					//GET /{index}/{type}/_search
 					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty())
-						return this.Raw.SearchGet<T>(pathInfo.Index,pathInfo.Type,u => pathInfo.RequestParameters);
+                        return this.Raw.SearchGet<T>(pathInfo.Index, pathInfo.Type, u => pathInfo.RequestParameters, plugin);
 					//GET /{index}/_search
 					if (!pathInfo.Index.IsNullOrEmpty())
-						return this.Raw.SearchGet<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+                        return this.Raw.SearchGet<T>(pathInfo.Index, u => pathInfo.RequestParameters, plugin);
 					//GET /_search
-					return this.Raw.SearchGet<T>(u => pathInfo.RequestParameters);
+                    return this.Raw.SearchGet<T>(u => pathInfo.RequestParameters, plugin);
 
 				case PathInfoHttpMethod.POST:
 					//POST /{index}/{type}/_search
 					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty() && body != null)
-						return this.Raw.Search<T>(pathInfo.Index,pathInfo.Type,body,u => pathInfo.RequestParameters);
+                        return this.Raw.Search<T>(pathInfo.Index, pathInfo.Type, body, u => pathInfo.RequestParameters, plugin);
 					//POST /{index}/_search
 					if (!pathInfo.Index.IsNullOrEmpty() && body != null)
-						return this.Raw.Search<T>(pathInfo.Index,body,u => pathInfo.RequestParameters);
+                        return this.Raw.Search<T>(pathInfo.Index, body, u => pathInfo.RequestParameters, plugin);
 					//POST /_search
 					if (body != null)
-						return this.Raw.Search<T>(body,u => pathInfo.RequestParameters);
+                        return this.Raw.Search<T>(body, u => pathInfo.RequestParameters, plugin);
 					break;
 
 			}
 			throw new DispatchException("Could not dispatch IElasticClient.Search() into any of the following paths: \r\n - /_search\r\n - /{index}/_search\r\n - /{index}/{type}/_search");
 		}
-		
-		
-		internal Task<ElasticsearchResponse<T>> SearchDispatchAsync<T>(ElasticsearchPathInfo<SearchRequestParameters> pathInfo , object body)
+
+
+        internal Task<ElasticsearchResponse<T>> SearchDispatchAsync<T>(ElasticsearchPathInfo<SearchRequestParameters> pathInfo, object body, string plugin = "_search")
 		{
 			switch(pathInfo.HttpMethod)
 			{
 				case PathInfoHttpMethod.GET:
 					//GET /{index}/{type}/_search
 					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty())
-						return this.Raw.SearchGetAsync<T>(pathInfo.Index,pathInfo.Type,u => pathInfo.RequestParameters);
+                        return this.Raw.SearchGetAsync<T>(pathInfo.Index, pathInfo.Type, u => pathInfo.RequestParameters, plugin);
 					//GET /{index}/_search
 					if (!pathInfo.Index.IsNullOrEmpty())
-						return this.Raw.SearchGetAsync<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+                        return this.Raw.SearchGetAsync<T>(pathInfo.Index, u => pathInfo.RequestParameters, plugin);
 					//GET /_search
-					return this.Raw.SearchGetAsync<T>(u => pathInfo.RequestParameters);
+                    return this.Raw.SearchGetAsync<T>(u => pathInfo.RequestParameters, plugin);
 
 				case PathInfoHttpMethod.POST:
 					//POST /{index}/{type}/_search
 					if (!pathInfo.Index.IsNullOrEmpty() && !pathInfo.Type.IsNullOrEmpty() && body != null)
-						return this.Raw.SearchAsync<T>(pathInfo.Index,pathInfo.Type,body,u => pathInfo.RequestParameters);
+                        return this.Raw.SearchAsync<T>(pathInfo.Index, pathInfo.Type, body, u => pathInfo.RequestParameters, plugin);
 					//POST /{index}/_search
 					if (!pathInfo.Index.IsNullOrEmpty() && body != null)
-						return this.Raw.SearchAsync<T>(pathInfo.Index,body,u => pathInfo.RequestParameters);
+                        return this.Raw.SearchAsync<T>(pathInfo.Index, body, u => pathInfo.RequestParameters, plugin);
 					//POST /_search
 					if (body != null)
-						return this.Raw.SearchAsync<T>(body,u => pathInfo.RequestParameters);
+                        return this.Raw.SearchAsync<T>(body, u => pathInfo.RequestParameters, plugin);
 					break;
 
 			}

--- a/src/Nest/Resolvers/Converters/DictionaryKeysAreNotPropertyNamesJsonConverter.cs
+++ b/src/Nest/Resolvers/Converters/DictionaryKeysAreNotPropertyNamesJsonConverter.cs
@@ -31,33 +31,40 @@ namespace Nest
 		{
 			var contract = serializer.ContractResolver as SettingsContractResolver;
 
-			IDictionary dictionary = (IDictionary) value;
-			writer.WriteStartObject();
+            if (value is IDictionary)
+            {
+                IDictionary dictionary = (IDictionary)value;
+                writer.WriteStartObject();
 
-			foreach (DictionaryEntry entry in dictionary)
-			{
-				if (entry.Value == null && serializer.NullValueHandling == NullValueHandling.Ignore)
-					continue;
-				string key;
-				var pp = entry.Key as PropertyPathMarker;
-				var pn = entry.Key as PropertyNameMarker;
-				var im = entry.Key as IndexNameMarker;
-				var tm = entry.Key as TypeNameMarker;
-				if (contract == null)
-					key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
-				else if (pp != null)
-					key = contract.Infer.PropertyPath(pp);
-				else if (pn != null)
-					key = contract.Infer.PropertyName(pn);
-				else if (im != null)
-					key = contract.Infer.IndexName(im);
-				else if (tm != null)
-					key = contract.Infer.TypeName(tm);
-				else
-					key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
-				writer.WritePropertyName(key);
-				serializer.Serialize(writer, entry.Value);
-			}
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    if (entry.Value == null && serializer.NullValueHandling == NullValueHandling.Ignore)
+                        continue;
+                    string key;
+                    var pp = entry.Key as PropertyPathMarker;
+                    var pn = entry.Key as PropertyNameMarker;
+                    var im = entry.Key as IndexNameMarker;
+                    if (contract == null)
+                        key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
+                    else if (pp != null)
+                        key = contract.Infer.PropertyPath(pp);
+                    else if (pn != null)
+                        key = contract.Infer.PropertyName(pn);
+                    else if (im != null)
+                        key = contract.Infer.IndexName(im);
+                    else
+                        key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
+                    writer.WritePropertyName(key);
+                    serializer.Serialize(writer, entry.Value);
+                }
+            }
+            else if(value is Search_request_class)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("search_request");
+                serializer.Serialize(writer, value);
+                //serializer.Serialize(writer, ((Search_request_class)value).size);
+            }
 
 			writer.WriteEndObject();
 		}

--- a/src/Nest/Resolvers/Converters/PropertyPathMarkerConverter.cs
+++ b/src/Nest/Resolvers/Converters/PropertyPathMarkerConverter.cs
@@ -6,69 +6,106 @@ using Newtonsoft.Json;
 
 namespace Nest.Resolvers.Converters
 {
-	public class PropertyPathMarkerConverter : JsonConverter
-	{
-		private readonly ElasticInferrer _infer;
-		public PropertyPathMarkerConverter(IConnectionSettingsValues connectionSettings)
-		{
-			_infer = new ElasticInferrer(connectionSettings);
-		}
 
-		public override bool CanRead { get { return false; } }
+    public class FieldMappingOuterClassConverter : JsonConverter
+    {
+        private readonly FieldMappingOuterClass _infer;
+        public FieldMappingOuterClassConverter(FieldMappingOuterClass a)
+        {
+            _infer = a;
+        }
+        public FieldMappingOuterClassConverter()
+        {
 
-		public override bool CanWrite { get { return true; } }
+        }
 
-		public override bool CanConvert(Type objectType)
-		{
-			return true; //only to be used with attribute or contract registration.
-		}
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-		{
-			var marker = value as PropertyPathMarker;
-			if (marker == null)
-			{
-				writer.WriteNull();
-				return;
-			}
-			writer.WriteValue(this._infer.PropertyPath(marker));
-		}
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-		{
-			return null;
-		}
+        public override bool CanRead { get { return false; } }
 
-	}
-	public class PropertyNameMarkerConverter : JsonConverter
-	{
-		private readonly ElasticInferrer _infer;
-		public PropertyNameMarkerConverter(IConnectionSettingsValues connectionSettings)
-		{
-			_infer = new ElasticInferrer(connectionSettings);
-		}
+        public override bool CanWrite { get { return true; } }
 
-		public override bool CanRead { get { return false; } }
+        public override bool CanConvert(Type objectType)
+        {
+            return true; //only to be used with attribute or contract registration.
+        }
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var marker = value as FieldMappingOuterClass;
+            if (marker == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            writer.WriteValue(this._infer.field_mapping);
+        }
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return null;
+        }
 
-		public override bool CanWrite { get { return true; } }
+    }
+    public class PropertyPathMarkerConverter : JsonConverter
+    {
+        private readonly ElasticInferrer _infer;
+        public PropertyPathMarkerConverter(IConnectionSettingsValues connectionSettings)
+        {
+            _infer = new ElasticInferrer(connectionSettings);
+        }
 
-		public override bool CanConvert(Type objectType)
-		{
-			return true; //only to be used with attribute or contract registration.
-		}
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-		{
-			var marker = value as PropertyNameMarker;
-			if (marker == null)
-			{
-				writer.WriteNull();
-				return;
-			}
-			writer.WriteValue(this._infer.PropertyName(marker));
-		}
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-		{
-			return null;
-		}
+        public override bool CanRead { get { return false; } }
 
-	}
+        public override bool CanWrite { get { return true; } }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true; //only to be used with attribute or contract registration.
+        }
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var marker = value as PropertyPathMarker;
+            if (marker == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            writer.WriteValue(this._infer.PropertyPath(marker));
+        }
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return null;
+        }
+
+    }
+    public class PropertyNameMarkerConverter : JsonConverter
+    {
+        private readonly ElasticInferrer _infer;
+        public PropertyNameMarkerConverter(IConnectionSettingsValues connectionSettings)
+        {
+            _infer = new ElasticInferrer(connectionSettings);
+        }
+
+        public override bool CanRead { get { return false; } }
+
+        public override bool CanWrite { get { return true; } }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true; //only to be used with attribute or contract registration.
+        }
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var marker = value as PropertyNameMarker;
+            if (marker == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            writer.WriteValue(this._infer.PropertyName(marker));
+        }
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return null;
+        }
+
+    }
 }
 

--- a/src/Nest/Resolvers/Converters/SortCollectionConverter.cs
+++ b/src/Nest/Resolvers/Converters/SortCollectionConverter.cs
@@ -72,18 +72,36 @@ namespace Nest.Resolvers.Converters
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
-			writer.WriteStartArray();
-			var sortItems = value as IList<KeyValuePair<PropertyPathMarker, ISort>>;
-			foreach (var item in sortItems)
-			{
-				writer.WriteStartObject();
-				var contract = serializer.ContractResolver as SettingsContractResolver;
-				var fieldName = contract.Infer.PropertyPath(item.Key);
-				writer.WritePropertyName(fieldName);
-				serializer.Serialize(writer, item.Value);
-				writer.WriteEndObject();
-			}
-			writer.WriteEndArray();
+            writer.WriteStartArray();
+            try
+            {
+                var sortItems = value as IList<KeyValuePair<PropertyPathMarker, ISort>>;
+                foreach (var item in sortItems)
+                {
+                    writer.WriteStartObject();
+                    var contract = serializer.ContractResolver as SettingsContractResolver;
+                    var fieldName = contract.Infer.PropertyPath(item.Key);
+                    writer.WritePropertyName(fieldName);
+                    serializer.Serialize(writer, item.Value);
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
+            }
+            catch
+            {
+                var item = value as FieldMappingOuterClass;
+                writer.WriteStartObject();
+                var contract = serializer.ContractResolver as SettingsContractResolver;
+                writer.WritePropertyName("title");
+                serializer.Serialize(writer, item.field_mapping["title"]);
+
+                writer.WritePropertyName("content");
+                serializer.Serialize(writer, item.field_mapping["content"]);
+
+                writer.WriteEndObject();
+
+                writer.WriteEndArray();
+            }
 		}
 
 		private void LoadGeoDistanceSortLocation(GeoDistanceSort sort, JObject j)

--- a/src/Nest/Resolvers/ElasticContractResolver.cs
+++ b/src/Nest/Resolvers/ElasticContractResolver.cs
@@ -47,6 +47,10 @@ namespace Nest.Resolvers
 
 			else if (objectType == typeof(Facet))
 				contract.Converter = new FacetConverter();
+
+            if (objectType == typeof(FieldMappingOuterClass))
+                contract.Converter = new FieldMappingOuterClassConverter();
+			
 			
 			else if (objectType == typeof(IAggregation))
 				contract.Converter = new AggregationConverter();
@@ -119,9 +123,6 @@ namespace Nest.Resolvers
 			defaultProperties = PropertiesOf<IMultiGetOperation>(type, memberSerialization, defaultProperties, lookup);
 			defaultProperties = PropertiesOf<IRepository>(type, memberSerialization, defaultProperties, lookup);
 			defaultProperties = PropertiesOf<ICreateAliasOperation>(type, memberSerialization, defaultProperties, lookup);
-			defaultProperties = PropertiesOf<IInnerHitsContainer>(type, memberSerialization, defaultProperties, lookup);
-			//defaultProperties = PropertiesOf<IGlobalInnerHit>(type, memberSerialization, defaultProperties, lookup);
-			defaultProperties = PropertiesOf<IInnerHits>(type, memberSerialization, defaultProperties, lookup);
 			return defaultProperties;
 		}
 


### PR DESCRIPTION
This is plugin implements on the fly data clustering for elastic search results. 

I implemented carrot2 plugin into eleasticsearch.net project for our internal project and wanted to share it with people. 

This plugin is useful if you like to have a RIPL or Foamtree chart. 

https://github.com/carrot2/elasticsearch-carrot2
