### PR TITLE
Support for murmur3 mapping type

### DIFF
--- a/src/Nest/Domain/Mapping/Descriptors/CorePropertiesDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/CorePropertiesDescriptor.cs
@@ -81,6 +81,16 @@ namespace Nest
 			return this;
 		}
 
+		public CorePropertiesDescriptor<T> Murmur3Hash(Func<MurmurHashMappingDescriptor<T>, MurmurHashMappingDescriptor<T>> selector)
+		{
+			selector.ThrowIfNull("selector");
+			var d = selector(new MurmurHashMappingDescriptor<T>());
+			if (d == null || d._Mapping.Name.IsConditionless())
+				throw new Exception("Could not get field name for murmur3 mapping");
+			this.Properties.Add(d._Mapping.Name, d._Mapping);
+			return this;
+		}
+
 		//Reminder if you are adding a new mapping type, may one appear in the future
 		//Add them to PropertiesDescriptor, CorePropertiesDescriptor (if its a new core type), SingleMappingDescriptor
 	}

--- a/src/Nest/Domain/Mapping/Descriptors/MurmurHashMappingDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/MurmurHashMappingDescriptor.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Nest
+{
+	public class MurmurHashMappingDescriptor<T> where T : class
+	{
+		internal Murmur3HashMapping _Mapping = new Murmur3HashMapping();
+
+		public MurmurHashMappingDescriptor<T> Name(string name)
+		{
+			this._Mapping.Name = name;
+			return this;
+		}
+
+		public MurmurHashMappingDescriptor<T> Name(Expression<Func<T, object>> objectPath)
+		{
+			this._Mapping.Name = objectPath;
+			return this;
+		}
+	}
+}

--- a/src/Nest/Domain/Mapping/Descriptors/PropertiesDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/PropertiesDescriptor.cs
@@ -173,6 +173,17 @@ namespace Nest
 			this.Properties.Add(customMapping.Name, customMapping);
 			return this;
 		}
+
+		public PropertiesDescriptor<T> Murmur3Hash(Func<MurmurHashMappingDescriptor<T>, MurmurHashMappingDescriptor<T>> selector)
+		{
+			selector.ThrowIfNull("selector");
+			var d = selector(new MurmurHashMappingDescriptor<T>());
+			if (d == null || d._Mapping.Name.IsConditionless())
+				throw new Exception("Could not get field name for mumur hash mapping");
+			this.Properties.Add(d._Mapping.Name, d._Mapping);
+			return this;
+		}
+
 		//Reminder if you are adding a new mapping type, may one appear in the future
 		//Add them to PropertiesDescriptor, CorePropertiesDescriptor (if its a new core type), SingleMappingDescriptor
 	}

--- a/src/Nest/Domain/Mapping/Descriptors/SingleMappingDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/SingleMappingDescriptor.cs
@@ -137,6 +137,15 @@ namespace Nest
             return d._Mapping;
         }
 
+		public IElasticType Murmur3Hash(Func<MurmurHashMappingDescriptor<T>, MurmurHashMappingDescriptor<T>> selector)
+		{
+			selector.ThrowIfNull("selector");
+			var d = selector(new MurmurHashMappingDescriptor<T>());
+			if (d == null)
+				throw new Exception("Could not get murmur hash mapping");
+			return d._Mapping;
+		}
+
 		//Reminder if you are adding a new mapping type, may one appear in the future
 		//Add them to PropertiesDescriptor, CorePropertiesDescriptor (if its a new core type), SingleMappingDescriptor
 	}

--- a/src/Nest/Domain/Mapping/Types/Murmur3HashMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/Murmur3HashMapping.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nest
+{
+	[JsonObject(MemberSerialization.OptIn)]
+	public class Murmur3HashMapping : MultiFieldMapping, IElasticType, IElasticCoreType
+	{
+		public Murmur3HashMapping() : base("murmur3") { }
+
+		[JsonIgnore]
+		public string IndexName { get; set; }
+	}
+}

--- a/src/Nest/Enums/FieldType.cs
+++ b/src/Nest/Enums/FieldType.cs
@@ -93,6 +93,11 @@ namespace Nest
 		/// Only set this if you need to force a value type to be mapped to an elasticsearch object type.
 		/// </summary>
 		[EnumMember(Value = "object")]
-		Object
+		Object,
+		/// <summary>
+		/// Murmur hash type, for use with the cardinality aggregation.
+		/// </summary>
+		[EnumMember(Value = "murmur3")]
+		Murmur3Hash
 	}
 }

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Domain\Geo\GeoLocation.cs" />
     <Compile Include="Domain\Geo\GeoPrecision.cs" />
     <Compile Include="Domain\Hit\ExplainGet.cs" />
+    <Compile Include="Domain\Mapping\Descriptors\MurmurHashMappingDescriptor.cs" />
     <Compile Include="Domain\Mapping\PropertyMapping.cs" />
     <Compile Include="Domain\Mapping\Descriptors\FieldDataFilterDescriptor.cs" />
     <Compile Include="Domain\Mapping\Descriptors\FieldDataFrequencyFilterDescriptor.cs" />
