### PR TITLE
Add size parameter to reindex descriptor

### DIFF
--- a/src/Nest/DSL/Reindex/ReindexDescriptor.cs
+++ b/src/Nest/DSL/Reindex/ReindexDescriptor.cs
@@ -6,6 +6,7 @@ namespace Nest
 		internal string _ToIndexName { get; set; }
 		internal string _FromIndexName { get; set; }
 		internal string _Scroll { get; set; }
+		internal int? _Size { get; set; }
 		
 		internal Func<QueryDescriptor<T>, QueryContainer> _QuerySelector { get; set; }
 
@@ -40,6 +41,25 @@ namespace Nest
 		{
 			scrollTime.ThrowIfNullOrEmpty("scrollTime");
 			this._Scroll = scrollTime;
+			return this;
+		}
+
+		/// <summary>
+		/// The number of hits to return. Defaults to 100. When using scroll search type,
+		/// size is actually multiplied by the number of shards!
+		/// </summary>
+		public ReindexDescriptor<T> Size(int size)
+		{
+			this._Size = size;
+			return this;
+		}
+
+		/// <summary>
+		/// The number of hits to return. Defaults to 100.
+		/// </summary>
+		public ReindexDescriptor<T> Take(int take)
+		{
+			this.Size(take);
 			return this;
 		}
 

--- a/src/Nest/Domain/Observers/ReindexObservable.cs
+++ b/src/Nest/Domain/Observers/ReindexObservable.cs
@@ -37,6 +37,7 @@ namespace Nest
 			var fromIndex = this._reindexDescriptor._FromIndexName;
 			var toIndex = this._reindexDescriptor._ToIndexName;
 			var scroll = this._reindexDescriptor._Scroll ?? "2m";
+			var size = this._reindexDescriptor._Size ?? 100;
 
 			fromIndex.ThrowIfNullOrEmpty("fromIndex");
 			toIndex.ThrowIfNullOrEmpty("toIndex");
@@ -56,7 +57,7 @@ namespace Nest
 					.Index(fromIndex)
 					.AllTypes()
 					.From(0)
-					.Take(100)
+					.Size(size)
 					.Query(this._reindexDescriptor._QuerySelector ?? (q=>q.MatchAll()))
 					.SearchType(SearchType.Scan)
 					.Scroll(scroll)

--- a/src/Tests/Nest.Tests.Integration/Index/ReindexTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Index/ReindexTests.cs
@@ -47,6 +47,7 @@ namespace Nest.Tests.Integration.Index
 				.ToIndex(toIndex)
 				.Query(q=>q.MatchAll())
 				.Scroll("10s")
+				.Size(100)
 				.CreateIndex(c=>c
 					.NumberOfReplicas(0)
 					.NumberOfShards(1)


### PR DESCRIPTION
The current scroll search size for reindexing is hard coded. Allow the size to be changed using the ReindexDescriptor.