### PR TITLE
MoreLikeThis query should accept documents or ids

### DIFF
--- a/src/Nest/DSL/Query/MoreLikeThisQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MoreLikeThisQueryDescriptor.cs
@@ -145,7 +145,9 @@ namespace Nest
 		{
 			get
 			{
-				return this.Self.LikeText.IsNullOrEmpty();
+				return this.Self.LikeText.IsNullOrEmpty()
+					&& (this.Self.Ids == null || !this.Self.Ids.Any())
+					&& (this.Self.Documents == null || !this.Self.Documents.Any());
 			}
 		}
 

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MoreLikeThisQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MoreLikeThisQueryJson.cs
@@ -88,7 +88,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 					.Document<MoreLikeThisTestDoc>(new MoreLikeThisTestDoc { Name = "foo" }, "myindex", "mytype")
 				);
 			var json = TestElasticClient.Serialize(s);
-
+			
 			const string expected = @"{
 				fields: [ ""name""],
 				docs: [
@@ -135,6 +135,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 			}";
 
             Verify<MoreLikeThisQueryDescriptor<object>>(json, expected);
+			Assert.AreEqual(false, ((IQuery)s).IsConditionless);
 		}
 
 		[Test]


### PR DESCRIPTION
Hello guys,

Right now we are unable to run query like this one:

````
var searchResponse = client.Search<Document>(s => s.Query(q => q
    .MoreLikeThis(mlt => mlt.Documents(docs => docs.Document(new Document {Id = 1})))));
````

It sends empty query to elasticsearch:
````
StatusCode: 200, 
Method: POST, 
Url: http://localhost:9200/my_index/document/_search, 
Request: {}, 
````

[Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_parameters_8) stays that
> The only required parameters are either docs, ids or like_text

so I think this PR should resolve the issue.

Reported on [SO](http://stackoverflow.com/questions/30598932/elasticsearch-nest-dismax-morelikethis-query).

Thanks.