@@ -162,6 +163,7 @@
     <Compile Include="Domain\Mapping\SubMappings\FieldData\FieldDataStringMapping.cs" />
     <Compile Include="Domain\Mapping\SubMappings\NormsMapping.cs" />
     <Compile Include="Domain\Mapping\SubMappings\MappingTransform.cs" />
+    <Compile Include="Domain\Mapping\Types\Murmur3HashMapping.cs" />
     <Compile Include="Domain\Observers\RestoreObserver.cs" />
     <Compile Include="Domain\Observers\SnapshotObserver.cs" />
     <Compile Include="Domain\Repository\SnapshotShardFailure.cs" />

--- a/src/Nest/Resolvers/Writers/TypeMappingWriter.cs
+++ b/src/Nest/Resolvers/Writers/TypeMappingWriter.cs
@@ -247,6 +247,8 @@ namespace Nest.Resolvers.Writers
 					return "nested";
 				case FieldType.Object:
 					return "object";
+				case FieldType.Murmur3Hash:
+					return "murmur3";
 				default:
 					return null;
 			}

--- a/src/Tests/Nest.Tests.Unit/Core/Map/FluentMappingFullExampleTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/FluentMappingFullExampleTests.cs
@@ -207,6 +207,7 @@ namespace Nest.Tests.Unit.Core.Map
 						.Fields(pprops => pprops
 							.String(ps => ps.Name(p => p.Name).Index(FieldIndexOption.NotAnalyzed))
 							.String(ps => ps.Name(p => p.Name.Suffix("searchable")).Index(FieldIndexOption.Analyzed))
+							.Murmur3Hash(ps => ps.Name(p => p.Name.Suffix("hash")))
 						)
 					)
 					.IP(s=>s
@@ -250,6 +251,9 @@ namespace Nest.Tests.Unit.Core.Map
 								.Default("u33")
 							)
 						)
+					)
+					.Murmur3Hash(mh => mh
+						.Name("hash")
 					)
 				)
 			);

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Properties/MultiFieldProperty.json
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Properties/MultiFieldProperty.json
@@ -1,19 +1,22 @@
   {
-  "elasticsearchprojects": {
-    "properties": {
-      "name": {
-        "type": "multi_field",
-        "fields": {
-          "name": {
-            "type": "string",
-            "index": "not_analyzed"
-          },
-          "searchable": {
-            "type": "string",
-            "index": "analyzed"
+    "elasticsearchprojects": {
+      "properties": {
+        "name": {
+          "type": "multi_field",
+          "fields": {
+            "name": {
+              "type": "string",
+              "index": "not_analyzed"
+            },
+            "searchable": {
+              "type": "string",
+              "index": "analyzed"
+            },
+            "hash": { 
+              "type": "murmur3"
+            }
           }
         }
       }
     }
-  }
 }

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Properties/MurmurHashProperty.json
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Properties/MurmurHashProperty.json
@@ -1,0 +1,9 @@
+  {
+    "elasticsearchprojects": {
+      "properties": {
+        "hash": { 
+          "type": "murmur3"
+        }
+      }
+    }
+}

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Properties/PropertiesTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Properties/PropertiesTests.cs
@@ -199,6 +199,7 @@ namespace Nest.Tests.Unit.Core.Map.Properties
 						.Fields(pprops => pprops
 							.String(ps => ps.Name(p => p.Name).Index(FieldIndexOption.NotAnalyzed))
 							.String(ps => ps.Name(p => p.Name.Suffix("searchable")).Index(FieldIndexOption.Analyzed))
+							.Murmur3Hash(ps => ps.Name(p => p.Name.Suffix("hash")))
 						)
 					)
 				)
@@ -366,6 +367,19 @@ namespace Nest.Tests.Unit.Core.Map.Properties
 								.Default("u33")
 							)
 						)
+					)
+				)
+			);
+			this.JsonEquals(result.ConnectionStatus.Request, MethodInfo.GetCurrentMethod());
+		}
+
+		[Test]
+		public void MurmurHashProperty()
+		{
+			var result = this._client.Map<ElasticsearchProject>(m => m
+				.Properties(props => props
+					.Murmur3Hash(mh => mh
+						.Name("hash")
 					)
 				)
 			);

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -621,6 +621,9 @@
     <None Include="Core\Map\Properties\NestedObjectProperty.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Core\Map\Properties\MurmurHashProperty.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Core\Map\Properties\ObjectProperty.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Adding support for the mumur3 mapping type, mainly for use with the cardinality aggregation as explained here: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html#_pre_computed_hashes

This feels a bit dirty though IMO, since we have to treat it as an `IElasticCoreType` in order for it to work as a multi field.

We need to rethink the current object graph for mapping types for 2.0, but that's a separate issue.

Closes #1441 