### PR TITLE
Feature/extensibility enhancements

### DIFF
--- a/src/Elasticsearch.Net/Domain/Response/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Domain/Response/ElasticsearchResponse.cs
@@ -19,6 +19,7 @@ using Elasticsearch.Net.Serialization;
 
 namespace Elasticsearch.Net
 {
+	// TODO: Make this class internal in 2.0
 	public static class ElasticsearchResponse
 	{
 		internal static ElasticsearchResponse<TTo> CloneFrom<TTo>(IElasticsearchResponse from, TTo to)

--- a/src/Elasticsearch.Net/Domain/Response/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Domain/Response/ElasticsearchResponse.cs
@@ -19,11 +19,9 @@ using Elasticsearch.Net.Serialization;
 
 namespace Elasticsearch.Net
 {
-	//TODO document and possibly rename some of the properties
-
 	public static class ElasticsearchResponse
 	{
-		public static ElasticsearchResponse<TTo> CloneFrom<TTo>(IElasticsearchResponse from, TTo to)
+		internal static ElasticsearchResponse<TTo> CloneFrom<TTo>(IElasticsearchResponse from, TTo to)
 		{
 			var response = new ElasticsearchResponse<TTo>(from.Settings)
 			{
@@ -45,7 +43,6 @@ namespace Elasticsearch.Net
  			return response;
 		}
 	}
-
 
 	public class ElasticsearchResponse<T> : IElasticsearchResponse
 	{

--- a/src/Nest/Domain/ICustomJson.cs
+++ b/src/Nest/Domain/ICustomJson.cs
@@ -2,14 +2,12 @@
 
 namespace Nest
 {
-	//If an object implements this then it can handle its own json representation
+	// If an object implements this then it can handle its own json representation
 	public interface ICustomJson
 	{
 		object GetCustomJson();
 	}
 
-	public interface IDomainObject
-	{
-		
-	}
+	// Any object that implements this will automatically be added to the serialization contract
+	public interface INestSerializable { }
 }

--- a/src/Nest/Domain/ICustomJson.cs
+++ b/src/Nest/Domain/ICustomJson.cs
@@ -2,12 +2,17 @@
 
 namespace Nest
 {
-	// If an object implements this then it can handle its own json representation
+	/// <summary>
+	/// If an object implements this then it can handle its own json representation
+	/// </summary>
 	public interface ICustomJson
 	{
 		object GetCustomJson();
 	}
 
-	// Any object that implements this will automatically be added to the serialization contract
+	/// <summary>
+	/// Any object that implements this interface will automatically have all 
+	/// JsonProperties of all of its implementing interfaces discovered.
+	/// </summary>
 	public interface INestSerializable { }
 }

--- a/src/Nest/ElasticClient-AliasExists.cs
+++ b/src/Nest/ElasticClient-AliasExists.cs
@@ -14,7 +14,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse AliasExists(Func<AliasExistsDescriptor, AliasExistsDescriptor> selector)
 		{
-			return this.Dispatch<AliasExistsDescriptor, AliasExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<AliasExistsDescriptor, AliasExistsRequestParameters, ExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesExistsAliasDispatch<ExistsResponse>(
 					p.DeserializationState(new AliasExistConverter(DeserializeExistsResponse))
@@ -25,7 +25,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse AliasExists(IAliasExistsRequest AliasRequest)
 		{
-			return this.Dispatch<IAliasExistsRequest, AliasExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<IAliasExistsRequest, AliasExistsRequestParameters, ExistsResponse>(
 				AliasRequest,
 				(p, d) => this.RawDispatch.IndicesExistsAliasDispatch<ExistsResponse>(
 					p.DeserializationState(new AliasExistConverter(DeserializeExistsResponse))
@@ -36,7 +36,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> AliasExistsAsync(Func<AliasExistsDescriptor, AliasExistsDescriptor> selector)
 		{
-			return this.DispatchAsync<AliasExistsDescriptor, AliasExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<AliasExistsDescriptor, AliasExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesExistsAliasDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new AliasExistConverter(DeserializeExistsResponse))
@@ -47,7 +47,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> AliasExistsAsync(IAliasExistsRequest AliasRequest)
 		{
-			return this.DispatchAsync<IAliasExistsRequest, AliasExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<IAliasExistsRequest, AliasExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				AliasRequest,
 				(p, d) => this.RawDispatch.IndicesExistsAliasDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new AliasExistConverter(DeserializeExistsResponse))

--- a/src/Nest/ElasticClient-Aliases.cs
+++ b/src/Nest/ElasticClient-Aliases.cs
@@ -15,7 +15,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse Alias(IAliasRequest aliasRequest)
 		{
-			return this.Dispatch<IAliasRequest, AliasRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<IAliasRequest, AliasRequestParameters, IndicesOperationResponse>(
 				aliasRequest,
 				(p, d) => this.RawDispatch.IndicesUpdateAliasesDispatch<IndicesOperationResponse>(p, d)
 			);
@@ -24,7 +24,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse Alias(Func<AliasDescriptor, AliasDescriptor> aliasSelector)
 		{
-			return this.Dispatch<AliasDescriptor, AliasRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<AliasDescriptor, AliasRequestParameters, IndicesOperationResponse>(
 				aliasSelector,
 				(p, d) => this.RawDispatch.IndicesUpdateAliasesDispatch<IndicesOperationResponse>(p, d)
 			);
@@ -33,7 +33,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> AliasAsync(IAliasRequest aliasRequest)
 		{
-			return this.DispatchAsync<IAliasRequest, AliasRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IAliasRequest, AliasRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 				aliasRequest,
 				(p, d) => this.RawDispatch.IndicesUpdateAliasesDispatchAsync<IndicesOperationResponse>(p, d)
 			);
@@ -42,7 +42,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> AliasAsync(Func<AliasDescriptor, AliasDescriptor> aliasSelector)
 		{
-			return this.DispatchAsync<AliasDescriptor, AliasRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<AliasDescriptor, AliasRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 				aliasSelector,
 				(p, d) => this.RawDispatch.IndicesUpdateAliasesDispatchAsync<IndicesOperationResponse>(p, d)
 			);
@@ -51,7 +51,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetAliasesResponse GetAlias(Func<GetAliasDescriptor, GetAliasDescriptor> GetAliasDescriptor)
 		{
-			return this.Dispatch<GetAliasDescriptor, GetAliasRequestParameters, GetAliasesResponse>(
+			return this.Dispatcher.Dispatch<GetAliasDescriptor, GetAliasRequestParameters, GetAliasesResponse>(
 				GetAliasDescriptor,
 				(p, d) => this.RawDispatch.IndicesGetAliasDispatch<GetAliasesResponse>(
 					p.DeserializationState(new GetAliasesConverter(DeserializeGetAliasesResponse))
@@ -62,7 +62,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetAliasesResponse GetAlias(IGetAliasRequest GetAliasRequest)
 		{
-			return this.Dispatch<IGetAliasRequest, GetAliasRequestParameters, GetAliasesResponse>(
+			return this.Dispatcher.Dispatch<IGetAliasRequest, GetAliasRequestParameters, GetAliasesResponse>(
 				GetAliasRequest,
 				(p, d) => this.RawDispatch.IndicesGetAliasDispatch<GetAliasesResponse>(
 					p.DeserializationState(new GetAliasesConverter(DeserializeGetAliasesResponse))
@@ -73,7 +73,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetAliasesResponse> GetAliasAsync(Func<GetAliasDescriptor, GetAliasDescriptor> GetAliasDescriptor)
 		{
-			return this.DispatchAsync<GetAliasDescriptor, GetAliasRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
+			return this.Dispatcher.DispatchAsync<GetAliasDescriptor, GetAliasRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
 				GetAliasDescriptor,
 				(p, d) => this.RawDispatch.IndicesGetAliasDispatchAsync<GetAliasesResponse>(
 					p.DeserializationState(new GetAliasesConverter(DeserializeGetAliasesResponse))
@@ -84,7 +84,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetAliasesResponse> GetAliasAsync(IGetAliasRequest GetAliasRequest)
 		{
-			return this.DispatchAsync<IGetAliasRequest, GetAliasRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
+			return this.Dispatcher.DispatchAsync<IGetAliasRequest, GetAliasRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
 				GetAliasRequest,
 				(p, d) => this.RawDispatch.IndicesGetAliasDispatchAsync<GetAliasesResponse>(
 					p.DeserializationState(new GetAliasesConverter(DeserializeGetAliasesResponse))
@@ -96,7 +96,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetAliasesResponse GetAliases(Func<GetAliasesDescriptor, GetAliasesDescriptor> getAliasesDescriptor)
 		{
-			return this.Dispatch<GetAliasesDescriptor, GetAliasesRequestParameters, GetAliasesResponse>(
+			return this.Dispatcher.Dispatch<GetAliasesDescriptor, GetAliasesRequestParameters, GetAliasesResponse>(
 				getAliasesDescriptor,
 				(p, d) => this.RawDispatch.IndicesGetAliasesDispatch<GetAliasesResponse>(
 					p.DeserializationState(new GetAliasesConverter(DeserializeGetAliasesResponse))
@@ -107,7 +107,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetAliasesResponse GetAliases(IGetAliasesRequest getAliasesRequest)
 		{
-			return this.Dispatch<IGetAliasesRequest, GetAliasesRequestParameters, GetAliasesResponse>(
+			return this.Dispatcher.Dispatch<IGetAliasesRequest, GetAliasesRequestParameters, GetAliasesResponse>(
 				getAliasesRequest,
 				(p, d) => this.RawDispatch.IndicesGetAliasesDispatch<GetAliasesResponse>(
 					p.DeserializationState(new GetAliasesConverter(DeserializeGetAliasesResponse))
@@ -118,7 +118,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetAliasesResponse> GetAliasesAsync(Func<GetAliasesDescriptor, GetAliasesDescriptor> getAliasesDescriptor)
 		{
-			return this.DispatchAsync<GetAliasesDescriptor, GetAliasesRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
+			return this.Dispatcher.DispatchAsync<GetAliasesDescriptor, GetAliasesRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
 				getAliasesDescriptor,
 				(p, d) => this.RawDispatch.IndicesGetAliasesDispatchAsync<GetAliasesResponse>(
 					p.DeserializationState(new GetAliasesConverter(DeserializeGetAliasesResponse))
@@ -129,7 +129,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetAliasesResponse> GetAliasesAsync(IGetAliasesRequest getAliasesRequest)
 		{
-			return this.DispatchAsync<IGetAliasesRequest, GetAliasesRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
+			return this.Dispatcher.DispatchAsync<IGetAliasesRequest, GetAliasesRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
 				getAliasesRequest,
 				(p, d) => this.RawDispatch.IndicesGetAliasesDispatchAsync<GetAliasesResponse>(
 					p.DeserializationState(new GetAliasesConverter(DeserializeGetAliasesResponse))
@@ -140,7 +140,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IPutAliasResponse PutAlias(IPutAliasRequest putAliasRequest)
 		{
-			return this.Dispatch<IPutAliasRequest, PutAliasRequestParameters, PutAliasResponse>(
+			return this.Dispatcher.Dispatch<IPutAliasRequest, PutAliasRequestParameters, PutAliasResponse>(
 				putAliasRequest,
 				(p, d) => this.RawDispatch.IndicesPutAliasDispatch<PutAliasResponse>(p, d)
 			);
@@ -149,7 +149,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IPutAliasResponse> PutAliasAsync(IPutAliasRequest putAliasRequest)
 		{
-			return this.DispatchAsync<IPutAliasRequest, PutAliasRequestParameters, PutAliasResponse, IPutAliasResponse>(
+			return this.Dispatcher.DispatchAsync<IPutAliasRequest, PutAliasRequestParameters, PutAliasResponse, IPutAliasResponse>(
 				putAliasRequest,
 				(p, d) => this.RawDispatch.IndicesPutAliasDispatchAsync<PutAliasResponse>(p, d)
 			);
@@ -158,7 +158,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IPutAliasResponse PutAlias(Func<PutAliasDescriptor, PutAliasDescriptor> putAliasDescriptor)
 		{
-			return this.Dispatch<PutAliasDescriptor, PutAliasRequestParameters, PutAliasResponse>(
+			return this.Dispatcher.Dispatch<PutAliasDescriptor, PutAliasRequestParameters, PutAliasResponse>(
 				putAliasDescriptor,
 				(p, d) => this.RawDispatch.IndicesPutAliasDispatch<PutAliasResponse>(p, d)
 			);
@@ -167,7 +167,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IPutAliasResponse> PutAliasAsync(Func<PutAliasDescriptor, PutAliasDescriptor> putAliasDescriptor)
 		{
-			return this.DispatchAsync<PutAliasDescriptor, PutAliasRequestParameters, PutAliasResponse, IPutAliasResponse>(
+			return this.Dispatcher.DispatchAsync<PutAliasDescriptor, PutAliasRequestParameters, PutAliasResponse, IPutAliasResponse>(
 				putAliasDescriptor,
 				(p, d) => this.RawDispatch.IndicesPutAliasDispatchAsync<PutAliasResponse>(p, d)
 			);
@@ -176,7 +176,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IDeleteAliasResponse DeleteAlias(IDeleteAliasRequest deleteAliasRequest)
 		{
-			return this.Dispatch<IDeleteAliasRequest, DeleteAliasRequestParameters, DeleteAliasResponse>(
+			return this.Dispatcher.Dispatch<IDeleteAliasRequest, DeleteAliasRequestParameters, DeleteAliasResponse>(
 				deleteAliasRequest,
 				(p, d) => this.RawDispatch.IndicesDeleteAliasDispatch<DeleteAliasResponse>(p)
 			);
@@ -185,7 +185,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IDeleteAliasResponse> DeleteAliasAsync(IDeleteAliasRequest deleteAliasRequest)
 		{
-			return this.DispatchAsync<IDeleteAliasRequest, DeleteAliasRequestParameters, DeleteAliasResponse, IDeleteAliasResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteAliasRequest, DeleteAliasRequestParameters, DeleteAliasResponse, IDeleteAliasResponse>(
 				deleteAliasRequest,
 				(p, d) => this.RawDispatch.IndicesDeleteAliasDispatchAsync<DeleteAliasResponse>(p)
 			);
@@ -195,7 +195,7 @@ namespace Nest
 		public IDeleteAliasResponse DeleteAlias<T>(Func<DeleteAliasDescriptor<T>, DeleteAliasDescriptor<T>> deleteAliasDescriptor)
 			where T : class
 		{
-			return this.Dispatch<DeleteAliasDescriptor<T>, DeleteAliasRequestParameters, DeleteAliasResponse>(
+			return this.Dispatcher.Dispatch<DeleteAliasDescriptor<T>, DeleteAliasRequestParameters, DeleteAliasResponse>(
 				deleteAliasDescriptor,
 				(p, d) => this.RawDispatch.IndicesDeleteAliasDispatch<DeleteAliasResponse>(p)
 			);
@@ -205,7 +205,7 @@ namespace Nest
 		public Task<IDeleteAliasResponse> DeleteAliasAsync<T>(Func<DeleteAliasDescriptor<T>, DeleteAliasDescriptor<T>> deleteAliasDescriptor)
 			where T : class
 		{
-			return this.DispatchAsync<DeleteAliasDescriptor<T>, DeleteAliasRequestParameters, DeleteAliasResponse, IDeleteAliasResponse>(
+			return this.Dispatcher.DispatchAsync<DeleteAliasDescriptor<T>, DeleteAliasRequestParameters, DeleteAliasResponse, IDeleteAliasResponse>(
 				deleteAliasDescriptor,
 				(p, d) => this.RawDispatch.IndicesDeleteAliasDispatchAsync<DeleteAliasResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Analyze.cs
+++ b/src/Nest/ElasticClient-Analyze.cs
@@ -9,7 +9,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IAnalyzeResponse Analyze(Func<AnalyzeDescriptor, AnalyzeDescriptor> analyzeSelector)
 		{
-			return this.Dispatch<AnalyzeDescriptor, AnalyzeRequestParameters, AnalyzeResponse>(
+			return this.Dispatcher.Dispatch<AnalyzeDescriptor, AnalyzeRequestParameters, AnalyzeResponse>(
 				analyzeSelector,
 				(p, d) =>
 				{
@@ -24,7 +24,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IAnalyzeResponse Analyze(IAnalyzeRequest analyzeRequest)
 		{
-			return this.Dispatch<IAnalyzeRequest, AnalyzeRequestParameters, AnalyzeResponse>(
+			return this.Dispatcher.Dispatch<IAnalyzeRequest, AnalyzeRequestParameters, AnalyzeResponse>(
 				analyzeRequest,
 				(p, d) =>
 				{
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IAnalyzeResponse> AnalyzeAsync(Func<AnalyzeDescriptor, AnalyzeDescriptor> analyzeSelector)
 		{
-			return this.DispatchAsync<AnalyzeDescriptor, AnalyzeRequestParameters, AnalyzeResponse, IAnalyzeResponse>(
+			return this.Dispatcher.DispatchAsync<AnalyzeDescriptor, AnalyzeRequestParameters, AnalyzeResponse, IAnalyzeResponse>(
 				analyzeSelector,
 				(p, d) =>
 				{
@@ -54,7 +54,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IAnalyzeResponse> AnalyzeAsync(IAnalyzeRequest analyzeRequest)
 		{
-			return this.DispatchAsync<IAnalyzeRequest, AnalyzeRequestParameters, AnalyzeResponse, IAnalyzeResponse>(
+			return this.Dispatcher.DispatchAsync<IAnalyzeRequest, AnalyzeRequestParameters, AnalyzeResponse, IAnalyzeResponse>(
 				analyzeRequest,
 				(p, d) =>
 				{

--- a/src/Nest/ElasticClient-Bulk.cs
+++ b/src/Nest/ElasticClient-Bulk.cs
@@ -11,7 +11,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IBulkResponse Bulk(IBulkRequest bulkRequest)
 		{
-			return this.Dispatch<IBulkRequest, BulkRequestParameters, BulkResponse>(
+			return this.Dispatcher.Dispatch<IBulkRequest, BulkRequestParameters, BulkResponse>(
 				bulkRequest,
 				(p, d) =>
 				{
@@ -24,7 +24,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IBulkResponse Bulk(Func<BulkDescriptor, BulkDescriptor> bulkSelector)
 		{
-			return this.Dispatch<BulkDescriptor, BulkRequestParameters, BulkResponse>(
+			return this.Dispatcher.Dispatch<BulkDescriptor, BulkRequestParameters, BulkResponse>(
 				bulkSelector,
 				(p, d) =>
 				{
@@ -37,7 +37,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IBulkResponse> BulkAsync(IBulkRequest bulkRequest)
 		{
-			return this.DispatchAsync<IBulkRequest, BulkRequestParameters, BulkResponse, IBulkResponse>(
+			return this.Dispatcher.DispatchAsync<IBulkRequest, BulkRequestParameters, BulkResponse, IBulkResponse>(
 				bulkRequest,
 				(p, d) =>
 				{
@@ -50,7 +50,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IBulkResponse> BulkAsync(Func<BulkDescriptor, BulkDescriptor> bulkSelector)
 		{
-			return this.DispatchAsync<BulkDescriptor, BulkRequestParameters, BulkResponse, IBulkResponse>(
+			return this.Dispatcher.DispatchAsync<BulkDescriptor, BulkRequestParameters, BulkResponse, IBulkResponse>(
 				bulkSelector,
 				(p, d) =>
 				{

--- a/src/Nest/ElasticClient-Cat.cs
+++ b/src/Nest/ElasticClient-Cat.cs
@@ -319,7 +319,7 @@ namespace Nest
 			where TParams : FluentRequestParameters<TParams>, new()
 			where TRequest : class, IRequest<TParams>, new()
 		{
-			return this.DispatchAsync<TRequest, TParams, CatResponse<TCatRecord>, ICatResponse<TCatRecord>>(
+			return this.Dispatcher.DispatchAsync<TRequest, TParams, CatResponse<TCatRecord>, ICatResponse<TCatRecord>>(
 				this.ForceConfiguration(selector, c => c.ContentType = "application/json"),
 				(p, d) => dispatch(p.DeserializationState(
 					new Func<IElasticsearchResponse, Stream, CatResponse<TCatRecord>>(this.DeserializeCatResponse<TCatRecord>))
@@ -335,7 +335,7 @@ namespace Nest
 			where TParams : FluentRequestParameters<TParams>, new()
 			where TRequest : IRequest<TParams> 
 		{
-			return this.DispatchAsync<TRequest, TParams, CatResponse<TCatRecord>, ICatResponse<TCatRecord>>(
+			return this.Dispatcher.DispatchAsync<TRequest, TParams, CatResponse<TCatRecord>, ICatResponse<TCatRecord>>(
 				this.ForceConfiguration(request, c => c.ContentType = "application/json"),
 				(p, d) => dispatch(p.DeserializationState(
 					new Func<IElasticsearchResponse, Stream, CatResponse<TCatRecord>>(this.DeserializeCatResponse<TCatRecord>))
@@ -351,7 +351,7 @@ namespace Nest
 			where TParams : FluentRequestParameters<TParams>, new()
 			where TRequest : class, IRequest<TParams>, new()
 		{
-			return this.Dispatch<TRequest, TParams, CatResponse<TCatRecord>>(
+			return this.Dispatcher.Dispatch<TRequest, TParams, CatResponse<TCatRecord>>(
 				this.ForceConfiguration(selector, c => c.ContentType = "application/json"),
 				(p, d) => dispatch(p.DeserializationState(
 					new Func<IElasticsearchResponse, Stream, CatResponse<TCatRecord>>(this.DeserializeCatResponse<TCatRecord>))
@@ -367,7 +367,7 @@ namespace Nest
 			where TParams : FluentRequestParameters<TParams>, new()
 			where TRequest : IRequest<TParams> 
 		{
-			return this.Dispatch<TRequest, TParams, CatResponse<TCatRecord>>(
+			return this.Dispatcher.Dispatch<TRequest, TParams, CatResponse<TCatRecord>>(
 				this.ForceConfiguration(request, c => c.ContentType = "application/json"),
 				(p, d) => dispatch(p.DeserializationState(
 					new Func<IElasticsearchResponse, Stream, CatResponse<TCatRecord>>(this.DeserializeCatResponse<TCatRecord>))

--- a/src/Nest/ElasticClient-ClearCache.cs
+++ b/src/Nest/ElasticClient-ClearCache.cs
@@ -12,7 +12,7 @@ namespace Nest
 		public IShardsOperationResponse ClearCache(Func<ClearCacheDescriptor, ClearCacheDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<ClearCacheDescriptor, ClearCacheRequestParameters, ShardsOperationResponse>(
+			return this.Dispatcher.Dispatch<ClearCacheDescriptor, ClearCacheRequestParameters, ShardsOperationResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesClearCacheDispatch<ShardsOperationResponse>(p)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IShardsOperationResponse ClearCache(IClearCacheRequest clearCacheRequest)
 		{
-			return this.Dispatch<IClearCacheRequest, ClearCacheRequestParameters, ShardsOperationResponse>(
+			return this.Dispatcher.Dispatch<IClearCacheRequest, ClearCacheRequestParameters, ShardsOperationResponse>(
 				clearCacheRequest,
 				(p, d) => this.RawDispatch.IndicesClearCacheDispatch<ShardsOperationResponse>(p)
 			);
@@ -31,7 +31,7 @@ namespace Nest
 		public Task<IShardsOperationResponse> ClearCacheAsync(Func<ClearCacheDescriptor, ClearCacheDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<ClearCacheDescriptor, ClearCacheRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+			return this.Dispatcher.DispatchAsync<ClearCacheDescriptor, ClearCacheRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesClearCacheDispatchAsync<ShardsOperationResponse>(p)
 			);
@@ -40,7 +40,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IShardsOperationResponse> ClearCacheAsync(IClearCacheRequest clearCacheRequest)
 		{
-			return this.DispatchAsync<IClearCacheRequest, ClearCacheRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IClearCacheRequest, ClearCacheRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
 				clearCacheRequest,
 				(p, d) => this.RawDispatch.IndicesClearCacheDispatchAsync<ShardsOperationResponse>(p)
 			);

--- a/src/Nest/ElasticClient-ClusterHealth.cs
+++ b/src/Nest/ElasticClient-ClusterHealth.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IHealthResponse ClusterHealth(Func<ClusterHealthDescriptor, ClusterHealthDescriptor> clusterHealthSelector = null)
 		{
 			clusterHealthSelector = clusterHealthSelector ?? (s => s);
-			return this.Dispatch<ClusterHealthDescriptor, ClusterHealthRequestParameters, HealthResponse>(
+			return this.Dispatcher.Dispatch<ClusterHealthDescriptor, ClusterHealthRequestParameters, HealthResponse>(
 				clusterHealthSelector,
 				(p, d) => this.RawDispatch.ClusterHealthDispatch<HealthResponse>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IHealthResponse ClusterHealth(IClusterHealthRequest clusterHealthRequest)
 		{
-			return this.Dispatch<IClusterHealthRequest, ClusterHealthRequestParameters, HealthResponse>(
+			return this.Dispatcher.Dispatch<IClusterHealthRequest, ClusterHealthRequestParameters, HealthResponse>(
 				clusterHealthRequest,
 				(p, d) => this.RawDispatch.ClusterHealthDispatch<HealthResponse>(p)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<IHealthResponse> ClusterHealthAsync(Func<ClusterHealthDescriptor, ClusterHealthDescriptor> clusterHealthSelector = null)
 		{
 			clusterHealthSelector = clusterHealthSelector ?? (s => s);
-			return this.DispatchAsync<ClusterHealthDescriptor, ClusterHealthRequestParameters, HealthResponse, IHealthResponse>(
+			return this.Dispatcher.DispatchAsync<ClusterHealthDescriptor, ClusterHealthRequestParameters, HealthResponse, IHealthResponse>(
 				clusterHealthSelector,
 				(p, d) => this.RawDispatch.ClusterHealthDispatchAsync<HealthResponse>(p)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IHealthResponse> ClusterHealthAsync(IClusterHealthRequest clusterHealthRequest)
 		{
-			return this.DispatchAsync<IClusterHealthRequest, ClusterHealthRequestParameters, HealthResponse, IHealthResponse>(
+			return this.Dispatcher.DispatchAsync<IClusterHealthRequest, ClusterHealthRequestParameters, HealthResponse, IHealthResponse>(
 				clusterHealthRequest,
 				(p, d) => this.RawDispatch.ClusterHealthDispatchAsync<HealthResponse>(p)
 			);

--- a/src/Nest/ElasticClient-ClusterPendingTasks.cs
+++ b/src/Nest/ElasticClient-ClusterPendingTasks.cs
@@ -13,7 +13,7 @@ namespace Nest
 		public IClusterPendingTasksResponse ClusterPendingTasks(Func<ClusterPendingTasksDescriptor, ClusterPendingTasksDescriptor> pendingTasksSelector = null)
 		{
 			pendingTasksSelector = pendingTasksSelector ?? (s => s);
-			return this.Dispatch<ClusterPendingTasksDescriptor, ClusterPendingTasksRequestParameters, ClusterPendingTasksResponse>(
+			return this.Dispatcher.Dispatch<ClusterPendingTasksDescriptor, ClusterPendingTasksRequestParameters, ClusterPendingTasksResponse>(
 				pendingTasksSelector,
 				(p, d) => this.RawDispatch.ClusterPendingTasksDispatch<ClusterPendingTasksResponse>(p)
 			);
@@ -23,7 +23,7 @@ namespace Nest
 		public Task<IClusterPendingTasksResponse> ClusterPendingTasksAsync(Func<ClusterPendingTasksDescriptor, ClusterPendingTasksDescriptor> pendingTasksSelector = null)
 		{
 			pendingTasksSelector = pendingTasksSelector ?? (s => s);
-			return this.DispatchAsync<ClusterPendingTasksDescriptor, ClusterPendingTasksRequestParameters, ClusterPendingTasksResponse, IClusterPendingTasksResponse>(
+			return this.Dispatcher.DispatchAsync<ClusterPendingTasksDescriptor, ClusterPendingTasksRequestParameters, ClusterPendingTasksResponse, IClusterPendingTasksResponse>(
 				pendingTasksSelector,
 				(p, d) => this.RawDispatch.ClusterPendingTasksDispatchAsync<ClusterPendingTasksResponse>(p)
 			);
@@ -32,7 +32,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IClusterPendingTasksResponse ClusterPendingTasks(IClusterPendingTasksRequest pendingTasksRequest)
 		{
-			return this.Dispatch<IClusterPendingTasksRequest, ClusterPendingTasksRequestParameters, ClusterPendingTasksResponse>(
+			return this.Dispatcher.Dispatch<IClusterPendingTasksRequest, ClusterPendingTasksRequestParameters, ClusterPendingTasksResponse>(
 				pendingTasksRequest,
 				(p, d) => this.RawDispatch.ClusterPendingTasksDispatch<ClusterPendingTasksResponse>(p)
 			);
@@ -41,7 +41,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IClusterPendingTasksResponse> ClusterPendingTasksAsync(IClusterPendingTasksRequest pendingTasksRequest)
 		{
-			return this.DispatchAsync<IClusterPendingTasksRequest, ClusterPendingTasksRequestParameters, ClusterPendingTasksResponse, IClusterPendingTasksResponse>(
+			return this.Dispatcher.DispatchAsync<IClusterPendingTasksRequest, ClusterPendingTasksRequestParameters, ClusterPendingTasksResponse, IClusterPendingTasksResponse>(
 				pendingTasksRequest,
 				(p, d) => this.RawDispatch.ClusterPendingTasksDispatchAsync<ClusterPendingTasksResponse>(p)
 			);

--- a/src/Nest/ElasticClient-ClusterReroute.cs
+++ b/src/Nest/ElasticClient-ClusterReroute.cs
@@ -13,7 +13,7 @@ namespace Nest
 		public IClusterRerouteResponse ClusterReroute(Func<ClusterRerouteDescriptor, ClusterRerouteDescriptor> clusterRerouteSelector)
 		{
 			clusterRerouteSelector = clusterRerouteSelector ?? (s => s);
-			return this.Dispatch<ClusterRerouteDescriptor, ClusterRerouteRequestParameters, ClusterRerouteResponse>(
+			return this.Dispatcher.Dispatch<ClusterRerouteDescriptor, ClusterRerouteRequestParameters, ClusterRerouteResponse>(
 				clusterRerouteSelector,
 				(p, d) => this.RawDispatch.ClusterRerouteDispatch<ClusterRerouteResponse>(p, d)
 			);
@@ -23,7 +23,7 @@ namespace Nest
 		public Task<IClusterRerouteResponse> ClusterRerouteAsync(Func<ClusterRerouteDescriptor, ClusterRerouteDescriptor> clusterRerouteSelector)
 		{
 			clusterRerouteSelector = clusterRerouteSelector ?? (s => s);
-			return this.DispatchAsync<ClusterRerouteDescriptor, ClusterRerouteRequestParameters, ClusterRerouteResponse, IClusterRerouteResponse>(
+			return this.Dispatcher.DispatchAsync<ClusterRerouteDescriptor, ClusterRerouteRequestParameters, ClusterRerouteResponse, IClusterRerouteResponse>(
 				clusterRerouteSelector,
 				(p, d) => this.RawDispatch.ClusterRerouteDispatchAsync<ClusterRerouteResponse>(p, d)
 			);
@@ -32,7 +32,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IClusterRerouteResponse ClusterReroute(IClusterRerouteRequest clusterRerouteRequest)
 		{
-			return this.Dispatch<IClusterRerouteRequest, ClusterRerouteRequestParameters, ClusterRerouteResponse>(
+			return this.Dispatcher.Dispatch<IClusterRerouteRequest, ClusterRerouteRequestParameters, ClusterRerouteResponse>(
 				clusterRerouteRequest,
 				(p, d) => this.RawDispatch.ClusterRerouteDispatch<ClusterRerouteResponse>(p, d)
 			);
@@ -41,7 +41,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IClusterRerouteResponse> ClusterRerouteAsync(IClusterRerouteRequest clusterRerouteRequest)
 		{
-			return this.DispatchAsync<IClusterRerouteRequest, ClusterRerouteRequestParameters, ClusterRerouteResponse, IClusterRerouteResponse>(
+			return this.Dispatcher.DispatchAsync<IClusterRerouteRequest, ClusterRerouteRequestParameters, ClusterRerouteResponse, IClusterRerouteResponse>(
 				clusterRerouteRequest,
 				(p, d) => this.RawDispatch.ClusterRerouteDispatchAsync<ClusterRerouteResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-ClusterSettings.cs
+++ b/src/Nest/ElasticClient-ClusterSettings.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IClusterPutSettingsResponse ClusterSettings(Func<ClusterSettingsDescriptor, ClusterSettingsDescriptor> selector)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<ClusterSettingsDescriptor, ClusterSettingsRequestParameters, ClusterPutSettingsResponse>(
+			return this.Dispatcher.Dispatch<ClusterSettingsDescriptor, ClusterSettingsRequestParameters, ClusterPutSettingsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.ClusterPutSettingsDispatch<ClusterPutSettingsResponse>(p, d)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 		public Task<IClusterPutSettingsResponse> ClusterSettingsAsync(Func<ClusterSettingsDescriptor, ClusterSettingsDescriptor> selector)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<ClusterSettingsDescriptor, ClusterSettingsRequestParameters, ClusterPutSettingsResponse, IClusterPutSettingsResponse >(
+			return this.Dispatcher.DispatchAsync<ClusterSettingsDescriptor, ClusterSettingsRequestParameters, ClusterPutSettingsResponse, IClusterPutSettingsResponse >(
 				selector,
 				(p, d) => this.RawDispatch.ClusterPutSettingsDispatchAsync<ClusterPutSettingsResponse>(p, d)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IClusterPutSettingsResponse ClusterSettings(IClusterSettingsRequest clusterSettingsRequest)
 		{
-			return this.Dispatch<IClusterSettingsRequest, ClusterSettingsRequestParameters, ClusterPutSettingsResponse>(
+			return this.Dispatcher.Dispatch<IClusterSettingsRequest, ClusterSettingsRequestParameters, ClusterPutSettingsResponse>(
 				clusterSettingsRequest,
 				(p, d) => this.RawDispatch.ClusterPutSettingsDispatch<ClusterPutSettingsResponse>(p, d)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IClusterPutSettingsResponse> ClusterSettingsAsync(IClusterSettingsRequest clusterSettingsRequest)
 		{
-			return this.DispatchAsync<IClusterSettingsRequest, ClusterSettingsRequestParameters, ClusterPutSettingsResponse, IClusterPutSettingsResponse >(
+			return this.Dispatcher.DispatchAsync<IClusterSettingsRequest, ClusterSettingsRequestParameters, ClusterPutSettingsResponse, IClusterPutSettingsResponse >(
 				clusterSettingsRequest,
 				(p, d) => this.RawDispatch.ClusterPutSettingsDispatchAsync<ClusterPutSettingsResponse>(p, d)
 			);
@@ -49,7 +49,7 @@ namespace Nest
 		public IClusterGetSettingsResponse ClusterGetSettings(Func<ClusterGetSettingsDescriptor, ClusterGetSettingsDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<ClusterGetSettingsDescriptor, ClusterGetSettingsRequestParameters, ClusterGetSettingsResponse>(
+			return this.Dispatcher.Dispatch<ClusterGetSettingsDescriptor, ClusterGetSettingsRequestParameters, ClusterGetSettingsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.ClusterGetSettingsDispatch<ClusterGetSettingsResponse>(p)
 			);
@@ -59,7 +59,7 @@ namespace Nest
 		public Task<IClusterGetSettingsResponse> ClusterGetSettingsAsync(Func<ClusterGetSettingsDescriptor, ClusterGetSettingsDescriptor> selector)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<ClusterGetSettingsDescriptor, ClusterGetSettingsRequestParameters, ClusterGetSettingsResponse, IClusterGetSettingsResponse>(
+			return this.Dispatcher.DispatchAsync<ClusterGetSettingsDescriptor, ClusterGetSettingsRequestParameters, ClusterGetSettingsResponse, IClusterGetSettingsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.ClusterGetSettingsDispatchAsync<ClusterGetSettingsResponse>(p)
 			);
@@ -68,7 +68,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IClusterGetSettingsResponse ClusterGetSettings(IClusterGetSettingsRequest clusterSettingsRequest)
 		{
-			return this.Dispatch<IClusterGetSettingsRequest, ClusterGetSettingsRequestParameters, ClusterGetSettingsResponse>(
+			return this.Dispatcher.Dispatch<IClusterGetSettingsRequest, ClusterGetSettingsRequestParameters, ClusterGetSettingsResponse>(
 				clusterSettingsRequest ?? new ClusterGetSettingsRequest(),
 				(p, d) => this.RawDispatch.ClusterGetSettingsDispatch<ClusterGetSettingsResponse>(p)
 			);
@@ -77,7 +77,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IClusterGetSettingsResponse> ClusterGetSettingsAsync(IClusterGetSettingsRequest clusterSettingsRequest = null)
 		{
-			return this.DispatchAsync<IClusterGetSettingsRequest, ClusterGetSettingsRequestParameters, ClusterGetSettingsResponse, IClusterGetSettingsResponse>(
+			return this.Dispatcher.DispatchAsync<IClusterGetSettingsRequest, ClusterGetSettingsRequestParameters, ClusterGetSettingsResponse, IClusterGetSettingsResponse>(
 				clusterSettingsRequest ?? new ClusterGetSettingsRequest(),
 				(p, d) => this.RawDispatch.ClusterGetSettingsDispatchAsync<ClusterGetSettingsResponse>(p)
 			);

--- a/src/Nest/ElasticClient-ClusterState.cs
+++ b/src/Nest/ElasticClient-ClusterState.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IClusterStateResponse ClusterState(Func<ClusterStateDescriptor, ClusterStateDescriptor> clusterStateSelector = null)
 		{
 			clusterStateSelector = clusterStateSelector ?? (s => s);
-			return this.Dispatch<ClusterStateDescriptor, ClusterStateRequestParameters, ClusterStateResponse>(
+			return this.Dispatcher.Dispatch<ClusterStateDescriptor, ClusterStateRequestParameters, ClusterStateResponse>(
 				clusterStateSelector,
 				(p, d) => this.RawDispatch.ClusterStateDispatch<ClusterStateResponse>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IClusterStateResponse ClusterState(IClusterStateRequest clusterStateRequest)
 		{
-			return this.Dispatch<IClusterStateRequest, ClusterStateRequestParameters, ClusterStateResponse>(
+			return this.Dispatcher.Dispatch<IClusterStateRequest, ClusterStateRequestParameters, ClusterStateResponse>(
 				clusterStateRequest,
 				(p, d) => this.RawDispatch.ClusterStateDispatch<ClusterStateResponse>(p)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<IClusterStateResponse> ClusterStateAsync(Func<ClusterStateDescriptor, ClusterStateDescriptor> clusterStateSelector = null)
 		{
 			clusterStateSelector = clusterStateSelector ?? (s => s);
-			return this.DispatchAsync<ClusterStateDescriptor, ClusterStateRequestParameters, ClusterStateResponse, IClusterStateResponse>(
+			return this.Dispatcher.DispatchAsync<ClusterStateDescriptor, ClusterStateRequestParameters, ClusterStateResponse, IClusterStateResponse>(
 				clusterStateSelector,
 				(p, d) => this.RawDispatch.ClusterStateDispatchAsync<ClusterStateResponse>(p)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IClusterStateResponse> ClusterStateAsync(IClusterStateRequest clusterStateRequest)
 		{
-			return this.DispatchAsync<IClusterStateRequest, ClusterStateRequestParameters, ClusterStateResponse, IClusterStateResponse>(
+			return this.Dispatcher.DispatchAsync<IClusterStateRequest, ClusterStateRequestParameters, ClusterStateResponse, IClusterStateResponse>(
 				clusterStateRequest,
 				(p, d) => this.RawDispatch.ClusterStateDispatchAsync<ClusterStateResponse>(p)
 			);

--- a/src/Nest/ElasticClient-ClusterStats.cs
+++ b/src/Nest/ElasticClient-ClusterStats.cs
@@ -13,7 +13,7 @@ namespace Nest
 		public IClusterStatsResponse ClusterStats(Func<ClusterStatsDescriptor, ClusterStatsDescriptor> clusterStatsSelector = null)
 		{
 			clusterStatsSelector = clusterStatsSelector ?? (s => s);
-			return this.Dispatch<ClusterStatsDescriptor, ClusterStatsRequestParameters, ClusterStatsResponse>(
+			return this.Dispatcher.Dispatch<ClusterStatsDescriptor, ClusterStatsRequestParameters, ClusterStatsResponse>(
 				clusterStatsSelector,
 				(p, d) => this.RawDispatch.ClusterStatsDispatch<ClusterStatsResponse>(p)
 			);
@@ -23,7 +23,7 @@ namespace Nest
 		public Task<IClusterStatsResponse> ClusterStatsAsync(Func<ClusterStatsDescriptor, ClusterStatsDescriptor> clusterStatsSelector = null)
 		{
 			clusterStatsSelector = clusterStatsSelector ?? (s => s);
-			return this.DispatchAsync<ClusterStatsDescriptor, ClusterStatsRequestParameters, ClusterStatsResponse, IClusterStatsResponse>(
+			return this.Dispatcher.DispatchAsync<ClusterStatsDescriptor, ClusterStatsRequestParameters, ClusterStatsResponse, IClusterStatsResponse>(
 				clusterStatsSelector,
 				(p, d) => this.RawDispatch.ClusterStatsDispatchAsync<ClusterStatsResponse>(p)
 			);
@@ -32,7 +32,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IClusterStatsResponse ClusterStats(IClusterStatsRequest clusterStatsRequest)
 		{
-			return this.Dispatch<IClusterStatsRequest, ClusterStatsRequestParameters, ClusterStatsResponse>(
+			return this.Dispatcher.Dispatch<IClusterStatsRequest, ClusterStatsRequestParameters, ClusterStatsResponse>(
 				clusterStatsRequest,
 				(p, d) => this.RawDispatch.ClusterStatsDispatch<ClusterStatsResponse>(p)
 			);
@@ -41,7 +41,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IClusterStatsResponse> ClusterStatsAsync(IClusterStatsRequest clusterStatsRequest)
 		{
-			return this.DispatchAsync<IClusterStatsRequest, ClusterStatsRequestParameters, ClusterStatsResponse, IClusterStatsResponse>(
+			return this.Dispatcher.DispatchAsync<IClusterStatsRequest, ClusterStatsRequestParameters, ClusterStatsResponse, IClusterStatsResponse>(
 				clusterStatsRequest,
 				(p, d) => this.RawDispatch.ClusterStatsDispatchAsync<ClusterStatsResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Count.cs
+++ b/src/Nest/ElasticClient-Count.cs
@@ -12,7 +12,7 @@ namespace Nest
 			where T : class
 		{
 			countSelector = countSelector ?? (s => s);
-			return this.Dispatch<CountDescriptor<T>, CountRequestParameters, CountResponse>(
+			return this.Dispatcher.Dispatch<CountDescriptor<T>, CountRequestParameters, CountResponse>(
 				countSelector,
 				(p, d) => this.RawDispatch.CountDispatch<CountResponse>(p, d)
 			);
@@ -22,7 +22,7 @@ namespace Nest
 		public ICountResponse Count<T>(ICountRequest countRequest) 
 			where T : class
 		{
-			return this.Dispatch<ICountRequest, CountRequestParameters, CountResponse>(
+			return this.Dispatcher.Dispatch<ICountRequest, CountRequestParameters, CountResponse>(
 				countRequest,
 				(p, d) => this.RawDispatch.CountDispatch<CountResponse>(p, d)
 			);
@@ -33,7 +33,7 @@ namespace Nest
 			where T : class
 		{
 			countSelector = countSelector ?? (s => s);
-			return this.DispatchAsync<CountDescriptor<T>, CountRequestParameters, CountResponse, ICountResponse>(
+			return this.Dispatcher.DispatchAsync<CountDescriptor<T>, CountRequestParameters, CountResponse, ICountResponse>(
 				countSelector,
 				(p, d) => this.RawDispatch.CountDispatchAsync<CountResponse>(p, d)
 			);
@@ -43,7 +43,7 @@ namespace Nest
 		public Task<ICountResponse> CountAsync<T>(ICountRequest countRequest)
 			where T : class
 		{
-			return this.DispatchAsync<ICountRequest, CountRequestParameters, CountResponse, ICountResponse>(
+			return this.Dispatcher.DispatchAsync<ICountRequest, CountRequestParameters, CountResponse, ICountResponse>(
 				countRequest,
 				(p, d) => this.RawDispatch.CountDispatchAsync<CountResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-CreateIndex.cs
+++ b/src/Nest/ElasticClient-CreateIndex.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IIndicesOperationResponse CreateIndex(Func<CreateIndexDescriptor, CreateIndexDescriptor> createIndexSelector)
 		{
 			var descriptor = createIndexSelector(new CreateIndexDescriptor(this._connectionSettings)); 
-			return this.Dispatch<ICreateIndexRequest, CreateIndexRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<ICreateIndexRequest, CreateIndexRequestParameters, IndicesOperationResponse>(
 				descriptor,
 				(p, d) => this.RawDispatch.IndicesCreateDispatch<IndicesOperationResponse>(p, d.IndexSettings)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse CreateIndex(ICreateIndexRequest createIndexRequest)
 		{
-			return this.Dispatch<ICreateIndexRequest, CreateIndexRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<ICreateIndexRequest, CreateIndexRequestParameters, IndicesOperationResponse>(
 				createIndexRequest,
 				(p, d) => this.RawDispatch.IndicesCreateDispatch<IndicesOperationResponse>(p, d.IndexSettings)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<IIndicesOperationResponse> CreateIndexAsync(Func<CreateIndexDescriptor, CreateIndexDescriptor> createIndexSelector)
 		{
 			var descriptor = createIndexSelector(new CreateIndexDescriptor(this._connectionSettings)); 
-			return this.DispatchAsync<ICreateIndexRequest, CreateIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<ICreateIndexRequest, CreateIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					descriptor,
 					(p, d) => this.RawDispatch.IndicesCreateDispatchAsync<IndicesOperationResponse>(p, d.IndexSettings)
 				);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> CreateIndexAsync(ICreateIndexRequest createIndexRequest)
 		{
-			return this.DispatchAsync<ICreateIndexRequest, CreateIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<ICreateIndexRequest, CreateIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 				createIndexRequest,
 				(p, d) => this.RawDispatch.IndicesCreateDispatchAsync<IndicesOperationResponse>(p, d.IndexSettings)
 			);

--- a/src/Nest/ElasticClient-Delete.cs
+++ b/src/Nest/ElasticClient-Delete.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IDeleteResponse Delete<T>(Func<DeleteDescriptor<T>, DeleteDescriptor<T>> deleteSelector) 
 			where T : class
 		{
-			return this.Dispatch<DeleteDescriptor<T>, DeleteRequestParameters, DeleteResponse>(
+			return this.Dispatcher.Dispatch<DeleteDescriptor<T>, DeleteRequestParameters, DeleteResponse>(
 				deleteSelector,
 				(p, d) => this.RawDispatch.DeleteDispatch<DeleteResponse>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IDeleteResponse Delete(IDeleteRequest deleteRequest) 
 		{
-			return this.Dispatch<IDeleteRequest, DeleteRequestParameters, DeleteResponse>(
+			return this.Dispatcher.Dispatch<IDeleteRequest, DeleteRequestParameters, DeleteResponse>(
 				deleteRequest,
 				(p, d) => this.RawDispatch.DeleteDispatch<DeleteResponse>(p)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<IDeleteResponse> DeleteAsync<T>(Func<DeleteDescriptor<T>, DeleteDescriptor<T>> deleteSelector)
 			where T : class
 		{
-			return this.DispatchAsync<DeleteDescriptor<T>, DeleteRequestParameters, DeleteResponse, IDeleteResponse>(
+			return this.Dispatcher.DispatchAsync<DeleteDescriptor<T>, DeleteRequestParameters, DeleteResponse, IDeleteResponse>(
 				deleteSelector,
 				(p, d) => this.RawDispatch.DeleteDispatchAsync<DeleteResponse>(p)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IDeleteResponse> DeleteAsync(IDeleteRequest deleteRequest)
 		{
-			return this.DispatchAsync<IDeleteRequest, DeleteRequestParameters, DeleteResponse, IDeleteResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteRequest, DeleteRequestParameters, DeleteResponse, IDeleteResponse>(
 				deleteRequest,
 				(p, d) => this.RawDispatch.DeleteDispatchAsync<DeleteResponse>(p)
 			);

--- a/src/Nest/ElasticClient-DeleteByQuery.cs
+++ b/src/Nest/ElasticClient-DeleteByQuery.cs
@@ -10,7 +10,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IDeleteResponse DeleteByQuery<T>(Func<DeleteByQueryDescriptor<T>, DeleteByQueryDescriptor<T>> deleteByQuerySelector) where T : class
 		{
-			return this.Dispatch<DeleteByQueryDescriptor<T>, DeleteByQueryRequestParameters, DeleteResponse>(
+			return this.Dispatcher.Dispatch<DeleteByQueryDescriptor<T>, DeleteByQueryRequestParameters, DeleteResponse>(
 				deleteByQuerySelector,
 				(p, d) => this.RawDispatch.DeleteByQueryDispatch<DeleteResponse>(p, d)
 			);
@@ -19,7 +19,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IDeleteResponse DeleteByQuery(IDeleteByQueryRequest deleteByQueryRequest) 
 		{
-			return this.Dispatch<IDeleteByQueryRequest, DeleteByQueryRequestParameters, DeleteResponse>(
+			return this.Dispatcher.Dispatch<IDeleteByQueryRequest, DeleteByQueryRequestParameters, DeleteResponse>(
 				deleteByQueryRequest,
 				(p, d) => this.RawDispatch.DeleteByQueryDispatch<DeleteResponse>(p, d)
 			);
@@ -28,7 +28,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IDeleteResponse> DeleteByQueryAsync<T>(Func<DeleteByQueryDescriptor<T>, DeleteByQueryDescriptor<T>> deleteByQuerySelector) where T : class
 		{
-			return this.DispatchAsync<DeleteByQueryDescriptor<T>, DeleteByQueryRequestParameters, DeleteResponse, IDeleteResponse>(
+			return this.Dispatcher.DispatchAsync<DeleteByQueryDescriptor<T>, DeleteByQueryRequestParameters, DeleteResponse, IDeleteResponse>(
 				deleteByQuerySelector,
 				(p, d) => this.RawDispatch.DeleteByQueryDispatchAsync<DeleteResponse>(p, d)
 			);
@@ -37,7 +37,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IDeleteResponse> DeleteByQueryAsync(IDeleteByQueryRequest deleteByQueryRequest) 
 		{
-			return this.DispatchAsync<IDeleteByQueryRequest, DeleteByQueryRequestParameters, DeleteResponse, IDeleteResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteByQueryRequest, DeleteByQueryRequestParameters, DeleteResponse, IDeleteResponse>(
 				deleteByQueryRequest,
 				(p, d) => this.RawDispatch.DeleteByQueryDispatchAsync<DeleteResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-DeleteIndex.cs
+++ b/src/Nest/ElasticClient-DeleteIndex.cs
@@ -11,7 +11,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesResponse DeleteIndex(Func<DeleteIndexDescriptor, DeleteIndexDescriptor> selector)
 		{
-			return this.Dispatch<DeleteIndexDescriptor, DeleteIndexRequestParameters, IndicesResponse>(
+			return this.Dispatcher.Dispatch<DeleteIndexDescriptor, DeleteIndexRequestParameters, IndicesResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesDeleteDispatch<IndicesResponse>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesResponse DeleteIndex(IDeleteIndexRequest deleteIndexRequest)
 		{
-			return this.Dispatch<IDeleteIndexRequest, DeleteIndexRequestParameters, IndicesResponse>(
+			return this.Dispatcher.Dispatch<IDeleteIndexRequest, DeleteIndexRequestParameters, IndicesResponse>(
 				deleteIndexRequest,
 				(p, d) => this.RawDispatch.IndicesDeleteDispatch<IndicesResponse>(p)
 			);
@@ -29,7 +29,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesResponse> DeleteIndexAsync(Func<DeleteIndexDescriptor, DeleteIndexDescriptor> selector)
 		{
-			return this.DispatchAsync<DeleteIndexDescriptor, DeleteIndexRequestParameters, IndicesResponse, IIndicesResponse>(
+			return this.Dispatcher.DispatchAsync<DeleteIndexDescriptor, DeleteIndexRequestParameters, IndicesResponse, IIndicesResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesDeleteDispatchAsync<IndicesResponse>(p)
 			);
@@ -38,7 +38,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesResponse> DeleteIndexAsync(IDeleteIndexRequest deleteIndexRequest)
 		{
-			return this.DispatchAsync<IDeleteIndexRequest, DeleteIndexRequestParameters, IndicesResponse, IIndicesResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteIndexRequest, DeleteIndexRequestParameters, IndicesResponse, IIndicesResponse>(
 				deleteIndexRequest,
 				(p, d) => this.RawDispatch.IndicesDeleteDispatchAsync<IndicesResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Exists.cs
+++ b/src/Nest/ElasticClient-Exists.cs
@@ -10,7 +10,7 @@ namespace Nest
 		public IExistsResponse DocumentExists<T>(Func<DocumentExistsDescriptor<T>, DocumentExistsDescriptor<T>> existsSelector)
 			where T : class
 		{
-			return this.Dispatch<DocumentExistsDescriptor<T>, DocumentExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<DocumentExistsDescriptor<T>, DocumentExistsRequestParameters, ExistsResponse>(
 				d => existsSelector(d.RequestConfiguration(r=>r.AllowedStatusCodes(404))),
 				(p, d) => ToExistsResponse(this.RawDispatch.ExistsDispatch<VoidResponse>(p))
 			);
@@ -19,7 +19,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse DocumentExists(IDocumentExistsRequest documentExistsRequest)
 		{
-			return this.Dispatch<IDocumentExistsRequest, DocumentExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<IDocumentExistsRequest, DocumentExistsRequestParameters, ExistsResponse>(
 				documentExistsRequest,
 				(p, d) => ToExistsResponse(this.RawDispatch.ExistsDispatch<VoidResponse>(p))
 			);
@@ -29,7 +29,7 @@ namespace Nest
 		public Task<IExistsResponse> DocumentExistsAsync<T>(Func<DocumentExistsDescriptor<T>, DocumentExistsDescriptor<T>> existsSelector)
 			where T : class
 		{
-			return this.DispatchAsync<DocumentExistsDescriptor<T>, DocumentExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<DocumentExistsDescriptor<T>, DocumentExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				d => existsSelector(d.RequestConfiguration(r=>r.AllowedStatusCodes(404))),
 				(p, d) => this.RawDispatch.ExistsDispatchAsync<ExistsResponse>(p)
 			);
@@ -38,7 +38,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> DocumentExistsAsync(IDocumentExistsRequest documentExistsRequest)
 		{
-			return this.DispatchAsync<IDocumentExistsRequest, DocumentExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<IDocumentExistsRequest, DocumentExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				documentExistsRequest,
 				(p, d) => this.RawDispatch.ExistsDispatchAsync<ExistsResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Explain.cs
+++ b/src/Nest/ElasticClient-Explain.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IExplainResponse<T> Explain<T>(Func<ExplainDescriptor<T>, ExplainDescriptor<T>> querySelector)
 			where T : class
 		{
-			return this.Dispatch<ExplainDescriptor<T>, ExplainRequestParameters, ExplainResponse<T>>(
+			return this.Dispatcher.Dispatch<ExplainDescriptor<T>, ExplainRequestParameters, ExplainResponse<T>>(
 				querySelector,
 				(p, d) => this.RawDispatch.ExplainDispatch<ExplainResponse<T>>(p, d)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 		public IExplainResponse<T> Explain<T>(IExplainRequest explainRequest)
 			where T : class
 		{
-			return this.Dispatch<IExplainRequest, ExplainRequestParameters, ExplainResponse<T>>(
+			return this.Dispatcher.Dispatch<IExplainRequest, ExplainRequestParameters, ExplainResponse<T>>(
 				explainRequest,
 				(p, d) => this.RawDispatch.ExplainDispatch<ExplainResponse<T>>(p, d)
 			);
@@ -31,7 +31,7 @@ namespace Nest
 		public Task<IExplainResponse<T>> ExplainAsync<T>(Func<ExplainDescriptor<T>, ExplainDescriptor<T>> querySelector)
 			where T : class
 		{
-			return this.DispatchAsync<ExplainDescriptor<T>, ExplainRequestParameters, ExplainResponse<T>, IExplainResponse<T>>(
+			return this.Dispatcher.DispatchAsync<ExplainDescriptor<T>, ExplainRequestParameters, ExplainResponse<T>, IExplainResponse<T>>(
 				querySelector,
 				(p, d) => this.RawDispatch.ExplainDispatchAsync<ExplainResponse<T>>(p, d)
 			);
@@ -41,7 +41,7 @@ namespace Nest
 		public Task<IExplainResponse<T>> ExplainAsync<T>(IExplainRequest explainRequest)
 			where T : class
 		{
-			return this.DispatchAsync<IExplainRequest, ExplainRequestParameters, ExplainResponse<T>, IExplainResponse<T>>(
+			return this.Dispatcher.DispatchAsync<IExplainRequest, ExplainRequestParameters, ExplainResponse<T>, IExplainResponse<T>>(
 				explainRequest,
 				(p, d) => this.RawDispatch.ExplainDispatchAsync<ExplainResponse<T>>(p, d)
 			);

--- a/src/Nest/ElasticClient-Flush.cs
+++ b/src/Nest/ElasticClient-Flush.cs
@@ -10,7 +10,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IShardsOperationResponse Flush(Func<FlushDescriptor, FlushDescriptor> selector)
 		{
-			return this.Dispatch<FlushDescriptor, FlushRequestParameters, ShardsOperationResponse>(
+			return this.Dispatcher.Dispatch<FlushDescriptor, FlushRequestParameters, ShardsOperationResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesFlushDispatch<ShardsOperationResponse>(p)
 			);
@@ -19,7 +19,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IShardsOperationResponse Flush(IFlushRequest flushRequest)
 		{
-			return this.Dispatch<IFlushRequest, FlushRequestParameters, ShardsOperationResponse>(
+			return this.Dispatcher.Dispatch<IFlushRequest, FlushRequestParameters, ShardsOperationResponse>(
 				flushRequest,
 				(p, d) => this.RawDispatch.IndicesFlushDispatch<ShardsOperationResponse>(p)
 			);
@@ -28,7 +28,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IShardsOperationResponse> FlushAsync(Func<FlushDescriptor, FlushDescriptor> selector)
 		{
-			return this.DispatchAsync<FlushDescriptor, FlushRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+			return this.Dispatcher.DispatchAsync<FlushDescriptor, FlushRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesFlushDispatchAsync<ShardsOperationResponse>(p)
 			);
@@ -37,7 +37,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IShardsOperationResponse> FlushAsync(IFlushRequest flushRequest)
 		{
-			return this.DispatchAsync<IFlushRequest, FlushRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IFlushRequest, FlushRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
 				flushRequest,
 				(p, d) => this.RawDispatch.IndicesFlushDispatchAsync<ShardsOperationResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Get.cs
+++ b/src/Nest/ElasticClient-Get.cs
@@ -11,7 +11,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetResponse<T> Get<T>(Func<GetDescriptor<T>, GetDescriptor<T>> getSelector) where T : class
 		{
-			return this.Dispatch<GetDescriptor<T>, GetRequestParameters, GetResponse<T>>(
+			return this.Dispatcher.Dispatch<GetDescriptor<T>, GetRequestParameters, GetResponse<T>>(
 				getSelector,
 				(p, d) => this.RawDispatch.GetDispatch<GetResponse<T>>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetResponse<T> Get<T>(IGetRequest getRequest) where T : class
 		{
-			return this.Dispatch<IGetRequest, GetRequestParameters, GetResponse<T>>(
+			return this.Dispatcher.Dispatch<IGetRequest, GetRequestParameters, GetResponse<T>>(
 				getRequest,
 				(p, d) => this.RawDispatch.GetDispatch<GetResponse<T>>(p)
 			);
@@ -29,7 +29,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetResponse<T>> GetAsync<T>(Func<GetDescriptor<T>, GetDescriptor<T>> getSelector) where T : class
 		{
-			return this.DispatchAsync<GetDescriptor<T>, GetRequestParameters, GetResponse<T>, IGetResponse<T>>(
+			return this.Dispatcher.DispatchAsync<GetDescriptor<T>, GetRequestParameters, GetResponse<T>, IGetResponse<T>>(
 				getSelector,
 				(p, d) => this.RawDispatch.GetDispatchAsync<GetResponse<T>>(p)
 			);
@@ -38,7 +38,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetResponse<T>> GetAsync<T>(IGetRequest getRequest) where T : class
 		{
-			return this.DispatchAsync<IGetRequest, GetRequestParameters, GetResponse<T>, IGetResponse<T>>(
+			return this.Dispatcher.DispatchAsync<IGetRequest, GetRequestParameters, GetResponse<T>, IGetResponse<T>>(
 				getRequest,
 				(p, d) => this.RawDispatch.GetDispatchAsync<GetResponse<T>>(p)
 			);

--- a/src/Nest/ElasticClient-GetIndex.cs
+++ b/src/Nest/ElasticClient-GetIndex.cs
@@ -14,7 +14,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetIndexResponse GetIndex(Func<GetIndexDescriptor, GetIndexDescriptor> getIndexSelector)
 		{
-			return this.Dispatch<GetIndexDescriptor, GetIndexRequestParameters, GetIndexResponse>(
+			return this.Dispatcher.Dispatch<GetIndexDescriptor, GetIndexRequestParameters, GetIndexResponse>(
 				getIndexSelector,
 				(p, d) => this.RawDispatch.IndicesGetDispatch<GetIndexResponse>(
 					p.DeserializationState(new GetIndexResponseConverter(this.DeserializeGetIndexResponse))
@@ -25,7 +25,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetIndexResponse GetIndex(IGetIndexRequest createIndexRequest)
 		{
-			return this.Dispatch<IGetIndexRequest, GetIndexRequestParameters, GetIndexResponse>(
+			return this.Dispatcher.Dispatch<IGetIndexRequest, GetIndexRequestParameters, GetIndexResponse>(
 				createIndexRequest,
 				(p, d) => this.RawDispatch.IndicesGetDispatch<GetIndexResponse>(
 					p.DeserializationState(new GetIndexResponseConverter(this.DeserializeGetIndexResponse))
@@ -36,7 +36,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetIndexResponse> GetIndexAsync(Func<GetIndexDescriptor, GetIndexDescriptor> getIndexSelector)
 		{
-			return this.DispatchAsync<GetIndexDescriptor, GetIndexRequestParameters, GetIndexResponse, IGetIndexResponse>(
+			return this.Dispatcher.DispatchAsync<GetIndexDescriptor, GetIndexRequestParameters, GetIndexResponse, IGetIndexResponse>(
 				getIndexSelector,
 				(p, d) => this.RawDispatch.IndicesGetDispatchAsync<GetIndexResponse>(
 					p.DeserializationState(new GetIndexResponseConverter(this.DeserializeGetIndexResponse))
@@ -47,7 +47,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetIndexResponse> GetIndexAsync(IGetIndexRequest createIndexRequest)
 		{
-			return this.DispatchAsync<IGetIndexRequest, GetIndexRequestParameters, GetIndexResponse, IGetIndexResponse>(
+			return this.Dispatcher.DispatchAsync<IGetIndexRequest, GetIndexRequestParameters, GetIndexResponse, IGetIndexResponse>(
 				createIndexRequest,
 				(p, d) => this.RawDispatch.IndicesGetDispatchAsync<GetIndexResponse>(
 					p.DeserializationState(new GetIndexResponseConverter(this.DeserializeGetIndexResponse))

--- a/src/Nest/ElasticClient-Index.cs
+++ b/src/Nest/ElasticClient-Index.cs
@@ -14,7 +14,7 @@ namespace Nest
 			@object.ThrowIfNull("object");
 			indexSelector = indexSelector ?? (s => s);
 			var descriptor = indexSelector(new IndexDescriptor<T>().IdFrom(@object));
-			return this.Dispatch<IndexDescriptor<T>, IndexRequestParameters, IndexResponse>(
+			return this.Dispatcher.Dispatch<IndexDescriptor<T>, IndexRequestParameters, IndexResponse>(
 				descriptor,
 				(p, d) => this.RawDispatch.IndexDispatch<IndexResponse>(p, @object));
 		}
@@ -23,7 +23,7 @@ namespace Nest
 		public IIndexResponse Index<T>(IIndexRequest<T> indexRequest)
 			where T : class
 		{
-			return this.Dispatch<IIndexRequest<T>, IndexRequestParameters, IndexResponse>(
+			return this.Dispatcher.Dispatch<IIndexRequest<T>, IndexRequestParameters, IndexResponse>(
 				indexRequest,
 				(p, d) => this.RawDispatch.IndexDispatch<IndexResponse>(p, indexRequest.Document));
 		}
@@ -35,7 +35,7 @@ namespace Nest
 			@object.ThrowIfNull("object");
 			indexSelector = indexSelector ?? (s => s);
 			var descriptor = indexSelector(new IndexDescriptor<T>().IdFrom(@object));
-			return this.DispatchAsync<IndexDescriptor<T>, IndexRequestParameters, IndexResponse, IIndexResponse>(
+			return this.Dispatcher.DispatchAsync<IndexDescriptor<T>, IndexRequestParameters, IndexResponse, IIndexResponse>(
 				descriptor,
 				(p, d) => this.RawDispatch.IndexDispatchAsync<IndexResponse>(p, @object));
 		}
@@ -44,7 +44,7 @@ namespace Nest
 		public Task<IIndexResponse> IndexAsync<T>(IIndexRequest<T> indexRequest)
 			where T : class
 		{
-			return this.DispatchAsync<IIndexRequest<T>, IndexRequestParameters, IndexResponse, IIndexResponse>(
+			return this.Dispatcher.DispatchAsync<IIndexRequest<T>, IndexRequestParameters, IndexResponse, IIndexResponse>(
 				indexRequest,
 				(p, d) => this.RawDispatch.IndexDispatchAsync<IndexResponse>(p, indexRequest.Document));
 		}

--- a/src/Nest/ElasticClient-IndexExists.cs
+++ b/src/Nest/ElasticClient-IndexExists.cs
@@ -13,7 +13,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse IndexExists(Func<IndexExistsDescriptor, IndexExistsDescriptor> selector)
 		{
-			return this.Dispatch<IndexExistsDescriptor, IndexExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<IndexExistsDescriptor, IndexExistsRequestParameters, ExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesExistsDispatch<ExistsResponse>(
 					p.DeserializationState(new IndexExistConverter(DeserializeExistsResponse))
@@ -24,7 +24,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse IndexExists(IIndexExistsRequest indexRequest)
 		{
-			return this.Dispatch<IIndexExistsRequest, IndexExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<IIndexExistsRequest, IndexExistsRequestParameters, ExistsResponse>(
 				indexRequest,
 				(p, d) => this.RawDispatch.IndicesExistsDispatch<ExistsResponse>(
 					p.DeserializationState(new IndexExistConverter(DeserializeExistsResponse))
@@ -35,7 +35,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> IndexExistsAsync(Func<IndexExistsDescriptor, IndexExistsDescriptor> selector)
 		{
-			return this.DispatchAsync<IndexExistsDescriptor, IndexExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<IndexExistsDescriptor, IndexExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesExistsDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new IndexExistConverter(DeserializeExistsResponse))
@@ -46,7 +46,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> IndexExistsAsync(IIndexExistsRequest indexRequest)
 		{
-			return this.DispatchAsync<IIndexExistsRequest, IndexExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<IIndexExistsRequest, IndexExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				indexRequest,
 				(p, d) => this.RawDispatch.IndicesExistsDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new IndexExistConverter(DeserializeExistsResponse))

--- a/src/Nest/ElasticClient-IndexSettings.cs
+++ b/src/Nest/ElasticClient-IndexSettings.cs
@@ -10,7 +10,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndexSettingsResponse GetIndexSettings(Func<GetIndexSettingsDescriptor, GetIndexSettingsDescriptor> selector)
 		{
-			return this.Dispatch<GetIndexSettingsDescriptor, GetIndexSettingsRequestParameters, IndexSettingsResponse>(
+			return this.Dispatcher.Dispatch<GetIndexSettingsDescriptor, GetIndexSettingsRequestParameters, IndexSettingsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesGetSettingsDispatch<IndexSettingsResponse>(p)
 			);
@@ -19,7 +19,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndexSettingsResponse GetIndexSettings(IGetIndexSettingsRequest getIndexSettingsRequest)
 		{
-			return this.Dispatch<IGetIndexSettingsRequest, GetIndexSettingsRequestParameters, IndexSettingsResponse>(
+			return this.Dispatcher.Dispatch<IGetIndexSettingsRequest, GetIndexSettingsRequestParameters, IndexSettingsResponse>(
 				getIndexSettingsRequest,
 				(p, d) => this.RawDispatch.IndicesGetSettingsDispatch<IndexSettingsResponse>(p)
 			);
@@ -28,7 +28,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndexSettingsResponse> GetIndexSettingsAsync(Func<GetIndexSettingsDescriptor, GetIndexSettingsDescriptor> selector)
 		{
-			return this.DispatchAsync
+			return this.Dispatcher.DispatchAsync
 				<GetIndexSettingsDescriptor, GetIndexSettingsRequestParameters, IndexSettingsResponse, IIndexSettingsResponse>(
 					selector,
 					(p, d) => this.RawDispatch.IndicesGetSettingsDispatchAsync<IndexSettingsResponse>(p)
@@ -38,7 +38,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndexSettingsResponse> GetIndexSettingsAsync(IGetIndexSettingsRequest getIndexSettingsRequest)
 		{
-			return this.DispatchAsync<IGetIndexSettingsRequest, GetIndexSettingsRequestParameters, IndexSettingsResponse, IIndexSettingsResponse>(
+			return this.Dispatcher.DispatchAsync<IGetIndexSettingsRequest, GetIndexSettingsRequestParameters, IndexSettingsResponse, IIndexSettingsResponse>(
 				getIndexSettingsRequest,
 				(p, d) => this.RawDispatch.IndicesGetSettingsDispatchAsync<IndexSettingsResponse>(p)
 			);

--- a/src/Nest/ElasticClient-IndicesStats.cs
+++ b/src/Nest/ElasticClient-IndicesStats.cs
@@ -12,7 +12,7 @@ namespace Nest
 		public IGlobalStatsResponse IndicesStats(Func<IndicesStatsDescriptor, IndicesStatsDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<IndicesStatsDescriptor, IndicesStatsRequestParameters, GlobalStatsResponse>(
+			return this.Dispatcher.Dispatch<IndicesStatsDescriptor, IndicesStatsRequestParameters, GlobalStatsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesStatsDispatch<GlobalStatsResponse>(p)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGlobalStatsResponse IndicesStats(IIndicesStatsRequest statsRequest)
 		{
-			return this.Dispatch<IIndicesStatsRequest, IndicesStatsRequestParameters, GlobalStatsResponse>(
+			return this.Dispatcher.Dispatch<IIndicesStatsRequest, IndicesStatsRequestParameters, GlobalStatsResponse>(
 				statsRequest,
 				(p, d) => this.RawDispatch.IndicesStatsDispatch<GlobalStatsResponse>(p)
 			);
@@ -31,7 +31,7 @@ namespace Nest
 		public Task<IGlobalStatsResponse> IndicesStatsAsync(Func<IndicesStatsDescriptor, IndicesStatsDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<IndicesStatsDescriptor, IndicesStatsRequestParameters, GlobalStatsResponse, IGlobalStatsResponse>(
+			return this.Dispatcher.DispatchAsync<IndicesStatsDescriptor, IndicesStatsRequestParameters, GlobalStatsResponse, IGlobalStatsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesStatsDispatchAsync<GlobalStatsResponse>(p)
 			);
@@ -40,7 +40,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGlobalStatsResponse> IndicesStatsAsync(IIndicesStatsRequest statsRequest)
 		{
-			return this.DispatchAsync<IIndicesStatsRequest, IndicesStatsRequestParameters, GlobalStatsResponse, IGlobalStatsResponse>(
+			return this.Dispatcher.DispatchAsync<IIndicesStatsRequest, IndicesStatsRequestParameters, GlobalStatsResponse, IGlobalStatsResponse>(
 				statsRequest,
 				(p, d) => this.RawDispatch.IndicesStatsDispatchAsync<GlobalStatsResponse>(p)
 			);

--- a/src/Nest/ElasticClient-MappingDelete.cs
+++ b/src/Nest/ElasticClient-MappingDelete.cs
@@ -13,7 +13,7 @@ namespace Nest
 			where T : class
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<DeleteMappingDescriptor<T>, DeleteMappingRequestParameters, IndicesResponse>(
+			return this.Dispatcher.Dispatch<DeleteMappingDescriptor<T>, DeleteMappingRequestParameters, IndicesResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesDeleteMappingDispatch<IndicesResponse>(p)
 			);
@@ -22,7 +22,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesResponse DeleteMapping(IDeleteMappingRequest deleteMappingRequest)
 		{
-			return this.Dispatch<IDeleteMappingRequest, DeleteMappingRequestParameters, IndicesResponse>(
+			return this.Dispatcher.Dispatch<IDeleteMappingRequest, DeleteMappingRequestParameters, IndicesResponse>(
 				deleteMappingRequest,
 				(p, d) => this.RawDispatch.IndicesDeleteMappingDispatch<IndicesResponse>(p)
 			);
@@ -33,7 +33,7 @@ namespace Nest
 			where T : class
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<DeleteMappingDescriptor<T>, DeleteMappingRequestParameters, IndicesResponse, IIndicesResponse>(
+			return this.Dispatcher.DispatchAsync<DeleteMappingDescriptor<T>, DeleteMappingRequestParameters, IndicesResponse, IIndicesResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesDeleteMappingDispatchAsync<IndicesResponse>(p)
 			);
@@ -42,7 +42,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesResponse> DeleteMappingAsync(IDeleteMappingRequest deleteMappingRequest)
 		{
-			return this.DispatchAsync<IDeleteMappingRequest, DeleteMappingRequestParameters, IndicesResponse, IIndicesResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteMappingRequest, DeleteMappingRequestParameters, IndicesResponse, IIndicesResponse>(
 				deleteMappingRequest,
 				(p, d) => this.RawDispatch.IndicesDeleteMappingDispatchAsync<IndicesResponse>(p)
 			);

--- a/src/Nest/ElasticClient-MappingGet.cs
+++ b/src/Nest/ElasticClient-MappingGet.cs
@@ -16,7 +16,7 @@ namespace Nest
 			where T : class
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<GetMappingDescriptor<T>, GetMappingRequestParameters, GetMappingResponse>(
+			return this.Dispatcher.Dispatch<GetMappingDescriptor<T>, GetMappingRequestParameters, GetMappingResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesGetMappingDispatch<GetMappingResponse>(
 					p.DeserializationState(new GetMappingConverter((r, s) => DeserializeGetMappingResponse(r, d, s)))
@@ -27,7 +27,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetMappingResponse GetMapping(IGetMappingRequest getMappingRequest)
 		{
-			return this.Dispatch<IGetMappingRequest, GetMappingRequestParameters, GetMappingResponse>(
+			return this.Dispatcher.Dispatch<IGetMappingRequest, GetMappingRequestParameters, GetMappingResponse>(
 				getMappingRequest,
 				(p, d) => this.RawDispatch.IndicesGetMappingDispatch<GetMappingResponse>(
 					p.DeserializationState(new GetMappingConverter((r, s) => DeserializeGetMappingResponse(r, d, s)))
@@ -40,7 +40,7 @@ namespace Nest
 			where T : class
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<GetMappingDescriptor<T>, GetMappingRequestParameters, GetMappingResponse, IGetMappingResponse>(
+			return this.Dispatcher.DispatchAsync<GetMappingDescriptor<T>, GetMappingRequestParameters, GetMappingResponse, IGetMappingResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesGetMappingDispatchAsync<GetMappingResponse>(
 					p.DeserializationState(new GetMappingConverter((r, s) => DeserializeGetMappingResponse(r, d, s)))
@@ -51,7 +51,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetMappingResponse> GetMappingAsync(IGetMappingRequest getMappingRequest)
 		{
-			return this.DispatchAsync<IGetMappingRequest, GetMappingRequestParameters, GetMappingResponse, IGetMappingResponse>(
+			return this.Dispatcher.DispatchAsync<IGetMappingRequest, GetMappingRequestParameters, GetMappingResponse, IGetMappingResponse>(
 				getMappingRequest,
 				(p, d) => this.RawDispatch.IndicesGetMappingDispatchAsync<GetMappingResponse>(
 					p.DeserializationState(new GetMappingConverter((r, s) => DeserializeGetMappingResponse(r, d, s)))

--- a/src/Nest/ElasticClient-MappingGetField.cs
+++ b/src/Nest/ElasticClient-MappingGetField.cs
@@ -16,7 +16,7 @@ namespace Nest
 			where T : class
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<GetFieldMappingDescriptor<T>, GetFieldMappingRequestParameters, GetFieldMappingResponse>(
+			return this.Dispatcher.Dispatch<GetFieldMappingDescriptor<T>, GetFieldMappingRequestParameters, GetFieldMappingResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesGetFieldMappingDispatch<GetFieldMappingResponse>(
 					p.DeserializationState(new GetFieldMappingConverter((r, s) => DeserializeGetFieldMappingResponse(r, d, s)))
@@ -27,7 +27,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetFieldMappingResponse GetFieldMapping(IGetFieldMappingRequest getFieldMappingRequest)
 		{
-			return this.Dispatch<IGetFieldMappingRequest, GetFieldMappingRequestParameters, GetFieldMappingResponse>(
+			return this.Dispatcher.Dispatch<IGetFieldMappingRequest, GetFieldMappingRequestParameters, GetFieldMappingResponse>(
 				getFieldMappingRequest,
 				(p, d) => this.RawDispatch.IndicesGetFieldMappingDispatch<GetFieldMappingResponse>(
 					p.DeserializationState(new GetFieldMappingConverter((r, s) => DeserializeGetFieldMappingResponse(r, d, s)))
@@ -40,7 +40,7 @@ namespace Nest
 			where T : class
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<GetFieldMappingDescriptor<T>, GetFieldMappingRequestParameters, GetFieldMappingResponse, IGetFieldMappingResponse>(
+			return this.Dispatcher.DispatchAsync<GetFieldMappingDescriptor<T>, GetFieldMappingRequestParameters, GetFieldMappingResponse, IGetFieldMappingResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesGetFieldMappingDispatchAsync<GetFieldMappingResponse>(
 					p.DeserializationState(new GetFieldMappingConverter((r, s) => DeserializeGetFieldMappingResponse(r, d, s)))
@@ -51,7 +51,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetFieldMappingResponse> GetFieldMappingAsync(IGetFieldMappingRequest getFieldMappingRequest)
 		{
-			return this.DispatchAsync<IGetFieldMappingRequest, GetFieldMappingRequestParameters, GetFieldMappingResponse, IGetFieldMappingResponse>(
+			return this.Dispatcher.DispatchAsync<IGetFieldMappingRequest, GetFieldMappingRequestParameters, GetFieldMappingResponse, IGetFieldMappingResponse>(
 				getFieldMappingRequest,
 				(p, d) => this.RawDispatch.IndicesGetFieldMappingDispatchAsync<GetFieldMappingResponse>(
 					p.DeserializationState(new GetFieldMappingConverter((r, s) => DeserializeGetFieldMappingResponse(r, d, s)))

--- a/src/Nest/ElasticClient-MappingType.cs
+++ b/src/Nest/ElasticClient-MappingType.cs
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesResponse Map(IPutMappingRequest putMappingRequest) 
 		{
-			return this.Dispatch<IPutMappingRequest, PutMappingRequestParameters, IndicesResponse>(
+			return this.Dispatcher.Dispatch<IPutMappingRequest, PutMappingRequestParameters, IndicesResponse>(
 				putMappingRequest,
 				(p, d) =>
 				{
@@ -45,7 +45,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesResponse> MapAsync(IPutMappingRequest putMappingRequest)
 		{
-			return this.DispatchAsync<IPutMappingRequest, PutMappingRequestParameters, IndicesResponse, IIndicesResponse>(
+			return this.Dispatcher.DispatchAsync<IPutMappingRequest, PutMappingRequestParameters, IndicesResponse, IIndicesResponse>(
 				putMappingRequest,
 				(p, d) =>
 				{

--- a/src/Nest/ElasticClient-MoreLikeThis.cs
+++ b/src/Nest/ElasticClient-MoreLikeThis.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public ISearchResponse<T> MoreLikeThis<T>(Func<MoreLikeThisDescriptor<T>, MoreLikeThisDescriptor<T>> mltSelector)
 			where T : class
 		{
-			return this.Dispatch<MoreLikeThisDescriptor<T>, MoreLikeThisRequestParameters, SearchResponse<T>>(
+			return this.Dispatcher.Dispatch<MoreLikeThisDescriptor<T>, MoreLikeThisRequestParameters, SearchResponse<T>>(
 				mltSelector,
 				(p, d) =>
 				{
@@ -26,7 +26,7 @@ namespace Nest
 		public ISearchResponse<T> MoreLikeThis<T>(IMoreLikeThisRequest moreLikeThisRequest)
 			where T : class
 		{
-			return this.Dispatch<IMoreLikeThisRequest, MoreLikeThisRequestParameters, SearchResponse<T>>(
+			return this.Dispatcher.Dispatch<IMoreLikeThisRequest, MoreLikeThisRequestParameters, SearchResponse<T>>(
 				moreLikeThisRequest,
 				(p, d) =>
 				{
@@ -40,7 +40,7 @@ namespace Nest
 		public Task<ISearchResponse<T>> MoreLikeThisAsync<T>(Func<MoreLikeThisDescriptor<T>, MoreLikeThisDescriptor<T>> mltSelector) 
 			where T : class
 		{
-			return this.DispatchAsync<MoreLikeThisDescriptor<T>, MoreLikeThisRequestParameters, SearchResponse<T>, ISearchResponse<T>>(
+			return this.Dispatcher.DispatchAsync<MoreLikeThisDescriptor<T>, MoreLikeThisRequestParameters, SearchResponse<T>, ISearchResponse<T>>(
 				mltSelector,
 				(p, d) =>
 				{
@@ -55,7 +55,7 @@ namespace Nest
 		public Task<ISearchResponse<T>> MoreLikeThisAsync<T>(IMoreLikeThisRequest moreLikeThisRequest) 
 			where T : class
 		{
-			return this.DispatchAsync<IMoreLikeThisRequest, MoreLikeThisRequestParameters, SearchResponse<T>, ISearchResponse<T>>(
+			return this.Dispatcher.DispatchAsync<IMoreLikeThisRequest, MoreLikeThisRequestParameters, SearchResponse<T>, ISearchResponse<T>>(
 				moreLikeThisRequest,
 				(p, d) =>
 				{

--- a/src/Nest/ElasticClient-MultiGet.cs
+++ b/src/Nest/ElasticClient-MultiGet.cs
@@ -20,7 +20,7 @@ namespace Nest
 			var descriptor = multiGetSelector(new MultiGetDescriptor());
 			var converter = CreateCovariantMultiGetConverter(descriptor);
 			var customCreator = new MultiGetConverter((r, s) => this.DeserializeMultiGetResponse(r, s, converter));
-			return this.Dispatch<MultiGetDescriptor, MultiGetRequestParameters, MultiGetResponse>(
+			return this.Dispatcher.Dispatch<MultiGetDescriptor, MultiGetRequestParameters, MultiGetResponse>(
 				descriptor,
 				(p, d) => this.RawDispatch.MgetDispatch<MultiGetResponse>(p.DeserializationState(customCreator), d)
 			);
@@ -31,7 +31,7 @@ namespace Nest
 		{
 			var converter = CreateCovariantMultiGetConverter(multiRequest);
 			var customCreator = new MultiGetConverter((r, s) => this.DeserializeMultiGetResponse(r, s, converter));
-			return this.Dispatch<IMultiGetRequest, MultiGetRequestParameters, MultiGetResponse>(
+			return this.Dispatcher.Dispatch<IMultiGetRequest, MultiGetRequestParameters, MultiGetResponse>(
 				multiRequest,
 				(p, d) => this.RawDispatch.MgetDispatch<MultiGetResponse>(p.DeserializationState(customCreator), d)
 			);
@@ -44,7 +44,7 @@ namespace Nest
 			var descriptor = multiGetSelector(new MultiGetDescriptor());
 			var converter = CreateCovariantMultiGetConverter(descriptor);
 			var customCreator = new MultiGetConverter((r, s) => this.DeserializeMultiGetResponse(r, s, converter));
-			return this.DispatchAsync<MultiGetDescriptor, MultiGetRequestParameters, MultiGetResponse, IMultiGetResponse>(
+			return this.Dispatcher.DispatchAsync<MultiGetDescriptor, MultiGetRequestParameters, MultiGetResponse, IMultiGetResponse>(
 				descriptor,
 				(p, d) => this.RawDispatch.MgetDispatchAsync<MultiGetResponse>(p.DeserializationState(customCreator), d)
 			);
@@ -55,7 +55,7 @@ namespace Nest
 		{
 			var converter = CreateCovariantMultiGetConverter(multiGetRequest);
 			var customCreator = new MultiGetConverter((r, s) => this.DeserializeMultiGetResponse(r, s, converter));
-			return this.DispatchAsync<IMultiGetRequest, MultiGetRequestParameters, MultiGetResponse, IMultiGetResponse>(
+			return this.Dispatcher.DispatchAsync<IMultiGetRequest, MultiGetRequestParameters, MultiGetResponse, IMultiGetResponse>(
 				multiGetRequest,
 				(p, d) => this.RawDispatch.MgetDispatchAsync<MultiGetResponse>(p.DeserializationState(customCreator), d)
 			);

--- a/src/Nest/ElasticClient-MultiPercolate.cs
+++ b/src/Nest/ElasticClient-MultiPercolate.cs
@@ -16,7 +16,7 @@ namespace Nest
 		{
 			multiPercolateSelector.ThrowIfNull("MultiPercolateSelector");
 			var descriptor = multiPercolateSelector(new MultiPercolateDescriptor());
-			return this.Dispatch<MultiPercolateDescriptor, MultiPercolateRequestParameters, MultiPercolateResponse>(
+			return this.Dispatcher.Dispatch<MultiPercolateDescriptor, MultiPercolateRequestParameters, MultiPercolateResponse>(
 				descriptor,
 				(p, d) =>
 				{
@@ -29,7 +29,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IMultiPercolateResponse MultiPercolate(IMultiPercolateRequest multiRequest)
 		{
-			return this.Dispatch<IMultiPercolateRequest, MultiPercolateRequestParameters, MultiPercolateResponse>(
+			return this.Dispatcher.Dispatch<IMultiPercolateRequest, MultiPercolateRequestParameters, MultiPercolateResponse>(
 				multiRequest,
 				(p, d) =>
 				{
@@ -44,7 +44,7 @@ namespace Nest
 		{
 			multiPercolateSelector.ThrowIfNull("MultiPercolateSelector");
 			var descriptor = multiPercolateSelector(new MultiPercolateDescriptor());
-			return this.DispatchAsync<MultiPercolateDescriptor, MultiPercolateRequestParameters, MultiPercolateResponse, IMultiPercolateResponse>(
+			return this.Dispatcher.DispatchAsync<MultiPercolateDescriptor, MultiPercolateRequestParameters, MultiPercolateResponse, IMultiPercolateResponse>(
 				descriptor,
 				(p, d) =>
 				{
@@ -57,7 +57,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IMultiPercolateResponse> MultiPercolateAsync(IMultiPercolateRequest multiPercolateRequest)
 		{
-			return this.DispatchAsync<IMultiPercolateRequest, MultiPercolateRequestParameters, MultiPercolateResponse, IMultiPercolateResponse>(
+			return this.Dispatcher.DispatchAsync<IMultiPercolateRequest, MultiPercolateRequestParameters, MultiPercolateResponse, IMultiPercolateResponse>(
 				multiPercolateRequest,
 				(p, d) =>
 				{

--- a/src/Nest/ElasticClient-MultiSearch.cs
+++ b/src/Nest/ElasticClient-MultiSearch.cs
@@ -16,7 +16,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IMultiSearchResponse MultiSearch(Func<MultiSearchDescriptor, MultiSearchDescriptor> multiSearchSelector)
 		{
-			return this.Dispatch<MultiSearchDescriptor, MultiSearchRequestParameters, MultiSearchResponse>(
+			return this.Dispatcher.Dispatch<MultiSearchDescriptor, MultiSearchRequestParameters, MultiSearchResponse>(
 				multiSearchSelector(new MultiSearchDescriptor()),
 				(p, d) =>
 				{
@@ -31,7 +31,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IMultiSearchResponse MultiSearch(IMultiSearchRequest multiSearchRequest)
 		{
-			return this.Dispatch<IMultiSearchRequest, MultiSearchRequestParameters, MultiSearchResponse>(
+			return this.Dispatcher.Dispatch<IMultiSearchRequest, MultiSearchRequestParameters, MultiSearchResponse>(
 				multiSearchRequest,
 				(p, d) =>
 				{
@@ -45,7 +45,7 @@ namespace Nest
 
 		/// <inheritdoc />
 		public Task<IMultiSearchResponse> MultiSearchAsync(Func<MultiSearchDescriptor, MultiSearchDescriptor> multiSearchSelector) {
-			return this.DispatchAsync<MultiSearchDescriptor, MultiSearchRequestParameters, MultiSearchResponse, IMultiSearchResponse>(
+			return this.Dispatcher.DispatchAsync<MultiSearchDescriptor, MultiSearchRequestParameters, MultiSearchResponse, IMultiSearchResponse>(
 				multiSearchSelector(new MultiSearchDescriptor()),
 				(p, d) =>
 				{
@@ -60,7 +60,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IMultiSearchResponse> MultiSearchAsync(IMultiSearchRequest multiSearchRequest) 
 		{
-			return this.DispatchAsync<IMultiSearchRequest, MultiSearchRequestParameters, MultiSearchResponse, IMultiSearchResponse>(
+			return this.Dispatcher.DispatchAsync<IMultiSearchRequest, MultiSearchRequestParameters, MultiSearchResponse, IMultiSearchResponse>(
 				multiSearchRequest,
 				(p, d) =>
 				{

--- a/src/Nest/ElasticClient-MultiTermVectors.cs
+++ b/src/Nest/ElasticClient-MultiTermVectors.cs
@@ -13,7 +13,7 @@ namespace Nest
 		public IMultiTermVectorResponse MultiTermVectors<T>(Func<MultiTermVectorsDescriptor<T>, MultiTermVectorsDescriptor<T>> multiTermVectorsSelector)
 			where T : class
 		{
-			return this.Dispatch<MultiTermVectorsDescriptor<T>, MultiTermVectorsRequestParameters, MultiTermVectorResponse>(
+			return this.Dispatcher.Dispatch<MultiTermVectorsDescriptor<T>, MultiTermVectorsRequestParameters, MultiTermVectorResponse>(
 				multiTermVectorsSelector,
 				(p, d) => this.RawDispatch.MtermvectorsDispatch<MultiTermVectorResponse>(p, d)
 			);
@@ -22,7 +22,7 @@ namespace Nest
 		///<inheritdoc />
 		public IMultiTermVectorResponse MultiTermVectors(IMultiTermVectorsRequest multiTermVectorsRequest)
 		{
-			return this.Dispatch<IMultiTermVectorsRequest, MultiTermVectorsRequestParameters, MultiTermVectorResponse>(
+			return this.Dispatcher.Dispatch<IMultiTermVectorsRequest, MultiTermVectorsRequestParameters, MultiTermVectorResponse>(
 				multiTermVectorsRequest,
 				(p, d) => this.RawDispatch.MtermvectorsDispatch<MultiTermVectorResponse>(p, d)
 			);
@@ -32,7 +32,7 @@ namespace Nest
 		public Task<IMultiTermVectorResponse> MultiTermVectorsAsync<T>(Func<MultiTermVectorsDescriptor<T>, MultiTermVectorsDescriptor<T>> multiTermVectorsSelector)
 			where T : class
 		{
-			return this.DispatchAsync<MultiTermVectorsDescriptor<T>, MultiTermVectorsRequestParameters, MultiTermVectorResponse, IMultiTermVectorResponse>(
+			return this.Dispatcher.DispatchAsync<MultiTermVectorsDescriptor<T>, MultiTermVectorsRequestParameters, MultiTermVectorResponse, IMultiTermVectorResponse>(
 				multiTermVectorsSelector,
 				(p, d) => this.RawDispatch.MtermvectorsDispatchAsync<MultiTermVectorResponse>(p, d)
 			);
@@ -41,7 +41,7 @@ namespace Nest
 		///<inheritdoc />
 		public Task<IMultiTermVectorResponse> MultiTermVectorsAsync(IMultiTermVectorsRequest multiTermVectorsRequest)
 		{
-			return this.DispatchAsync<IMultiTermVectorsRequest, MultiTermVectorsRequestParameters, MultiTermVectorResponse, IMultiTermVectorResponse>(
+			return this.Dispatcher.DispatchAsync<IMultiTermVectorsRequest, MultiTermVectorsRequestParameters, MultiTermVectorResponse, IMultiTermVectorResponse>(
 				multiTermVectorsRequest,
 				(p, d) => this.RawDispatch.MtermvectorsDispatchAsync<MultiTermVectorResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-Nodes.cs
+++ b/src/Nest/ElasticClient-Nodes.cs
@@ -17,7 +17,7 @@ namespace Nest
 		public INodeInfoResponse NodesInfo(Func<NodesInfoDescriptor, NodesInfoDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<NodesInfoDescriptor, NodesInfoRequestParameters, NodeInfoResponse>(
+			return this.Dispatcher.Dispatch<NodesInfoDescriptor, NodesInfoRequestParameters, NodeInfoResponse>(
 				selector,
 				(p, d) => this.RawDispatch.NodesInfoDispatch<NodeInfoResponse>(p)
 			);
@@ -26,7 +26,7 @@ namespace Nest
 		/// <inheritdoc />
 		public INodeInfoResponse NodesInfo(INodesInfoRequest nodesInfoRequest)
 		{
-			return this.Dispatch<INodesInfoRequest, NodesInfoRequestParameters, NodeInfoResponse>(
+			return this.Dispatcher.Dispatch<INodesInfoRequest, NodesInfoRequestParameters, NodeInfoResponse>(
 				nodesInfoRequest,
 				(p, d) => this.RawDispatch.NodesInfoDispatch<NodeInfoResponse>(p)
 			);
@@ -36,7 +36,7 @@ namespace Nest
 		public Task<INodeInfoResponse> NodesInfoAsync(Func<NodesInfoDescriptor, NodesInfoDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<NodesInfoDescriptor, NodesInfoRequestParameters, NodeInfoResponse, INodeInfoResponse>(
+			return this.Dispatcher.DispatchAsync<NodesInfoDescriptor, NodesInfoRequestParameters, NodeInfoResponse, INodeInfoResponse>(
 				selector,
 				(p, d) => this.RawDispatch.NodesInfoDispatchAsync<NodeInfoResponse>(p)
 			);
@@ -45,7 +45,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<INodeInfoResponse> NodesInfoAsync(INodesInfoRequest nodesInfoRequest)
 		{
-			return this.DispatchAsync<INodesInfoRequest, NodesInfoRequestParameters, NodeInfoResponse, INodeInfoResponse>(
+			return this.Dispatcher.DispatchAsync<INodesInfoRequest, NodesInfoRequestParameters, NodeInfoResponse, INodeInfoResponse>(
 				nodesInfoRequest,
 				(p, d) => this.RawDispatch.NodesInfoDispatchAsync<NodeInfoResponse>(p)
 			);
@@ -58,7 +58,7 @@ namespace Nest
 		public INodeStatsResponse NodesStats(Func<NodesStatsDescriptor, NodesStatsDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<NodesStatsDescriptor, NodesStatsRequestParameters, NodeStatsResponse>(
+			return this.Dispatcher.Dispatch<NodesStatsDescriptor, NodesStatsRequestParameters, NodeStatsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.NodesStatsDispatch<NodeStatsResponse>(p)
 			);
@@ -67,7 +67,7 @@ namespace Nest
 		/// <inheritdoc />
 		public INodeStatsResponse NodesStats(INodesStatsRequest nodesStatsRequest)
 		{
-			return this.Dispatch<INodesStatsRequest, NodesStatsRequestParameters, NodeStatsResponse>(
+			return this.Dispatcher.Dispatch<INodesStatsRequest, NodesStatsRequestParameters, NodeStatsResponse>(
 				nodesStatsRequest,
 				(p, d) => this.RawDispatch.NodesStatsDispatch<NodeStatsResponse>(p)
 			);
@@ -77,7 +77,7 @@ namespace Nest
 		public Task<INodeStatsResponse> NodesStatsAsync(Func<NodesStatsDescriptor, NodesStatsDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<NodesStatsDescriptor, NodesStatsRequestParameters, NodeStatsResponse, INodeStatsResponse>(
+			return this.Dispatcher.DispatchAsync<NodesStatsDescriptor, NodesStatsRequestParameters, NodeStatsResponse, INodeStatsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.NodesStatsDispatchAsync<NodeStatsResponse>(p)
 			);
@@ -86,7 +86,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<INodeStatsResponse> NodesStatsAsync(INodesStatsRequest nodesStatsRequest)
 		{
-			return this.DispatchAsync<INodesStatsRequest, NodesStatsRequestParameters, NodeStatsResponse, INodeStatsResponse>(
+			return this.Dispatcher.DispatchAsync<INodesStatsRequest, NodesStatsRequestParameters, NodeStatsResponse, INodeStatsResponse>(
 				nodesStatsRequest,
 				(p, d) => this.RawDispatch.NodesStatsDispatchAsync<NodeStatsResponse>(p)
 			);
@@ -96,7 +96,7 @@ namespace Nest
 		public INodesHotThreadsResponse NodesHotThreads(Func<NodesHotThreadsDescriptor, NodesHotThreadsDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<NodesHotThreadsDescriptor, NodesHotThreadsRequestParameters, NodesHotThreadsResponse>(
+			return this.Dispatcher.Dispatch<NodesHotThreadsDescriptor, NodesHotThreadsRequestParameters, NodesHotThreadsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.NodesHotThreadsDispatch<NodesHotThreadsResponse>(
 					p.DeserializationState(new NodesHotThreadConverter(DeserializeNodesHotThreadResponse)))
@@ -106,7 +106,7 @@ namespace Nest
 		/// <inheritdoc />
 		public INodesHotThreadsResponse NodesHotThreads(INodesHotThreadsRequest nodesHotThreadsRequest)
 		{
-			return this.Dispatch<INodesHotThreadsRequest, NodesHotThreadsRequestParameters, NodesHotThreadsResponse>(
+			return this.Dispatcher.Dispatch<INodesHotThreadsRequest, NodesHotThreadsRequestParameters, NodesHotThreadsResponse>(
 				nodesHotThreadsRequest,
 				(p, d) => this.RawDispatch.NodesHotThreadsDispatch<NodesHotThreadsResponse>(
 					p.DeserializationState(new NodesHotThreadConverter(DeserializeNodesHotThreadResponse)))
@@ -117,7 +117,7 @@ namespace Nest
 		public Task<INodesHotThreadsResponse> NodesHotThreadsAsync(Func<NodesHotThreadsDescriptor, NodesHotThreadsDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<NodesHotThreadsDescriptor, NodesHotThreadsRequestParameters, NodesHotThreadsResponse, INodesHotThreadsResponse>(
+			return this.Dispatcher.DispatchAsync<NodesHotThreadsDescriptor, NodesHotThreadsRequestParameters, NodesHotThreadsResponse, INodesHotThreadsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.NodesHotThreadsDispatchAsync<NodesHotThreadsResponse>(
 					p.DeserializationState(new NodesHotThreadConverter(DeserializeNodesHotThreadResponse)))
@@ -127,7 +127,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<INodesHotThreadsResponse> NodesHotThreadsAsync(INodesHotThreadsRequest nodesHotThreadsRequest)
 		{
-			return this.DispatchAsync<INodesHotThreadsRequest, NodesHotThreadsRequestParameters, NodesHotThreadsResponse, INodesHotThreadsResponse>(
+			return this.Dispatcher.DispatchAsync<INodesHotThreadsRequest, NodesHotThreadsRequestParameters, NodesHotThreadsResponse, INodesHotThreadsResponse>(
 				nodesHotThreadsRequest,
 				(p, d) => this.RawDispatch.NodesHotThreadsDispatchAsync<NodesHotThreadsResponse>(
 					p.DeserializationState(new NodesHotThreadConverter(DeserializeNodesHotThreadResponse)))
@@ -138,7 +138,7 @@ namespace Nest
 		public INodesShutdownResponse NodesShutdown(Func<NodesShutdownDescriptor, NodesShutdownDescriptor> nodesShutdownSelector = null)
 		{
 			nodesShutdownSelector = nodesShutdownSelector ?? (s => s);
-			return this.Dispatch<NodesShutdownDescriptor, NodesShutdownRequestParameters, NodesShutdownResponse>(
+			return this.Dispatcher.Dispatch<NodesShutdownDescriptor, NodesShutdownRequestParameters, NodesShutdownResponse>(
 				nodesShutdownSelector,
 				(p, d) => this.RawDispatch.NodesShutdownDispatch<NodesShutdownResponse>(p)
 			);
@@ -148,7 +148,7 @@ namespace Nest
 		public Task<INodesShutdownResponse> NodesShutdownAsync(Func<NodesShutdownDescriptor, NodesShutdownDescriptor> nodesShutdownSelector = null)
 		{
 			nodesShutdownSelector = nodesShutdownSelector ?? (s => s);
-			return this.DispatchAsync<NodesShutdownDescriptor, NodesShutdownRequestParameters, NodesShutdownResponse, INodesShutdownResponse>(
+			return this.Dispatcher.DispatchAsync<NodesShutdownDescriptor, NodesShutdownRequestParameters, NodesShutdownResponse, INodesShutdownResponse>(
 				nodesShutdownSelector,
 				(p, d) => this.RawDispatch.NodesShutdownDispatchAsync<NodesShutdownResponse>(p)
 			);
@@ -157,7 +157,7 @@ namespace Nest
 		/// <inheritdoc />
 		public INodesShutdownResponse NodesShutdown(INodesShutdownRequest nodesShutdownRequest)
 		{
-			return this.Dispatch<INodesShutdownRequest, NodesShutdownRequestParameters, NodesShutdownResponse>(
+			return this.Dispatcher.Dispatch<INodesShutdownRequest, NodesShutdownRequestParameters, NodesShutdownResponse>(
 				nodesShutdownRequest,
 				(p, d) => this.RawDispatch.NodesShutdownDispatch<NodesShutdownResponse>(p)
 			);
@@ -166,7 +166,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<INodesShutdownResponse> NodesShutdownAsync(INodesShutdownRequest nodesShutdownRequest)
 		{
-			return this.DispatchAsync<INodesShutdownRequest, NodesShutdownRequestParameters, NodesShutdownResponse, INodesShutdownResponse>(
+			return this.Dispatcher.DispatchAsync<INodesShutdownRequest, NodesShutdownRequestParameters, NodesShutdownResponse, INodesShutdownResponse>(
 				nodesShutdownRequest,
 				(p, d) => this.RawDispatch.NodesShutdownDispatchAsync<NodesShutdownResponse>(p)
 			);

--- a/src/Nest/ElasticClient-OpenClose.cs
+++ b/src/Nest/ElasticClient-OpenClose.cs
@@ -9,7 +9,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse OpenIndex(Func<OpenIndexDescriptor, OpenIndexDescriptor> openIndexSelector)
 		{
-			return this.Dispatch<OpenIndexDescriptor, OpenIndexRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<OpenIndexDescriptor, OpenIndexRequestParameters, IndicesOperationResponse>(
 				openIndexSelector,
 				(p, d) => this.RawDispatch.IndicesOpenDispatch<IndicesOperationResponse>(p)
 			);
@@ -18,7 +18,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse OpenIndex(IOpenIndexRequest openIndexRequest)
 		{
-			return this.Dispatch<IOpenIndexRequest, OpenIndexRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<IOpenIndexRequest, OpenIndexRequestParameters, IndicesOperationResponse>(
 				openIndexRequest,
 				(p, d) => this.RawDispatch.IndicesOpenDispatch<IndicesOperationResponse>(p)
 			);
@@ -27,7 +27,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> OpenIndexAsync(Func<OpenIndexDescriptor, OpenIndexDescriptor> openIndexSelector)
 		{
-			return this.DispatchAsync<OpenIndexDescriptor, OpenIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<OpenIndexDescriptor, OpenIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 				openIndexSelector,
 				(p, d) => this.RawDispatch.IndicesOpenDispatchAsync<IndicesOperationResponse>(p)
 			);
@@ -36,7 +36,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> OpenIndexAsync(IOpenIndexRequest openIndexRequest)
 		{
-			return this.DispatchAsync<IOpenIndexRequest, OpenIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IOpenIndexRequest, OpenIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 				openIndexRequest,
 				(p, d) => this.RawDispatch.IndicesOpenDispatchAsync<IndicesOperationResponse>(p)
 			);
@@ -48,7 +48,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse CloseIndex(Func<CloseIndexDescriptor, CloseIndexDescriptor> closeIndexSelector)
 		{
-			return this.Dispatch<CloseIndexDescriptor, CloseIndexRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<CloseIndexDescriptor, CloseIndexRequestParameters, IndicesOperationResponse>(
 				closeIndexSelector,
 				(p, d) => this.RawDispatch.IndicesCloseDispatch<IndicesOperationResponse>(p)
 			);
@@ -57,7 +57,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse CloseIndex(ICloseIndexRequest closeIndexRequest)
 		{
-			return this.Dispatch<ICloseIndexRequest, CloseIndexRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<ICloseIndexRequest, CloseIndexRequestParameters, IndicesOperationResponse>(
 				closeIndexRequest,
 				(p, d) => this.RawDispatch.IndicesCloseDispatch<IndicesOperationResponse>(p)
 			);
@@ -66,7 +66,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> CloseIndexAsync(Func<CloseIndexDescriptor, CloseIndexDescriptor> closeIndexSelector)
 		{
-			return this.DispatchAsync
+			return this.Dispatcher.DispatchAsync
 				<CloseIndexDescriptor, CloseIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					closeIndexSelector,
 					(p, d) => this.RawDispatch.IndicesCloseDispatchAsync<IndicesOperationResponse>(p)
@@ -76,7 +76,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> CloseIndexAsync(ICloseIndexRequest closeIndexRequest)
 		{
-			return this.DispatchAsync<ICloseIndexRequest, CloseIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<ICloseIndexRequest, CloseIndexRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					closeIndexRequest,
 					(p, d) => this.RawDispatch.IndicesCloseDispatchAsync<IndicesOperationResponse>(p)
 				);

--- a/src/Nest/ElasticClient-Optimize.cs
+++ b/src/Nest/ElasticClient-Optimize.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IShardsOperationResponse Optimize(Func<OptimizeDescriptor, OptimizeDescriptor> optimizeSelector = null)
 		{
 			optimizeSelector = optimizeSelector ?? (s => s);
-			return this.Dispatch<OptimizeDescriptor, OptimizeRequestParameters, ShardsOperationResponse>(
+			return this.Dispatcher.Dispatch<OptimizeDescriptor, OptimizeRequestParameters, ShardsOperationResponse>(
 				optimizeSelector,
 				(p, d) => this.RawDispatch.IndicesOptimizeDispatch<ShardsOperationResponse>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IShardsOperationResponse Optimize(IOptimizeRequest optimizeRequest)
 		{
-			return this.Dispatch<IOptimizeRequest, OptimizeRequestParameters, ShardsOperationResponse>(
+			return this.Dispatcher.Dispatch<IOptimizeRequest, OptimizeRequestParameters, ShardsOperationResponse>(
 				optimizeRequest,
 				(p, d) => this.RawDispatch.IndicesOptimizeDispatch<ShardsOperationResponse>(p)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<IShardsOperationResponse> OptimizeAsync(Func<OptimizeDescriptor, OptimizeDescriptor> optimizeSelector = null)
 		{
 			optimizeSelector = optimizeSelector ?? (s => s);
-			return this.DispatchAsync<OptimizeDescriptor, OptimizeRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+			return this.Dispatcher.DispatchAsync<OptimizeDescriptor, OptimizeRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
 				optimizeSelector,
 				(p, d) => this.RawDispatch.IndicesOptimizeDispatchAsync<ShardsOperationResponse>(p)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IShardsOperationResponse> OptimizeAsync(IOptimizeRequest optimizeRequest)
 		{
-			return this.DispatchAsync<IOptimizeRequest, OptimizeRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IOptimizeRequest, OptimizeRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
 				optimizeRequest,
 				(p, d) => this.RawDispatch.IndicesOptimizeDispatchAsync<ShardsOperationResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Percolate.cs
+++ b/src/Nest/ElasticClient-Percolate.cs
@@ -13,7 +13,7 @@ namespace Nest
 			where T : class
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<UnregisterPercolatorDescriptor<T>, DeleteRequestParameters, UnregisterPercolateResponse>(
+			return this.Dispatcher.Dispatch<UnregisterPercolatorDescriptor<T>, DeleteRequestParameters, UnregisterPercolateResponse>(
 				s => selector(s.Name(name)),
 				(p, d) => this.RawDispatch.DeleteDispatch<UnregisterPercolateResponse>(p)
 			);
@@ -22,7 +22,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IUnregisterPercolateResponse UnregisterPercolator(IUnregisterPercolatorRequest unregisterPercolatorRequest)
 		{
-			return this.Dispatch<IUnregisterPercolatorRequest, DeleteRequestParameters, UnregisterPercolateResponse>(
+			return this.Dispatcher.Dispatch<IUnregisterPercolatorRequest, DeleteRequestParameters, UnregisterPercolateResponse>(
 				unregisterPercolatorRequest,
 				(p, d) => this.RawDispatch.DeleteDispatch<UnregisterPercolateResponse>(p)
 			);
@@ -33,7 +33,7 @@ namespace Nest
 			where T : class
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<UnregisterPercolatorDescriptor<T>, DeleteRequestParameters, UnregisterPercolateResponse, IUnregisterPercolateResponse>(
+			return this.Dispatcher.DispatchAsync<UnregisterPercolatorDescriptor<T>, DeleteRequestParameters, UnregisterPercolateResponse, IUnregisterPercolateResponse>(
 					s => selector(s.Name(name)),
 					(p, d) => this.RawDispatch.DeleteDispatchAsync<UnregisterPercolateResponse>(p)
 				);
@@ -42,7 +42,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IUnregisterPercolateResponse> UnregisterPercolatorAsync(IUnregisterPercolatorRequest unregisterPercolatorRequest)
 		{
-			return this.DispatchAsync<IUnregisterPercolatorRequest, DeleteRequestParameters, UnregisterPercolateResponse, IUnregisterPercolateResponse>(
+			return this.Dispatcher.DispatchAsync<IUnregisterPercolatorRequest, DeleteRequestParameters, UnregisterPercolateResponse, IUnregisterPercolateResponse>(
 					unregisterPercolatorRequest,
 					(p, d) => this.RawDispatch.DeleteDispatchAsync<UnregisterPercolateResponse>(p)
 				);
@@ -55,7 +55,7 @@ namespace Nest
 			where T : class
 		{
 			percolatorSelector.ThrowIfNull("percolatorSelector");
-			return this.Dispatch<RegisterPercolatorDescriptor<T>, IndexRequestParameters, RegisterPercolateResponse>(
+			return this.Dispatcher.Dispatch<RegisterPercolatorDescriptor<T>, IndexRequestParameters, RegisterPercolateResponse>(
 				s => percolatorSelector(s.Name(name)),
 				(p, d) => this.RawDispatch.IndexDispatch<RegisterPercolateResponse>(p, d)
 			);
@@ -64,7 +64,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IRegisterPercolateResponse RegisterPercolator(IRegisterPercolatorRequest registerPercolatorRequest)
 		{
-			return this.Dispatch<IRegisterPercolatorRequest, IndexRequestParameters, RegisterPercolateResponse>(
+			return this.Dispatcher.Dispatch<IRegisterPercolatorRequest, IndexRequestParameters, RegisterPercolateResponse>(
 				registerPercolatorRequest,
 				(p, d) => this.RawDispatch.IndexDispatch<RegisterPercolateResponse>(p, d)
 			);
@@ -75,7 +75,7 @@ namespace Nest
 			where T : class
 		{
 			percolatorSelector.ThrowIfNull("percolatorSelector");
-			return this.DispatchAsync
+			return this.Dispatcher.DispatchAsync
 				<RegisterPercolatorDescriptor<T>, IndexRequestParameters, RegisterPercolateResponse, IRegisterPercolateResponse>(
 					s => percolatorSelector(s.Name(name)),
 					(p, d) => this.RawDispatch.IndexDispatchAsync<RegisterPercolateResponse>(p, d)
@@ -85,7 +85,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IRegisterPercolateResponse> RegisterPercolatorAsync(IRegisterPercolatorRequest registerPercolatorRequest) 
 		{
-			return this.DispatchAsync<IRegisterPercolatorRequest, IndexRequestParameters, RegisterPercolateResponse, IRegisterPercolateResponse>(
+			return this.Dispatcher.DispatchAsync<IRegisterPercolatorRequest, IndexRequestParameters, RegisterPercolateResponse, IRegisterPercolateResponse>(
 					registerPercolatorRequest,
 					(p, d) => this.RawDispatch.IndexDispatchAsync<RegisterPercolateResponse>(p, d)
 				);
@@ -97,7 +97,7 @@ namespace Nest
 			where T : class
 		{
 			percolateSelector = percolateSelector ?? (s => s);
-			return this.Dispatch<PercolateDescriptor<T>, PercolateRequestParameters, PercolateResponse>(
+			return this.Dispatcher.Dispatch<PercolateDescriptor<T>, PercolateRequestParameters, PercolateResponse>(
 				percolateSelector,
 				(p, d) => this.RawDispatch.PercolateDispatch<PercolateResponse>(p, d)
 			);
@@ -107,7 +107,7 @@ namespace Nest
 		public IPercolateResponse Percolate<T>(IPercolateRequest<T> percolateRequest)
 			where T : class
 		{
-			return this.Dispatch<IPercolateRequest<T>, PercolateRequestParameters, PercolateResponse>(
+			return this.Dispatcher.Dispatch<IPercolateRequest<T>, PercolateRequestParameters, PercolateResponse>(
 				percolateRequest,
 				(p, d) => this.RawDispatch.PercolateDispatch<PercolateResponse>(p, d)
 			);
@@ -118,7 +118,7 @@ namespace Nest
 			where T : class
 		{
 			percolateSelector = percolateSelector ?? (s => s);
-			return this.DispatchAsync<PercolateDescriptor<T>, PercolateRequestParameters, PercolateResponse, IPercolateResponse>(
+			return this.Dispatcher.DispatchAsync<PercolateDescriptor<T>, PercolateRequestParameters, PercolateResponse, IPercolateResponse>(
 				percolateSelector,
 				(p, d) => this.RawDispatch.PercolateDispatchAsync<PercolateResponse>(p, d)
 			);
@@ -128,7 +128,7 @@ namespace Nest
 		public Task<IPercolateResponse> PercolateAsync<T>(IPercolateRequest<T> percolateRequest)
 			where T : class
 		{
-			return this.DispatchAsync<IPercolateRequest<T>, PercolateRequestParameters, PercolateResponse, IPercolateResponse>(
+			return this.Dispatcher.DispatchAsync<IPercolateRequest<T>, PercolateRequestParameters, PercolateResponse, IPercolateResponse>(
 				percolateRequest,
 				(p, d) => this.RawDispatch.PercolateDispatchAsync<PercolateResponse>(p, d)
 			);
@@ -140,7 +140,7 @@ namespace Nest
 		public IPercolateCountResponse PercolateCount<T>(Func<PercolateCountDescriptor<T>, PercolateCountDescriptor<T>> percolateSelector)
 			where T : class
 		{
-			return this.Dispatch<PercolateCountDescriptor<T>, PercolateCountRequestParameters, PercolateCountResponse>(
+			return this.Dispatcher.Dispatch<PercolateCountDescriptor<T>, PercolateCountRequestParameters, PercolateCountResponse>(
 				percolateSelector,
 				(p, d) => this.RawDispatch.CountPercolateDispatch<PercolateCountResponse>(p, d)
 			);
@@ -151,7 +151,7 @@ namespace Nest
 			where T : class
 		{
 			percolateSelector = percolateSelector ?? (s => s);
-			return this.Dispatch<PercolateCountDescriptor<T>, PercolateCountRequestParameters, PercolateCountResponse>(
+			return this.Dispatcher.Dispatch<PercolateCountDescriptor<T>, PercolateCountRequestParameters, PercolateCountResponse>(
 				s => percolateSelector(s.Object(@object)),
 				(p, d) => this.RawDispatch.CountPercolateDispatch<PercolateCountResponse>(p, d)
 			);
@@ -161,7 +161,7 @@ namespace Nest
 		public IPercolateCountResponse PercolateCount<T>(IPercolateCountRequest<T> percolateCountRequest)
 			where T : class
 		{
-			return this.Dispatch<IPercolateCountRequest<T>, PercolateCountRequestParameters, PercolateCountResponse>(
+			return this.Dispatcher.Dispatch<IPercolateCountRequest<T>, PercolateCountRequestParameters, PercolateCountResponse>(
 				percolateCountRequest,
 				(p, d) => this.RawDispatch.CountPercolateDispatch<PercolateCountResponse>(p, d)
 			);
@@ -171,7 +171,7 @@ namespace Nest
 		public Task<IPercolateCountResponse> PercolateCountAsync<T>(Func<PercolateCountDescriptor<T>, PercolateCountDescriptor<T>> percolateSelector)
 			where T : class
 		{
-			return this.DispatchAsync<PercolateCountDescriptor<T>, PercolateCountRequestParameters, PercolateCountResponse, IPercolateCountResponse>(
+			return this.Dispatcher.DispatchAsync<PercolateCountDescriptor<T>, PercolateCountRequestParameters, PercolateCountResponse, IPercolateCountResponse>(
 				percolateSelector,
 				(p, d) => this.RawDispatch.CountPercolateDispatchAsync<PercolateCountResponse>(p, d)
 			);
@@ -182,7 +182,7 @@ namespace Nest
 			where T : class
 		{
 			percolateSelector = percolateSelector ?? (s => s);
-			return this.DispatchAsync<PercolateCountDescriptor<T>, PercolateCountRequestParameters, PercolateCountResponse, IPercolateCountResponse>(
+			return this.Dispatcher.DispatchAsync<PercolateCountDescriptor<T>, PercolateCountRequestParameters, PercolateCountResponse, IPercolateCountResponse>(
 				s => percolateSelector(s.Object(@object)),
 				(p, d) => this.RawDispatch.CountPercolateDispatchAsync<PercolateCountResponse>(p, d)
 			);
@@ -192,7 +192,7 @@ namespace Nest
 		public Task<IPercolateCountResponse> PercolateCountAsync<T>(IPercolateCountRequest<T> percolateCountRequest)
 			where T : class
 		{
-			return this.DispatchAsync<IPercolateCountRequest<T>, PercolateCountRequestParameters, PercolateCountResponse, IPercolateCountResponse>(
+			return this.Dispatcher.DispatchAsync<IPercolateCountRequest<T>, PercolateCountRequestParameters, PercolateCountResponse, IPercolateCountResponse>(
 				percolateCountRequest,
 				(p, d) => this.RawDispatch.CountPercolateDispatchAsync<PercolateCountResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-Ping.cs
+++ b/src/Nest/ElasticClient-Ping.cs
@@ -16,7 +16,7 @@ namespace Nest
 		public IPingResponse Ping(Func<PingDescriptor, PingDescriptor> pingSelector = null)
 		{
 			pingSelector = pingSelector ?? (s => s);
-			return this.Dispatch<PingDescriptor, PingRequestParameters, PingResponse>(
+			return this.Dispatcher.Dispatch<PingDescriptor, PingRequestParameters, PingResponse>(
 				pingSelector,
 				(p, d) => 
 				{	
@@ -33,7 +33,7 @@ namespace Nest
 		public Task<IPingResponse> PingAsync(Func<PingDescriptor, PingDescriptor> pingSelector = null)
 		{
 			pingSelector = pingSelector ?? (s => s);
-			return this.DispatchAsync<PingDescriptor, PingRequestParameters, PingResponse, IPingResponse>(
+			return this.Dispatcher.DispatchAsync<PingDescriptor, PingRequestParameters, PingResponse, IPingResponse>(
 				pingSelector,
 				(p, d) =>
 				{
@@ -48,7 +48,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IPingResponse Ping(IPingRequest pingRequest)
 		{
-			return this.Dispatch<IPingRequest, PingRequestParameters, PingResponse>(
+			return this.Dispatcher.Dispatch<IPingRequest, PingRequestParameters, PingResponse>(
 				pingRequest,
 				(p, d) =>
 				{
@@ -63,7 +63,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IPingResponse> PingAsync(IPingRequest pingRequest)
 		{
-			return this.DispatchAsync<IPingRequest, PingRequestParameters, PingResponse, IPingResponse>(
+			return this.Dispatcher.DispatchAsync<IPingRequest, PingRequestParameters, PingResponse, IPingResponse>(
 				pingRequest,
 				(p, d) =>
 				{

--- a/src/Nest/ElasticClient-RecoveryStatus.cs
+++ b/src/Nest/ElasticClient-RecoveryStatus.cs
@@ -15,7 +15,7 @@ namespace Nest
 		public IRecoveryStatusResponse RecoveryStatus(Func<RecoveryStatusDescriptor, RecoveryStatusDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<RecoveryStatusDescriptor, RecoveryStatusRequestParameters, RecoveryStatusResponse>(
+			return this.Dispatcher.Dispatch<RecoveryStatusDescriptor, RecoveryStatusRequestParameters, RecoveryStatusResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesRecoveryDispatch<RecoveryStatusResponse>(
 					p.DeserializationState(new RecoveryStatusConverter(DeserializeRecoveryStatusResponse))
@@ -26,7 +26,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IRecoveryStatusResponse RecoveryStatus(IRecoveryStatusRequest statusRequest)
 		{
-			return this.Dispatch<IRecoveryStatusRequest, RecoveryStatusRequestParameters, RecoveryStatusResponse>(
+			return this.Dispatcher.Dispatch<IRecoveryStatusRequest, RecoveryStatusRequestParameters, RecoveryStatusResponse>(
 				statusRequest,
 				(p, d) => this.RawDispatch.IndicesRecoveryDispatch<RecoveryStatusResponse>(
 					p.DeserializationState(new RecoveryStatusConverter(DeserializeRecoveryStatusResponse))
@@ -38,7 +38,7 @@ namespace Nest
 		public Task<IRecoveryStatusResponse> RecoveryStatusAsync(Func<RecoveryStatusDescriptor, RecoveryStatusDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<RecoveryStatusDescriptor, RecoveryStatusRequestParameters, RecoveryStatusResponse, IRecoveryStatusResponse>(
+			return this.Dispatcher.DispatchAsync<RecoveryStatusDescriptor, RecoveryStatusRequestParameters, RecoveryStatusResponse, IRecoveryStatusResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesRecoveryDispatchAsync<RecoveryStatusResponse>(
 					p.DeserializationState(new RecoveryStatusConverter(DeserializeRecoveryStatusResponse))
@@ -49,7 +49,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IRecoveryStatusResponse> RecoveryStatusAsync(IRecoveryStatusRequest statusRequest)
 		{
-			return this.DispatchAsync<IRecoveryStatusRequest, RecoveryStatusRequestParameters, RecoveryStatusResponse, IRecoveryStatusResponse>(
+			return this.Dispatcher.DispatchAsync<IRecoveryStatusRequest, RecoveryStatusRequestParameters, RecoveryStatusResponse, IRecoveryStatusResponse>(
 				statusRequest,
 				(p, d) => this.RawDispatch.IndicesRecoveryDispatchAsync<RecoveryStatusResponse>(
 					p.DeserializationState(new RecoveryStatusConverter(DeserializeRecoveryStatusResponse))

--- a/src/Nest/ElasticClient-Refresh.cs
+++ b/src/Nest/ElasticClient-Refresh.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IShardsOperationResponse Refresh(Func<RefreshDescriptor, RefreshDescriptor> refreshSelector = null)
 		{
 			refreshSelector = refreshSelector ?? (s => s);
-			return this.Dispatch<RefreshDescriptor, RefreshRequestParameters, ShardsOperationResponse>(
+			return this.Dispatcher.Dispatch<RefreshDescriptor, RefreshRequestParameters, ShardsOperationResponse>(
 				refreshSelector,
 				(p, d) => this.RawDispatch.IndicesRefreshDispatch<ShardsOperationResponse>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IShardsOperationResponse Refresh(IRefreshRequest refreshRequest)
 		{
-			return this.Dispatch<IRefreshRequest, RefreshRequestParameters, ShardsOperationResponse>(
+			return this.Dispatcher.Dispatch<IRefreshRequest, RefreshRequestParameters, ShardsOperationResponse>(
 				refreshRequest,
 				(p, d) => this.RawDispatch.IndicesRefreshDispatch<ShardsOperationResponse>(p)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<IShardsOperationResponse> RefreshAsync(Func<RefreshDescriptor, RefreshDescriptor> refreshSelector = null)
 		{
 			refreshSelector = refreshSelector ?? (s => s);
-			return this.DispatchAsync<RefreshDescriptor, RefreshRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+			return this.Dispatcher.DispatchAsync<RefreshDescriptor, RefreshRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
 				refreshSelector,
 				(p, d) => this.RawDispatch.IndicesRefreshDispatchAsync<ShardsOperationResponse>(p)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IShardsOperationResponse> RefreshAsync(IRefreshRequest refreshRequest)
 		{
-			return this.DispatchAsync<IRefreshRequest, RefreshRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IRefreshRequest, RefreshRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
 				refreshRequest,
 				(p, d) => this.RawDispatch.IndicesRefreshDispatchAsync<ShardsOperationResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Repository.cs
+++ b/src/Nest/ElasticClient-Repository.cs
@@ -13,7 +13,7 @@ namespace Nest
 		public IAcknowledgedResponse CreateRepository(string name, Func<CreateRepositoryDescriptor, CreateRepositoryDescriptor> selector)
 		{
 			name.ThrowIfNullOrEmpty("name");
-			return this.Dispatch<CreateRepositoryDescriptor, CreateRepositoryRequestParameters, AcknowledgedResponse>(
+			return this.Dispatcher.Dispatch<CreateRepositoryDescriptor, CreateRepositoryRequestParameters, AcknowledgedResponse>(
 				s => selector(s.Repository(name)),
 				(p, d) => this.RawDispatch.SnapshotCreateRepositoryDispatch<AcknowledgedResponse>(p, ((ICreateRepositoryRequest)d).Repository)
 			);
@@ -22,7 +22,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IAcknowledgedResponse CreateRepository(ICreateRepositoryRequest request)
 		{
-			return this.Dispatch<ICreateRepositoryRequest, CreateRepositoryRequestParameters, AcknowledgedResponse>(
+			return this.Dispatcher.Dispatch<ICreateRepositoryRequest, CreateRepositoryRequestParameters, AcknowledgedResponse>(
 				request,
 				(p, d) => this.RawDispatch.SnapshotCreateRepositoryDispatch<AcknowledgedResponse>(p, ((ICreateRepositoryRequest)d).Repository)
 			);
@@ -32,7 +32,7 @@ namespace Nest
 		public Task<IAcknowledgedResponse> CreateRepositoryAsync(string name, Func<CreateRepositoryDescriptor, CreateRepositoryDescriptor> selector)
 		{
 			name.ThrowIfNullOrEmpty("name");
-			return this.DispatchAsync<CreateRepositoryDescriptor, CreateRepositoryRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
+			return this.Dispatcher.DispatchAsync<CreateRepositoryDescriptor, CreateRepositoryRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
 				s => selector(s.Repository(name)),
 				(p, d) => this.RawDispatch.SnapshotCreateRepositoryDispatchAsync<AcknowledgedResponse>(p, ((ICreateRepositoryRequest)d).Repository)
 			);
@@ -41,7 +41,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IAcknowledgedResponse> CreateRepositoryAsync(ICreateRepositoryRequest request)
 		{
-			return this.DispatchAsync<ICreateRepositoryRequest, CreateRepositoryRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
+			return this.Dispatcher.DispatchAsync<ICreateRepositoryRequest, CreateRepositoryRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
 				request,
 				(p, d) => this.RawDispatch.SnapshotCreateRepositoryDispatchAsync<AcknowledgedResponse>(p, ((ICreateRepositoryRequest)d).Repository)
 			);
@@ -50,7 +50,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetRepositoryResponse GetRepository(Func<GetRepositoryDescriptor, GetRepositoryDescriptor> selector)
 		{
-			return this.Dispatch<GetRepositoryDescriptor, GetRepositoryRequestParameters, GetRepositoryResponse>(
+			return this.Dispatcher.Dispatch<GetRepositoryDescriptor, GetRepositoryRequestParameters, GetRepositoryResponse>(
 				selector,
 				(p, d) => this.RawDispatch.SnapshotGetRepositoryDispatch<GetRepositoryResponse>(p)
 			);
@@ -59,7 +59,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetRepositoryResponse GetRepository(IGetRepositoryRequest request)
 		{
-			return this.Dispatch<IGetRepositoryRequest, GetRepositoryRequestParameters, GetRepositoryResponse>(
+			return this.Dispatcher.Dispatch<IGetRepositoryRequest, GetRepositoryRequestParameters, GetRepositoryResponse>(
 				request,
 				(p, d) => this.RawDispatch.SnapshotGetRepositoryDispatch<GetRepositoryResponse>(p)
 			);
@@ -68,7 +68,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetRepositoryResponse> GetRepositoryAsync(Func<GetRepositoryDescriptor, GetRepositoryDescriptor> selector)
 		{
-			return this.DispatchAsync<GetRepositoryDescriptor, GetRepositoryRequestParameters, GetRepositoryResponse, IGetRepositoryResponse>(
+			return this.Dispatcher.DispatchAsync<GetRepositoryDescriptor, GetRepositoryRequestParameters, GetRepositoryResponse, IGetRepositoryResponse>(
 				selector,
 				(p, d) => this.RawDispatch.SnapshotGetRepositoryDispatchAsync<GetRepositoryResponse>(p)
 			);
@@ -77,7 +77,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetRepositoryResponse> GetRepositoryAsync(IGetRepositoryRequest request)
 		{
-			return this.DispatchAsync<IGetRepositoryRequest, GetRepositoryRequestParameters, GetRepositoryResponse, IGetRepositoryResponse>(
+			return this.Dispatcher.DispatchAsync<IGetRepositoryRequest, GetRepositoryRequestParameters, GetRepositoryResponse, IGetRepositoryResponse>(
 				request,
 				(p, d) => this.RawDispatch.SnapshotGetRepositoryDispatchAsync<GetRepositoryResponse>(p)
 			);
@@ -88,7 +88,7 @@ namespace Nest
 		{
 			name.ThrowIfNullOrEmpty("name");
 			selector = selector ?? (s => s);
-			return this.Dispatch<DeleteRepositoryDescriptor, DeleteRepositoryRequestParameters, AcknowledgedResponse>(
+			return this.Dispatcher.Dispatch<DeleteRepositoryDescriptor, DeleteRepositoryRequestParameters, AcknowledgedResponse>(
 				s => selector(s.Repository(name)),
 				(p, d) => this.RawDispatch.SnapshotDeleteRepositoryDispatch<AcknowledgedResponse>(p)
 			);
@@ -97,7 +97,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IAcknowledgedResponse DeleteRepository(IDeleteRepositoryRequest deleteRepositoryRequest)
 		{
-			return this.Dispatch<IDeleteRepositoryRequest, DeleteRepositoryRequestParameters, AcknowledgedResponse>(
+			return this.Dispatcher.Dispatch<IDeleteRepositoryRequest, DeleteRepositoryRequestParameters, AcknowledgedResponse>(
 				deleteRepositoryRequest,
 				(p, d) => this.RawDispatch.SnapshotDeleteRepositoryDispatch<AcknowledgedResponse>(p)
 			);
@@ -108,7 +108,7 @@ namespace Nest
 		{
 			name.ThrowIfNullOrEmpty("name");
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<DeleteRepositoryDescriptor, DeleteRepositoryRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
+			return this.Dispatcher.DispatchAsync<DeleteRepositoryDescriptor, DeleteRepositoryRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
 				s => selector(s.Repository(name)),
 				(p, d) => this.RawDispatch.SnapshotDeleteRepositoryDispatchAsync<AcknowledgedResponse>(p)
 			);
@@ -117,7 +117,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IAcknowledgedResponse> DeleteRepositoryAsync(IDeleteRepositoryRequest deleteRepositoryRequest)
 		{
-			return this.DispatchAsync<IDeleteRepositoryRequest, DeleteRepositoryRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteRepositoryRequest, DeleteRepositoryRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
 				deleteRepositoryRequest,
 				(p, d) => this.RawDispatch.SnapshotDeleteRepositoryDispatchAsync<AcknowledgedResponse>(p)
 			);
@@ -128,7 +128,7 @@ namespace Nest
 		{
 			name.ThrowIfNullOrEmpty("name");
 			selector = selector ?? (s => s);
-			return this.Dispatch<VerifyRepositoryDescriptor, VerifyRepositoryRequestParameters, VerifyRepositoryResponse>(
+			return this.Dispatcher.Dispatch<VerifyRepositoryDescriptor, VerifyRepositoryRequestParameters, VerifyRepositoryResponse>(
 				s => selector(s.Repository(name)),
 				(p, d) => this.RawDispatch.SnapshotVerifyRepositoryDispatch<VerifyRepositoryResponse>(p)
 			);
@@ -137,7 +137,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IVerifyRepositoryResponse VerifyRepository(IVerifyRepositoryRequest verifyRepositoryRequest)
 		{
-			return this.Dispatch<IVerifyRepositoryRequest, VerifyRepositoryRequestParameters, VerifyRepositoryResponse>(
+			return this.Dispatcher.Dispatch<IVerifyRepositoryRequest, VerifyRepositoryRequestParameters, VerifyRepositoryResponse>(
 				verifyRepositoryRequest,
 				(p, d) => this.RawDispatch.SnapshotVerifyRepositoryDispatch<VerifyRepositoryResponse>(p)
 			);
@@ -148,7 +148,7 @@ namespace Nest
 		{
 			name.ThrowIfNullOrEmpty("name");
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<VerifyRepositoryDescriptor, VerifyRepositoryRequestParameters, VerifyRepositoryResponse, IVerifyRepositoryResponse>(
+			return this.Dispatcher.DispatchAsync<VerifyRepositoryDescriptor, VerifyRepositoryRequestParameters, VerifyRepositoryResponse, IVerifyRepositoryResponse>(
 				s => selector(s.Repository(name)),
 				(p, d) => this.RawDispatch.SnapshotVerifyRepositoryDispatchAsync<VerifyRepositoryResponse>(p)
 			);
@@ -157,7 +157,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IVerifyRepositoryResponse> VerifyRepositoryAsync(IVerifyRepositoryRequest verifyRepositoryRequest)
 		{
-			return this.DispatchAsync<IVerifyRepositoryRequest, VerifyRepositoryRequestParameters, VerifyRepositoryResponse, IVerifyRepositoryResponse>(
+			return this.Dispatcher.DispatchAsync<IVerifyRepositoryRequest, VerifyRepositoryRequestParameters, VerifyRepositoryResponse, IVerifyRepositoryResponse>(
 				verifyRepositoryRequest,
 				(p, d) => this.RawDispatch.SnapshotVerifyRepositoryDispatchAsync<VerifyRepositoryResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Restore.cs
+++ b/src/Nest/ElasticClient-Restore.cs
@@ -9,7 +9,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IRestoreResponse Restore(IRestoreRequest restoreRequest)
 		{
-			return this.Dispatch<IRestoreRequest, RestoreRequestParameters, RestoreResponse>(
+			return this.Dispatcher.Dispatch<IRestoreRequest, RestoreRequestParameters, RestoreResponse>(
 				restoreRequest,
 				(p, d) => this.RawDispatch.SnapshotRestoreDispatch<RestoreResponse>(p, d)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 			snapshotName.ThrowIfNullOrEmpty("name");
 			repository.ThrowIfNullOrEmpty("repository");
 			selector = selector ?? (s => s);
-			return this.Dispatch<RestoreDescriptor, RestoreRequestParameters, RestoreResponse>(
+			return this.Dispatcher.Dispatch<RestoreDescriptor, RestoreRequestParameters, RestoreResponse>(
 				s => selector(s.Snapshot(snapshotName).Repository(repository)),
 				(p, d) => this.RawDispatch.SnapshotRestoreDispatch<RestoreResponse>(p, d)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IRestoreResponse> RestoreAsync(IRestoreRequest restoreRequest)
 		{
-			return this.DispatchAsync<IRestoreRequest, RestoreRequestParameters, RestoreResponse, IRestoreResponse>(
+			return this.Dispatcher.DispatchAsync<IRestoreRequest, RestoreRequestParameters, RestoreResponse, IRestoreResponse>(
 				restoreRequest,
 				(p, d) => this.RawDispatch.SnapshotRestoreDispatchAsync<RestoreResponse>(p, d)
 			);
@@ -42,7 +42,7 @@ namespace Nest
 			snapshotName.ThrowIfNullOrEmpty("name");
 			repository.ThrowIfNullOrEmpty("repository");
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<RestoreDescriptor, RestoreRequestParameters, RestoreResponse, IRestoreResponse>(
+			return this.Dispatcher.DispatchAsync<RestoreDescriptor, RestoreRequestParameters, RestoreResponse, IRestoreResponse>(
 				s => selector(s.Snapshot(snapshotName).Repository(repository)),
 				(p, d) => this.RawDispatch.SnapshotRestoreDispatchAsync<RestoreResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-RootNodeInfo.cs
+++ b/src/Nest/ElasticClient-RootNodeInfo.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IRootInfoResponse RootNodeInfo(Func<InfoDescriptor, InfoDescriptor> selector = null)
 		{
 			selector = selector ?? (i => i);
-			return this.Dispatch<InfoDescriptor, InfoRequestParameters, RootInfoResponse>(
+			return this.Dispatcher.Dispatch<InfoDescriptor, InfoRequestParameters, RootInfoResponse>(
 				selector,
 				(p, d) => this.RawDispatch.InfoDispatch<RootInfoResponse>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IRootInfoResponse RootNodeInfo(IInfoRequest infoRequest)
 		{
-			return this.Dispatch<IInfoRequest, InfoRequestParameters, RootInfoResponse>(
+			return this.Dispatcher.Dispatch<IInfoRequest, InfoRequestParameters, RootInfoResponse>(
 				infoRequest,
 				(p, d) => this.RawDispatch.InfoDispatch<RootInfoResponse>(p)
 				);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<IRootInfoResponse> RootNodeInfoAsync(Func<InfoDescriptor, InfoDescriptor> selector = null)
 		{
 			selector = selector ?? (i => i);
-			return this.DispatchAsync<InfoDescriptor, InfoRequestParameters, RootInfoResponse, IRootInfoResponse>(
+			return this.Dispatcher.DispatchAsync<InfoDescriptor, InfoRequestParameters, RootInfoResponse, IRootInfoResponse>(
 				selector,
 				(p, d) => this.RawDispatch.InfoDispatchAsync<RootInfoResponse>(p)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IRootInfoResponse> RootNodeInfoAsync(IInfoRequest inforRequest)
 		{
-			return this.DispatchAsync<IInfoRequest, InfoRequestParameters, RootInfoResponse, IRootInfoResponse>(
+			return this.Dispatcher.DispatchAsync<IInfoRequest, InfoRequestParameters, RootInfoResponse, IRootInfoResponse>(
 				inforRequest,
 				(p, d) => this.RawDispatch.InfoDispatchAsync<RootInfoResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Scripts.cs
+++ b/src/Nest/ElasticClient-Scripts.cs
@@ -8,7 +8,7 @@ namespace Nest
     {
         public IPutScriptResponse PutScript(Func<PutScriptDescriptor, PutScriptDescriptor> putScriptDescriptor)
         {
-            return this.Dispatch<PutScriptDescriptor, PutScriptRequestParameters, PutScriptResponse>(
+            return this.Dispatcher.Dispatch<PutScriptDescriptor, PutScriptRequestParameters, PutScriptResponse>(
                     putScriptDescriptor,
                     (p, d) => this.RawDispatch.PutScriptDispatch<PutScriptResponse>(p, d)
                 );
@@ -16,7 +16,7 @@ namespace Nest
 
         public Task<IPutScriptResponse> PutScriptAsync(Func<PutScriptDescriptor, PutScriptDescriptor> putScriptDescriptor)
         {
-            return this.DispatchAsync<PutScriptDescriptor, PutScriptRequestParameters, PutScriptResponse, IPutScriptResponse>(
+            return this.Dispatcher.DispatchAsync<PutScriptDescriptor, PutScriptRequestParameters, PutScriptResponse, IPutScriptResponse>(
                     putScriptDescriptor,
                     (p, d) => this.RawDispatch.PutScriptDispatchAsync<PutScriptResponse>(p, d)
                 );
@@ -24,7 +24,7 @@ namespace Nest
 
         public IGetScriptResponse GetScript(Func<GetScriptDescriptor, GetScriptDescriptor> getScriptDescriptor)
         {
-            return this.Dispatch<GetScriptDescriptor, GetScriptRequestParameters, GetScriptResponse>(
+            return this.Dispatcher.Dispatch<GetScriptDescriptor, GetScriptRequestParameters, GetScriptResponse>(
                     getScriptDescriptor,
                     (p, d) => this.RawDispatch.GetScriptDispatch<GetScriptResponse>(p)
                 );
@@ -32,7 +32,7 @@ namespace Nest
 
         public Task<IGetScriptResponse> GetScriptAsync(Func<GetScriptDescriptor, GetScriptDescriptor> getScriptDescriptor)
         {
-            return this.DispatchAsync<GetScriptDescriptor, GetScriptRequestParameters, GetScriptResponse, IGetScriptResponse>(
+            return this.Dispatcher.DispatchAsync<GetScriptDescriptor, GetScriptRequestParameters, GetScriptResponse, IGetScriptResponse>(
                     getScriptDescriptor,
                     (p, d) => this.RawDispatch.GetScriptDispatchAsync<GetScriptResponse>(p)
                 );
@@ -40,7 +40,7 @@ namespace Nest
 
         public IDeleteScriptResponse DeleteScript(Func<DeleteScriptDescriptor, DeleteScriptDescriptor> deleteScriptDescriptor)
         {
-            return this.Dispatch<DeleteScriptDescriptor, DeleteScriptRequestParameters, DeleteScriptResponse>(
+            return this.Dispatcher.Dispatch<DeleteScriptDescriptor, DeleteScriptRequestParameters, DeleteScriptResponse>(
                     deleteScriptDescriptor,
                     (p, d) => this.RawDispatch.DeleteScriptDispatch<DeleteScriptResponse>(p)
                 );
@@ -48,7 +48,7 @@ namespace Nest
 
         public Task<IDeleteScriptResponse> DeleteScriptAsync(Func<DeleteScriptDescriptor, DeleteScriptDescriptor> deleteScriptDescriptor)
         {
-            return this.DispatchAsync<DeleteScriptDescriptor, DeleteScriptRequestParameters, DeleteScriptResponse, IDeleteScriptResponse>(
+            return this.Dispatcher.DispatchAsync<DeleteScriptDescriptor, DeleteScriptRequestParameters, DeleteScriptResponse, IDeleteScriptResponse>(
                     deleteScriptDescriptor,
                     (p, d) => this.RawDispatch.DeleteScriptDispatchAsync<DeleteScriptResponse>(p)
                 );

--- a/src/Nest/ElasticClient-Scroll.cs
+++ b/src/Nest/ElasticClient-Scroll.cs
@@ -9,7 +9,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISearchResponse<T> Scroll<T>(IScrollRequest request) where T : class
 		{
-			return this.Dispatch<IScrollRequest, ScrollRequestParameters, SearchResponse<T>>(
+			return this.Dispatcher.Dispatch<IScrollRequest, ScrollRequestParameters, SearchResponse<T>>(
 				request,
 				(p, d) =>
 				{
@@ -22,7 +22,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISearchResponse<T> Scroll<T>(Func<ScrollDescriptor<T>, ScrollDescriptor<T>> scrollSelector) where T : class
 		{
-			return this.Dispatch<ScrollDescriptor<T>, ScrollRequestParameters, SearchResponse<T>>(
+			return this.Dispatcher.Dispatch<ScrollDescriptor<T>, ScrollRequestParameters, SearchResponse<T>>(
 				scrollSelector,
 				(p, d) =>
 				{
@@ -36,7 +36,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ISearchResponse<T>> ScrollAsync<T>(IScrollRequest request) where T : class
 		{
-			return this.DispatchAsync<IScrollRequest, ScrollRequestParameters, SearchResponse<T>, ISearchResponse<T>>(
+			return this.Dispatcher.DispatchAsync<IScrollRequest, ScrollRequestParameters, SearchResponse<T>, ISearchResponse<T>>(
 				request,
 				(p, d) =>
 				{
@@ -50,7 +50,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ISearchResponse<T>> ScrollAsync<T>(Func<ScrollDescriptor<T>, ScrollDescriptor<T>> scrollSelector) where T : class
 		{
-			return this.DispatchAsync<ScrollDescriptor<T>, ScrollRequestParameters, SearchResponse<T>, ISearchResponse<T>>(
+			return this.Dispatcher.DispatchAsync<ScrollDescriptor<T>, ScrollRequestParameters, SearchResponse<T>, ISearchResponse<T>>(
 				scrollSelector,
 				(p, d) =>
 				{
@@ -66,7 +66,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IEmptyResponse ClearScroll(Func<ClearScrollDescriptor, ClearScrollDescriptor> clearScrollSelector)
 		{
-			return this.Dispatch<ClearScrollDescriptor, ClearScrollRequestParameters, EmptyResponse>(
+			return this.Dispatcher.Dispatch<ClearScrollDescriptor, ClearScrollRequestParameters, EmptyResponse>(
 				clearScrollSelector,
 				(p, d) =>
 				{
@@ -79,7 +79,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IEmptyResponse ClearScroll(IClearScrollRequest clearScrollRequest)
 		{
-			return this.Dispatch<IClearScrollRequest, ClearScrollRequestParameters, EmptyResponse>(
+			return this.Dispatcher.Dispatch<IClearScrollRequest, ClearScrollRequestParameters, EmptyResponse>(
 				clearScrollRequest,
 				(p, d) =>
 				{
@@ -92,7 +92,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IEmptyResponse> ClearScrollAsync(Func<ClearScrollDescriptor, ClearScrollDescriptor> clearScrollSelector)
 		{
-			return this.DispatchAsync<ClearScrollDescriptor, ClearScrollRequestParameters, EmptyResponse, IEmptyResponse>(
+			return this.Dispatcher.DispatchAsync<ClearScrollDescriptor, ClearScrollRequestParameters, EmptyResponse, IEmptyResponse>(
 				clearScrollSelector,
 				(p, d) =>
 				{
@@ -105,7 +105,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IEmptyResponse> ClearScrollAsync(IClearScrollRequest clearScrollRequest)
 		{
-			return this.DispatchAsync<IClearScrollRequest, ClearScrollRequestParameters, EmptyResponse, IEmptyResponse>(
+			return this.Dispatcher.DispatchAsync<IClearScrollRequest, ClearScrollRequestParameters, EmptyResponse, IEmptyResponse>(
 				clearScrollRequest,
 				(p, d) =>
 				{

--- a/src/Nest/ElasticClient-SearchExists.cs
+++ b/src/Nest/ElasticClient-SearchExists.cs
@@ -13,7 +13,7 @@ namespace Nest
 		public IExistsResponse SearchExists<T>(Func<SearchExistsDescriptor<T>, SearchExistsDescriptor<T>> selector)
 			where T : class
 		{
-			return this.Dispatch<SearchExistsDescriptor<T>, SearchExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<SearchExistsDescriptor<T>, SearchExistsRequestParameters, ExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.SearchExistsDispatch<ExistsResponse>(
 					p.DeserializationState(new SearchExistConverter(DeserializeExistsResponse))
@@ -25,7 +25,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse SearchExists(ISearchExistsRequest indexRequest)
 		{
-			return this.Dispatch<ISearchExistsRequest, SearchExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<ISearchExistsRequest, SearchExistsRequestParameters, ExistsResponse>(
 				indexRequest,
 				(p, d) => this.RawDispatch.SearchExistsDispatch<ExistsResponse>(
 					p.DeserializationState(new SearchExistConverter(DeserializeExistsResponse))
@@ -38,7 +38,7 @@ namespace Nest
 		public Task<IExistsResponse> SearchExistsAsync<T>(Func<SearchExistsDescriptor<T>, SearchExistsDescriptor<T>> selector)
 			where T : class
 		{
-			return this.DispatchAsync<SearchExistsDescriptor<T>, SearchExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<SearchExistsDescriptor<T>, SearchExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.SearchExistsDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new SearchExistConverter(DeserializeExistsResponse))
@@ -50,7 +50,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> SearchExistsAsync(ISearchExistsRequest indexRequest)
 		{
-			return this.DispatchAsync<ISearchExistsRequest, SearchExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<ISearchExistsRequest, SearchExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				indexRequest,
 				(p, d) => this.RawDispatch.SearchExistsDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new SearchExistConverter(DeserializeExistsResponse))

--- a/src/Nest/ElasticClient-SearchShards.cs
+++ b/src/Nest/ElasticClient-SearchShards.cs
@@ -13,7 +13,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISearchShardsResponse SearchShards<T>(Func<SearchShardsDescriptor<T>, SearchShardsDescriptor<T>> searchSelector) where T : class
 		{
-			return this.Dispatch<SearchShardsDescriptor<T>, SearchShardsRequestParameters, SearchShardsResponse>(
+			return this.Dispatcher.Dispatch<SearchShardsDescriptor<T>, SearchShardsRequestParameters, SearchShardsResponse>(
 				searchSelector,
 				(p, d) => this.RawDispatch.SearchShardsDispatch<SearchShardsResponse>(p)
 			);
@@ -22,7 +22,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISearchShardsResponse SearchShards(ISearchShardsRequest request)
 		{
-			return this.Dispatch<ISearchShardsRequest, SearchShardsRequestParameters, SearchShardsResponse>(
+			return this.Dispatcher.Dispatch<ISearchShardsRequest, SearchShardsRequestParameters, SearchShardsResponse>(
 				request,
 				(p, d) => this.RawDispatch.SearchShardsDispatch<SearchShardsResponse>(p)
 			);
@@ -32,7 +32,7 @@ namespace Nest
 		public Task<ISearchShardsResponse> SearchShardsAsync<T>(Func<SearchShardsDescriptor<T>, SearchShardsDescriptor<T>> searchSelector)
 			where T : class
 		{
-			return this.DispatchAsync<SearchShardsDescriptor<T>, SearchShardsRequestParameters, SearchShardsResponse, ISearchShardsResponse>(
+			return this.Dispatcher.DispatchAsync<SearchShardsDescriptor<T>, SearchShardsRequestParameters, SearchShardsResponse, ISearchShardsResponse>(
 				searchSelector,
 				(p, d) => this.RawDispatch.SearchShardsDispatchAsync<SearchShardsResponse>(p)
 			);
@@ -41,7 +41,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ISearchShardsResponse> SearchShardsAsync(ISearchShardsRequest request)
 		{
-			return this.DispatchAsync<ISearchShardsRequest, SearchShardsRequestParameters, SearchShardsResponse, ISearchShardsResponse>(
+			return this.Dispatcher.DispatchAsync<ISearchShardsRequest, SearchShardsRequestParameters, SearchShardsResponse, ISearchShardsResponse>(
 				request,
 				(p, d) => this.RawDispatch.SearchShardsDispatchAsync<SearchShardsResponse>(p)
 			);

--- a/src/Nest/ElasticClient-SearchTemplate.cs
+++ b/src/Nest/ElasticClient-SearchTemplate.cs
@@ -112,7 +112,7 @@ namespace Nest
 		public IGetSearchTemplateResponse GetSearchTemplate(string name, Func<GetSearchTemplateDescriptor, GetSearchTemplateDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<GetSearchTemplateDescriptor, GetTemplateRequestParameters, GetSearchTemplateResponse>(
+			return this.Dispatcher.Dispatch<GetSearchTemplateDescriptor, GetTemplateRequestParameters, GetSearchTemplateResponse>(
 				d => selector(d.Name(name)),
 				(p, d) => this.RawDispatch.GetTemplateDispatch<GetSearchTemplateResponse>(p)
 			);
@@ -120,7 +120,7 @@ namespace Nest
 
 		public IGetSearchTemplateResponse GetSearchTemplate(IGetSearchTemplateRequest request)
 		{
-			return this.Dispatch<IGetSearchTemplateRequest, GetTemplateRequestParameters, GetSearchTemplateResponse>(
+			return this.Dispatcher.Dispatch<IGetSearchTemplateRequest, GetTemplateRequestParameters, GetSearchTemplateResponse>(
 				request,
 				(p, d) => this.RawDispatch.GetTemplateDispatch<GetSearchTemplateResponse>(p)
 			);
@@ -129,7 +129,7 @@ namespace Nest
 		public Task<IGetSearchTemplateResponse> GetSearchTemplateAsync(string name, Func<GetSearchTemplateDescriptor, GetSearchTemplateDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<GetSearchTemplateDescriptor, GetTemplateRequestParameters, GetSearchTemplateResponse, IGetSearchTemplateResponse>(
+			return this.Dispatcher.DispatchAsync<GetSearchTemplateDescriptor, GetTemplateRequestParameters, GetSearchTemplateResponse, IGetSearchTemplateResponse>(
 				d => selector(d.Name(name)),
 				(p, d) => this.RawDispatch.GetTemplateDispatchAsync<GetSearchTemplateResponse>(p)
 			);
@@ -137,7 +137,7 @@ namespace Nest
 
 		public Task<IGetSearchTemplateResponse> GetSearchTemplateAsync(IGetSearchTemplateRequest request)
 		{
-			return this.DispatchAsync<IGetSearchTemplateRequest, GetTemplateRequestParameters, GetSearchTemplateResponse, IGetSearchTemplateResponse>(
+			return this.Dispatcher.DispatchAsync<IGetSearchTemplateRequest, GetTemplateRequestParameters, GetSearchTemplateResponse, IGetSearchTemplateResponse>(
 				request,
 				(p, d) => this.RawDispatch.GetTemplateDispatchAsync<GetSearchTemplateResponse>(p)
 			);
@@ -146,7 +146,7 @@ namespace Nest
 		public IPutSearchTemplateResponse PutSearchTemplate(string name, Func<PutSearchTemplateDescriptor, PutSearchTemplateDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<PutSearchTemplateDescriptor, PutTemplateRequestParameters, PutSearchTemplateResponse>(
+			return this.Dispatcher.Dispatch<PutSearchTemplateDescriptor, PutTemplateRequestParameters, PutSearchTemplateResponse>(
 				d => selector(d.Name(name)),
 				(p, d) => this.RawDispatch.PutTemplateDispatch<PutSearchTemplateResponse>(p, d)
 			);
@@ -154,7 +154,7 @@ namespace Nest
 
 		public IPutSearchTemplateResponse PutSearchTemplate(IPutSearchTemplateRequest request)
 		{
-			return this.Dispatch<IPutSearchTemplateRequest, PutTemplateRequestParameters, PutSearchTemplateResponse>(
+			return this.Dispatcher.Dispatch<IPutSearchTemplateRequest, PutTemplateRequestParameters, PutSearchTemplateResponse>(
 				request,
 				(p, d) => this.RawDispatch.PutTemplateDispatch<PutSearchTemplateResponse>(p, d)
 			);
@@ -163,7 +163,7 @@ namespace Nest
 		public Task<IPutSearchTemplateResponse> PutSearchTemplateAsync(string name, Func<PutSearchTemplateDescriptor, PutSearchTemplateDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<PutSearchTemplateDescriptor, PutTemplateRequestParameters, PutSearchTemplateResponse, IPutSearchTemplateResponse>(
+			return this.Dispatcher.DispatchAsync<PutSearchTemplateDescriptor, PutTemplateRequestParameters, PutSearchTemplateResponse, IPutSearchTemplateResponse>(
 				d => selector(d.Name(name)),
 				(p, d) => this.RawDispatch.PutTemplateDispatchAsync<PutSearchTemplateResponse>(p, d)
 			);
@@ -171,7 +171,7 @@ namespace Nest
 
 		public Task<IPutSearchTemplateResponse> PutSearchTemplateAsync(IPutSearchTemplateRequest request)
 		{
-			return this.DispatchAsync<IPutSearchTemplateRequest, PutTemplateRequestParameters, PutSearchTemplateResponse, IPutSearchTemplateResponse>(
+			return this.Dispatcher.DispatchAsync<IPutSearchTemplateRequest, PutTemplateRequestParameters, PutSearchTemplateResponse, IPutSearchTemplateResponse>(
 				request,
 				(p, d) => this.RawDispatch.PutTemplateDispatchAsync<PutSearchTemplateResponse>(p, d)
 			);
@@ -180,7 +180,7 @@ namespace Nest
 		public IDeleteSearchTemplateResponse DeleteSearchTemplate(string name, Func<DeleteSearchTemplateDescriptor, DeleteSearchTemplateDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<DeleteSearchTemplateDescriptor, DeleteTemplateRequestParameters, DeleteSearchTemplateResponse>(
+			return this.Dispatcher.Dispatch<DeleteSearchTemplateDescriptor, DeleteTemplateRequestParameters, DeleteSearchTemplateResponse>(
 				d => selector(d.Name(name)),
 				(p, d) => this.RawDispatch.DeleteTemplateDispatch<DeleteSearchTemplateResponse>(p)
 			);
@@ -188,7 +188,7 @@ namespace Nest
 
 		public IDeleteSearchTemplateResponse DeleteSearchTemplate(IDeleteSearchTemplateRequest request)
 		{
-			return this.Dispatch<IDeleteSearchTemplateRequest, DeleteTemplateRequestParameters, DeleteSearchTemplateResponse>(
+			return this.Dispatcher.Dispatch<IDeleteSearchTemplateRequest, DeleteTemplateRequestParameters, DeleteSearchTemplateResponse>(
 				request,
 				(p, d) => this.RawDispatch.DeleteTemplateDispatch<DeleteSearchTemplateResponse>(p)
 			);
@@ -197,7 +197,7 @@ namespace Nest
 		public Task<IDeleteSearchTemplateResponse> DeleteSearchTemplateAsync(string name, Func<DeleteSearchTemplateDescriptor, DeleteSearchTemplateDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<DeleteSearchTemplateDescriptor, DeleteTemplateRequestParameters, DeleteSearchTemplateResponse, IDeleteSearchTemplateResponse>(
+			return this.Dispatcher.DispatchAsync<DeleteSearchTemplateDescriptor, DeleteTemplateRequestParameters, DeleteSearchTemplateResponse, IDeleteSearchTemplateResponse>(
 				d => selector(d.Name(name)),
 				(p, d) => this.RawDispatch.DeleteTemplateDispatchAsync<DeleteSearchTemplateResponse>(p)
 			);
@@ -205,7 +205,7 @@ namespace Nest
 
 		public Task<IDeleteSearchTemplateResponse> DeleteSearchTemplateAsync(IDeleteSearchTemplateRequest request)
 		{
-			return this.DispatchAsync<IDeleteSearchTemplateRequest, DeleteTemplateRequestParameters, DeleteSearchTemplateResponse, IDeleteSearchTemplateResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteSearchTemplateRequest, DeleteTemplateRequestParameters, DeleteSearchTemplateResponse, IDeleteSearchTemplateResponse>(
 				request,
 				(p, d) => this.RawDispatch.DeleteTemplateDispatchAsync<DeleteSearchTemplateResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Segments.cs
+++ b/src/Nest/ElasticClient-Segments.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public ISegmentsResponse Segments(Func<SegmentsDescriptor, SegmentsDescriptor> segmentsSelector = null)
 		{
 			segmentsSelector = segmentsSelector ?? (s => s);
-			return this.Dispatch<SegmentsDescriptor, SegmentsRequestParameters, SegmentsResponse>(
+			return this.Dispatcher.Dispatch<SegmentsDescriptor, SegmentsRequestParameters, SegmentsResponse>(
 				segmentsSelector,
 				(p, d) => this.RawDispatch.IndicesSegmentsDispatch<SegmentsResponse>(p)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISegmentsResponse Segments(ISegmentsRequest segmentsRequest)
 		{
-			return this.Dispatch<ISegmentsRequest, SegmentsRequestParameters, SegmentsResponse>(
+			return this.Dispatcher.Dispatch<ISegmentsRequest, SegmentsRequestParameters, SegmentsResponse>(
 				segmentsRequest,
 				(p, d) => this.RawDispatch.IndicesSegmentsDispatch<SegmentsResponse>(p)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<ISegmentsResponse> SegmentsAsync(Func<SegmentsDescriptor, SegmentsDescriptor> segmentsSelector = null)
 		{
 			segmentsSelector = segmentsSelector ?? (s => s);
-			return this.DispatchAsync<SegmentsDescriptor, SegmentsRequestParameters, SegmentsResponse, ISegmentsResponse>(
+			return this.Dispatcher.DispatchAsync<SegmentsDescriptor, SegmentsRequestParameters, SegmentsResponse, ISegmentsResponse>(
 				segmentsSelector,
 				(p, d) => this.RawDispatch.IndicesSegmentsDispatchAsync<SegmentsResponse>(p)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ISegmentsResponse> SegmentsAsync(ISegmentsRequest segmentsRequest)
 		{
-			return this.DispatchAsync<ISegmentsRequest, SegmentsRequestParameters, SegmentsResponse, ISegmentsResponse>(
+			return this.Dispatcher.DispatchAsync<ISegmentsRequest, SegmentsRequestParameters, SegmentsResponse, ISegmentsResponse>(
 				segmentsRequest,
 				(p, d) => this.RawDispatch.IndicesSegmentsDispatchAsync<SegmentsResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Snapshot.cs
+++ b/src/Nest/ElasticClient-Snapshot.cs
@@ -12,7 +12,7 @@ namespace Nest
 			snapshotName.ThrowIfNullOrEmpty("name");
 			repository.ThrowIfNullOrEmpty("repository");
 			selector = selector ?? (s => s);
-			return this.Dispatch<SnapshotDescriptor, SnapshotRequestParameters, SnapshotResponse>(
+			return this.Dispatcher.Dispatch<SnapshotDescriptor, SnapshotRequestParameters, SnapshotResponse>(
 				s => selector(s.Snapshot(snapshotName).Repository(repository)),
 				(p, d) => this.RawDispatch.SnapshotCreateDispatch<SnapshotResponse>(p, d)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISnapshotResponse Snapshot(ISnapshotRequest snapshotRequest)
 		{
-			return this.Dispatch<ISnapshotRequest, SnapshotRequestParameters, SnapshotResponse>(
+			return this.Dispatcher.Dispatch<ISnapshotRequest, SnapshotRequestParameters, SnapshotResponse>(
 				snapshotRequest,
 				(p, d) => this.RawDispatch.SnapshotCreateDispatch<SnapshotResponse>(p, d)
 			);
@@ -33,7 +33,7 @@ namespace Nest
 			snapshotName.ThrowIfNullOrEmpty("name");
 			repository.ThrowIfNullOrEmpty("repository");
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<SnapshotDescriptor, SnapshotRequestParameters, SnapshotResponse, ISnapshotResponse>(
+			return this.Dispatcher.DispatchAsync<SnapshotDescriptor, SnapshotRequestParameters, SnapshotResponse, ISnapshotResponse>(
 				s => selector(s.Snapshot(snapshotName).Repository(repository)),
 				(p, d) => this.RawDispatch.SnapshotCreateDispatchAsync<SnapshotResponse>(p, d)
 			);
@@ -42,7 +42,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ISnapshotResponse> SnapshotAsync(ISnapshotRequest snapshotRequest)
 		{
-			return this.DispatchAsync<ISnapshotRequest, SnapshotRequestParameters, SnapshotResponse, ISnapshotResponse>(
+			return this.Dispatcher.DispatchAsync<ISnapshotRequest, SnapshotRequestParameters, SnapshotResponse, ISnapshotResponse>(
 				snapshotRequest,
 				(p, d) => this.RawDispatch.SnapshotCreateDispatchAsync<SnapshotResponse>(p, d)
 			);
@@ -73,7 +73,7 @@ namespace Nest
 			snapshotName.ThrowIfNullOrEmpty("name");
 			repository.ThrowIfNullOrEmpty("repository");
 			selector = selector ?? (s => s);
-			return this.Dispatch<GetSnapshotDescriptor, GetSnapshotRequestParameters, GetSnapshotResponse>(
+			return this.Dispatcher.Dispatch<GetSnapshotDescriptor, GetSnapshotRequestParameters, GetSnapshotResponse>(
 				s => selector(s.Snapshot(snapshotName).Repository(repository)),
 				(p, d) => this.RawDispatch.SnapshotGetDispatch<GetSnapshotResponse>(p)
 			);
@@ -82,7 +82,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IGetSnapshotResponse GetSnapshot(IGetSnapshotRequest getSnapshotRequest)
 		{
-			return this.Dispatch<IGetSnapshotRequest, GetSnapshotRequestParameters, GetSnapshotResponse>(
+			return this.Dispatcher.Dispatch<IGetSnapshotRequest, GetSnapshotRequestParameters, GetSnapshotResponse>(
 				getSnapshotRequest,
 				(p, d) => this.RawDispatch.SnapshotGetDispatch<GetSnapshotResponse>(p)
 			);
@@ -94,7 +94,7 @@ namespace Nest
 			snapshotName.ThrowIfNullOrEmpty("name");
 			repository.ThrowIfNullOrEmpty("repository");
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<GetSnapshotDescriptor, GetSnapshotRequestParameters, GetSnapshotResponse, IGetSnapshotResponse>(
+			return this.Dispatcher.DispatchAsync<GetSnapshotDescriptor, GetSnapshotRequestParameters, GetSnapshotResponse, IGetSnapshotResponse>(
 				s => selector(s.Snapshot(snapshotName).Repository(repository)),
 				(p, d) => this.RawDispatch.SnapshotGetDispatchAsync<GetSnapshotResponse>(p)
 			);
@@ -103,7 +103,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IGetSnapshotResponse> GetSnapshotAsync(IGetSnapshotRequest getSnapshotRequest)
 		{
-			return this.DispatchAsync<IGetSnapshotRequest, GetSnapshotRequestParameters, GetSnapshotResponse, IGetSnapshotResponse>(
+			return this.Dispatcher.DispatchAsync<IGetSnapshotRequest, GetSnapshotRequestParameters, GetSnapshotResponse, IGetSnapshotResponse>(
 				getSnapshotRequest,
 				(p, d) => this.RawDispatch.SnapshotGetDispatchAsync<GetSnapshotResponse>(p)
 			);
@@ -113,7 +113,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISnapshotStatusResponse SnapshotStatus(Func<SnapshotStatusDescriptor, SnapshotStatusDescriptor> selector = null)
 		{
-			return this.Dispatch<SnapshotStatusDescriptor, SnapshotStatusRequestParameters, SnapshotStatusResponse>(
+			return this.Dispatcher.Dispatch<SnapshotStatusDescriptor, SnapshotStatusRequestParameters, SnapshotStatusResponse>(
 				selector,
 				(p, d) => this.RawDispatch.SnapshotStatusDispatch<SnapshotStatusResponse>(p)
 			);
@@ -122,7 +122,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISnapshotStatusResponse SnapshotStatus(ISnapshotStatusRequest getSnapshotRequest)
 		{
-			return this.Dispatch<ISnapshotStatusRequest, SnapshotStatusRequestParameters, SnapshotStatusResponse>(
+			return this.Dispatcher.Dispatch<ISnapshotStatusRequest, SnapshotStatusRequestParameters, SnapshotStatusResponse>(
 				getSnapshotRequest,
 				(p, d) => this.RawDispatch.SnapshotStatusDispatch<SnapshotStatusResponse>(p)
 			);
@@ -131,7 +131,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ISnapshotStatusResponse> SnapshotStatusAsync(Func<SnapshotStatusDescriptor, SnapshotStatusDescriptor> selector = null)
 		{
-			return this.DispatchAsync<SnapshotStatusDescriptor, SnapshotStatusRequestParameters, SnapshotStatusResponse, ISnapshotStatusResponse>(
+			return this.Dispatcher.DispatchAsync<SnapshotStatusDescriptor, SnapshotStatusRequestParameters, SnapshotStatusResponse, ISnapshotStatusResponse>(
 				selector,
 				(p, d) => this.RawDispatch.SnapshotStatusDispatchAsync<SnapshotStatusResponse>(p)
 			);
@@ -140,7 +140,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ISnapshotStatusResponse> SnapshotStatusAsync(ISnapshotStatusRequest getSnapshotRequest)
 		{
-			return this.DispatchAsync<ISnapshotStatusRequest, SnapshotStatusRequestParameters, SnapshotStatusResponse, ISnapshotStatusResponse>(
+			return this.Dispatcher.DispatchAsync<ISnapshotStatusRequest, SnapshotStatusRequestParameters, SnapshotStatusResponse, ISnapshotStatusResponse>(
 				getSnapshotRequest,
 				(p, d) => this.RawDispatch.SnapshotStatusDispatchAsync<SnapshotStatusResponse>(p)
 			);
@@ -152,7 +152,7 @@ namespace Nest
 			snapshotName.ThrowIfNullOrEmpty("name");
 			repository.ThrowIfNullOrEmpty("repository");
 			selector = selector ?? (s => s);
-			return this.Dispatch<DeleteSnapshotDescriptor, DeleteSnapshotRequestParameters, AcknowledgedResponse>(
+			return this.Dispatcher.Dispatch<DeleteSnapshotDescriptor, DeleteSnapshotRequestParameters, AcknowledgedResponse>(
 				s => selector(s.Snapshot(snapshotName).Repository(repository)),
 				(p, d) => this.RawDispatch.SnapshotDeleteDispatch<AcknowledgedResponse>(p)
 			);
@@ -161,7 +161,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IAcknowledgedResponse DeleteSnapshot(IDeleteSnapshotRequest deleteSnapshotRequest)
 		{
-			return this.Dispatch<IDeleteSnapshotRequest, DeleteSnapshotRequestParameters, AcknowledgedResponse>(
+			return this.Dispatcher.Dispatch<IDeleteSnapshotRequest, DeleteSnapshotRequestParameters, AcknowledgedResponse>(
 				deleteSnapshotRequest,
 				(p, d) => this.RawDispatch.SnapshotDeleteDispatch<AcknowledgedResponse>(p)
 			);
@@ -173,7 +173,7 @@ namespace Nest
 			snapshotName.ThrowIfNullOrEmpty("name");
 			repository.ThrowIfNullOrEmpty("repository");
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<DeleteSnapshotDescriptor, DeleteSnapshotRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
+			return this.Dispatcher.DispatchAsync<DeleteSnapshotDescriptor, DeleteSnapshotRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
 				s => selector(s.Snapshot(snapshotName).Repository(repository)),
 				(p, d) => this.RawDispatch.SnapshotDeleteDispatchAsync<AcknowledgedResponse>(p)
 			);
@@ -182,7 +182,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IAcknowledgedResponse> DeleteSnapshotAsync(IDeleteSnapshotRequest deleteSnapshotRequest)
 		{
-			return this.DispatchAsync<IDeleteSnapshotRequest, DeleteSnapshotRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteSnapshotRequest, DeleteSnapshotRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
 				deleteSnapshotRequest,
 				(p, d) => this.RawDispatch.SnapshotDeleteDispatchAsync<AcknowledgedResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Status.cs
+++ b/src/Nest/ElasticClient-Status.cs
@@ -12,7 +12,7 @@ namespace Nest
 		public IStatusResponse Status(Func<IndicesStatusDescriptor, IndicesStatusDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<IndicesStatusDescriptor, IndicesStatusRequestParameters, StatusResponse>(
+			return this.Dispatcher.Dispatch<IndicesStatusDescriptor, IndicesStatusRequestParameters, StatusResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesStatusDispatch<StatusResponse>(p)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IStatusResponse Status(IIndicesStatusRequest statusRequest)
 		{
-			return this.Dispatch<IIndicesStatusRequest, IndicesStatusRequestParameters, StatusResponse>(
+			return this.Dispatcher.Dispatch<IIndicesStatusRequest, IndicesStatusRequestParameters, StatusResponse>(
 				statusRequest,
 				(p, d) => this.RawDispatch.IndicesStatusDispatch<StatusResponse>(p)
 			);
@@ -31,7 +31,7 @@ namespace Nest
 		public Task<IStatusResponse> StatusAsync(Func<IndicesStatusDescriptor, IndicesStatusDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<IndicesStatusDescriptor, IndicesStatusRequestParameters, StatusResponse, IStatusResponse>(
+			return this.Dispatcher.DispatchAsync<IndicesStatusDescriptor, IndicesStatusRequestParameters, StatusResponse, IStatusResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesStatusDispatchAsync<StatusResponse>(p)
 			);
@@ -40,7 +40,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IStatusResponse> StatusAsync(IIndicesStatusRequest statusRequest)
 		{
-			return this.DispatchAsync<IIndicesStatusRequest, IndicesStatusRequestParameters, StatusResponse, IStatusResponse>(
+			return this.Dispatcher.DispatchAsync<IIndicesStatusRequest, IndicesStatusRequestParameters, StatusResponse, IStatusResponse>(
 				statusRequest,
 				(p, d) => this.RawDispatch.IndicesStatusDispatchAsync<StatusResponse>(p)
 			);

--- a/src/Nest/ElasticClient-Suggest.cs
+++ b/src/Nest/ElasticClient-Suggest.cs
@@ -12,7 +12,7 @@ namespace Nest
 		public ISuggestResponse Suggest<T>(Func<SuggestDescriptor<T>, SuggestDescriptor<T>> selector)
 			where T : class
 		{
-			return this.Dispatch<SuggestDescriptor<T>, SuggestRequestParameters, SuggestResponse>(
+			return this.Dispatcher.Dispatch<SuggestDescriptor<T>, SuggestRequestParameters, SuggestResponse>(
 				selector,
 				(p, d) => this.RawDispatch.SuggestDispatch<SuggestResponse>(p, d)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ISuggestResponse Suggest(ISuggestRequest suggestRequest)
 		{
-			return this.Dispatch<ISuggestRequest, SuggestRequestParameters, SuggestResponse>(
+			return this.Dispatcher.Dispatch<ISuggestRequest, SuggestRequestParameters, SuggestResponse>(
 				suggestRequest,
 				(p, d) => this.RawDispatch.SuggestDispatch<SuggestResponse>(p, d)
 			);
@@ -31,7 +31,7 @@ namespace Nest
 		public Task<ISuggestResponse> SuggestAsync<T>(Func<SuggestDescriptor<T>, SuggestDescriptor<T>> selector)
 			where T : class
 		{
-			return this.DispatchAsync<SuggestDescriptor<T>, SuggestRequestParameters, SuggestResponse, ISuggestResponse>(
+			return this.Dispatcher.DispatchAsync<SuggestDescriptor<T>, SuggestRequestParameters, SuggestResponse, ISuggestResponse>(
 				selector,
 				(p, d) => this.RawDispatch.SuggestDispatchAsync<SuggestResponse>(p, d)
 			);
@@ -40,7 +40,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ISuggestResponse> SuggestAsync(ISuggestRequest suggestRequest)
 		{
-			return this.DispatchAsync<ISuggestRequest, SuggestRequestParameters, SuggestResponse, ISuggestResponse>(
+			return this.Dispatcher.DispatchAsync<ISuggestRequest, SuggestRequestParameters, SuggestResponse, ISuggestResponse>(
 				suggestRequest,
 				(p, d) => this.RawDispatch.SuggestDispatchAsync<SuggestResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-Template.cs
+++ b/src/Nest/ElasticClient-Template.cs
@@ -15,7 +15,7 @@ namespace Nest
 		public ITemplateResponse GetTemplate(string name, Func<GetTemplateDescriptor, GetTemplateDescriptor> getTemplateSelector = null)
 		{
 			getTemplateSelector = getTemplateSelector ?? (s => s);
-			return this.Dispatch<GetTemplateDescriptor, GetTemplateRequestParameters, TemplateResponse>(
+			return this.Dispatcher.Dispatch<GetTemplateDescriptor, GetTemplateRequestParameters, TemplateResponse>(
 				d => getTemplateSelector(d.Name(name)),
 				(p, d) => RawDispatch.IndicesGetTemplateDispatch<TemplateResponse>(
 					p.DeserializationState((GetTemplateConverter) DeserializeTemplateResponse)
@@ -26,7 +26,7 @@ namespace Nest
 		/// <inheritdoc />
 		public ITemplateResponse GetTemplate(IGetTemplateRequest getTemplateRequest)
 		{
-			return this.Dispatch<IGetTemplateRequest, GetTemplateRequestParameters, TemplateResponse>(
+			return this.Dispatcher.Dispatch<IGetTemplateRequest, GetTemplateRequestParameters, TemplateResponse>(
 				getTemplateRequest,
 				(p, d) => RawDispatch.IndicesGetTemplateDispatch<TemplateResponse>(
 					p.DeserializationState((GetTemplateConverter) DeserializeTemplateResponse)
@@ -38,7 +38,7 @@ namespace Nest
 		public Task<ITemplateResponse> GetTemplateAsync(string name, Func<GetTemplateDescriptor, GetTemplateDescriptor> getTemplateSelector = null)
 		{
 			getTemplateSelector = getTemplateSelector ?? (s => s);
-			return this.DispatchAsync<GetTemplateDescriptor, GetTemplateRequestParameters, TemplateResponse, ITemplateResponse>(
+			return this.Dispatcher.DispatchAsync<GetTemplateDescriptor, GetTemplateRequestParameters, TemplateResponse, ITemplateResponse>(
 				d => getTemplateSelector(d.Name(name)),
 				(p, d) => this.RawDispatch.IndicesGetTemplateDispatchAsync<TemplateResponse>(
 					p.DeserializationState((GetTemplateConverter) DeserializeTemplateResponse)
@@ -49,7 +49,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<ITemplateResponse> GetTemplateAsync(IGetTemplateRequest getTemplateRequest)
 		{
-			return this.DispatchAsync<IGetTemplateRequest, GetTemplateRequestParameters, TemplateResponse, ITemplateResponse>(
+			return this.Dispatcher.DispatchAsync<IGetTemplateRequest, GetTemplateRequestParameters, TemplateResponse, ITemplateResponse>(
 				getTemplateRequest,
 				(p, d) => this.RawDispatch.IndicesGetTemplateDispatchAsync<TemplateResponse>(
 					p.DeserializationState((GetTemplateConverter) DeserializeTemplateResponse)
@@ -64,7 +64,7 @@ namespace Nest
 		{
 			putTemplateSelector.ThrowIfNull("putTemplateSelector");
 			var descriptor = putTemplateSelector(new PutTemplateDescriptor(_connectionSettings).Name(name));
-			return this.Dispatch<IPutTemplateRequest, PutTemplateRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<IPutTemplateRequest, PutTemplateRequestParameters, IndicesOperationResponse>(
 				descriptor,
 				(p, d) => this.RawDispatch.IndicesPutTemplateDispatch<IndicesOperationResponse>(p, d.TemplateMapping)
 			);
@@ -73,7 +73,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse PutTemplate(IPutTemplateRequest putTemplateRequest)
 		{
-			return this.Dispatch<IPutTemplateRequest, PutTemplateRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<IPutTemplateRequest, PutTemplateRequestParameters, IndicesOperationResponse>(
 				putTemplateRequest,
 				(p, d) => this.RawDispatch.IndicesPutTemplateDispatch<IndicesOperationResponse>(p, d.TemplateMapping)
 			);
@@ -84,7 +84,7 @@ namespace Nest
 		{
 			putTemplateSelector.ThrowIfNull("putTemplateSelector");
 			var descriptor = putTemplateSelector(new PutTemplateDescriptor(_connectionSettings).Name(name));
-			return this.DispatchAsync<IPutTemplateRequest, PutTemplateRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IPutTemplateRequest, PutTemplateRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					descriptor,
 					(p, d) => this.RawDispatch.IndicesPutTemplateDispatchAsync<IndicesOperationResponse>(p, d.TemplateMapping)
 				);
@@ -93,7 +93,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> PutTemplateAsync(IPutTemplateRequest putTemplateRequest)
 		{
-			return this.DispatchAsync<IPutTemplateRequest, PutTemplateRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IPutTemplateRequest, PutTemplateRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					putTemplateRequest,
 					(p, d) => this.RawDispatch.IndicesPutTemplateDispatchAsync<IndicesOperationResponse>(p, d.TemplateMapping)
 				);
@@ -105,7 +105,7 @@ namespace Nest
 		public IIndicesOperationResponse DeleteTemplate(string name, Func<DeleteTemplateDescriptor, DeleteTemplateDescriptor> deleteTemplateSelector = null)
 		{
 			deleteTemplateSelector = deleteTemplateSelector ?? (s => s);
-			return this.Dispatch<DeleteTemplateDescriptor, DeleteTemplateRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<DeleteTemplateDescriptor, DeleteTemplateRequestParameters, IndicesOperationResponse>(
 				d => deleteTemplateSelector(d.Name(name)),
 				(p, d) => this.RawDispatch.IndicesDeleteTemplateDispatch<IndicesOperationResponse>(p)
 			);
@@ -114,7 +114,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse DeleteTemplate(IDeleteTemplateRequest deleteTemplateRequest)
 		{
-			return this.Dispatch<IDeleteTemplateRequest, DeleteTemplateRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<IDeleteTemplateRequest, DeleteTemplateRequestParameters, IndicesOperationResponse>(
 				deleteTemplateRequest,
 				(p, d) => this.RawDispatch.IndicesDeleteTemplateDispatch<IndicesOperationResponse>(p)
 			);
@@ -131,7 +131,7 @@ namespace Nest
 		public Task<IIndicesOperationResponse> DeleteTemplateAsync(string name, Func<DeleteTemplateDescriptor, DeleteTemplateDescriptor> deleteTemplateSelector = null)
 		{
 			deleteTemplateSelector = deleteTemplateSelector ?? (s => s);
-			return this.DispatchAsync
+			return this.Dispatcher.DispatchAsync
 				<DeleteTemplateDescriptor, DeleteTemplateRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					d => deleteTemplateSelector(d.Name(name)),
 					(p, d) => this.RawDispatch.IndicesDeleteTemplateDispatchAsync<IndicesOperationResponse>(p)
@@ -148,7 +148,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> DeleteTemplateAsync(IDeleteTemplateRequest deleteTemplateRequest)
 		{
-			return this.DispatchAsync<IDeleteTemplateRequest, DeleteTemplateRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteTemplateRequest, DeleteTemplateRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					deleteTemplateRequest,
 					(p, d) => this.RawDispatch.IndicesDeleteTemplateDispatchAsync<IndicesOperationResponse>(p)
 				);

--- a/src/Nest/ElasticClient-TemplateExists.cs
+++ b/src/Nest/ElasticClient-TemplateExists.cs
@@ -14,7 +14,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse TemplateExists(Func<TemplateExistsDescriptor, TemplateExistsDescriptor> selector)
 		{
-			return this.Dispatch<TemplateExistsDescriptor, TemplateExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<TemplateExistsDescriptor, TemplateExistsRequestParameters, ExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesExistsTemplateDispatch<ExistsResponse>(
 					p.DeserializationState(new TemplateExistConverter(DeserializeExistsResponse))
@@ -25,7 +25,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse TemplateExists(ITemplateExistsRequest templateRequest)
 		{
-			return this.Dispatch<ITemplateExistsRequest, TemplateExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<ITemplateExistsRequest, TemplateExistsRequestParameters, ExistsResponse>(
 				templateRequest,
 				(p, d) => this.RawDispatch.IndicesExistsTemplateDispatch<ExistsResponse>(
 					p.DeserializationState(new TemplateExistConverter(DeserializeExistsResponse))
@@ -36,7 +36,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> TemplateExistsAsync(Func<TemplateExistsDescriptor, TemplateExistsDescriptor> selector)
 		{
-			return this.DispatchAsync<TemplateExistsDescriptor, TemplateExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<TemplateExistsDescriptor, TemplateExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesExistsTemplateDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new TemplateExistConverter(DeserializeExistsResponse))
@@ -47,7 +47,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> TemplateExistsAsync(ITemplateExistsRequest templateRequest)
 		{
-			return this.DispatchAsync<ITemplateExistsRequest, TemplateExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<ITemplateExistsRequest, TemplateExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				templateRequest,
 				(p, d) => this.RawDispatch.IndicesExistsTemplateDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new TemplateExistConverter(DeserializeExistsResponse))

--- a/src/Nest/ElasticClient-TermVector.cs
+++ b/src/Nest/ElasticClient-TermVector.cs
@@ -12,7 +12,7 @@ namespace Nest
 		public ITermVectorResponse TermVector<T>(Func<TermvectorDescriptor<T>, TermvectorDescriptor<T>> termVectorSelector)
 			where T : class
 		{
-			return this.Dispatch<TermvectorDescriptor<T>, TermvectorRequestParameters, TermVectorResponse>(
+			return this.Dispatcher.Dispatch<TermvectorDescriptor<T>, TermvectorRequestParameters, TermVectorResponse>(
 				termVectorSelector,
 				(p, d) => this.RawDispatch.TermvectorDispatch<TermVectorResponse>(p, d)
 			);
@@ -21,7 +21,7 @@ namespace Nest
 		///<inheritdoc />
 		public ITermVectorResponse TermVector(ITermvectorRequest termvectorRequest)
 		{
-			return this.Dispatch<ITermvectorRequest, TermvectorRequestParameters, TermVectorResponse>(
+			return this.Dispatcher.Dispatch<ITermvectorRequest, TermvectorRequestParameters, TermVectorResponse>(
 				termvectorRequest,
 				(p, d) => this.RawDispatch.TermvectorDispatch<TermVectorResponse>(p, d)
 			);
@@ -31,7 +31,7 @@ namespace Nest
 		public Task<ITermVectorResponse> TermVectorAsync<T>(Func<TermvectorDescriptor<T>, TermvectorDescriptor<T>> termVectorSelector)
 			where T : class
 		{
-			return this.DispatchAsync<TermvectorDescriptor<T>, TermvectorRequestParameters, TermVectorResponse, ITermVectorResponse>(
+			return this.Dispatcher.DispatchAsync<TermvectorDescriptor<T>, TermvectorRequestParameters, TermVectorResponse, ITermVectorResponse>(
 				termVectorSelector,
 				(p, d) => this.RawDispatch.TermvectorDispatchAsync<TermVectorResponse>(p, d)
 			);
@@ -40,7 +40,7 @@ namespace Nest
 		///<inheritdoc />
 		public Task<ITermVectorResponse> TermVectorAsync(ITermvectorRequest termvectorRequest)
 		{
-			return this.DispatchAsync<ITermvectorRequest , TermvectorRequestParameters, TermVectorResponse, ITermVectorResponse>(
+			return this.Dispatcher.DispatchAsync<ITermvectorRequest , TermvectorRequestParameters, TermVectorResponse, ITermVectorResponse>(
 				termvectorRequest,
 				(p, d) => this.RawDispatch.TermvectorDispatchAsync<TermVectorResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-TypeExists.cs
+++ b/src/Nest/ElasticClient-TypeExists.cs
@@ -13,7 +13,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse TypeExists(Func<TypeExistsDescriptor, TypeExistsDescriptor> selector)
 		{
-			return this.Dispatch<TypeExistsDescriptor, TypeExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<TypeExistsDescriptor, TypeExistsRequestParameters, ExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesExistsTypeDispatch<ExistsResponse>(
 					p.DeserializationState(new TypeExistConverter(DeserializeExistsResponse))
@@ -24,7 +24,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IExistsResponse TypeExists(ITypeExistsRequest TypeRequest)
 		{
-			return this.Dispatch<ITypeExistsRequest, TypeExistsRequestParameters, ExistsResponse>(
+			return this.Dispatcher.Dispatch<ITypeExistsRequest, TypeExistsRequestParameters, ExistsResponse>(
 				TypeRequest,
 				(p, d) => this.RawDispatch.IndicesExistsTypeDispatch<ExistsResponse>(
 					p.DeserializationState(new TypeExistConverter(DeserializeExistsResponse))
@@ -35,7 +35,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> TypeExistsAsync(Func<TypeExistsDescriptor, TypeExistsDescriptor> selector)
 		{
-			return this.DispatchAsync<TypeExistsDescriptor, TypeExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<TypeExistsDescriptor, TypeExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				selector,
 				(p, d) => this.RawDispatch.IndicesExistsTypeDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new TypeExistConverter(DeserializeExistsResponse))
@@ -46,7 +46,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IExistsResponse> TypeExistsAsync(ITypeExistsRequest TypeRequest)
 		{
-			return this.DispatchAsync<ITypeExistsRequest, TypeExistsRequestParameters, ExistsResponse, IExistsResponse>(
+			return this.Dispatcher.DispatchAsync<ITypeExistsRequest, TypeExistsRequestParameters, ExistsResponse, IExistsResponse>(
 				TypeRequest,
 				(p, d) => this.RawDispatch.IndicesExistsTypeDispatchAsync<ExistsResponse>(
 					p.DeserializationState(new TypeExistConverter(DeserializeExistsResponse))

--- a/src/Nest/ElasticClient-Update.cs
+++ b/src/Nest/ElasticClient-Update.cs
@@ -24,7 +24,7 @@ namespace Nest
 			where T : class
 			where K : class
 		{
-			return this.Dispatch<UpdateDescriptor<T, K>, UpdateRequestParameters, UpdateResponse>(
+			return this.Dispatcher.Dispatch<UpdateDescriptor<T, K>, UpdateRequestParameters, UpdateResponse>(
 				updateSelector,
 				(p, d) => this.RawDispatch.UpdateDispatch<UpdateResponse>(p, d)
 			);
@@ -34,7 +34,7 @@ namespace Nest
 			where T : class
 			where K : class
 		{
-			return this.Dispatch<IUpdateRequest<T, K>, UpdateRequestParameters, UpdateResponse>(
+			return this.Dispatcher.Dispatch<IUpdateRequest<T, K>, UpdateRequestParameters, UpdateResponse>(
 				updateSelector,
 				(p, d) => this.RawDispatch.UpdateDispatch<UpdateResponse>(p, d)
 			);
@@ -59,7 +59,7 @@ namespace Nest
 			where T : class
 			where K : class
 		{
-			return this.DispatchAsync<UpdateDescriptor<T, K>, UpdateRequestParameters, UpdateResponse, IUpdateResponse>(
+			return this.Dispatcher.DispatchAsync<UpdateDescriptor<T, K>, UpdateRequestParameters, UpdateResponse, IUpdateResponse>(
 				updateSelector,
 				(p, d) => this.RawDispatch.UpdateDispatchAsync<UpdateResponse>(p, d)
 			);
@@ -70,7 +70,7 @@ namespace Nest
 			where T : class
 			where K : class
 		{
-			return this.DispatchAsync<IUpdateRequest<T, K>, UpdateRequestParameters, UpdateResponse, IUpdateResponse>(
+			return this.Dispatcher.DispatchAsync<IUpdateRequest<T, K>, UpdateRequestParameters, UpdateResponse, IUpdateResponse>(
 				updateRequest,
 				(p, d) => this.RawDispatch.UpdateDispatchAsync<UpdateResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-UpdateSettings.cs
+++ b/src/Nest/ElasticClient-UpdateSettings.cs
@@ -10,7 +10,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IAcknowledgedResponse UpdateSettings(Func<UpdateSettingsDescriptor, UpdateSettingsDescriptor> updateSettingsSelector)
 		{
-			return this.Dispatch<UpdateSettingsDescriptor, UpdateSettingsRequestParameters, AcknowledgedResponse>(
+			return this.Dispatcher.Dispatch<UpdateSettingsDescriptor, UpdateSettingsRequestParameters, AcknowledgedResponse>(
 				updateSettingsSelector,
 				(p, d) => this.RawDispatch.IndicesPutSettingsDispatch<AcknowledgedResponse>(p, d)
 			);
@@ -19,7 +19,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IAcknowledgedResponse UpdateSettings(IUpdateSettingsRequest updateSettingsRequest)
 		{
-			return this.Dispatch<IUpdateSettingsRequest, UpdateSettingsRequestParameters, AcknowledgedResponse>(
+			return this.Dispatcher.Dispatch<IUpdateSettingsRequest, UpdateSettingsRequestParameters, AcknowledgedResponse>(
 				updateSettingsRequest,
 				(p, d) => this.RawDispatch.IndicesPutSettingsDispatch<AcknowledgedResponse>(p, d)
 			);
@@ -28,7 +28,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IAcknowledgedResponse> UpdateSettingsAsync(Func<UpdateSettingsDescriptor, UpdateSettingsDescriptor> updateSettingsSelector)
 		{
-			return this.DispatchAsync<UpdateSettingsDescriptor, UpdateSettingsRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
+			return this.Dispatcher.DispatchAsync<UpdateSettingsDescriptor, UpdateSettingsRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
 					updateSettingsSelector,
 					(p, d) => this.RawDispatch.IndicesPutSettingsDispatchAsync<AcknowledgedResponse>(p, d)
 				);
@@ -37,7 +37,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IAcknowledgedResponse> UpdateSettingsAsync(IUpdateSettingsRequest updateSettingsRequest)
 		{
-			return this.DispatchAsync<IUpdateSettingsRequest, UpdateSettingsRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
+			return this.Dispatcher.DispatchAsync<IUpdateSettingsRequest, UpdateSettingsRequestParameters, AcknowledgedResponse, IAcknowledgedResponse>(
 					updateSettingsRequest,
 					(p, d) => this.RawDispatch.IndicesPutSettingsDispatchAsync<AcknowledgedResponse>(p, d)
 				);

--- a/src/Nest/ElasticClient-Upgrade.cs
+++ b/src/Nest/ElasticClient-Upgrade.cs
@@ -14,7 +14,7 @@ namespace Nest
 	{
 		public IUpgradeResponse Upgrade(IUpgradeRequest upgradeRequest)
 		{
-			return this.Dispatch<IUpgradeRequest, UpgradeRequestParameters, UpgradeResponse>(
+			return this.Dispatcher.Dispatch<IUpgradeRequest, UpgradeRequestParameters, UpgradeResponse>(
 				upgradeRequest,
 				(p, d) => this.RawDispatch.IndicesUpgradeDispatch<UpgradeResponse>(p)
 			);	
@@ -23,7 +23,7 @@ namespace Nest
 		public IUpgradeResponse Upgrade(Func<UpgradeDescriptor, UpgradeDescriptor> upgradeDescriptor = null)
 		{
 			upgradeDescriptor = upgradeDescriptor ?? (s => s);
-			return this.Dispatch<UpgradeDescriptor, UpgradeRequestParameters, UpgradeResponse>(
+			return this.Dispatcher.Dispatch<UpgradeDescriptor, UpgradeRequestParameters, UpgradeResponse>(
 				upgradeDescriptor,
 				(p, d) => this.RawDispatch.IndicesUpgradeDispatch<UpgradeResponse>(p)
 			);
@@ -31,7 +31,7 @@ namespace Nest
 
 		public Task<IUpgradeResponse> UpgradeAsync(IUpgradeRequest upgradeRequest)
 		{
-			return this.DispatchAsync<IUpgradeRequest, UpgradeRequestParameters, UpgradeResponse, IUpgradeResponse>(
+			return this.Dispatcher.DispatchAsync<IUpgradeRequest, UpgradeRequestParameters, UpgradeResponse, IUpgradeResponse>(
 				upgradeRequest,
 				(p, d) => this.RawDispatch.IndicesUpgradeDispatchAsync<UpgradeResponse>(p)
 			);
@@ -40,7 +40,7 @@ namespace Nest
 		public Task<IUpgradeResponse> UpgradeAsync(Func<UpgradeDescriptor, UpgradeDescriptor> upgradeDescriptor = null)
 		{
 			upgradeDescriptor = upgradeDescriptor ?? (s => s);
-			return this.DispatchAsync<UpgradeDescriptor, UpgradeRequestParameters, UpgradeResponse, IUpgradeResponse>(
+			return this.Dispatcher.DispatchAsync<UpgradeDescriptor, UpgradeRequestParameters, UpgradeResponse, IUpgradeResponse>(
 				upgradeDescriptor,
 				(p, d) => this.RawDispatch.IndicesUpgradeDispatchAsync<UpgradeResponse>(p)
 			);
@@ -48,7 +48,7 @@ namespace Nest
 
 		public IUpgradeStatusResponse UpgradeStatus(IUpgradeStatusRequest upgradeStatusRequest)
 		{
-			return this.Dispatch<IUpgradeStatusRequest, UpgradeStatusRequestParameters, UpgradeStatusResponse>(
+			return this.Dispatcher.Dispatch<IUpgradeStatusRequest, UpgradeStatusRequestParameters, UpgradeStatusResponse>(
 				upgradeStatusRequest,
 				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatch<UpgradeStatusResponse>(
 					p.DeserializationState(new UpgradeStatusResponseConverter((r, s) => DeserializeUpgradeStatusResponse(r, s)))
@@ -59,7 +59,7 @@ namespace Nest
 		public IUpgradeStatusResponse UpgradeStatus(Func<UpgradeStatusDescriptor, UpgradeStatusDescriptor> upgradeStatusDescriptor = null)
 		{
 			upgradeStatusDescriptor = upgradeStatusDescriptor ?? (s => s);
-			return this.Dispatch<UpgradeStatusDescriptor, UpgradeStatusRequestParameters, UpgradeStatusResponse>(
+			return this.Dispatcher.Dispatch<UpgradeStatusDescriptor, UpgradeStatusRequestParameters, UpgradeStatusResponse>(
 				upgradeStatusDescriptor,
 				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatch<UpgradeStatusResponse>(
 					p.DeserializationState(new UpgradeStatusResponseConverter((r, s) => DeserializeUpgradeStatusResponse(r, s)))
@@ -69,7 +69,7 @@ namespace Nest
 
 		public Task<IUpgradeStatusResponse> UpgradeStatusAsync(IUpgradeStatusRequest upgradeStatusRequest)
 		{
-			return this.DispatchAsync<IUpgradeStatusRequest, UpgradeStatusRequestParameters, UpgradeStatusResponse, IUpgradeStatusResponse>(
+			return this.Dispatcher.DispatchAsync<IUpgradeStatusRequest, UpgradeStatusRequestParameters, UpgradeStatusResponse, IUpgradeStatusResponse>(
 				upgradeStatusRequest,
 				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatchAsync<UpgradeStatusResponse>(
 					p.DeserializationState(new UpgradeStatusResponseConverter((r, s) => DeserializeUpgradeStatusResponse(r, s)))
@@ -80,7 +80,7 @@ namespace Nest
 		public Task<IUpgradeStatusResponse> UpgradeStatusAsync(Func<UpgradeStatusDescriptor, UpgradeStatusDescriptor> upgradeStatusDescriptor = null)
 		{
 			upgradeStatusDescriptor = upgradeStatusDescriptor ?? (s => s);
-			return this.DispatchAsync<UpgradeStatusDescriptor, UpgradeStatusRequestParameters, UpgradeStatusResponse, IUpgradeStatusResponse>(
+			return this.Dispatcher.DispatchAsync<UpgradeStatusDescriptor, UpgradeStatusRequestParameters, UpgradeStatusResponse, IUpgradeStatusResponse>(
 				upgradeStatusDescriptor,
 				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatchAsync<UpgradeStatusResponse>(
 					p.DeserializationState(new UpgradeStatusResponseConverter((r, s) => DeserializeUpgradeStatusResponse(r, s)))

--- a/src/Nest/ElasticClient-Validate.cs
+++ b/src/Nest/ElasticClient-Validate.cs
@@ -11,7 +11,7 @@ namespace Nest
 		public IValidateResponse Validate<T>(Func<ValidateQueryDescriptor<T>, ValidateQueryDescriptor<T>> querySelector)
 			where T : class
 		{
-			return this.Dispatch<ValidateQueryDescriptor<T>, ValidateQueryRequestParameters, ValidateResponse>(
+			return this.Dispatcher.Dispatch<ValidateQueryDescriptor<T>, ValidateQueryRequestParameters, ValidateResponse>(
 				querySelector,
 				(p, d) => this.RawDispatch.IndicesValidateQueryDispatch<ValidateResponse>(p, d)
 			);
@@ -20,7 +20,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IValidateResponse Validate(IValidateQueryRequest validateQueryRequest)
 		{
-			return this.Dispatch<IValidateQueryRequest, ValidateQueryRequestParameters, ValidateResponse>(
+			return this.Dispatcher.Dispatch<IValidateQueryRequest, ValidateQueryRequestParameters, ValidateResponse>(
 				validateQueryRequest,
 				(p, d) => this.RawDispatch.IndicesValidateQueryDispatch<ValidateResponse>(p, d)
 			);
@@ -30,7 +30,7 @@ namespace Nest
 		public Task<IValidateResponse> ValidateAsync<T>(Func<ValidateQueryDescriptor<T>, ValidateQueryDescriptor<T>> querySelector)
 			where T : class
 		{
-			return this.DispatchAsync<ValidateQueryDescriptor<T>, ValidateQueryRequestParameters, ValidateResponse, IValidateResponse>(
+			return this.Dispatcher.DispatchAsync<ValidateQueryDescriptor<T>, ValidateQueryRequestParameters, ValidateResponse, IValidateResponse>(
 				querySelector,
 				(p, d) => this.RawDispatch.IndicesValidateQueryDispatchAsync<ValidateResponse>(p, d)
 			);
@@ -39,7 +39,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IValidateResponse> ValidateAsync(IValidateQueryRequest validateQueryRequest)
 		{
-			return this.DispatchAsync<IValidateQueryRequest, ValidateQueryRequestParameters, ValidateResponse, IValidateResponse>(
+			return this.Dispatcher.DispatchAsync<IValidateQueryRequest, ValidateQueryRequestParameters, ValidateResponse, IValidateResponse>(
 				validateQueryRequest,
 				(p, d) => this.RawDispatch.IndicesValidateQueryDispatchAsync<ValidateResponse>(p, d)
 			);

--- a/src/Nest/ElasticClient-Warmers.cs
+++ b/src/Nest/ElasticClient-Warmers.cs
@@ -16,7 +16,7 @@ namespace Nest
 		public IIndicesOperationResponse PutWarmer(string name, Func<PutWarmerDescriptor, PutWarmerDescriptor> selector)
 		{
 			selector.ThrowIfNull("selector");
-			return this.Dispatch<PutWarmerDescriptor, PutWarmerRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<PutWarmerDescriptor, PutWarmerRequestParameters, IndicesOperationResponse>(
 				d => selector(d.Name(name).AllIndices()),
 				(p, d) => this.RawDispatch.IndicesPutWarmerDispatch<IndicesOperationResponse>(p, d)
 			);
@@ -25,7 +25,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse PutWarmer(IPutWarmerRequest putWarmerRequest)
 		{
-			return this.Dispatch<IPutWarmerRequest, PutWarmerRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<IPutWarmerRequest, PutWarmerRequestParameters, IndicesOperationResponse>(
 				putWarmerRequest,
 				(p, d) => this.RawDispatch.IndicesPutWarmerDispatch<IndicesOperationResponse>(p, d)
 			);
@@ -35,7 +35,7 @@ namespace Nest
 		public Task<IIndicesOperationResponse> PutWarmerAsync(string name, Func<PutWarmerDescriptor, PutWarmerDescriptor> selector)
 		{
 			selector.ThrowIfNull("selector");
-			return this.DispatchAsync<PutWarmerDescriptor, PutWarmerRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<PutWarmerDescriptor, PutWarmerRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 				d => selector(d.Name(name).AllIndices()),
 				(p, d) => this.RawDispatch.IndicesPutWarmerDispatchAsync<IndicesOperationResponse>(p, d)
 			);
@@ -44,7 +44,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> PutWarmerAsync(IPutWarmerRequest putWarmerRequest)
 		{
-			return this.DispatchAsync<IPutWarmerRequest, PutWarmerRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IPutWarmerRequest, PutWarmerRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 				putWarmerRequest,
 				(p, d) => this.RawDispatch.IndicesPutWarmerDispatchAsync<IndicesOperationResponse>(p, d)
 			);
@@ -56,7 +56,7 @@ namespace Nest
 		public IWarmerResponse GetWarmer(string name, Func<GetWarmerDescriptor, GetWarmerDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<GetWarmerDescriptor, GetWarmerRequestParameters, WarmerResponse>(
+			return this.Dispatcher.Dispatch<GetWarmerDescriptor, GetWarmerRequestParameters, WarmerResponse>(
 				d => selector(d.Name(name).AllIndices()),
 				(p, d) => this.RawDispatch.IndicesGetWarmerDispatch<WarmerResponse>(
 					p.DeserializationState(new GetWarmerConverter(DeserializeWarmerResponse))
@@ -67,7 +67,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IWarmerResponse GetWarmer(IGetWarmerRequest getWarmerRequest)
 		{
-			return this.Dispatch<IGetWarmerRequest, GetWarmerRequestParameters, WarmerResponse>(
+			return this.Dispatcher.Dispatch<IGetWarmerRequest, GetWarmerRequestParameters, WarmerResponse>(
 				getWarmerRequest,
 				(p, d) => this.RawDispatch.IndicesGetWarmerDispatch<WarmerResponse>(
 					p.DeserializationState(new GetWarmerConverter(DeserializeWarmerResponse))
@@ -79,7 +79,7 @@ namespace Nest
 		public Task<IWarmerResponse> GetWarmerAsync(string name, Func<GetWarmerDescriptor, GetWarmerDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync<GetWarmerDescriptor, GetWarmerRequestParameters, WarmerResponse, IWarmerResponse>(
+			return this.Dispatcher.DispatchAsync<GetWarmerDescriptor, GetWarmerRequestParameters, WarmerResponse, IWarmerResponse>(
 				d => selector(d.Name(name).AllIndices()),
 				(p, d) => this.RawDispatch.IndicesGetWarmerDispatchAsync<WarmerResponse>(
 					p.DeserializationState(new GetWarmerConverter(DeserializeWarmerResponse))
@@ -90,7 +90,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IWarmerResponse> GetWarmerAsync(IGetWarmerRequest getWarmerRequest)
 		{
-			return this.DispatchAsync<IGetWarmerRequest, GetWarmerRequestParameters, WarmerResponse, IWarmerResponse>(
+			return this.Dispatcher.DispatchAsync<IGetWarmerRequest, GetWarmerRequestParameters, WarmerResponse, IWarmerResponse>(
 				getWarmerRequest,
 				(p, d) => this.RawDispatch.IndicesGetWarmerDispatchAsync<WarmerResponse>(
 					p.DeserializationState(new GetWarmerConverter(DeserializeWarmerResponse))
@@ -104,7 +104,7 @@ namespace Nest
 		public IIndicesOperationResponse DeleteWarmer(string name, Func<DeleteWarmerDescriptor, DeleteWarmerDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.Dispatch<DeleteWarmerDescriptor, DeleteWarmerRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<DeleteWarmerDescriptor, DeleteWarmerRequestParameters, IndicesOperationResponse>(
 				d => selector(d.Name(name).AllIndices()),
 				(p, d) => this.RawDispatch.IndicesDeleteWarmerDispatch<IndicesOperationResponse>(p)
 			);
@@ -113,7 +113,7 @@ namespace Nest
 		/// <inheritdoc />
 		public IIndicesOperationResponse DeleteWarmer(IDeleteWarmerRequest deleteWarmerRequest)
 		{
-			return this.Dispatch<IDeleteWarmerRequest, DeleteWarmerRequestParameters, IndicesOperationResponse>(
+			return this.Dispatcher.Dispatch<IDeleteWarmerRequest, DeleteWarmerRequestParameters, IndicesOperationResponse>(
 				deleteWarmerRequest,
 				(p, d) => this.RawDispatch.IndicesDeleteWarmerDispatch<IndicesOperationResponse>(p)
 			);
@@ -123,7 +123,7 @@ namespace Nest
 		public Task<IIndicesOperationResponse> DeleteWarmerAsync(string name, Func<DeleteWarmerDescriptor, DeleteWarmerDescriptor> selector = null)
 		{
 			selector = selector ?? (s => s);
-			return this.DispatchAsync
+			return this.Dispatcher.DispatchAsync
 				<DeleteWarmerDescriptor, DeleteWarmerRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					d => selector(d.Name(name).AllIndices()),
 					(p, d) => this.RawDispatch.IndicesDeleteWarmerDispatchAsync<IndicesOperationResponse>(p)
@@ -133,7 +133,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Task<IIndicesOperationResponse> DeleteWarmerAsync(IDeleteWarmerRequest deleteWarmerRequest)
 		{
-			return this.DispatchAsync<IDeleteWarmerRequest, DeleteWarmerRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
+			return this.Dispatcher.DispatchAsync<IDeleteWarmerRequest, DeleteWarmerRequestParameters, IndicesOperationResponse, IIndicesOperationResponse>(
 					deleteWarmerRequest,
 					(p, d) => this.RawDispatch.IndicesDeleteWarmerDispatchAsync<IndicesOperationResponse>(p)
 				);

--- a/src/Nest/ElasticClient.cs
+++ b/src/Nest/ElasticClient.cs
@@ -17,8 +17,9 @@ namespace Nest
 	{
 		private readonly IConnectionSettingsValues _connectionSettings;
 
+		internal IHighLevelToLowLevelDispatcher Dispatcher { get { return this; } }
 		internal RawDispatch RawDispatch { get; set; }
-
+		
 		public IConnection Connection { get; protected set; }
 		public INestSerializer Serializer { get; protected set; }
 		public IElasticsearchClient Raw { get; protected set; }
@@ -56,31 +57,58 @@ namespace Nest
 
 		}
 
-
-		public R Dispatch<D, Q, R>(
-			Func<D, D> selector
-			, Func<ElasticsearchPathInfo<Q>, D, ElasticsearchResponse<R>> dispatch
-			)
-			where Q : FluentRequestParameters<Q>, new()
-			where D : IRequest<Q>, new()
-			where R : BaseResponse
+		public static void Warmup()
 		{
-			selector.ThrowIfNull("selector");
-			var descriptor = selector(new D());
-			return this.Dispatch<D, Q, R>(descriptor, dispatch);
+			var client = new ElasticClient(connection: new InMemoryConnection());
+			var stream = new MemoryStream("{}".Utf8Bytes());
+			client.Serializer.Serialize(new SearchDescriptor<object>());
+			client.Serializer.Deserialize<SearchDescriptor<object>>(stream);
+			var connection = new HttpConnection(new ConnectionSettings());
+			client.RootNodeInfo();
+			client.Search<object>(s => s.MatchAll().Index("someindex"));
 		}
 
-		public R Dispatch<D, Q, R>(
-			D descriptor
-			, Func<ElasticsearchPathInfo<Q>, D, ElasticsearchResponse<R>> dispatch
-			)
-			where Q : FluentRequestParameters<Q>, new()
-			where D : IRequest<Q>
-			where R : BaseResponse
+		R IHighLevelToLowLevelDispatcher.Dispatch<D, Q, R>(D descriptor, Func<ElasticsearchPathInfo<Q>, D, ElasticsearchResponse<R>> dispatch)
 		{
 			var pathInfo = descriptor.ToPathInfo(this._connectionSettings);
 			var response = dispatch(pathInfo, descriptor);
 			return ResultsSelector<D, Q, R>(response, descriptor);
+		}
+
+		R IHighLevelToLowLevelDispatcher.Dispatch<D, Q, R>(Func<D, D> selector, Func<ElasticsearchPathInfo<Q>, D, ElasticsearchResponse<R>> dispatch)
+		{
+			selector.ThrowIfNull("selector");
+			var descriptor = selector(new D());
+			return this.Dispatcher.Dispatch<D, Q, R>(descriptor, dispatch);
+		}
+
+		Task<I> IHighLevelToLowLevelDispatcher.DispatchAsync<D, Q, R, I>(D descriptor, Func<ElasticsearchPathInfo<Q>, D, Task<ElasticsearchResponse<R>>> dispatch)
+		{
+			var pathInfo = descriptor.ToPathInfo(this._connectionSettings);
+			return dispatch(pathInfo, descriptor)
+				.ContinueWith<I>(r =>
+				{
+					if (r.IsFaulted && r.Exception != null)
+					{
+						var mr = r.Exception.InnerException as MaxRetryException;
+						if (mr != null)
+							mr.RethrowKeepingStackTrace();
+
+						var ae = r.Exception.Flatten();
+						if (ae.InnerException != null)
+							ae.InnerException.RethrowKeepingStackTrace();
+
+						ae.RethrowKeepingStackTrace();
+					}
+					return ResultsSelector<D, Q, R>(r.Result, descriptor);
+				});
+		}
+
+		Task<I> IHighLevelToLowLevelDispatcher.DispatchAsync<D, Q, R, I>(Func<D, D> selector, Func<ElasticsearchPathInfo<Q>, D, Task<ElasticsearchResponse<R>>> dispatch)
+		{
+			selector.ThrowIfNull("selector");
+			var descriptor = selector(new D());
+			return this.Dispatcher.DispatchAsync<D, Q, R, I>(descriptor, dispatch);
 		}
 
 		private static R ResultsSelector<D, Q, R>(
@@ -111,49 +139,6 @@ namespace Nest
 			return r;
 		}
 
-		public Task<I> DispatchAsync<D, Q, R, I>(
-			Func<D, D> selector
-			, Func<ElasticsearchPathInfo<Q>, D, Task<ElasticsearchResponse<R>>> dispatch
-			)
-			where Q : FluentRequestParameters<Q>, new()
-			where D : IRequest<Q>, new()
-			where R : BaseResponse, I
-			where I : IResponse
-		{
-			selector.ThrowIfNull("selector");
-			var descriptor = selector(new D());
-			return this.DispatchAsync<D, Q, R, I>(descriptor, dispatch);
-		}
-
-		public Task<I> DispatchAsync<D, Q, R, I>(
-			D descriptor
-			, Func<ElasticsearchPathInfo<Q>, D, Task<ElasticsearchResponse<R>>> dispatch
-			)
-			where Q : FluentRequestParameters<Q>, new()
-			where D : IRequest<Q>
-			where R : BaseResponse, I
-			where I : IResponse
-		{
-			var pathInfo = descriptor.ToPathInfo(this._connectionSettings);
-			return dispatch(pathInfo, descriptor)
-				.ContinueWith<I>(r =>
-				{
-					if (r.IsFaulted && r.Exception != null)
-					{
-						var mr = r.Exception.InnerException as MaxRetryException;
-						if (mr != null)
-							mr.RethrowKeepingStackTrace();
-
-						var ae = r.Exception.Flatten();
-						if (ae.InnerException != null)
-							ae.InnerException.RethrowKeepingStackTrace();
-
-						ae.RethrowKeepingStackTrace();
-					}
-					return ResultsSelector<D, Q, R>(r.Result, descriptor);
-				});
-		}
-
 		private TRequest ForceConfiguration<TRequest>(
 			Func<TRequest, TRequest> selector, Action<IRequestConfiguration> setter
 			)
@@ -172,17 +157,5 @@ namespace Nest
 			request.RequestConfiguration = configuration;
 			return request;
 		}
-
-		public static void Warmup()
-		{
-			var client = new ElasticClient(connection: new InMemoryConnection());
-			var stream = new MemoryStream("{}".Utf8Bytes());
-			client.Serializer.Serialize(new SearchDescriptor<object>());
-			client.Serializer.Deserialize<SearchDescriptor<object>>(stream);
-			var connection = new HttpConnection(new ConnectionSettings());
-			client.RootNodeInfo();
-			client.Search<object>(s => s.MatchAll().Index("someindex"));
-		}
-
 	}
 }

--- a/src/Nest/Resolvers/ElasticContractResolver.cs
+++ b/src/Nest/Resolvers/ElasticContractResolver.cs
@@ -122,7 +122,7 @@ namespace Nest.Resolvers
 			defaultProperties = PropertiesOf<IInnerHitsContainer>(type, memberSerialization, defaultProperties, lookup);
 			//defaultProperties = PropertiesOf<IGlobalInnerHit>(type, memberSerialization, defaultProperties, lookup);
 			defaultProperties = PropertiesOf<IInnerHits>(type, memberSerialization, defaultProperties, lookup);
-			defaultProperties = PropertiesOf<IDomainObject>(type, memberSerialization, defaultProperties, lookup);
+			defaultProperties = PropertiesOf<INestSerializable>(type, memberSerialization, defaultProperties, lookup);
 			return defaultProperties;
 		}
 


### PR DESCRIPTION
* `ElasticClient` now implements `IHighLevelToLowLevelDispatcher` explicitly so the internal-ish dispatch methods are less exposed.  This required casting to `IHighLevelToLowLevelDispatcher` in order to access the dispatch methods, so I added an internal `Dispatcher { get { return this; } }` convenience property (much like we do with `Self` in the descriptors).

* Renamed `IDomainObject` to the more descriptive`INestSerializable`.

* Changed `CloneFrom()` back to internal since it doesn't need to be exposed.