### PR TITLE
Elasticsearch 1.6 feature parity

### DIFF
--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/bulk.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/bulk.json
@@ -1,6 +1,6 @@
 {
   "bulk": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html",
     "methods": ["POST", "PUT"],
     "url": {
       "path": "/_bulk",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.aliases.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.aliases.json
@@ -1,6 +1,6 @@
 {
   "cat.aliases": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/aliases",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.allocation.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.allocation.json
@@ -1,6 +1,6 @@
 {
   "cat.allocation": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/allocation",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.count.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.count.json
@@ -1,6 +1,6 @@
 {
   "cat.count": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/count",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.fielddata.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.fielddata.json
@@ -1,6 +1,6 @@
 {
   "cat.fielddata": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/fielddata",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.health.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.health.json
@@ -1,6 +1,6 @@
 {
   "cat.health": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/health",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.help.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.help.json
@@ -1,6 +1,6 @@
 {
   "cat.help": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.indices.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.indices.json
@@ -1,6 +1,6 @@
 {
   "cat.indices": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/indices",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.master.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.master.json
@@ -1,6 +1,6 @@
 {
   "cat.master": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/master",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.nodes.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.nodes.json
@@ -1,6 +1,6 @@
 {
   "cat.nodes": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/nodes",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.pending_tasks.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.pending_tasks.json
@@ -1,6 +1,6 @@
 {
   "cat.pending_tasks": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/pending_tasks",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.plugins.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.plugins.json
@@ -1,6 +1,6 @@
 {
   "cat.plugins": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/plugins",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.recovery.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.recovery.json
@@ -1,6 +1,6 @@
 {
   "cat.recovery": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/recovery",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.segments.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.segments.json
@@ -1,6 +1,6 @@
 {
   "cat.segments": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/segments",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.shards.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.shards.json
@@ -1,6 +1,6 @@
 {
   "cat.shards": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/shards",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.thread_pool.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.thread_pool.json
@@ -1,6 +1,6 @@
 {
   "cat.thread_pool": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cat/thread_pool",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/clear_scroll.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/clear_scroll.json
@@ -1,6 +1,6 @@
 {
   "clear_scroll": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_search/scroll/{scroll_id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.get_settings.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.get_settings.json
@@ -1,6 +1,6 @@
 {
   "cluster.get_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/settings",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.health.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.health.json
@@ -1,6 +1,6 @@
 {
   "cluster.health": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/health",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.pending_tasks.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.pending_tasks.json
@@ -1,6 +1,6 @@
 {
   "cluster.pending_tasks": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/pending_tasks",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.put_settings.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.put_settings.json
@@ -1,6 +1,6 @@
 {
   "cluster.put_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html",
     "methods": ["PUT"],
     "url": {
       "path": "/_cluster/settings",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.reroute.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.reroute.json
@@ -1,6 +1,6 @@
 {
   "cluster.reroute": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html",
     "methods": ["POST"],
     "url": {
       "path": "/_cluster/reroute",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.state.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.state.json
@@ -1,6 +1,6 @@
 {
   "cluster.state": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/state",
@@ -16,7 +16,7 @@
         },
         "metric" : {
           "type" : "list",
-          "options" : ["_all", "blocks", "metadata", "nodes", "routing_table", "master_node", "version"],
+          "options" : ["_all", "blocks", "metadata", "nodes", "routing_table", "routing_nodes", "master_node", "version"],
           "description" : "Limit the information returned to the specified metrics"
         }
       },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.stats.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cluster.stats.json
@@ -1,6 +1,6 @@
 {
   "cluster.stats": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html",
     "methods": ["GET"],
     "url": {
       "path": "/_cluster/stats",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/count.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/count.json
@@ -1,6 +1,6 @@
 {
   "count": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_count",
@@ -42,9 +42,35 @@
           "type" : "string",
           "description" : "Specific routing value"
         },
-        "source": {
+        "q": {
           "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
+          "description" : "Query in the Lucene query string syntax"
+        },
+        "analyzer": {
+          "type" : "string",
+          "description" : "The analyzer to use for the query string"
+        },
+        "analyze_wildcard": {
+          "type" : "boolean",
+          "description" : "Specify whether wildcard and prefix queries should be analyzed (default: false)"
+        },
+        "default_operator": {
+          "type" : "enum",
+          "options" : ["AND","OR"],
+          "default" : "OR",
+          "description" : "The default operator for query string query (AND or OR)"
+        },
+        "df": {
+          "type" : "string",
+          "description" : "The field to use as default where no field prefix is given in the query string"
+        },
+        "lenient": {
+          "type" : "boolean",
+          "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
+        },
+        "lowercase_expanded_terms": {
+          "type" : "boolean",
+          "description" : "Specify whether query terms should be lowercased"
         }
       }
     },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/count_percolate.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/count_percolate.json
@@ -1,6 +1,6 @@
 {
   "count_percolate": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/_percolate/count",
@@ -23,10 +23,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "routing": {
           "type": "list",
           "description": "A comma-separated list of specific routing values"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/delete.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/delete.json
@@ -1,6 +1,6 @@
 {
   "delete": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/{type}/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/delete_by_query.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/delete_by_query.json
@@ -1,6 +1,6 @@
 {
   "delete_by_query": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/_query",
@@ -63,10 +63,6 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
-        },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
         },
         "timeout": {
           "type" : "time",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/delete_script.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/delete_script.json
@@ -1,6 +1,6 @@
 {
   "delete_script": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_scripts/{lang}/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/delete_template.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/delete_template.json
@@ -1,6 +1,6 @@
 {
   "delete_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_search/template/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/exists.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/exists.json
@@ -1,6 +1,6 @@
 {
   "exists": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/{index}/{type}/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/explain.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/explain.json
@@ -1,6 +1,6 @@
 {
   "explain": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/{id}/_explain",
@@ -68,10 +68,6 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
-        },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
         },
         "_source": {
           "type" : "list",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/field_stats.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/field_stats.json
@@ -1,0 +1,46 @@
+{
+  "field_stats": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html",
+    "methods": ["GET", "POST"],
+    "url": {
+      "path": "/_field_stats",
+      "paths": [
+        "/_field_stats",
+        "/{index}/_field_stats"
+      ],
+      "parts": {
+        "index": {
+          "type" : "list",
+          "description" : "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"
+        }
+      },
+      "params": {
+        "fields": {
+          "type" : "list",
+          "description" : "A comma-separated list of fields for to get field statistics for (min value, max value, and more)"
+        },
+        "level": {
+          "type" : "enum",
+          "options" : ["indices", "cluster"],
+          "default" : "cluster",
+          "description" : "Defines if field stats should be returned on a per index level or on a cluster wide level"
+        },
+        "ignore_unavailable": {
+          "type" : "boolean",
+          "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+        },
+        "allow_no_indices": {
+          "type" : "boolean",
+          "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        },
+        "expand_wildcards": {
+          "type" : "enum",
+          "options" : ["open","closed","none","all"],
+          "default" : "open",
+          "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/get.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/get.json
@@ -1,6 +1,6 @@
 {
   "get": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html",
     "methods": ["GET"],
     "url": {
       "path": "/{index}/{type}/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/get_script.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/get_script.json
@@ -1,6 +1,6 @@
 {
   "get_script": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["GET"],
     "url": {
       "path": "/_scripts/{lang}/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/get_source.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/get_source.json
@@ -1,6 +1,6 @@
 {
   "get_source": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html",
     "methods": ["GET"],
     "url": {
       "path": "/{index}/{type}/{id}/_source",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/get_template.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/get_template.json
@@ -1,6 +1,6 @@
 {
   "get_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html",
     "methods": ["GET"],
     "url": {
       "path": "/_search/template/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/index.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/index.json
@@ -1,6 +1,6 @@
 {
   "index": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html",
     "methods": ["POST", "PUT"],
     "url": {
       "path": "/{index}/{type}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.analyze.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.analyze.json
@@ -1,6 +1,6 @@
 {
   "indices.analyze": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_analyze",
@@ -12,10 +12,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "analyzer": {
           "type" : "string",
           "description" : "The name of the analyzer to use"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.clear_cache.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.clear_cache.json
@@ -1,6 +1,6 @@
 {
   "indices.clear_cache": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_cache/clear",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.close.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.close.json
@@ -1,6 +1,6 @@
 {
   "indices.close": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html",
     "methods": ["POST"],
     "url": {
       "path": "/{index}/_close",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.create.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.create.json
@@ -1,6 +1,6 @@
 {
   "indices.create": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete.json
@@ -1,6 +1,6 @@
 {
   "indices.delete": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete_alias.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete_alias.json
@@ -1,6 +1,6 @@
 {
   "indices.delete_alias": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/_alias/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete_mapping.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete_mapping.json
@@ -1,6 +1,6 @@
 {
   "indices.delete_mapping": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/{type}/_mapping",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete_template.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete_template.json
@@ -1,6 +1,6 @@
 {
   "indices.delete_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_template/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete_warmer.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.delete_warmer.json
@@ -1,6 +1,6 @@
 {
   "indices.delete_warmer": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/_warmer/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.exists.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.exists.json
@@ -1,6 +1,6 @@
 {
   "indices.exists": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/{index}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.exists_alias.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.exists_alias.json
@@ -1,6 +1,6 @@
 {
   "indices.exists_alias": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/_alias/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.exists_template.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.exists_template.json
@@ -1,6 +1,6 @@
 {
   "indices.exists_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/_template/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.exists_type.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.exists_type.json
@@ -1,6 +1,6 @@
 {
   "indices.exists_type": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html",
     "methods": ["HEAD"],
     "url": {
       "path": "/{index}/{type}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.flush.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.flush.json
@@ -1,6 +1,6 @@
 {
   "indices.flush": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_flush",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.flush_synced.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.flush_synced.json
@@ -1,0 +1,39 @@
+{
+  "indices.flush_synced": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html",
+    "methods": ["POST", "GET"],
+    "url": {
+      "path": "/_flush/synced",
+      "paths": [
+        "/_flush/synced",
+        "/{index}/_flush/synced"
+      ],
+      "parts": {
+        "index": {
+          "type" : "list",
+          "description" : "A comma-separated list of index names; use `_all` or empty string for all indices"
+        },
+        "ignore_unavailable": {
+          "type": "boolean",
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+        },
+        "allow_no_indices": {
+          "type": "boolean",
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        },
+        "expand_wildcards": {
+          "type": "enum",
+          "options": [
+            "open",
+            "closed",
+            "none",
+            "all"
+          ],
+          "default": "open",
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.flush_synced.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.flush_synced.json
@@ -1,6 +1,6 @@
 {
   "indices.flush_synced": {
-    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_flush/synced",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get.json
@@ -1,6 +1,6 @@
 {
   "indices.get":{
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html",
     "methods":[ "GET" ],
     "url":{
       "path":"/{index}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_alias.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_alias.json
@@ -1,6 +1,6 @@
 {
   "indices.get_alias": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html",
     "methods": ["GET"],
     "url": {
       "path": "/_alias/",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_aliases.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_aliases.json
@@ -1,6 +1,6 @@
 {
   "indices.get_aliases": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html",
     "methods": ["GET"],
     "url": {
       "path": "/_aliases",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_field_mapping.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_field_mapping.json
@@ -1,6 +1,6 @@
 {
   "indices.get_field_mapping": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html",
     "methods": ["GET"],
     "url": {
       "path": "/_mapping/field/{field}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_mapping.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_mapping.json
@@ -1,6 +1,6 @@
 {
   "indices.get_mapping": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html",
     "methods": ["GET"],
     "url": {
       "path": "/_mapping",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_settings.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_settings.json
@@ -1,6 +1,6 @@
 {
   "indices.get_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html",
     "methods": ["GET"],
     "url": {
       "path": "/_settings",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_template.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_template.json
@@ -1,6 +1,6 @@
 {
   "indices.get_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html",
     "methods": ["GET"],
     "url": {
       "path": "/_template/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_upgrade.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_upgrade.json
@@ -1,6 +1,6 @@
 {
   "indices.get_upgrade": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
     "methods": ["GET"],
     "url": {
       "path": "/_upgrade",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_warmer.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.get_warmer.json
@@ -1,6 +1,6 @@
 {
   "indices.get_warmer": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html",
     "methods": ["GET"],
     "url": {
       "path": "/_warmer",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.open.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.open.json
@@ -1,6 +1,6 @@
 {
   "indices.open": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html",
     "methods": ["POST"],
     "url": {
       "path": "/{index}/_open",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.optimize.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.optimize.json
@@ -1,6 +1,6 @@
 {
   "indices.optimize": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_optimize",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_alias.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_alias.json
@@ -1,6 +1,6 @@
 {
   "indices.put_alias": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/_alias/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_mapping.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_mapping.json
@@ -1,6 +1,6 @@
 {
   "indices.put_mapping": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/{type}/_mapping",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_settings.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_settings.json
@@ -1,6 +1,6 @@
 {
   "indices.put_settings": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html",
     "methods": ["PUT"],
     "url": {
       "path": "/_settings",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_template.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_template.json
@@ -1,6 +1,6 @@
 {
   "indices.put_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_template/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_warmer.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.put_warmer.json
@@ -1,6 +1,6 @@
 {
   "indices.put_warmer": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/_warmer/{name}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.recovery.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.recovery.json
@@ -1,6 +1,6 @@
 {
     "indices.recovery" : {
-        "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html",
+        "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html",
         "methods": ["GET"],
         "url": {
             "path": "/_recovery",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.refresh.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.refresh.json
@@ -1,6 +1,6 @@
 {
   "indices.refresh": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_refresh",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.segments.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.segments.json
@@ -1,6 +1,6 @@
 {
   "indices.segments": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html",
     "methods": ["GET"],
     "url": {
       "path": "/_segments",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.stats.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.stats.json
@@ -1,6 +1,6 @@
 {
   "indices.stats": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html",
     "methods": ["GET"],
     "url": {
       "path": "/_stats",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.status.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.status.json
@@ -1,6 +1,6 @@
 {
   "indices.status": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html",
     "methods": ["GET"],
     "url": {
       "path": "/_status",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.update_aliases.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.update_aliases.json
@@ -1,6 +1,6 @@
 {
   "indices.update_aliases": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html",
     "methods": ["POST"],
     "url": {
       "path": "/_aliases",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.upgrade.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.upgrade.json
@@ -1,6 +1,6 @@
 {
   "indices.upgrade": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
     "methods": ["POST"],
     "url": {
       "path": "/_upgrade",
@@ -27,8 +27,12 @@
             "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
         },
         "wait_for_completion": {
+           "type" : "boolean",
+            "description" : "Specify whether the request should block until the all segments are upgraded (default: true)"
+	},
+        "only_ancient_segments": {
           "type" : "boolean",
-          "description" : "Specify whether the request should block until the all segments are upgraded (default: true)"
+          "description" : "If true, only ancient (an older Lucene major release) segments will be upgraded"
         }
       }
     },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.validate_query.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.validate_query.json
@@ -66,6 +66,10 @@
         "lowercase_expanded_terms": {
           "type" : "boolean",
           "description" : "Specify whether query terms should be lowercased"
+        },
+        "rewrite": {
+          "type": "boolean",
+          "description": "Provide a more detailed explanation showing the actual Lucene query that will be executed."
         }
       }
     },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.validate_query.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.validate_query.json
@@ -1,6 +1,6 @@
 {
   "indices.validate_query": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_validate/query",
@@ -37,13 +37,35 @@
         "operation_threading": {
           "description" : "TODO: ?"
         },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
-        },
         "q": {
           "type" : "string",
           "description" : "Query in the Lucene query string syntax"
+        },
+        "analyzer": {
+          "type" : "string",
+          "description" : "The analyzer to use for the query string"
+        },
+        "analyze_wildcard": {
+          "type" : "boolean",
+          "description" : "Specify whether wildcard and prefix queries should be analyzed (default: false)"
+        },
+        "default_operator": {
+          "type" : "enum",
+          "options" : ["AND","OR"],
+          "default" : "OR",
+          "description" : "The default operator for query string query (AND or OR)"
+        },
+        "df": {
+          "type" : "string",
+          "description" : "The field to use as default where no field prefix is given in the query string"
+        },
+        "lenient": {
+          "type" : "boolean",
+          "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
+        },
+        "lowercase_expanded_terms": {
+          "type" : "boolean",
+          "description" : "Specify whether query terms should be lowercased"
         }
       }
     },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/info.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/info.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "documentation": "http://www.elasticsearch.org/guide/",
+    "documentation": "http://www.elastic.co/guide/",
     "methods": ["GET"],
     "url": {
       "path": "/",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mget.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mget.json
@@ -1,6 +1,6 @@
 {
   "mget": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_mget",
@@ -16,10 +16,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "fields": {
           "type": "list",
           "description" : "A comma-separated list of fields to return in the response"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mlt.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mlt.json
@@ -1,6 +1,6 @@
 {
   "mlt": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/{id}/_mlt",
@@ -23,10 +23,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "boost_terms": {
           "type" : "number",
           "description" : "The boost factor"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mpercolate.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mpercolate.json
@@ -1,6 +1,6 @@
 {
   "mpercolate": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_mpercolate",
@@ -16,10 +16,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "ignore_unavailable": {
           "type": "boolean",
           "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/msearch.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/msearch.json
@@ -1,6 +1,6 @@
 {
   "msearch": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_msearch",
@@ -16,10 +16,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "search_type": {
           "type" : "enum",
           "options" : ["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"],

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mtermvectors.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/mtermvectors.json
@@ -1,6 +1,6 @@
 {
   "mtermvectors" : {
-    "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html",
+    "documentation" : "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
       "path" : "/_mtermvectors",
@@ -20,10 +20,6 @@
          }
       },
       "params" : {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "ids" : {
           "type" : "list",
           "description" : "A comma-separated list of documents ids. You must define ids as parameter or set \"ids\" or \"docs\" in the request body",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/nodes.hot_threads.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/nodes.hot_threads.json
@@ -1,6 +1,6 @@
 {
   "nodes.hot_threads": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html",
     "methods": ["GET"],
     "url": {
       "path": "/_nodes/hot_threads",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/nodes.info.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/nodes.info.json
@@ -1,6 +1,6 @@
 {
   "nodes.info": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html",
     "methods": ["GET"],
     "url": {
       "path": "/_nodes",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/nodes.shutdown.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/nodes.shutdown.json
@@ -1,6 +1,6 @@
 {
   "nodes.shutdown": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html",
     "methods": ["POST"],
     "url": {
       "path": "/_shutdown",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/nodes.stats.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/nodes.stats.json
@@ -1,6 +1,6 @@
 {
   "nodes.stats": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html",
     "methods": ["GET"],
     "url": {
       "path": "/_nodes/stats",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/percolate.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/percolate.json
@@ -1,6 +1,6 @@
 {
   "percolate": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/_percolate",
@@ -23,10 +23,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "routing": {
           "type" : "list",
           "description" : "A comma-separated list of specific routing values"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/ping.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/ping.json
@@ -1,6 +1,6 @@
 {
   "ping": {
-    "documentation": "http://www.elasticsearch.org/guide/",
+    "documentation": "http://www.elastic.co/guide/",
     "methods": ["HEAD"],
     "url": {
       "path": "/",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/put_script.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/put_script.json
@@ -1,6 +1,6 @@
 {
   "put_script": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_scripts/{lang}/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/put_template.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/put_template.json
@@ -1,6 +1,6 @@
 {
   "put_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_search/template/{id}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/root.html
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/root.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Language" content="en">
     
     
-    <title>elasticsearch/rest-api-spec/api at v1.5.2 Â· elastic/elasticsearch Â· GitHub</title>
+    <title>elasticsearch/rest-api-spec/api at v1.6.0 Â· elastic/elasticsearch Â· GitHub</title>
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
     <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
     <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-114.png">
@@ -32,36 +32,36 @@
     <meta name="selected-link" value="repo_source" data-pjax-transient>
       <meta name="google-analytics" content="UA-3769691-2">
 
-    <meta content="collector.githubapp.com" name="octolytics-host" /><meta content="collector-cdn.github.com" name="octolytics-script-host" /><meta content="github" name="octolytics-app-id" /><meta content="60E16102:02CA:FD304AB:554A589A" name="octolytics-dimension-request_id" />
+    <meta content="collector.githubapp.com" name="octolytics-host" /><meta content="collector-cdn.github.com" name="octolytics-script-host" /><meta content="github" name="octolytics-app-id" /><meta content="60E16102:0684:1A516D7:557A0062" name="octolytics-dimension-request_id" />
     
     <meta content="Rails, view, files#disambiguate" name="analytics-event" />
     <meta class="js-ga-set" name="dimension1" content="Logged Out">
-    <meta class="js-ga-set" name="dimension2" content="Header v3">
     <meta name="is-dotcom" content="true">
-    <meta name="hostname" content="github.com">
+      <meta name="hostname" content="github.com">
     <meta name="user-login" content="">
 
-    
-    <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
+      <link rel="icon" sizes="any" mask href="https://assets-cdn.github.com/pinned-octocat.svg">
+      <meta name="theme-color" content="#4078c0">
+      <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
 
 
     <meta content="authenticity_token" name="csrf-param" />
-<meta content="ho7p0sEtaXPFYYbQ1OITay2i+HBBK3DsSbdxzHODmydy9ozT9ghpGZ+H4CCRmuOO8Ytqygun66fEPHbHr8+f1Q==" name="csrf-token" />
+<meta content="nbEtnvu3yx1Ci8p7s0cgMQ7L0D+G9bV4gxGmfMrAQFgcuGyGlxgjAWLB4CjdvkpzPZ9yWNu69XLHqlVKixH/+g==" name="csrf-token" />
 
-    <link href="https://assets-cdn.github.com/assets/github-151090982a2c2c28413901d35eb6c3c28cd671be5a101bcaec3d0e55a4ea39b7.css" media="all" rel="stylesheet" />
-    <link href="https://assets-cdn.github.com/assets/github2-ca7a40afa0db1779efa9ffb34d294ce481fd29f4e44c7a92d9e568a4cce75671.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github/index-61b260d732e9f1dd827b15f60326633780fe0bfc6b99da69b40d0c857926c6ff.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github2/index-0bbd23bc506411254609d413396a7734e06c7729ba5ce9ad80d793f95716203b.css" media="all" rel="stylesheet" />
     
     
 
 
-    <meta http-equiv="x-pjax-version" content="81b2b43007725a4504e8fb5d4c12fc0d">
+    <meta http-equiv="x-pjax-version" content="f435d20dffc0d5d57bf6ae309941491c">
 
       
   <meta name="description" content="elasticsearch - Open Source, Distributed, RESTful Search Engine">
   <meta name="go-import" content="github.com/elastic/elasticsearch git https://github.com/elastic/elasticsearch.git">
 
   <meta content="6764390" name="octolytics-dimension-user_id" /><meta content="elastic" name="octolytics-dimension-user_login" /><meta content="507775" name="octolytics-dimension-repository_id" /><meta content="elastic/elasticsearch" name="octolytics-dimension-repository_nwo" /><meta content="true" name="octolytics-dimension-repository_public" /><meta content="false" name="octolytics-dimension-repository_is_fork" /><meta content="507775" name="octolytics-dimension-repository_network_root_id" /><meta content="elastic/elasticsearch" name="octolytics-dimension-repository_network_root_nwo" />
-  <link href="https://github.com/elastic/elasticsearch/commits/v1.5.2.atom" rel="alternate" title="Recent Commits to elasticsearch:v1.5.2" type="application/atom+xml">
+  <link href="https://github.com/elastic/elasticsearch/commits/v1.6.0.atom" rel="alternate" title="Recent Commits to elasticsearch:v1.6.0" type="application/atom+xml">
 
   </head>
 
@@ -84,21 +84,23 @@
 
     <div class="header-actions" role="navigation">
         <a class="btn btn-primary" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign up</a>
-      <a class="btn" href="/login?return_to=%2Felastic%2Felasticsearch%2Ftree%2Fv1.5.2%2Frest-api-spec%2Fapi" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
+      <a class="btn" href="/login?return_to=%2Felastic%2Felasticsearch%2Ftree%2Fv1.6.0%2Frest-api-spec%2Fapi" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
     </div>
 
     <div class="site-search repo-scope js-site-search" role="search">
       <form accept-charset="UTF-8" action="/elastic/elasticsearch/search" class="js-site-search-form" data-global-search-url="/search" data-repo-search-url="/elastic/elasticsearch/search" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
-  <input type="text"
-    class="js-site-search-field is-clearable"
-    data-hotkey="s"
-    name="q"
-    placeholder="Search"
-    data-global-scope-placeholder="Search GitHub"
-    data-repo-scope-placeholder="Search"
-    tabindex="1"
-    autocapitalize="off">
-  <div class="scope-badge">This repository</div>
+  <label class="js-chromeless-input-container form-control">
+    <div class="scope-badge">This repository</div>
+    <input type="text"
+      class="js-site-search-focus js-site-search-field is-clearable chromeless-input"
+      data-hotkey="s"
+      name="q"
+      placeholder="Search"
+      data-global-scope-placeholder="Search GitHub"
+      data-repo-scope-placeholder="Search"
+      tabindex="1"
+      autocapitalize="off">
+  </label>
 </form>
     </div>
 
@@ -129,6 +131,7 @@
     </div>
     <div class="pagehead repohead instapaper_ignore readability-menu">
       <div class="container">
+
         
 <ul class="pagehead-actions">
 
@@ -140,7 +143,7 @@
     Watch
   </a>
   <a class="social-count" href="/elastic/elasticsearch/watchers">
-    1,153
+    1,192
   </a>
 
   </li>
@@ -154,7 +157,7 @@
   </a>
 
     <a class="social-count js-social-count" href="/elastic/elasticsearch/stargazers">
-      11,083
+      11,568
     </a>
 
   </li>
@@ -167,7 +170,7 @@
         Fork
       </a>
       <a href="/elastic/elasticsearch/network" class="social-count">
-        3,488
+        3,661
       </a>
     </li>
 </ul>
@@ -176,7 +179,7 @@
           <span class="mega-octicon octicon-repo"></span>
           <span class="author"><a href="/elastic" class="url fn" itemprop="url" rel="author"><span itemprop="title">elastic</span></a></span><!--
        --><span class="path-divider">/</span><!--
-       --><strong><a href="/elastic/elasticsearch" class="js-current-repository" data-pjax="#js-repo-pjax-container">elasticsearch</a></strong>
+       --><strong><a href="/elastic/elasticsearch" data-pjax="#js-repo-pjax-container">elasticsearch</a></strong>
 
           <span class="page-context-loader">
             <img alt="" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
@@ -196,7 +199,7 @@
      data-issue-count-url="/elastic/elasticsearch/issues/counts">
   <ul class="sunken-menu-group">
     <li class="tooltipped tooltipped-w" aria-label="Code">
-      <a href="/elastic/elasticsearch/tree/v1.5.2" aria-label="Code" class="selected js-selected-navigation-item sunken-menu-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /elastic/elasticsearch/tree/v1.5.2">
+      <a href="/elastic/elasticsearch/tree/v1.6.0" aria-label="Code" class="selected js-selected-navigation-item sunken-menu-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /elastic/elasticsearch/tree/v1.6.0">
         <span class="octicon octicon-code"></span> <span class="full-word">Code</span>
         <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
 </a>    </li>
@@ -237,9 +240,8 @@
 
               <div class="only-with-full-nav">
                   
-<div class="clone-url open"
-  data-protocol-type="http"
-  data-url="/users/set_protocol?protocol_selector=http&amp;protocol_type=clone">
+<div class="js-clone-url clone-url open"
+  data-protocol-type="http">
   <h3><span class="text-emphasized">HTTPS</span> clone URL</h3>
   <div class="input-group js-zeroclipboard-container">
     <input type="text" class="input-mini input-monospace js-url-field js-zeroclipboard-target"
@@ -251,9 +253,8 @@
 </div>
 
   
-<div class="clone-url "
-  data-protocol-type="subversion"
-  data-url="/users/set_protocol?protocol_selector=subversion&amp;protocol_type=clone">
+<div class="js-clone-url clone-url "
+  data-protocol-type="subversion">
   <h3><span class="text-emphasized">Subversion</span> checkout URL</h3>
   <div class="input-group js-zeroclipboard-container">
     <input type="text" class="input-mini input-monospace js-url-field js-zeroclipboard-target"
@@ -266,17 +267,17 @@
 
 
 
-<p class="clone-options">You can clone with
-  <a href="#" class="js-clone-selector" data-protocol="http">HTTPS</a> or <a href="#" class="js-clone-selector" data-protocol="subversion">Subversion</a>.
+<div class="clone-options">You can clone with
+  <form accept-charset="UTF-8" action="/users/set_protocol?protocol_selector=http&amp;protocol_type=clone" class="inline-form js-clone-selector-form " data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="dLfLU26I1huKP51r51Of3EaQcx1mOt2iTiO24NRcVFg9Ys9zVJw/ohkO99/PBXG9koPF78DRpEzIZmAl4wS6wA==" /></div><button class="btn-link js-clone-selector" data-protocol="http" type="submit">HTTPS</button></form> or <form accept-charset="UTF-8" action="/users/set_protocol?protocol_selector=subversion&amp;protocol_type=clone" class="inline-form js-clone-selector-form " data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="Ws4F1Dw45M9BJAfExyszZdTwVqQAcNivAwou0Iney5pGDLpnFQUWs1yx7oCZ0eR+Kl4NIOa2vr47Te2vwbidoQ==" /></div><button class="btn-link js-clone-selector" data-protocol="subversion" type="submit">Subversion</button></form>.
   <a href="https://help.github.com/articles/which-remote-url-should-i-use" class="help tooltipped tooltipped-n" aria-label="Get help on which URL is right for you.">
     <span class="octicon octicon-question"></span>
   </a>
-</p>
+</div>
 
 
 
 
-                <a href="/elastic/elasticsearch/archive/v1.5.2.zip"
+                <a href="/elastic/elasticsearch/archive/v1.6.0.zip"
                    class="btn btn-sm sidebar-button"
                    aria-label="Download the contents of elastic/elasticsearch as a zip file"
                    title="Download the contents of elastic/elasticsearch as a zip file"
@@ -294,13 +295,12 @@
   
 <div class="select-menu js-menu-container js-select-menu left">
   <span class="btn btn-sm select-menu-button js-menu-target css-truncate" data-hotkey="w"
-    data-master-branch="master"
-    data-ref="v1.5.2"
-    title="v1.5.2"
+    data-ref="v1.6.0"
+    title="v1.6.0"
     role="button" aria-label="Switch branches or tags" tabindex="0" aria-haspopup="true">
     <span class="octicon octicon-tag"></span>
     <i>tag:</i>
-    <span class="js-select-button css-truncate-target">v1.5.2</span>
+    <span class="js-select-button css-truncate-target">v1.6.0</span>
   </span>
 
   <div class="select-menu-modal-holder js-menu-content js-navigation-container" data-pjax aria-hidden="true">
@@ -493,6 +493,16 @@
               </span>
             </a>
             <a class="select-menu-item js-navigation-item js-navigation-open "
+               href="/elastic/elasticsearch/tree/1.6/rest-api-spec/api"
+               data-name="1.6"
+               data-skip-pjax="true"
+               rel="nofollow">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <span class="select-menu-item-text css-truncate-target" title="1.6">
+                1.6
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
                href="/elastic/elasticsearch/tree/1.x/rest-api-spec/api"
                data-name="1.x"
                data-skip-pjax="true"
@@ -563,16 +573,6 @@
               </span>
             </a>
             <a class="select-menu-item js-navigation-item js-navigation-open "
-               href="/elastic/elasticsearch/tree/feature/aggs_2_0/rest-api-spec/api"
-               data-name="feature/aggs_2_0"
-               data-skip-pjax="true"
-               rel="nofollow">
-              <span class="select-menu-item-icon octicon octicon-check"></span>
-              <span class="select-menu-item-text css-truncate-target" title="feature/aggs_2_0">
-                feature/aggs_2_0
-              </span>
-            </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
                href="/elastic/elasticsearch/tree/feature/bench/rest-api-spec/api"
                data-name="feature/bench"
                data-skip-pjax="true"
@@ -620,36 +620,6 @@
               <span class="select-menu-item-icon octicon octicon-check"></span>
               <span class="select-menu-item-text css-truncate-target" title="feature/query-refactoring">
                 feature/query-refactoring
-              </span>
-            </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
-               href="/elastic/elasticsearch/tree/feature/reducers/rest-api-spec/api"
-               data-name="feature/reducers"
-               data-skip-pjax="true"
-               rel="nofollow">
-              <span class="select-menu-item-icon octicon octicon-check"></span>
-              <span class="select-menu-item-text css-truncate-target" title="feature/reducers">
-                feature/reducers
-              </span>
-            </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
-               href="/elastic/elasticsearch/tree/feature/synced_flush/rest-api-spec/api"
-               data-name="feature/synced_flush"
-               data-skip-pjax="true"
-               rel="nofollow">
-              <span class="select-menu-item-icon octicon octicon-check"></span>
-              <span class="select-menu-item-text css-truncate-target" title="feature/synced_flush">
-                feature/synced_flush
-              </span>
-            </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
-               href="/elastic/elasticsearch/tree/feature/transformers/rest-api-spec/api"
-               data-name="feature/transformers"
-               data-skip-pjax="true"
-               rel="nofollow">
-              <span class="select-menu-item-icon octicon octicon-check"></span>
-              <span class="select-menu-item-text css-truncate-target" title="feature/transformers">
-                feature/transformers
               </span>
             </a>
             <a class="select-menu-item js-navigation-item js-navigation-open "
@@ -712,6 +682,15 @@
 
 
             <div class="select-menu-item js-navigation-item selected">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/elastic/elasticsearch/tree/v1.6.0/rest-api-spec/api"
+                 data-name="v1.6.0"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text css-truncate-target"
+                 title="v1.6.0">v1.6.0</a>
+            </div>
+            <div class="select-menu-item js-navigation-item ">
               <span class="select-menu-item-icon octicon octicon-check"></span>
               <a href="/elastic/elasticsearch/tree/v1.5.2/rest-api-spec/api"
                  data-name="v1.5.2"
@@ -1602,15 +1581,6 @@
                  class="js-navigation-open select-menu-item-text css-truncate-target"
                  title="v0.16.3">v0.16.3</a>
             </div>
-            <div class="select-menu-item js-navigation-item ">
-              <span class="select-menu-item-icon octicon octicon-check"></span>
-              <a href="/elastic/elasticsearch/tree/v0.16.2/rest-api-spec/api"
-                 data-name="v0.16.2"
-                 data-skip-pjax="true"
-                 rel="nofollow"
-                 class="js-navigation-open select-menu-item-text css-truncate-target"
-                 title="v0.16.2">v0.16.2</a>
-            </div>
         </div>
 
         <div class="select-menu-no-results">Nothing to show</div>
@@ -1622,17 +1592,17 @@
 
 
   <div class="btn-group right">
-    <a href="/elastic/elasticsearch/find/v1.5.2" data-pjax data-hotkey="t" class="js-show-file-finder btn btn-sm empty-icon tooltipped tooltipped-s" aria-label="Quickly jump between files">
+    <a href="/elastic/elasticsearch/find/v1.6.0" data-pjax data-hotkey="t" class="js-show-file-finder btn btn-sm empty-icon tooltipped tooltipped-s" aria-label="Quickly jump between files">
       <span class="octicon octicon-list-unordered"></span>
     </a>
-    <a href="/elastic/elasticsearch/commits/v1.5.2/rest-api-spec/api" class="btn btn-sm empty-icon tooltipped tooltipped-s" aria-label="Browse commits for this branch">
+    <a href="/elastic/elasticsearch/commits/v1.6.0/rest-api-spec/api" class="btn btn-sm empty-icon tooltipped tooltipped-s" aria-label="Browse commits for this branch">
       <span class="octicon octicon-history"></span>
     </a>
   </div>
 
-  <div class="breadcrumb"><span class='repo-root js-repo-root'><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/elastic/elasticsearch/tree/v1.5.2" class="" data-branch="v1.5.2" data-direction="back" data-pjax="true" itemscope="url"><span itemprop="title">elasticsearch</span></a></span></span><span class="separator">/</span><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/elastic/elasticsearch/tree/v1.5.2/rest-api-spec" class="" data-branch="v1.5.2" data-direction="back" data-pjax="true" itemscope="url"><span itemprop="title">rest-api-spec</span></a></span><span class="separator">/</span><strong class="final-path">api</strong><span class="separator">/</span>
+  <div class="breadcrumb"><span class="repo-root js-repo-root"><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/elastic/elasticsearch/tree/v1.6.0" class="" data-branch="v1.6.0" data-pjax="true" itemscope="url"><span itemprop="title">elasticsearch</span></a></span></span><span class="separator">/</span><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/elastic/elasticsearch/tree/v1.6.0/rest-api-spec" class="" data-branch="v1.6.0" data-pjax="true" itemscope="url"><span itemprop="title">rest-api-spec</span></a></span><span class="separator">/</span><strong class="final-path">api</strong><span class="separator">/</span>
   <span class="js-new-blob-form tooltipped tooltipped-e text-muted" aria-label="Select a branch to create a new file">
-    <span class="js-new-blob-submit octicon octicon-plus" data-test-id="create-new-git-file"></span>
+    <span class="js-new-blob-submit octicon octicon-plus"></span>
   </span>
 </div>
 
@@ -1640,7 +1610,7 @@
 
 
 
-  <include-fragment class="commit commit-loader commit-tease" src="/elastic/elasticsearch/tree-commit/62ff9868b4c8a0c45860bebb259e21980778ab1c/rest-api-spec/api">
+  <include-fragment class="commit commit-loader commit-tease" src="/elastic/elasticsearch/tree-commit/cdd3ac4dde4f69524ec0a14de3828cb95bbb86d0/rest-api-spec/api">
     <p class="commit-title blank">
       Fetching latest commitâ€¦
     </p>
@@ -1650,13 +1620,13 @@
     </div>
 </include-fragment>
   
-<include-fragment class="file-wrap" src="/elastic/elasticsearch/file-list/v1.5.2/rest-api-spec/api">
-  <a href="/elastic/elasticsearch/tree/62ff9868b4c8a0c45860bebb259e21980778ab1c/rest-api-spec/api" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
+<include-fragment class="file-wrap" src="/elastic/elasticsearch/file-list/v1.6.0/rest-api-spec/api">
+  <a href="/elastic/elasticsearch/tree/cdd3ac4dde4f69524ec0a14de3828cb95bbb86d0/rest-api-spec/api" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
 
   <table class="files" data-pjax>
       <tr class="up-tree">
         <td></td>
-        <td><a href="/elastic/elasticsearch/tree/v1.5.2/rest-api-spec" rel="nofollow" title="Go to parent directory">..</a></td>
+        <td><a href="/elastic/elasticsearch/tree/v1.6.0/rest-api-spec" rel="nofollow" title="Go to parent directory">..</a></td>
         <td></td>
         <td></td>
       </tr>
@@ -1674,7 +1644,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/bulk.json" class="js-directory-link" id="6c4fbc1bd36df5d9905ce1df9cf222c0-53a2e204211ba869f01a7b736de35ef7435b9d27" title="bulk.json">bulk.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/bulk.json" class="js-directory-link" id="6c4fbc1bd36df5d9905ce1df9cf222c0-74e39f82d87d5382cc9bcd7c695ef336476d784e" title="bulk.json">bulk.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1691,7 +1661,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.aliases.json" class="js-directory-link" id="22e2d431e2e1793e41b5f065dceaa89e-539f9c79a6f7ccbb69aba2baa8ac68b71e86f8cc" title="cat.aliases.json">cat.aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.aliases.json" class="js-directory-link" id="22e2d431e2e1793e41b5f065dceaa89e-fea23d1962101e60946899685465a228dee4ccd5" title="cat.aliases.json">cat.aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1708,7 +1678,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.allocation.json" class="js-directory-link" id="4579bbcb4332bcaa7d0fb18c63b2fdd1-c2783e10dc6ff84cb8871f4c25b441b6c264c332" title="cat.allocation.json">cat.allocation.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.allocation.json" class="js-directory-link" id="4579bbcb4332bcaa7d0fb18c63b2fdd1-13d536f293842def1df4370f03a935b99b20788d" title="cat.allocation.json">cat.allocation.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1725,7 +1695,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.count.json" class="js-directory-link" id="aa6d9382bc0b00917e17cb6dec212d42-6b5b7d7b71f17f64a99b22c9da86bceb07e2cf42" title="cat.count.json">cat.count.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.count.json" class="js-directory-link" id="aa6d9382bc0b00917e17cb6dec212d42-5b238601db41762bf16aa524856273b7d0d417a2" title="cat.count.json">cat.count.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1742,7 +1712,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.fielddata.json" class="js-directory-link" id="ac8f77984707b6255de6dc1447665b53-2550f421ecad415ebbb6f7cc6fe9e7ba9bff99c0" title="cat.fielddata.json">cat.fielddata.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.fielddata.json" class="js-directory-link" id="ac8f77984707b6255de6dc1447665b53-a380b558e89b42f34d8e55be4438dbacfbf12f42" title="cat.fielddata.json">cat.fielddata.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1759,7 +1729,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.health.json" class="js-directory-link" id="2339db869d5a3d7653d999028dbf5dbb-f8d73aee819c005fedcbf369530857fb113f16fd" title="cat.health.json">cat.health.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.health.json" class="js-directory-link" id="2339db869d5a3d7653d999028dbf5dbb-222286c6b2db3b96af01f0c69d3a572232ab4e99" title="cat.health.json">cat.health.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1776,7 +1746,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.help.json" class="js-directory-link" id="2c1bf912a288d9a69ad3aa77a0ad1c3a-d7f291353881d6da5524f775ce801604deee38e5" title="cat.help.json">cat.help.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.help.json" class="js-directory-link" id="2c1bf912a288d9a69ad3aa77a0ad1c3a-c4692e839c94bc89de29e255214633038defd1c7" title="cat.help.json">cat.help.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1793,7 +1763,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.indices.json" class="js-directory-link" id="51f4fa0dcdc855c076d42cd209daefbf-55fb1c6598e2e888011f930cff101bd9584e44df" title="cat.indices.json">cat.indices.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.indices.json" class="js-directory-link" id="51f4fa0dcdc855c076d42cd209daefbf-08adffab0f354858fe3b352863d4ce41c6b519c6" title="cat.indices.json">cat.indices.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1810,7 +1780,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.master.json" class="js-directory-link" id="777752fc1e100524ad85bffc292b262b-83b88210b0a8996a13a6b30fa3b1966e71f393da" title="cat.master.json">cat.master.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.master.json" class="js-directory-link" id="777752fc1e100524ad85bffc292b262b-b5e229776103d68e96cf33f6ee4c1a5e3ab566d0" title="cat.master.json">cat.master.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1827,7 +1797,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.nodes.json" class="js-directory-link" id="c673b074876c5b81edb6826075e32d92-a458165ad99c385b97d5dd27338ef86b6a22c4ba" title="cat.nodes.json">cat.nodes.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.nodes.json" class="js-directory-link" id="c673b074876c5b81edb6826075e32d92-ff240dd4cee4d01eff120e3c02b9669314e38b8a" title="cat.nodes.json">cat.nodes.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1844,7 +1814,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.pending_tasks.json" class="js-directory-link" id="a51d665aca06cbf8fca196ef68c5490e-7e2c6b42a4dd80b9edb1c40ceab54ff8bd32fb2a" title="cat.pending_tasks.json">cat.pending_tasks.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.pending_tasks.json" class="js-directory-link" id="a51d665aca06cbf8fca196ef68c5490e-8b52c521fcaee7e6b6c6acace8386d153e96d858" title="cat.pending_tasks.json">cat.pending_tasks.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1861,7 +1831,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.plugins.json" class="js-directory-link" id="babca80f1103a775be37ca111c02126b-c5f4b60fb7db598b4d1646afd5b1949094c115de" title="cat.plugins.json">cat.plugins.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.plugins.json" class="js-directory-link" id="babca80f1103a775be37ca111c02126b-55ee66a27926774a1cd4345bdc523dcc7f5bfa3e" title="cat.plugins.json">cat.plugins.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1878,7 +1848,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.recovery.json" class="js-directory-link" id="b2755b9dbefea2a2111d7d436f45eeb2-6b215566733bc74083803005e34b37034ef0e0b4" title="cat.recovery.json">cat.recovery.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.recovery.json" class="js-directory-link" id="b2755b9dbefea2a2111d7d436f45eeb2-a190e35b3c79c58f1b8207eaa245e4e752aacd08" title="cat.recovery.json">cat.recovery.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1895,7 +1865,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.segments.json" class="js-directory-link" id="f83e55e75343f860635f6a521d60cf41-25dce003df408c1524bcfc3bcd7c07677decd2c4" title="cat.segments.json">cat.segments.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.segments.json" class="js-directory-link" id="f83e55e75343f860635f6a521d60cf41-f032f4d38e6ed89f24317bfb510a0d9c61663958" title="cat.segments.json">cat.segments.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1912,7 +1882,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.shards.json" class="js-directory-link" id="864b15ab41822be341f433cdcd6b294a-df3825fc07894c9551b2a5c122c3f6665d9c0b13" title="cat.shards.json">cat.shards.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.shards.json" class="js-directory-link" id="864b15ab41822be341f433cdcd6b294a-6d1ffc37ba1ffbd54888c4ed3eb173b063220554" title="cat.shards.json">cat.shards.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1929,7 +1899,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cat.thread_pool.json" class="js-directory-link" id="0f45c62bc5b57fcaf01a0ee8e2be1a1f-a0bd7868a56f5d0b92d4d8d21c3e76dba7f6b508" title="cat.thread_pool.json">cat.thread_pool.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.thread_pool.json" class="js-directory-link" id="0f45c62bc5b57fcaf01a0ee8e2be1a1f-cb8e5e13632a24a2800a5e379088d215281d84f6" title="cat.thread_pool.json">cat.thread_pool.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1946,7 +1916,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/clear_scroll.json" class="js-directory-link" id="fb88c998e68dce2106c94c0bc6cc3dac-22c49a2317cae611669303b65d2e76991f29fb07" title="clear_scroll.json">clear_scroll.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/clear_scroll.json" class="js-directory-link" id="fb88c998e68dce2106c94c0bc6cc3dac-ff4e0bea3275f3b632f094b181c5d8ee2bd37567" title="clear_scroll.json">clear_scroll.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1963,7 +1933,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cluster.get_settings.json" class="js-directory-link" id="381ace7cc8ee62a6a019ff3d4fa5918b-98e2b3b5dcbc40732ef0a06029b13bd745dfbcfa" title="cluster.get_settings.json">cluster.get_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.get_settings.json" class="js-directory-link" id="381ace7cc8ee62a6a019ff3d4fa5918b-69b35e043a8cded02836d1259e76cf3ad81170cb" title="cluster.get_settings.json">cluster.get_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1980,7 +1950,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cluster.health.json" class="js-directory-link" id="c2c52db081b723be399bb732f65aca84-9d679d673fc84161a94b854fc85692c73d369460" title="cluster.health.json">cluster.health.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.health.json" class="js-directory-link" id="c2c52db081b723be399bb732f65aca84-367a6e9563ed917e3192333cdcb456f1e21e9286" title="cluster.health.json">cluster.health.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1997,7 +1967,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cluster.pending_tasks.json" class="js-directory-link" id="8a69fbf26be58ddfb4da9890e9ab2c28-09a5fe7998b6dedb5573bc668206b362962faa47" title="cluster.pending_tasks.json">cluster.pending_tasks.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.pending_tasks.json" class="js-directory-link" id="8a69fbf26be58ddfb4da9890e9ab2c28-e88413ed73360778b04bf9de7f08449207933508" title="cluster.pending_tasks.json">cluster.pending_tasks.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2014,7 +1984,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cluster.put_settings.json" class="js-directory-link" id="e87166468da155e9d9c15de6e56a9f9e-692b1420a053bf151d4b7289ef50dd8c198b5dfe" title="cluster.put_settings.json">cluster.put_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.put_settings.json" class="js-directory-link" id="e87166468da155e9d9c15de6e56a9f9e-1c434b2f5db28898d4f257996c61b16df7d70763" title="cluster.put_settings.json">cluster.put_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2031,7 +2001,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cluster.reroute.json" class="js-directory-link" id="a2b21ed6ff197a1803c961126ab8960c-0bb4b5c877dd0f997845c05f0a6f3b82484814c6" title="cluster.reroute.json">cluster.reroute.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.reroute.json" class="js-directory-link" id="a2b21ed6ff197a1803c961126ab8960c-3f621aff066f05b99cf4fcf286424ec2191fc050" title="cluster.reroute.json">cluster.reroute.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2048,7 +2018,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cluster.state.json" class="js-directory-link" id="6acc013937ed94065ffab45cc3d7ec36-90cdd60ac7532f9301feb9ade1eab80a77277c97" title="cluster.state.json">cluster.state.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.state.json" class="js-directory-link" id="6acc013937ed94065ffab45cc3d7ec36-72de5e3c91ab30775dd6aec2ec47e3a8208b2e33" title="cluster.state.json">cluster.state.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2065,7 +2035,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/cluster.stats.json" class="js-directory-link" id="ddd8cd720c91c6531768ce3ede81e8d3-8964b58483e72b2772408611813bdf8a8de7b97c" title="cluster.stats.json">cluster.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.stats.json" class="js-directory-link" id="ddd8cd720c91c6531768ce3ede81e8d3-25ea04a29332b708eb31799683c397b714afa042" title="cluster.stats.json">cluster.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2082,7 +2052,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/count.json" class="js-directory-link" id="3baa357d5adf340622c003b0856dd25f-89fc31de2fe3ac661357cb38aa71dba3395bd408" title="count.json">count.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/count.json" class="js-directory-link" id="3baa357d5adf340622c003b0856dd25f-a1fddb9bfeccc3b683896221ad54e569b66ba4ea" title="count.json">count.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2099,7 +2069,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/count_percolate.json" class="js-directory-link" id="2d9528db75f1df48e5cc5080a4dbdb3e-000368f07ab409f3030659df8d9e2f3a7653f058" title="count_percolate.json">count_percolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/count_percolate.json" class="js-directory-link" id="2d9528db75f1df48e5cc5080a4dbdb3e-55d7952df65eea7704ed1efc9a28abc9e32e501c" title="count_percolate.json">count_percolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2116,7 +2086,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/delete.json" class="js-directory-link" id="32e7b62c510daf7d16345f4d4bb54d69-961f03fdea7ccb8a244b672d1cb521d17dee674c" title="delete.json">delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/delete.json" class="js-directory-link" id="32e7b62c510daf7d16345f4d4bb54d69-0910f71143886cabea44a1dac68c771101bd14cf" title="delete.json">delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2133,7 +2103,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/delete_by_query.json" class="js-directory-link" id="1be069693a43a7efc73e3cbbee3df9d6-461e74a9ca6458d551b1f4c3bf9cfb4047547926" title="delete_by_query.json">delete_by_query.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/delete_by_query.json" class="js-directory-link" id="1be069693a43a7efc73e3cbbee3df9d6-15ef9982fee6194017b25b896f0b2758dc27f1b8" title="delete_by_query.json">delete_by_query.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2150,7 +2120,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/delete_script.json" class="js-directory-link" id="0f1829713245eba3e6695da9d37342c1-897f2e20669a0772debb00ed41db5f7e7ada582c" title="delete_script.json">delete_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/delete_script.json" class="js-directory-link" id="0f1829713245eba3e6695da9d37342c1-d3f7771fc852cc31c5eb4d108cf5b2bdc1514f4a" title="delete_script.json">delete_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2167,7 +2137,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/delete_template.json" class="js-directory-link" id="64be6114ddd1e414654ed6b052a067ba-2fbdf0c6c7c87df9252fe1f4c7bf94746ed27a88" title="delete_template.json">delete_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/delete_template.json" class="js-directory-link" id="64be6114ddd1e414654ed6b052a067ba-9e928342d075e01084c74189791833739dad055d" title="delete_template.json">delete_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2184,7 +2154,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/exists.json" class="js-directory-link" id="3d89dbbbdf2cfe3ecaccea759487838f-b7ba6495b3f46864f54399a6aa25f0d075505022" title="exists.json">exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/exists.json" class="js-directory-link" id="3d89dbbbdf2cfe3ecaccea759487838f-f61d9cbb586eb8014da024ceacaffbfa0f7a9273" title="exists.json">exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2201,7 +2171,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/explain.json" class="js-directory-link" id="f1262f2a3266d79bc85a4907d455c177-bee897b73a1f3b95e7ad5a9990d677ff4608dff7" title="explain.json">explain.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/explain.json" class="js-directory-link" id="f1262f2a3266d79bc85a4907d455c177-0e9a99202f41df778717a75dc573bc8bdef6aac2" title="explain.json">explain.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2218,7 +2188,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/get.json" class="js-directory-link" id="08e364c89f4f291dd93f7be65f3c1629-80b2d395fa7924012cdb67abbd613b6f71897adf" title="get.json">get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/field_stats.json" class="js-directory-link" id="6f118aa7a31508b462aae4b9be7f3e9d-e3c5e6d45df3f263fedd6edd31fd428f0625da3c" title="field_stats.json">field_stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2235,7 +2205,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/get_script.json" class="js-directory-link" id="ec949f8f96d44ae7d86392e6939249fc-49e3c8a8540e72a3652ca942cb39d75b4fe23b6d" title="get_script.json">get_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/get.json" class="js-directory-link" id="08e364c89f4f291dd93f7be65f3c1629-73b5d11b4bf981aa86404854337c48ce758f8ede" title="get.json">get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2252,7 +2222,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/get_source.json" class="js-directory-link" id="06c3cb0e17ebff492b057f22db913580-c94d47ab009adecaff49eb0c85a570f6f1188079" title="get_source.json">get_source.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/get_script.json" class="js-directory-link" id="ec949f8f96d44ae7d86392e6939249fc-d6cae320caa142e1ad0ec7a318c97e5482180f47" title="get_script.json">get_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2269,7 +2239,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/get_template.json" class="js-directory-link" id="ab816619a3803791da2da066912f78f0-c4d292455c242b2b89695ca445c43c3d20ff803d" title="get_template.json">get_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/get_source.json" class="js-directory-link" id="06c3cb0e17ebff492b057f22db913580-2ed323e82464fc6ef529292c22d5db7c9759ce1c" title="get_source.json">get_source.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2286,7 +2256,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/index.json" class="js-directory-link" id="9e743aa713dcae5405f290e3db88178b-b0d643d74e191637f5350255144461e2674ee448" title="index.json">index.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/get_template.json" class="js-directory-link" id="ab816619a3803791da2da066912f78f0-8052b1d63fb3ffa9c520aaabccc9b1b624af96f1" title="get_template.json">get_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2303,7 +2273,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.analyze.json" class="js-directory-link" id="ea53ca0f9f948fb3fa7fb805c578af11-0ae30310fe6ca91f138988d830507b038a7e05f4" title="indices.analyze.json">indices.analyze.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/index.json" class="js-directory-link" id="9e743aa713dcae5405f290e3db88178b-86ce6e2e99f2c2334a9a42b2de9cba1a28489f0e" title="index.json">index.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2320,7 +2290,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.clear_cache.json" class="js-directory-link" id="2c9d7dd90e792d3063a65d93493a8d3e-0f85ea0038c506df1915da60a59ce54e063f18d1" title="indices.clear_cache.json">indices.clear_cache.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.analyze.json" class="js-directory-link" id="ea53ca0f9f948fb3fa7fb805c578af11-7f65a6622d5db17f5698f4a9dc951ea9d3b6d0e3" title="indices.analyze.json">indices.analyze.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2337,7 +2307,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.close.json" class="js-directory-link" id="d613995d3cc3e47e00e6584ccfb82a35-82ae9abd54ca046b1985ec74e6f91b70eb22874d" title="indices.close.json">indices.close.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.clear_cache.json" class="js-directory-link" id="2c9d7dd90e792d3063a65d93493a8d3e-31e8f4e723693d84409a5739d1d64849917ea7e8" title="indices.clear_cache.json">indices.clear_cache.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2354,7 +2324,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.create.json" class="js-directory-link" id="63f95a3c21061e2fb572cef0eb2eab90-33c02f2fb0d3e2c8504a52affef67b753ef250eb" title="indices.create.json">indices.create.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.close.json" class="js-directory-link" id="d613995d3cc3e47e00e6584ccfb82a35-534373b5d4ca622dfaa264744a5ac24c94a86587" title="indices.close.json">indices.close.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2371,7 +2341,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.delete.json" class="js-directory-link" id="a48e4dc86992215871f3270ad541bc6d-fee34f1ab3ad869c238eb1a975aeb4440026459e" title="indices.delete.json">indices.delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.create.json" class="js-directory-link" id="63f95a3c21061e2fb572cef0eb2eab90-1cefae61c9706bd31ae1b8d165f4ea0331193f52" title="indices.create.json">indices.create.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2388,7 +2358,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.delete_alias.json" class="js-directory-link" id="9a24979aa4a99ba087361de8997ba9d8-0b26ad5061bbd32ed77f791d2db0db79bf22faef" title="indices.delete_alias.json">indices.delete_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete.json" class="js-directory-link" id="a48e4dc86992215871f3270ad541bc6d-b0414322cb6d3adf5306a2e0aec29644435b0fef" title="indices.delete.json">indices.delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2405,7 +2375,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.delete_mapping.json" class="js-directory-link" id="e3979fad32decf2cf51ff65aa1509d47-e1cce4bb772d22e72a988f2735a242de7f6d3982" title="indices.delete_mapping.json">indices.delete_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete_alias.json" class="js-directory-link" id="9a24979aa4a99ba087361de8997ba9d8-24a443a1b45c5d3440a8be819ccc899c713daa34" title="indices.delete_alias.json">indices.delete_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2422,7 +2392,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.delete_template.json" class="js-directory-link" id="7e86ed5d6fec40fca7550c69311db515-f012f0af313ba5fd15c7c69a452e016f2a634363" title="indices.delete_template.json">indices.delete_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete_mapping.json" class="js-directory-link" id="e3979fad32decf2cf51ff65aa1509d47-bf166f81bf75fd235c944718027071db2743239e" title="indices.delete_mapping.json">indices.delete_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2439,7 +2409,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.delete_warmer.json" class="js-directory-link" id="0cb555d38237effd9567bb06c47530c3-f05a144df531f857334b62bc60c477884703c2c4" title="indices.delete_warmer.json">indices.delete_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete_template.json" class="js-directory-link" id="7e86ed5d6fec40fca7550c69311db515-ff6b837a156d3b43591935deb6809ff1548c2a6b" title="indices.delete_template.json">indices.delete_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2456,7 +2426,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.exists.json" class="js-directory-link" id="8adc33572e46831f609304d8616b1b1d-3f04ec31f7962d898c4465fc05c846491d985c2c" title="indices.exists.json">indices.exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete_warmer.json" class="js-directory-link" id="0cb555d38237effd9567bb06c47530c3-c9d5f414963a9729a003a11f646b6b36b0e703bd" title="indices.delete_warmer.json">indices.delete_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2473,7 +2443,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.exists_alias.json" class="js-directory-link" id="a8d7a4ce4b4a60cb658f043d5488dd39-d3c37092206ffd79cca192c60f0644d026a50bc5" title="indices.exists_alias.json">indices.exists_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.exists.json" class="js-directory-link" id="8adc33572e46831f609304d8616b1b1d-9e1ca824c9e82b4d755cb99bf6315902d0e1b074" title="indices.exists.json">indices.exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2490,7 +2460,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.exists_template.json" class="js-directory-link" id="3431ee0eca88f8bae40fe200f78f2d99-ac2de5099bde4c1644b4a93bf3ef150378d275d5" title="indices.exists_template.json">indices.exists_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.exists_alias.json" class="js-directory-link" id="a8d7a4ce4b4a60cb658f043d5488dd39-af3f80ad13d760a8dffa624eb798a14d7995871f" title="indices.exists_alias.json">indices.exists_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2507,7 +2477,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.exists_type.json" class="js-directory-link" id="e3050c1e9f7f37ca82a87ed38a0bb95f-77ad9122da869b6728018eef9817764402007bd6" title="indices.exists_type.json">indices.exists_type.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.exists_template.json" class="js-directory-link" id="3431ee0eca88f8bae40fe200f78f2d99-3114e15b0bb183744601787ad699458fe1d2e053" title="indices.exists_template.json">indices.exists_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2524,7 +2494,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.flush.json" class="js-directory-link" id="9c0d06f79fd7551fb765652a4296136e-31aef0b93f92308fc861c75be775c049a267eff7" title="indices.flush.json">indices.flush.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.exists_type.json" class="js-directory-link" id="e3050c1e9f7f37ca82a87ed38a0bb95f-5709734b0808f94e63951099c220165623e18499" title="indices.exists_type.json">indices.exists_type.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2541,7 +2511,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get.json" class="js-directory-link" id="c7dfb0129e6d01bcdaa59a6d9bef56b1-3aa92c3bddd67c197f7c716fa23617e12081b894" title="indices.get.json">indices.get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.flush.json" class="js-directory-link" id="9c0d06f79fd7551fb765652a4296136e-7ed13f036cdd0621fe26ae62ce2309b7c32846cc" title="indices.flush.json">indices.flush.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2558,7 +2528,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get_alias.json" class="js-directory-link" id="b359991822afa51a4920347b06236830-35e83998dfc41baad603e94a4f98316439ab95f0" title="indices.get_alias.json">indices.get_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.flush_synced.json" class="js-directory-link" id="1c80af8fdeffd1c1809f79ec7f2bcef5-e2d40a9c4027b431ab914b89687afc3a685c2770" title="indices.flush_synced.json">indices.flush_synced.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2575,7 +2545,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get_aliases.json" class="js-directory-link" id="a4b0f80dfc2206cac0dae0dd5c2edf63-f79aed96ae648ac7d5b7bd285e9c96f4a6809a5d" title="indices.get_aliases.json">indices.get_aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get.json" class="js-directory-link" id="c7dfb0129e6d01bcdaa59a6d9bef56b1-e1c77270127cbaf747638a5d1819e7936e55b42c" title="indices.get.json">indices.get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2592,7 +2562,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get_field_mapping.json" class="js-directory-link" id="7a95e8e39115ae0693c0e9ebac94aae4-1529d5e8a656dbf13764383548d159951a4bc339" title="indices.get_field_mapping.json">indices.get_field_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_alias.json" class="js-directory-link" id="b359991822afa51a4920347b06236830-b1f71439097add306cebe02faedb9d088ed01f72" title="indices.get_alias.json">indices.get_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2609,7 +2579,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get_mapping.json" class="js-directory-link" id="043a6a009b58931d43b9f4fcf495e584-ae91872d4645f4eec7ce980e98e7b14c4f9137c8" title="indices.get_mapping.json">indices.get_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_aliases.json" class="js-directory-link" id="a4b0f80dfc2206cac0dae0dd5c2edf63-9d9cd6f921a09af920c5f0c6037a1c8638b93712" title="indices.get_aliases.json">indices.get_aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2626,7 +2596,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get_settings.json" class="js-directory-link" id="573611d97c9a674af4eb1fd67f06ba87-1d4307be1013973c712021e3ca9223b31a766c41" title="indices.get_settings.json">indices.get_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_field_mapping.json" class="js-directory-link" id="7a95e8e39115ae0693c0e9ebac94aae4-164f8c025aa69403508298e7c3552b83e451ad28" title="indices.get_field_mapping.json">indices.get_field_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2643,7 +2613,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get_template.json" class="js-directory-link" id="6a31359bb097d3ebbe0a9ee6758c86ea-496d2b723fd271255baeaf372377ba4bcdcf48eb" title="indices.get_template.json">indices.get_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_mapping.json" class="js-directory-link" id="043a6a009b58931d43b9f4fcf495e584-f223806d63d57c3a03c02d3f950c78e2d2ea9ebb" title="indices.get_mapping.json">indices.get_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2660,7 +2630,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get_upgrade.json" class="js-directory-link" id="8a2688acbdae5eff0da90082f894d6ff-9b4de2ff2b6a8f7229899c9b67990831083f9914" title="indices.get_upgrade.json">indices.get_upgrade.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_settings.json" class="js-directory-link" id="573611d97c9a674af4eb1fd67f06ba87-e2fee434c6621e2d4d2846f5d9e8a23523e3103f" title="indices.get_settings.json">indices.get_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2677,7 +2647,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.get_warmer.json" class="js-directory-link" id="696ba757658b41eb345ac40688505bf3-b4224fe475bb1ca18914d7a7298e801764ed63ba" title="indices.get_warmer.json">indices.get_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_template.json" class="js-directory-link" id="6a31359bb097d3ebbe0a9ee6758c86ea-20caee3a732a6ac020df5e4d65ad38d3eb9ebf89" title="indices.get_template.json">indices.get_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2694,7 +2664,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.open.json" class="js-directory-link" id="373e5d7e5484cc081c4980032ab53333-f0ef781a7b843470fab94f4094e940b300bc3c73" title="indices.open.json">indices.open.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_upgrade.json" class="js-directory-link" id="8a2688acbdae5eff0da90082f894d6ff-63d9bbf418bab2863bdf23f0506298995fc491a9" title="indices.get_upgrade.json">indices.get_upgrade.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2711,7 +2681,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.optimize.json" class="js-directory-link" id="8efebf88db11882bb5adedfc25de4847-7eb029732be901d29e5e73ab6ef0bbd49c85fcd3" title="indices.optimize.json">indices.optimize.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_warmer.json" class="js-directory-link" id="696ba757658b41eb345ac40688505bf3-51a62b9ce338015637fc698629e5d6e5eac21ab9" title="indices.get_warmer.json">indices.get_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2728,7 +2698,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.put_alias.json" class="js-directory-link" id="7c4d55dd18903fbe6a08229325f31825-9c88c04870b2511a20c8d935bac6b948bf97f0e9" title="indices.put_alias.json">indices.put_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.open.json" class="js-directory-link" id="373e5d7e5484cc081c4980032ab53333-334ad5ea0437f72e0054ec876abfd65e4ea13323" title="indices.open.json">indices.open.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2745,7 +2715,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.put_mapping.json" class="js-directory-link" id="250bd21a9bccfcf55d2e743ea58da37e-4fcbde3f4dd786a89360487000094039cc8d7798" title="indices.put_mapping.json">indices.put_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.optimize.json" class="js-directory-link" id="8efebf88db11882bb5adedfc25de4847-ab45ede9b052d977153a070e1cc7f836e7d67d20" title="indices.optimize.json">indices.optimize.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2762,7 +2732,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.put_settings.json" class="js-directory-link" id="d6b150b68eeb6f484cdae6fec82c913f-33766effcc938a859b8d238b853ad2553e36c70a" title="indices.put_settings.json">indices.put_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_alias.json" class="js-directory-link" id="7c4d55dd18903fbe6a08229325f31825-aab8da146ecf2609b8687bddb4b973199434f543" title="indices.put_alias.json">indices.put_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2779,7 +2749,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.put_template.json" class="js-directory-link" id="481ea697fa69449ad04daf3c10691415-7b9ec451f7235e04e4f55f904d96cd565c7decae" title="indices.put_template.json">indices.put_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_mapping.json" class="js-directory-link" id="250bd21a9bccfcf55d2e743ea58da37e-44aba72eed29523ef8cf01c450f2a5b228cb9bd2" title="indices.put_mapping.json">indices.put_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2796,7 +2766,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.put_warmer.json" class="js-directory-link" id="7144ddc1e315d2eb87f6d7fa415b3027-bdeee77862e7c67044b4caf4412d9a9f20c41e97" title="indices.put_warmer.json">indices.put_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_settings.json" class="js-directory-link" id="d6b150b68eeb6f484cdae6fec82c913f-b7ad400591acdccec26fa6088175e0b60911afa9" title="indices.put_settings.json">indices.put_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2813,7 +2783,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.recovery.json" class="js-directory-link" id="7a1cc9a6701c8cfa3c52bbaffa9f22b8-c27436a65db9276f1d50345b83db1fb23422c998" title="indices.recovery.json">indices.recovery.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_template.json" class="js-directory-link" id="481ea697fa69449ad04daf3c10691415-daa30fcc8fb41ebf5549351b7b26912f652d11db" title="indices.put_template.json">indices.put_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2830,7 +2800,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.refresh.json" class="js-directory-link" id="3717be850ac7c14c749c955fb79f61d7-e372170784978f993652700ec4cc5511d4c29b90" title="indices.refresh.json">indices.refresh.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_warmer.json" class="js-directory-link" id="7144ddc1e315d2eb87f6d7fa415b3027-4caa83a940ad50fe7645bfa91f04d189021309a3" title="indices.put_warmer.json">indices.put_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2847,7 +2817,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.segments.json" class="js-directory-link" id="56a2f2774152e652738ca9703cf447dc-2b0cb55d5175bebe0c3068f5bc3dd9319ef49f22" title="indices.segments.json">indices.segments.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.recovery.json" class="js-directory-link" id="7a1cc9a6701c8cfa3c52bbaffa9f22b8-2b94f1ad3d6920f905242ed843bcb6102a51afed" title="indices.recovery.json">indices.recovery.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2864,7 +2834,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.stats.json" class="js-directory-link" id="cb782133ac617be36b33b196df8059b5-6c59a33d7cc8a1bd7344968002f7cc347e32f5df" title="indices.stats.json">indices.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.refresh.json" class="js-directory-link" id="3717be850ac7c14c749c955fb79f61d7-a8bfc95ab3ac12fc23c4649ec074194ad27ee9e2" title="indices.refresh.json">indices.refresh.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2881,7 +2851,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.status.json" class="js-directory-link" id="2cc01e73929605ba4a1f29ef7bd89c47-6fec80c5cdada83629e2c927f48801fa1477c678" title="indices.status.json">indices.status.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.segments.json" class="js-directory-link" id="56a2f2774152e652738ca9703cf447dc-8beb5871c65392982e5472f601053f60e5ea09b2" title="indices.segments.json">indices.segments.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2898,7 +2868,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.update_aliases.json" class="js-directory-link" id="655e7332a9c5cd438b45d4ff1cb30b85-5b375eed8f0bdbb68cc85823206e0f20920a9c6f" title="indices.update_aliases.json">indices.update_aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.stats.json" class="js-directory-link" id="cb782133ac617be36b33b196df8059b5-e4bb414c88589dc58777dddfa0cedbb205c08686" title="indices.stats.json">indices.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2915,7 +2885,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.upgrade.json" class="js-directory-link" id="49572445346c6fe5f226279051b88082-c53d69a2d13e6a89668915413b85e0f96d6e32d0" title="indices.upgrade.json">indices.upgrade.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.status.json" class="js-directory-link" id="2cc01e73929605ba4a1f29ef7bd89c47-45805ab2fe9b13f958afaa2113501d108c50390e" title="indices.status.json">indices.status.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2932,7 +2902,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/indices.validate_query.json" class="js-directory-link" id="abeaaf04f453c9902ecb8d3315d3d43d-1f88c769c875cd2bbdafd1c66f75fc89c42636b3" title="indices.validate_query.json">indices.validate_query.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.update_aliases.json" class="js-directory-link" id="655e7332a9c5cd438b45d4ff1cb30b85-2ca4be33819052a8b1a85db847847009a9c20347" title="indices.update_aliases.json">indices.update_aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2949,7 +2919,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/info.json" class="js-directory-link" id="379da8ee275d0393f12cdff8542d368d-b83b666a6551eddf418955443bcd2ad9491c2960" title="info.json">info.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.upgrade.json" class="js-directory-link" id="49572445346c6fe5f226279051b88082-250b7c3fb8930ecd81fc1847a090295b248df63a" title="indices.upgrade.json">indices.upgrade.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2966,7 +2936,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/mget.json" class="js-directory-link" id="7db3deffe9680ffd2cdb16a331aea2fa-9d2d84867226baa4b4b5d31b57443f9e4a3273ac" title="mget.json">mget.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.validate_query.json" class="js-directory-link" id="abeaaf04f453c9902ecb8d3315d3d43d-0dc9a0d41c6460d17b5e9cc639f3b1d0befc087d" title="indices.validate_query.json">indices.validate_query.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2983,7 +2953,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/mlt.json" class="js-directory-link" id="85fe94abc6068cd67d547c5c09f278b3-63b15bf3b84bc8b554975321bc1d731c45b5ee44" title="mlt.json">mlt.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/info.json" class="js-directory-link" id="379da8ee275d0393f12cdff8542d368d-63754eb7f7c3ccae5da2b584be5ba2a90c71fa4a" title="info.json">info.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3000,7 +2970,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/mpercolate.json" class="js-directory-link" id="9410cd2b17f09ec3ccfa9fbc452c0e98-a657b3b31a597a1fba474bf97200b7fec32286fe" title="mpercolate.json">mpercolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/mget.json" class="js-directory-link" id="7db3deffe9680ffd2cdb16a331aea2fa-cd5d9cc6358eea6135b1640ed090b9210b5a787e" title="mget.json">mget.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3017,7 +2987,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/msearch.json" class="js-directory-link" id="41473f6391667dbfeb8f12856e6dbf9b-6926c8741e470e565ade8f37ba2f020d871ef1f1" title="msearch.json">msearch.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/mlt.json" class="js-directory-link" id="85fe94abc6068cd67d547c5c09f278b3-05921c10cf8a0c76ce44ccba96e75dfc2bbf0505" title="mlt.json">mlt.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3034,7 +3004,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/mtermvectors.json" class="js-directory-link" id="717daf7be8083a78bf284fe4a9a25223-e4b536557fa636d6ec245539f5f35a1127bbdf20" title="mtermvectors.json">mtermvectors.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/mpercolate.json" class="js-directory-link" id="9410cd2b17f09ec3ccfa9fbc452c0e98-a92e7c3f0350be543d888765d9eb47767597b2d4" title="mpercolate.json">mpercolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3051,7 +3021,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/nodes.hot_threads.json" class="js-directory-link" id="0ef0e709908091e3498307d32d74fa69-03a11a309248aefa6fe09f3123ee7505f87add88" title="nodes.hot_threads.json">nodes.hot_threads.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/msearch.json" class="js-directory-link" id="41473f6391667dbfeb8f12856e6dbf9b-788a326b98dd676b46ea087b86adc63093779e8b" title="msearch.json">msearch.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3068,7 +3038,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/nodes.info.json" class="js-directory-link" id="827644931be55e9818fb73ba26553cba-2d1c1076469ac7f1557455fd3def028271394628" title="nodes.info.json">nodes.info.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/mtermvectors.json" class="js-directory-link" id="717daf7be8083a78bf284fe4a9a25223-e3c6cd3f414ab9f17c2307de437375b5c18db902" title="mtermvectors.json">mtermvectors.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3085,7 +3055,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/nodes.shutdown.json" class="js-directory-link" id="b87d2a5a6a497bc76aa25fb8a2e71226-578abe06f074a9444f8c63b501eaf034b60e1c5f" title="nodes.shutdown.json">nodes.shutdown.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/nodes.hot_threads.json" class="js-directory-link" id="0ef0e709908091e3498307d32d74fa69-c0ca4cece19923ac18a8867d2ca333c3c6d85ed7" title="nodes.hot_threads.json">nodes.hot_threads.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3102,7 +3072,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/nodes.stats.json" class="js-directory-link" id="1402dc0afe821bc096932f4af7774b7b-6ccd0ad4478b8a5dc544818573170fb5b041c217" title="nodes.stats.json">nodes.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/nodes.info.json" class="js-directory-link" id="827644931be55e9818fb73ba26553cba-03f04d75d84fe823613e57b654c67cd471a419a9" title="nodes.info.json">nodes.info.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3119,7 +3089,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/percolate.json" class="js-directory-link" id="4b2043d3c446183feab58857c7d22954-9115594d1f0018a231767d072aba56d3d5747d25" title="percolate.json">percolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/nodes.shutdown.json" class="js-directory-link" id="b87d2a5a6a497bc76aa25fb8a2e71226-50e1d13448a6e293a40fbcf0567c51fbc7aa5432" title="nodes.shutdown.json">nodes.shutdown.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3136,7 +3106,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/ping.json" class="js-directory-link" id="2c0ccb85c134546fc2419cd212d7c7a1-65e18563718206e43267b28e58e835f487049019" title="ping.json">ping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/nodes.stats.json" class="js-directory-link" id="1402dc0afe821bc096932f4af7774b7b-a7b63b7681e586fb1ae259946d3250ba668a1807" title="nodes.stats.json">nodes.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3153,7 +3123,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/put_script.json" class="js-directory-link" id="3e5e341e9944ac912cd75b44d94ffb18-e7c27fa0dc404752767305da8d2e26dbca5cd92f" title="put_script.json">put_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/percolate.json" class="js-directory-link" id="4b2043d3c446183feab58857c7d22954-ee008c7c68ec85facbda4c8ac7fecf7fb5cf09f9" title="percolate.json">percolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3170,7 +3140,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/put_template.json" class="js-directory-link" id="eb9589368281828322f480b4696c4a51-22ab54bc4f5023f1c7c76e61eea07529a5cb242a" title="put_template.json">put_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/ping.json" class="js-directory-link" id="2c0ccb85c134546fc2419cd212d7c7a1-41310bb30d4942e3edb97d489c5613685227ca33" title="ping.json">ping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3187,7 +3157,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/scroll.json" class="js-directory-link" id="b68a77ffff64b26fa9efb03e5f4fec69-ba223992f56a0fd5d4416fbe21f2aea6aaf7c656" title="scroll.json">scroll.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/put_script.json" class="js-directory-link" id="3e5e341e9944ac912cd75b44d94ffb18-1a0d6ac5f74a3a6016759884301a1e0252b45f73" title="put_script.json">put_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3204,7 +3174,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/search.json" class="js-directory-link" id="36e64ee591eb44c77488faec76357456-a89d5e442791802f67116d619661bf7921fab334" title="search.json">search.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/put_template.json" class="js-directory-link" id="eb9589368281828322f480b4696c4a51-845a368493e97af0b5a1a818454c0da795d8eb03" title="put_template.json">put_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3221,7 +3191,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/search_exists.json" class="js-directory-link" id="05525aaadd0ea9bb5405273c1ccbeb9c-b0989b44ff6b4f44b7fe596837f1d0fe9312d01d" title="search_exists.json">search_exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/scroll.json" class="js-directory-link" id="b68a77ffff64b26fa9efb03e5f4fec69-07fdb0134de900dff7447cdc1027a09cd637d634" title="scroll.json">scroll.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3238,7 +3208,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/search_shards.json" class="js-directory-link" id="087e36570eccc7017ef612e4d4fcab82-1f39d4d56a4497f8f5d279b0d1a6bcb65b78bdfb" title="search_shards.json">search_shards.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/search.json" class="js-directory-link" id="36e64ee591eb44c77488faec76357456-d7a65bd74e0baf563c5176fd74e75288768f60f1" title="search.json">search.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3255,7 +3225,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/search_template.json" class="js-directory-link" id="271a84623de72292ff6257d567a959a8-75a1f94ba7e29e761b634ec82eebc8606e8e79cb" title="search_template.json">search_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/search_exists.json" class="js-directory-link" id="05525aaadd0ea9bb5405273c1ccbeb9c-a8970467d1c11870059a945a2a161271b42102e6" title="search_exists.json">search_exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3272,7 +3242,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.create.json" class="js-directory-link" id="3142f56582a6a4f221f2ca9613092485-b0608ab78c724ecbd33f9edbceabcf2b67a27dfa" title="snapshot.create.json">snapshot.create.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/search_shards.json" class="js-directory-link" id="087e36570eccc7017ef612e4d4fcab82-8bd4a4084cb13c81542a3cadf6fb501c956e60c2" title="search_shards.json">search_shards.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3289,7 +3259,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.create_repository.json" class="js-directory-link" id="3c7efb7259ad685fcc61441956417466-929a0424874b5a4e05939d2f068b35feba8d4377" title="snapshot.create_repository.json">snapshot.create_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/search_template.json" class="js-directory-link" id="271a84623de72292ff6257d567a959a8-a1122f19a1e80fc5506dd23edff72ab3dc00393f" title="search_template.json">search_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3306,7 +3276,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.delete.json" class="js-directory-link" id="057c6616838d5438ead24db42bab5b2e-de004b2a8759f8badaf832ba15b361ebadc1098b" title="snapshot.delete.json">snapshot.delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.create.json" class="js-directory-link" id="3142f56582a6a4f221f2ca9613092485-6f3c4f9b390b06c21092b1905ce0ccd1a72e0e94" title="snapshot.create.json">snapshot.create.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3323,7 +3293,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.delete_repository.json" class="js-directory-link" id="9af95f6a49693f226af744dec7d88ed3-d879c7544267f3876d2349b7bf48c36e4f71bc99" title="snapshot.delete_repository.json">snapshot.delete_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.create_repository.json" class="js-directory-link" id="3c7efb7259ad685fcc61441956417466-a88aa5a1b98c90ce894d3535ddf58717dfcaf5d1" title="snapshot.create_repository.json">snapshot.create_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3340,7 +3310,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.get.json" class="js-directory-link" id="651bdc0b78c2633f9a5da0947a67d317-9639b92541a7ea490e8dea1b19dfaf09b41f72b2" title="snapshot.get.json">snapshot.get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.delete.json" class="js-directory-link" id="057c6616838d5438ead24db42bab5b2e-b0501535af2b53f912dc5c9f87464f7130c5e0e0" title="snapshot.delete.json">snapshot.delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3357,7 +3327,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.get_repository.json" class="js-directory-link" id="2dd6796f7524ee470c4ba617cb6be760-567dce0c040b1d6b5d11a14abff88d5e5271687f" title="snapshot.get_repository.json">snapshot.get_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.delete_repository.json" class="js-directory-link" id="9af95f6a49693f226af744dec7d88ed3-a23ca289a193ea0bead9d89bb668152939b30dee" title="snapshot.delete_repository.json">snapshot.delete_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3374,7 +3344,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.restore.json" class="js-directory-link" id="b2377ab03bc2e7f239f6f9d2b1689802-6c9da74e9a2e1801aae4bc08073e05b474ba12a9" title="snapshot.restore.json">snapshot.restore.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.get.json" class="js-directory-link" id="651bdc0b78c2633f9a5da0947a67d317-46a5b2a7101100d72f4b84f80cc799a7db708261" title="snapshot.get.json">snapshot.get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3391,7 +3361,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.status.json" class="js-directory-link" id="e790b0dada2bf67f54709c5f222b8ef1-a258713f601139c6b3ad9befb7febe0077d4ca21" title="snapshot.status.json">snapshot.status.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.get_repository.json" class="js-directory-link" id="2dd6796f7524ee470c4ba617cb6be760-02b6a7b4ee67b26655fd68283b461a44bc4688fc" title="snapshot.get_repository.json">snapshot.get_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3408,7 +3378,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/snapshot.verify_repository.json" class="js-directory-link" id="4b88bdf4b93ee8150855454ee6b250f4-40615039c8e60068a35d2a24e09cb7f20387f9cc" title="snapshot.verify_repository.json">snapshot.verify_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.restore.json" class="js-directory-link" id="b2377ab03bc2e7f239f6f9d2b1689802-fb5ee8102aa62189b49af02acfbb3f1b26061ada" title="snapshot.restore.json">snapshot.restore.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3425,7 +3395,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/suggest.json" class="js-directory-link" id="ede60bf6805d74020a897b7189fd2c28-b0a1f7a90469511a3616d224e322a44d2cb4610a" title="suggest.json">suggest.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.status.json" class="js-directory-link" id="e790b0dada2bf67f54709c5f222b8ef1-ebc9180cb527c8e3dc1a6cc78e327b8e8e82d2f9" title="snapshot.status.json">snapshot.status.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3442,7 +3412,7 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/termvector.json" class="js-directory-link" id="007656edbf5dfa6498a00a62c187d2c6-3480556948df6abba6657f8131e1c5d7f0038be2" title="termvector.json">termvector.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.verify_repository.json" class="js-directory-link" id="4b88bdf4b93ee8150855454ee6b250f4-0d9a97c10877b5494b9eb5074f2a0953ac7a9e70" title="snapshot.verify_repository.json">snapshot.verify_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3459,7 +3429,41 @@
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.5.2/rest-api-spec/api/update.json" class="js-directory-link" id="2103efac9db966ed8688bc9b541c1638-1b36fcbe4b86083bec51e83f2899de61c52cc30a" title="update.json">update.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/suggest.json" class="js-directory-link" id="ede60bf6805d74020a897b7189fd2c28-d737e251d045da09c86858a9ec112c5831a0ec3f" title="suggest.json">suggest.json</a></span>
+          </td>
+          <td class="message">
+            <span class="css-truncate css-truncate-target">
+              
+            </span>
+          </td>
+          <td class="age">
+            <span class="css-truncate css-truncate-target"></span>
+          </td>
+        </tr>
+        <tr>
+          <td class="icon">
+            <span class="octicon octicon-file-text"></span>
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+          </td>
+          <td class="content">
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/termvector.json" class="js-directory-link" id="007656edbf5dfa6498a00a62c187d2c6-116aea619bfbf0eeabb2aef183f01710e55d7bcb" title="termvector.json">termvector.json</a></span>
+          </td>
+          <td class="message">
+            <span class="css-truncate css-truncate-target">
+              
+            </span>
+          </td>
+          <td class="age">
+            <span class="css-truncate css-truncate-target"></span>
+          </td>
+        </tr>
+        <tr>
+          <td class="icon">
+            <span class="octicon octicon-file-text"></span>
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+          </td>
+          <td class="content">
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/update.json" class="js-directory-link" id="2103efac9db966ed8688bc9b541c1638-2cfe7992ffde46c319620769a02d5d44e14d8757" title="update.json">update.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3498,6 +3502,7 @@
       <li><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
         <li><a href="https://github.com/blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
         <li><a href="https://github.com/about" data-ga-click="Footer, go to about, text:about">About</a></li>
+      <li><a href="https://help.github.com" data-ga-click="Footer, go to help, text:help">Help</a></li>
 
     </ul>
 
@@ -3505,7 +3510,7 @@
       <span class="mega-octicon octicon-mark-github" title="GitHub"></span>
 </a>
     <ul class="site-footer-links">
-      <li>&copy; 2015 <span title="0.06589s from github-fe123-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+      <li>&copy; 2015 <span title="0.04728s from github-fe122-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
         <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
         <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
         <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
@@ -3547,11 +3552,10 @@
     </div>
 
 
-      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-84fc3143b171e74e470108cd11d4b5f9941e18d77c48b5129eee1cc3e2a7c210.js"></script>
-      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-6041f8d69bcb162df9379deea911e6650ef05c165928b3b952b10fa547d2bed2.js"></script>
+      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-dea2e78f4b34a1f3429ade94f98bd25fad6bbe8d28635a93d9caeb68e3c2d258.js"></script>
+      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github/index-42e4be905d0eeef68d11167fbeb73eeaffd7b523509fd330a025c339a4488dc7.js"></script>
       
       
-
   </body>
 </html>
 

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/root.html
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/root.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Language" content="en">
     
     
-    <title>elasticsearch/rest-api-spec/api at v1.6.0 Â· elastic/elasticsearch Â· GitHub</title>
+    <title>elasticsearch/rest-api-spec/api at 1.6 Â· elastic/elasticsearch Â· GitHub</title>
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
     <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
     <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-114.png">
@@ -32,7 +32,7 @@
     <meta name="selected-link" value="repo_source" data-pjax-transient>
       <meta name="google-analytics" content="UA-3769691-2">
 
-    <meta content="collector.githubapp.com" name="octolytics-host" /><meta content="collector-cdn.github.com" name="octolytics-script-host" /><meta content="github" name="octolytics-app-id" /><meta content="60E16102:0684:1A516D7:557A0062" name="octolytics-dimension-request_id" />
+    <meta content="collector.githubapp.com" name="octolytics-host" /><meta content="collector-cdn.github.com" name="octolytics-script-host" /><meta content="github" name="octolytics-app-id" /><meta content="4257743B:1F58:D7A1B29:55817C34" name="octolytics-dimension-request_id" />
     
     <meta content="Rails, view, files#disambiguate" name="analytics-event" />
     <meta class="js-ga-set" name="dimension1" content="Logged Out">
@@ -46,22 +46,22 @@
 
 
     <meta content="authenticity_token" name="csrf-param" />
-<meta content="nbEtnvu3yx1Ci8p7s0cgMQ7L0D+G9bV4gxGmfMrAQFgcuGyGlxgjAWLB4CjdvkpzPZ9yWNu69XLHqlVKixH/+g==" name="csrf-token" />
+<meta content="U1JggEiCImHR6RZEdspFxcDZbbUPZqDT737hEAwmjavZW+t4ZgSVZz6Wqf2JaHm13JIR6MYfQ2idb8xTz/haEQ==" name="csrf-token" />
 
-    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github/index-61b260d732e9f1dd827b15f60326633780fe0bfc6b99da69b40d0c857926c6ff.css" media="all" rel="stylesheet" />
-    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github2/index-0bbd23bc506411254609d413396a7734e06c7729ba5ce9ad80d793f95716203b.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github/index-4a8149b8016d5359ad2c49df2fad7583fdb965107b7f7de91a17b687336fef9f.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github2/index-c97c34f354d881281585ec0a7f62b8a8c7c53c18bf0d31f189803de93868c450.css" media="all" rel="stylesheet" />
     
     
 
 
-    <meta http-equiv="x-pjax-version" content="f435d20dffc0d5d57bf6ae309941491c">
+    <meta http-equiv="x-pjax-version" content="3de249314b795cd27e4b9992a06e2862">
 
       
   <meta name="description" content="elasticsearch - Open Source, Distributed, RESTful Search Engine">
   <meta name="go-import" content="github.com/elastic/elasticsearch git https://github.com/elastic/elasticsearch.git">
 
   <meta content="6764390" name="octolytics-dimension-user_id" /><meta content="elastic" name="octolytics-dimension-user_login" /><meta content="507775" name="octolytics-dimension-repository_id" /><meta content="elastic/elasticsearch" name="octolytics-dimension-repository_nwo" /><meta content="true" name="octolytics-dimension-repository_public" /><meta content="false" name="octolytics-dimension-repository_is_fork" /><meta content="507775" name="octolytics-dimension-repository_network_root_id" /><meta content="elastic/elasticsearch" name="octolytics-dimension-repository_network_root_nwo" />
-  <link href="https://github.com/elastic/elasticsearch/commits/v1.6.0.atom" rel="alternate" title="Recent Commits to elasticsearch:v1.6.0" type="application/atom+xml">
+  <link href="https://github.com/elastic/elasticsearch/commits/1.6.atom" rel="alternate" title="Recent Commits to elasticsearch:1.6" type="application/atom+xml">
 
   </head>
 
@@ -84,7 +84,7 @@
 
     <div class="header-actions" role="navigation">
         <a class="btn btn-primary" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign up</a>
-      <a class="btn" href="/login?return_to=%2Felastic%2Felasticsearch%2Ftree%2Fv1.6.0%2Frest-api-spec%2Fapi" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
+      <a class="btn" href="/login?return_to=%2Felastic%2Felasticsearch%2Ftree%2F1.6%2Frest-api-spec%2Fapi" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
     </div>
 
     <div class="site-search repo-scope js-site-search" role="search">
@@ -143,7 +143,7 @@
     Watch
   </a>
   <a class="social-count" href="/elastic/elasticsearch/watchers">
-    1,192
+    1,201
   </a>
 
   </li>
@@ -157,7 +157,7 @@
   </a>
 
     <a class="social-count js-social-count" href="/elastic/elasticsearch/stargazers">
-      11,568
+      11,652
     </a>
 
   </li>
@@ -170,7 +170,7 @@
         Fork
       </a>
       <a href="/elastic/elasticsearch/network" class="social-count">
-        3,661
+        3,691
       </a>
     </li>
 </ul>
@@ -182,7 +182,7 @@
        --><strong><a href="/elastic/elasticsearch" data-pjax="#js-repo-pjax-container">elasticsearch</a></strong>
 
           <span class="page-context-loader">
-            <img alt="" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </span>
 
         </h1>
@@ -199,23 +199,23 @@
      data-issue-count-url="/elastic/elasticsearch/issues/counts">
   <ul class="sunken-menu-group">
     <li class="tooltipped tooltipped-w" aria-label="Code">
-      <a href="/elastic/elasticsearch/tree/v1.6.0" aria-label="Code" class="selected js-selected-navigation-item sunken-menu-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /elastic/elasticsearch/tree/v1.6.0">
+      <a href="/elastic/elasticsearch/tree/1.6" aria-label="Code" class="selected js-selected-navigation-item sunken-menu-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /elastic/elasticsearch/tree/1.6">
         <span class="octicon octicon-code"></span> <span class="full-word">Code</span>
-        <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+        <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>    </li>
 
       <li class="tooltipped tooltipped-w" aria-label="Issues">
         <a href="/elastic/elasticsearch/issues" aria-label="Issues" class="js-selected-navigation-item sunken-menu-item" data-hotkey="g i" data-selected-links="repo_issues repo_labels repo_milestones /elastic/elasticsearch/issues">
           <span class="octicon octicon-issue-opened"></span> <span class="full-word">Issues</span>
           <span class="js-issue-replace-counter"></span>
-          <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+          <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>      </li>
 
     <li class="tooltipped tooltipped-w" aria-label="Pull requests">
       <a href="/elastic/elasticsearch/pulls" aria-label="Pull requests" class="js-selected-navigation-item sunken-menu-item" data-hotkey="g p" data-selected-links="repo_pulls /elastic/elasticsearch/pulls">
           <span class="octicon octicon-git-pull-request"></span> <span class="full-word">Pull requests</span>
           <span class="js-pull-replace-counter"></span>
-          <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+          <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>    </li>
 
   </ul>
@@ -225,13 +225,13 @@
     <li class="tooltipped tooltipped-w" aria-label="Pulse">
       <a href="/elastic/elasticsearch/pulse" aria-label="Pulse" class="js-selected-navigation-item sunken-menu-item" data-selected-links="pulse /elastic/elasticsearch/pulse">
         <span class="octicon octicon-pulse"></span> <span class="full-word">Pulse</span>
-        <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+        <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>    </li>
 
     <li class="tooltipped tooltipped-w" aria-label="Graphs">
       <a href="/elastic/elasticsearch/graphs" aria-label="Graphs" class="js-selected-navigation-item sunken-menu-item" data-selected-links="repo_graphs repo_contributors /elastic/elasticsearch/graphs">
         <span class="octicon octicon-graph"></span> <span class="full-word">Graphs</span>
-        <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+        <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>    </li>
   </ul>
 
@@ -268,7 +268,7 @@
 
 
 <div class="clone-options">You can clone with
-  <form accept-charset="UTF-8" action="/users/set_protocol?protocol_selector=http&amp;protocol_type=clone" class="inline-form js-clone-selector-form " data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="dLfLU26I1huKP51r51Of3EaQcx1mOt2iTiO24NRcVFg9Ys9zVJw/ohkO99/PBXG9koPF78DRpEzIZmAl4wS6wA==" /></div><button class="btn-link js-clone-selector" data-protocol="http" type="submit">HTTPS</button></form> or <form accept-charset="UTF-8" action="/users/set_protocol?protocol_selector=subversion&amp;protocol_type=clone" class="inline-form js-clone-selector-form " data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="Ws4F1Dw45M9BJAfExyszZdTwVqQAcNivAwou0Iney5pGDLpnFQUWs1yx7oCZ0eR+Kl4NIOa2vr47Te2vwbidoQ==" /></div><button class="btn-link js-clone-selector" data-protocol="subversion" type="submit">Subversion</button></form>.
+  <form accept-charset="UTF-8" action="/users/set_protocol?protocol_selector=http&amp;protocol_type=clone" class="inline-form js-clone-selector-form " data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="ntQRRD8fKheHy81NSRRyszMazetweLnpZ7jbU0/H+JAm3qp5Q8FhCdca+Xg9YQmZSQEeBKpzeLiDsXvJ3Gm4HA==" /></div><button class="btn-link js-clone-selector" data-protocol="http" type="submit">HTTPS</button></form> or <form accept-charset="UTF-8" action="/users/set_protocol?protocol_selector=subversion&amp;protocol_type=clone" class="inline-form js-clone-selector-form " data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="cyGPOY1GtftFPaAqXUmzUwPc3yoEaYkyS5ZkXpzXMxFviPRPDsOfHRs3CAsrRGZ+Pk6XwhvrKyyOIyfEHn6uZQ==" /></div><button class="btn-link js-clone-selector" data-protocol="subversion" type="submit">Subversion</button></form>.
   <a href="https://help.github.com/articles/which-remote-url-should-i-use" class="help tooltipped tooltipped-n" aria-label="Get help on which URL is right for you.">
     <span class="octicon octicon-question"></span>
   </a>
@@ -277,7 +277,7 @@
 
 
 
-                <a href="/elastic/elasticsearch/archive/v1.6.0.zip"
+                <a href="/elastic/elasticsearch/archive/1.6.zip"
                    class="btn btn-sm sidebar-button"
                    aria-label="Download the contents of elastic/elasticsearch as a zip file"
                    title="Download the contents of elastic/elasticsearch as a zip file"
@@ -295,12 +295,12 @@
   
 <div class="select-menu js-menu-container js-select-menu left">
   <span class="btn btn-sm select-menu-button js-menu-target css-truncate" data-hotkey="w"
-    data-ref="v1.6.0"
-    title="v1.6.0"
+    data-ref="1.6"
+    title="1.6"
     role="button" aria-label="Switch branches or tags" tabindex="0" aria-haspopup="true">
-    <span class="octicon octicon-tag"></span>
-    <i>tag:</i>
-    <span class="js-select-button css-truncate-target">v1.6.0</span>
+    <span class="octicon octicon-git-branch"></span>
+    <i>branch:</i>
+    <span class="js-select-button css-truncate-target">1.6</span>
   </span>
 
   <div class="select-menu-modal-holder js-menu-content js-navigation-container" data-pjax aria-hidden="true">
@@ -492,7 +492,7 @@
                 1.5
               </span>
             </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
+            <a class="select-menu-item js-navigation-item js-navigation-open selected"
                href="/elastic/elasticsearch/tree/1.6/rest-api-spec/api"
                data-name="1.6"
                data-skip-pjax="true"
@@ -681,7 +681,7 @@
         <div data-filterable-for="context-commitish-filter-field" data-filterable-type="substring">
 
 
-            <div class="select-menu-item js-navigation-item selected">
+            <div class="select-menu-item js-navigation-item ">
               <span class="select-menu-item-icon octicon octicon-check"></span>
               <a href="/elastic/elasticsearch/tree/v1.6.0/rest-api-spec/api"
                  data-name="v1.6.0"
@@ -1592,41 +1592,62 @@
 
 
   <div class="btn-group right">
-    <a href="/elastic/elasticsearch/find/v1.6.0" data-pjax data-hotkey="t" class="js-show-file-finder btn btn-sm empty-icon tooltipped tooltipped-s" aria-label="Quickly jump between files">
+    <a href="/elastic/elasticsearch/find/1.6" data-pjax data-hotkey="t" class="js-show-file-finder btn btn-sm empty-icon tooltipped tooltipped-s" aria-label="Quickly jump between files">
       <span class="octicon octicon-list-unordered"></span>
     </a>
-    <a href="/elastic/elasticsearch/commits/v1.6.0/rest-api-spec/api" class="btn btn-sm empty-icon tooltipped tooltipped-s" aria-label="Browse commits for this branch">
+    <a href="/elastic/elasticsearch/commits/1.6/rest-api-spec/api" class="btn btn-sm empty-icon tooltipped tooltipped-s" aria-label="Browse commits for this branch">
       <span class="octicon octicon-history"></span>
     </a>
   </div>
 
-  <div class="breadcrumb"><span class="repo-root js-repo-root"><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/elastic/elasticsearch/tree/v1.6.0" class="" data-branch="v1.6.0" data-pjax="true" itemscope="url"><span itemprop="title">elasticsearch</span></a></span></span><span class="separator">/</span><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/elastic/elasticsearch/tree/v1.6.0/rest-api-spec" class="" data-branch="v1.6.0" data-pjax="true" itemscope="url"><span itemprop="title">rest-api-spec</span></a></span><span class="separator">/</span><strong class="final-path">api</strong><span class="separator">/</span>
-  <span class="js-new-blob-form tooltipped tooltipped-e text-muted" aria-label="Select a branch to create a new file">
-    <span class="js-new-blob-submit octicon octicon-plus"></span>
-  </span>
+  <div class="breadcrumb"><span class="repo-root js-repo-root"><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/elastic/elasticsearch/tree/1.6" class="" data-branch="1.6" data-pjax="true" itemscope="url"><span itemprop="title">elasticsearch</span></a></span></span><span class="separator">/</span><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/elastic/elasticsearch/tree/1.6/rest-api-spec" class="" data-branch="1.6" data-pjax="true" itemscope="url"><span itemprop="title">rest-api-spec</span></a></span><span class="separator">/</span><strong class="final-path">api</strong><span class="separator">/</span>
+    <a class="btn-link disabled tooltipped tooltipped-e" href="#" aria-label="You must be signed in to make or propose changes">
+      <span class="octicon octicon-plus"></span>
+    </a>
 </div>
 
 </div>
 
 
+    <div class="branch-infobar clearfix">
+        <p>
+          This branch is 4254 commits ahead, 6585 commits behind master
+        </p>
 
-  <include-fragment class="commit commit-loader commit-tease" src="/elastic/elasticsearch/tree-commit/cdd3ac4dde4f69524ec0a14de3828cb95bbb86d0/rest-api-spec/api">
+      <ul class="lightweight-actions">
+        <li>
+            <a href="/elastic/elasticsearch/pull/new/1.6">
+              <span class="octicon octicon-git-pull-request"></span>
+              Pull Request
+            </a>
+        </li>
+        <li>
+          <a href="/elastic/elasticsearch/compare/1.6">
+            <span class="octicon octicon-diff"></span>
+            Compare
+          </a>
+        </li>
+      </ul>
+
+    </div>
+
+  <include-fragment class="commit commit-loader commit-tease" src="/elastic/elasticsearch/tree-commit/e6a9ce680ca563cd209369b1d9ddce345206819c/rest-api-spec/api">
     <p class="commit-title blank">
       Fetching latest commitâ€¦
     </p>
     <div class="commit-meta">
-      <p class="loader-loading"><img alt="" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-EAF2F5-0bdc57d34b85c4a4de9d0d1db10cd70e8a95f33ff4f46c5a8c48b4bf4e5a9abe.gif" width="16" /></p>
+      <p class="loader-loading"><img alt="" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32-EAF2F5.gif" width="16" /></p>
       <p class="loader-error">Cannot retrieve the latest commit at this time</p>
     </div>
 </include-fragment>
   
-<include-fragment class="file-wrap" src="/elastic/elasticsearch/file-list/v1.6.0/rest-api-spec/api">
-  <a href="/elastic/elasticsearch/tree/cdd3ac4dde4f69524ec0a14de3828cb95bbb86d0/rest-api-spec/api" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
+<include-fragment class="file-wrap" src="/elastic/elasticsearch/file-list/1.6/rest-api-spec/api">
+  <a href="/elastic/elasticsearch/tree/e6a9ce680ca563cd209369b1d9ddce345206819c/rest-api-spec/api" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
 
   <table class="files" data-pjax>
       <tr class="up-tree">
         <td></td>
-        <td><a href="/elastic/elasticsearch/tree/v1.6.0/rest-api-spec" rel="nofollow" title="Go to parent directory">..</a></td>
+        <td><a href="/elastic/elasticsearch/tree/1.6/rest-api-spec" rel="nofollow" title="Go to parent directory">..</a></td>
         <td></td>
         <td></td>
       </tr>
@@ -1641,10 +1662,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/bulk.json" class="js-directory-link" id="6c4fbc1bd36df5d9905ce1df9cf222c0-74e39f82d87d5382cc9bcd7c695ef336476d784e" title="bulk.json">bulk.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/bulk.json" class="js-directory-link" id="6c4fbc1bd36df5d9905ce1df9cf222c0-74e39f82d87d5382cc9bcd7c695ef336476d784e" title="bulk.json">bulk.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1658,10 +1679,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.aliases.json" class="js-directory-link" id="22e2d431e2e1793e41b5f065dceaa89e-fea23d1962101e60946899685465a228dee4ccd5" title="cat.aliases.json">cat.aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.aliases.json" class="js-directory-link" id="22e2d431e2e1793e41b5f065dceaa89e-fea23d1962101e60946899685465a228dee4ccd5" title="cat.aliases.json">cat.aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1675,10 +1696,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.allocation.json" class="js-directory-link" id="4579bbcb4332bcaa7d0fb18c63b2fdd1-13d536f293842def1df4370f03a935b99b20788d" title="cat.allocation.json">cat.allocation.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.allocation.json" class="js-directory-link" id="4579bbcb4332bcaa7d0fb18c63b2fdd1-13d536f293842def1df4370f03a935b99b20788d" title="cat.allocation.json">cat.allocation.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1692,10 +1713,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.count.json" class="js-directory-link" id="aa6d9382bc0b00917e17cb6dec212d42-5b238601db41762bf16aa524856273b7d0d417a2" title="cat.count.json">cat.count.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.count.json" class="js-directory-link" id="aa6d9382bc0b00917e17cb6dec212d42-5b238601db41762bf16aa524856273b7d0d417a2" title="cat.count.json">cat.count.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1709,10 +1730,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.fielddata.json" class="js-directory-link" id="ac8f77984707b6255de6dc1447665b53-a380b558e89b42f34d8e55be4438dbacfbf12f42" title="cat.fielddata.json">cat.fielddata.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.fielddata.json" class="js-directory-link" id="ac8f77984707b6255de6dc1447665b53-a380b558e89b42f34d8e55be4438dbacfbf12f42" title="cat.fielddata.json">cat.fielddata.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1726,10 +1747,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.health.json" class="js-directory-link" id="2339db869d5a3d7653d999028dbf5dbb-222286c6b2db3b96af01f0c69d3a572232ab4e99" title="cat.health.json">cat.health.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.health.json" class="js-directory-link" id="2339db869d5a3d7653d999028dbf5dbb-222286c6b2db3b96af01f0c69d3a572232ab4e99" title="cat.health.json">cat.health.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1743,10 +1764,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.help.json" class="js-directory-link" id="2c1bf912a288d9a69ad3aa77a0ad1c3a-c4692e839c94bc89de29e255214633038defd1c7" title="cat.help.json">cat.help.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.help.json" class="js-directory-link" id="2c1bf912a288d9a69ad3aa77a0ad1c3a-c4692e839c94bc89de29e255214633038defd1c7" title="cat.help.json">cat.help.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1760,10 +1781,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.indices.json" class="js-directory-link" id="51f4fa0dcdc855c076d42cd209daefbf-08adffab0f354858fe3b352863d4ce41c6b519c6" title="cat.indices.json">cat.indices.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.indices.json" class="js-directory-link" id="51f4fa0dcdc855c076d42cd209daefbf-08adffab0f354858fe3b352863d4ce41c6b519c6" title="cat.indices.json">cat.indices.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1777,10 +1798,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.master.json" class="js-directory-link" id="777752fc1e100524ad85bffc292b262b-b5e229776103d68e96cf33f6ee4c1a5e3ab566d0" title="cat.master.json">cat.master.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.master.json" class="js-directory-link" id="777752fc1e100524ad85bffc292b262b-b5e229776103d68e96cf33f6ee4c1a5e3ab566d0" title="cat.master.json">cat.master.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1794,10 +1815,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.nodes.json" class="js-directory-link" id="c673b074876c5b81edb6826075e32d92-ff240dd4cee4d01eff120e3c02b9669314e38b8a" title="cat.nodes.json">cat.nodes.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.nodes.json" class="js-directory-link" id="c673b074876c5b81edb6826075e32d92-ff240dd4cee4d01eff120e3c02b9669314e38b8a" title="cat.nodes.json">cat.nodes.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1811,10 +1832,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.pending_tasks.json" class="js-directory-link" id="a51d665aca06cbf8fca196ef68c5490e-8b52c521fcaee7e6b6c6acace8386d153e96d858" title="cat.pending_tasks.json">cat.pending_tasks.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.pending_tasks.json" class="js-directory-link" id="a51d665aca06cbf8fca196ef68c5490e-8b52c521fcaee7e6b6c6acace8386d153e96d858" title="cat.pending_tasks.json">cat.pending_tasks.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1828,10 +1849,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.plugins.json" class="js-directory-link" id="babca80f1103a775be37ca111c02126b-55ee66a27926774a1cd4345bdc523dcc7f5bfa3e" title="cat.plugins.json">cat.plugins.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.plugins.json" class="js-directory-link" id="babca80f1103a775be37ca111c02126b-55ee66a27926774a1cd4345bdc523dcc7f5bfa3e" title="cat.plugins.json">cat.plugins.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1845,10 +1866,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.recovery.json" class="js-directory-link" id="b2755b9dbefea2a2111d7d436f45eeb2-a190e35b3c79c58f1b8207eaa245e4e752aacd08" title="cat.recovery.json">cat.recovery.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.recovery.json" class="js-directory-link" id="b2755b9dbefea2a2111d7d436f45eeb2-a190e35b3c79c58f1b8207eaa245e4e752aacd08" title="cat.recovery.json">cat.recovery.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1862,10 +1883,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.segments.json" class="js-directory-link" id="f83e55e75343f860635f6a521d60cf41-f032f4d38e6ed89f24317bfb510a0d9c61663958" title="cat.segments.json">cat.segments.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.segments.json" class="js-directory-link" id="f83e55e75343f860635f6a521d60cf41-f032f4d38e6ed89f24317bfb510a0d9c61663958" title="cat.segments.json">cat.segments.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1879,10 +1900,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.shards.json" class="js-directory-link" id="864b15ab41822be341f433cdcd6b294a-6d1ffc37ba1ffbd54888c4ed3eb173b063220554" title="cat.shards.json">cat.shards.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.shards.json" class="js-directory-link" id="864b15ab41822be341f433cdcd6b294a-6d1ffc37ba1ffbd54888c4ed3eb173b063220554" title="cat.shards.json">cat.shards.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1896,10 +1917,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cat.thread_pool.json" class="js-directory-link" id="0f45c62bc5b57fcaf01a0ee8e2be1a1f-cb8e5e13632a24a2800a5e379088d215281d84f6" title="cat.thread_pool.json">cat.thread_pool.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cat.thread_pool.json" class="js-directory-link" id="0f45c62bc5b57fcaf01a0ee8e2be1a1f-cb8e5e13632a24a2800a5e379088d215281d84f6" title="cat.thread_pool.json">cat.thread_pool.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1913,10 +1934,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/clear_scroll.json" class="js-directory-link" id="fb88c998e68dce2106c94c0bc6cc3dac-ff4e0bea3275f3b632f094b181c5d8ee2bd37567" title="clear_scroll.json">clear_scroll.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/clear_scroll.json" class="js-directory-link" id="fb88c998e68dce2106c94c0bc6cc3dac-ff4e0bea3275f3b632f094b181c5d8ee2bd37567" title="clear_scroll.json">clear_scroll.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1930,10 +1951,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.get_settings.json" class="js-directory-link" id="381ace7cc8ee62a6a019ff3d4fa5918b-69b35e043a8cded02836d1259e76cf3ad81170cb" title="cluster.get_settings.json">cluster.get_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cluster.get_settings.json" class="js-directory-link" id="381ace7cc8ee62a6a019ff3d4fa5918b-69b35e043a8cded02836d1259e76cf3ad81170cb" title="cluster.get_settings.json">cluster.get_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1947,10 +1968,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.health.json" class="js-directory-link" id="c2c52db081b723be399bb732f65aca84-367a6e9563ed917e3192333cdcb456f1e21e9286" title="cluster.health.json">cluster.health.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cluster.health.json" class="js-directory-link" id="c2c52db081b723be399bb732f65aca84-367a6e9563ed917e3192333cdcb456f1e21e9286" title="cluster.health.json">cluster.health.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1964,10 +1985,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.pending_tasks.json" class="js-directory-link" id="8a69fbf26be58ddfb4da9890e9ab2c28-e88413ed73360778b04bf9de7f08449207933508" title="cluster.pending_tasks.json">cluster.pending_tasks.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cluster.pending_tasks.json" class="js-directory-link" id="8a69fbf26be58ddfb4da9890e9ab2c28-e88413ed73360778b04bf9de7f08449207933508" title="cluster.pending_tasks.json">cluster.pending_tasks.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1981,10 +2002,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.put_settings.json" class="js-directory-link" id="e87166468da155e9d9c15de6e56a9f9e-1c434b2f5db28898d4f257996c61b16df7d70763" title="cluster.put_settings.json">cluster.put_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cluster.put_settings.json" class="js-directory-link" id="e87166468da155e9d9c15de6e56a9f9e-1c434b2f5db28898d4f257996c61b16df7d70763" title="cluster.put_settings.json">cluster.put_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -1998,10 +2019,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.reroute.json" class="js-directory-link" id="a2b21ed6ff197a1803c961126ab8960c-3f621aff066f05b99cf4fcf286424ec2191fc050" title="cluster.reroute.json">cluster.reroute.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cluster.reroute.json" class="js-directory-link" id="a2b21ed6ff197a1803c961126ab8960c-3f621aff066f05b99cf4fcf286424ec2191fc050" title="cluster.reroute.json">cluster.reroute.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2015,10 +2036,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.state.json" class="js-directory-link" id="6acc013937ed94065ffab45cc3d7ec36-72de5e3c91ab30775dd6aec2ec47e3a8208b2e33" title="cluster.state.json">cluster.state.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cluster.state.json" class="js-directory-link" id="6acc013937ed94065ffab45cc3d7ec36-72de5e3c91ab30775dd6aec2ec47e3a8208b2e33" title="cluster.state.json">cluster.state.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2032,10 +2053,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/cluster.stats.json" class="js-directory-link" id="ddd8cd720c91c6531768ce3ede81e8d3-25ea04a29332b708eb31799683c397b714afa042" title="cluster.stats.json">cluster.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/cluster.stats.json" class="js-directory-link" id="ddd8cd720c91c6531768ce3ede81e8d3-25ea04a29332b708eb31799683c397b714afa042" title="cluster.stats.json">cluster.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2049,10 +2070,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/count.json" class="js-directory-link" id="3baa357d5adf340622c003b0856dd25f-a1fddb9bfeccc3b683896221ad54e569b66ba4ea" title="count.json">count.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/count.json" class="js-directory-link" id="3baa357d5adf340622c003b0856dd25f-a1fddb9bfeccc3b683896221ad54e569b66ba4ea" title="count.json">count.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2066,10 +2087,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/count_percolate.json" class="js-directory-link" id="2d9528db75f1df48e5cc5080a4dbdb3e-55d7952df65eea7704ed1efc9a28abc9e32e501c" title="count_percolate.json">count_percolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/count_percolate.json" class="js-directory-link" id="2d9528db75f1df48e5cc5080a4dbdb3e-55d7952df65eea7704ed1efc9a28abc9e32e501c" title="count_percolate.json">count_percolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2083,10 +2104,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/delete.json" class="js-directory-link" id="32e7b62c510daf7d16345f4d4bb54d69-0910f71143886cabea44a1dac68c771101bd14cf" title="delete.json">delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/delete.json" class="js-directory-link" id="32e7b62c510daf7d16345f4d4bb54d69-0910f71143886cabea44a1dac68c771101bd14cf" title="delete.json">delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2100,10 +2121,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/delete_by_query.json" class="js-directory-link" id="1be069693a43a7efc73e3cbbee3df9d6-15ef9982fee6194017b25b896f0b2758dc27f1b8" title="delete_by_query.json">delete_by_query.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/delete_by_query.json" class="js-directory-link" id="1be069693a43a7efc73e3cbbee3df9d6-15ef9982fee6194017b25b896f0b2758dc27f1b8" title="delete_by_query.json">delete_by_query.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2117,10 +2138,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/delete_script.json" class="js-directory-link" id="0f1829713245eba3e6695da9d37342c1-d3f7771fc852cc31c5eb4d108cf5b2bdc1514f4a" title="delete_script.json">delete_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/delete_script.json" class="js-directory-link" id="0f1829713245eba3e6695da9d37342c1-d3f7771fc852cc31c5eb4d108cf5b2bdc1514f4a" title="delete_script.json">delete_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2134,10 +2155,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/delete_template.json" class="js-directory-link" id="64be6114ddd1e414654ed6b052a067ba-9e928342d075e01084c74189791833739dad055d" title="delete_template.json">delete_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/delete_template.json" class="js-directory-link" id="64be6114ddd1e414654ed6b052a067ba-9e928342d075e01084c74189791833739dad055d" title="delete_template.json">delete_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2151,10 +2172,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/exists.json" class="js-directory-link" id="3d89dbbbdf2cfe3ecaccea759487838f-f61d9cbb586eb8014da024ceacaffbfa0f7a9273" title="exists.json">exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/exists.json" class="js-directory-link" id="3d89dbbbdf2cfe3ecaccea759487838f-f61d9cbb586eb8014da024ceacaffbfa0f7a9273" title="exists.json">exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2168,10 +2189,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/explain.json" class="js-directory-link" id="f1262f2a3266d79bc85a4907d455c177-0e9a99202f41df778717a75dc573bc8bdef6aac2" title="explain.json">explain.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/explain.json" class="js-directory-link" id="f1262f2a3266d79bc85a4907d455c177-0e9a99202f41df778717a75dc573bc8bdef6aac2" title="explain.json">explain.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2185,10 +2206,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/field_stats.json" class="js-directory-link" id="6f118aa7a31508b462aae4b9be7f3e9d-e3c5e6d45df3f263fedd6edd31fd428f0625da3c" title="field_stats.json">field_stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/field_stats.json" class="js-directory-link" id="6f118aa7a31508b462aae4b9be7f3e9d-e3c5e6d45df3f263fedd6edd31fd428f0625da3c" title="field_stats.json">field_stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2202,10 +2223,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/get.json" class="js-directory-link" id="08e364c89f4f291dd93f7be65f3c1629-73b5d11b4bf981aa86404854337c48ce758f8ede" title="get.json">get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/get.json" class="js-directory-link" id="08e364c89f4f291dd93f7be65f3c1629-73b5d11b4bf981aa86404854337c48ce758f8ede" title="get.json">get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2219,10 +2240,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/get_script.json" class="js-directory-link" id="ec949f8f96d44ae7d86392e6939249fc-d6cae320caa142e1ad0ec7a318c97e5482180f47" title="get_script.json">get_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/get_script.json" class="js-directory-link" id="ec949f8f96d44ae7d86392e6939249fc-d6cae320caa142e1ad0ec7a318c97e5482180f47" title="get_script.json">get_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2236,10 +2257,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/get_source.json" class="js-directory-link" id="06c3cb0e17ebff492b057f22db913580-2ed323e82464fc6ef529292c22d5db7c9759ce1c" title="get_source.json">get_source.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/get_source.json" class="js-directory-link" id="06c3cb0e17ebff492b057f22db913580-2ed323e82464fc6ef529292c22d5db7c9759ce1c" title="get_source.json">get_source.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2253,10 +2274,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/get_template.json" class="js-directory-link" id="ab816619a3803791da2da066912f78f0-8052b1d63fb3ffa9c520aaabccc9b1b624af96f1" title="get_template.json">get_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/get_template.json" class="js-directory-link" id="ab816619a3803791da2da066912f78f0-8052b1d63fb3ffa9c520aaabccc9b1b624af96f1" title="get_template.json">get_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2270,10 +2291,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/index.json" class="js-directory-link" id="9e743aa713dcae5405f290e3db88178b-86ce6e2e99f2c2334a9a42b2de9cba1a28489f0e" title="index.json">index.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/index.json" class="js-directory-link" id="9e743aa713dcae5405f290e3db88178b-86ce6e2e99f2c2334a9a42b2de9cba1a28489f0e" title="index.json">index.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2287,10 +2308,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.analyze.json" class="js-directory-link" id="ea53ca0f9f948fb3fa7fb805c578af11-7f65a6622d5db17f5698f4a9dc951ea9d3b6d0e3" title="indices.analyze.json">indices.analyze.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.analyze.json" class="js-directory-link" id="ea53ca0f9f948fb3fa7fb805c578af11-7f65a6622d5db17f5698f4a9dc951ea9d3b6d0e3" title="indices.analyze.json">indices.analyze.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2304,10 +2325,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.clear_cache.json" class="js-directory-link" id="2c9d7dd90e792d3063a65d93493a8d3e-31e8f4e723693d84409a5739d1d64849917ea7e8" title="indices.clear_cache.json">indices.clear_cache.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.clear_cache.json" class="js-directory-link" id="2c9d7dd90e792d3063a65d93493a8d3e-31e8f4e723693d84409a5739d1d64849917ea7e8" title="indices.clear_cache.json">indices.clear_cache.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2321,10 +2342,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.close.json" class="js-directory-link" id="d613995d3cc3e47e00e6584ccfb82a35-534373b5d4ca622dfaa264744a5ac24c94a86587" title="indices.close.json">indices.close.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.close.json" class="js-directory-link" id="d613995d3cc3e47e00e6584ccfb82a35-534373b5d4ca622dfaa264744a5ac24c94a86587" title="indices.close.json">indices.close.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2338,10 +2359,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.create.json" class="js-directory-link" id="63f95a3c21061e2fb572cef0eb2eab90-1cefae61c9706bd31ae1b8d165f4ea0331193f52" title="indices.create.json">indices.create.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.create.json" class="js-directory-link" id="63f95a3c21061e2fb572cef0eb2eab90-1cefae61c9706bd31ae1b8d165f4ea0331193f52" title="indices.create.json">indices.create.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2355,10 +2376,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete.json" class="js-directory-link" id="a48e4dc86992215871f3270ad541bc6d-b0414322cb6d3adf5306a2e0aec29644435b0fef" title="indices.delete.json">indices.delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.delete.json" class="js-directory-link" id="a48e4dc86992215871f3270ad541bc6d-b0414322cb6d3adf5306a2e0aec29644435b0fef" title="indices.delete.json">indices.delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2372,10 +2393,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete_alias.json" class="js-directory-link" id="9a24979aa4a99ba087361de8997ba9d8-24a443a1b45c5d3440a8be819ccc899c713daa34" title="indices.delete_alias.json">indices.delete_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.delete_alias.json" class="js-directory-link" id="9a24979aa4a99ba087361de8997ba9d8-24a443a1b45c5d3440a8be819ccc899c713daa34" title="indices.delete_alias.json">indices.delete_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2389,10 +2410,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete_mapping.json" class="js-directory-link" id="e3979fad32decf2cf51ff65aa1509d47-bf166f81bf75fd235c944718027071db2743239e" title="indices.delete_mapping.json">indices.delete_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.delete_mapping.json" class="js-directory-link" id="e3979fad32decf2cf51ff65aa1509d47-bf166f81bf75fd235c944718027071db2743239e" title="indices.delete_mapping.json">indices.delete_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2406,10 +2427,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete_template.json" class="js-directory-link" id="7e86ed5d6fec40fca7550c69311db515-ff6b837a156d3b43591935deb6809ff1548c2a6b" title="indices.delete_template.json">indices.delete_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.delete_template.json" class="js-directory-link" id="7e86ed5d6fec40fca7550c69311db515-ff6b837a156d3b43591935deb6809ff1548c2a6b" title="indices.delete_template.json">indices.delete_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2423,10 +2444,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.delete_warmer.json" class="js-directory-link" id="0cb555d38237effd9567bb06c47530c3-c9d5f414963a9729a003a11f646b6b36b0e703bd" title="indices.delete_warmer.json">indices.delete_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.delete_warmer.json" class="js-directory-link" id="0cb555d38237effd9567bb06c47530c3-c9d5f414963a9729a003a11f646b6b36b0e703bd" title="indices.delete_warmer.json">indices.delete_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2440,10 +2461,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.exists.json" class="js-directory-link" id="8adc33572e46831f609304d8616b1b1d-9e1ca824c9e82b4d755cb99bf6315902d0e1b074" title="indices.exists.json">indices.exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.exists.json" class="js-directory-link" id="8adc33572e46831f609304d8616b1b1d-9e1ca824c9e82b4d755cb99bf6315902d0e1b074" title="indices.exists.json">indices.exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2457,10 +2478,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.exists_alias.json" class="js-directory-link" id="a8d7a4ce4b4a60cb658f043d5488dd39-af3f80ad13d760a8dffa624eb798a14d7995871f" title="indices.exists_alias.json">indices.exists_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.exists_alias.json" class="js-directory-link" id="a8d7a4ce4b4a60cb658f043d5488dd39-af3f80ad13d760a8dffa624eb798a14d7995871f" title="indices.exists_alias.json">indices.exists_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2474,10 +2495,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.exists_template.json" class="js-directory-link" id="3431ee0eca88f8bae40fe200f78f2d99-3114e15b0bb183744601787ad699458fe1d2e053" title="indices.exists_template.json">indices.exists_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.exists_template.json" class="js-directory-link" id="3431ee0eca88f8bae40fe200f78f2d99-3114e15b0bb183744601787ad699458fe1d2e053" title="indices.exists_template.json">indices.exists_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2491,10 +2512,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.exists_type.json" class="js-directory-link" id="e3050c1e9f7f37ca82a87ed38a0bb95f-5709734b0808f94e63951099c220165623e18499" title="indices.exists_type.json">indices.exists_type.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.exists_type.json" class="js-directory-link" id="e3050c1e9f7f37ca82a87ed38a0bb95f-5709734b0808f94e63951099c220165623e18499" title="indices.exists_type.json">indices.exists_type.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2508,10 +2529,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.flush.json" class="js-directory-link" id="9c0d06f79fd7551fb765652a4296136e-7ed13f036cdd0621fe26ae62ce2309b7c32846cc" title="indices.flush.json">indices.flush.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.flush.json" class="js-directory-link" id="9c0d06f79fd7551fb765652a4296136e-7ed13f036cdd0621fe26ae62ce2309b7c32846cc" title="indices.flush.json">indices.flush.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2525,10 +2546,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.flush_synced.json" class="js-directory-link" id="1c80af8fdeffd1c1809f79ec7f2bcef5-e2d40a9c4027b431ab914b89687afc3a685c2770" title="indices.flush_synced.json">indices.flush_synced.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.flush_synced.json" class="js-directory-link" id="1c80af8fdeffd1c1809f79ec7f2bcef5-1c411b1d5af6f437d0cd711740300fd2b51b7a4f" title="indices.flush_synced.json">indices.flush_synced.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2542,10 +2563,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get.json" class="js-directory-link" id="c7dfb0129e6d01bcdaa59a6d9bef56b1-e1c77270127cbaf747638a5d1819e7936e55b42c" title="indices.get.json">indices.get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get.json" class="js-directory-link" id="c7dfb0129e6d01bcdaa59a6d9bef56b1-e1c77270127cbaf747638a5d1819e7936e55b42c" title="indices.get.json">indices.get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2559,10 +2580,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_alias.json" class="js-directory-link" id="b359991822afa51a4920347b06236830-b1f71439097add306cebe02faedb9d088ed01f72" title="indices.get_alias.json">indices.get_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get_alias.json" class="js-directory-link" id="b359991822afa51a4920347b06236830-b1f71439097add306cebe02faedb9d088ed01f72" title="indices.get_alias.json">indices.get_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2576,10 +2597,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_aliases.json" class="js-directory-link" id="a4b0f80dfc2206cac0dae0dd5c2edf63-9d9cd6f921a09af920c5f0c6037a1c8638b93712" title="indices.get_aliases.json">indices.get_aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get_aliases.json" class="js-directory-link" id="a4b0f80dfc2206cac0dae0dd5c2edf63-9d9cd6f921a09af920c5f0c6037a1c8638b93712" title="indices.get_aliases.json">indices.get_aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2593,10 +2614,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_field_mapping.json" class="js-directory-link" id="7a95e8e39115ae0693c0e9ebac94aae4-164f8c025aa69403508298e7c3552b83e451ad28" title="indices.get_field_mapping.json">indices.get_field_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get_field_mapping.json" class="js-directory-link" id="7a95e8e39115ae0693c0e9ebac94aae4-164f8c025aa69403508298e7c3552b83e451ad28" title="indices.get_field_mapping.json">indices.get_field_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2610,10 +2631,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_mapping.json" class="js-directory-link" id="043a6a009b58931d43b9f4fcf495e584-f223806d63d57c3a03c02d3f950c78e2d2ea9ebb" title="indices.get_mapping.json">indices.get_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get_mapping.json" class="js-directory-link" id="043a6a009b58931d43b9f4fcf495e584-f223806d63d57c3a03c02d3f950c78e2d2ea9ebb" title="indices.get_mapping.json">indices.get_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2627,10 +2648,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_settings.json" class="js-directory-link" id="573611d97c9a674af4eb1fd67f06ba87-e2fee434c6621e2d4d2846f5d9e8a23523e3103f" title="indices.get_settings.json">indices.get_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get_settings.json" class="js-directory-link" id="573611d97c9a674af4eb1fd67f06ba87-e2fee434c6621e2d4d2846f5d9e8a23523e3103f" title="indices.get_settings.json">indices.get_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2644,10 +2665,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_template.json" class="js-directory-link" id="6a31359bb097d3ebbe0a9ee6758c86ea-20caee3a732a6ac020df5e4d65ad38d3eb9ebf89" title="indices.get_template.json">indices.get_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get_template.json" class="js-directory-link" id="6a31359bb097d3ebbe0a9ee6758c86ea-20caee3a732a6ac020df5e4d65ad38d3eb9ebf89" title="indices.get_template.json">indices.get_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2661,10 +2682,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_upgrade.json" class="js-directory-link" id="8a2688acbdae5eff0da90082f894d6ff-63d9bbf418bab2863bdf23f0506298995fc491a9" title="indices.get_upgrade.json">indices.get_upgrade.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get_upgrade.json" class="js-directory-link" id="8a2688acbdae5eff0da90082f894d6ff-63d9bbf418bab2863bdf23f0506298995fc491a9" title="indices.get_upgrade.json">indices.get_upgrade.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2678,10 +2699,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.get_warmer.json" class="js-directory-link" id="696ba757658b41eb345ac40688505bf3-51a62b9ce338015637fc698629e5d6e5eac21ab9" title="indices.get_warmer.json">indices.get_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.get_warmer.json" class="js-directory-link" id="696ba757658b41eb345ac40688505bf3-51a62b9ce338015637fc698629e5d6e5eac21ab9" title="indices.get_warmer.json">indices.get_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2695,10 +2716,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.open.json" class="js-directory-link" id="373e5d7e5484cc081c4980032ab53333-334ad5ea0437f72e0054ec876abfd65e4ea13323" title="indices.open.json">indices.open.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.open.json" class="js-directory-link" id="373e5d7e5484cc081c4980032ab53333-334ad5ea0437f72e0054ec876abfd65e4ea13323" title="indices.open.json">indices.open.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2712,10 +2733,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.optimize.json" class="js-directory-link" id="8efebf88db11882bb5adedfc25de4847-ab45ede9b052d977153a070e1cc7f836e7d67d20" title="indices.optimize.json">indices.optimize.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.optimize.json" class="js-directory-link" id="8efebf88db11882bb5adedfc25de4847-ab45ede9b052d977153a070e1cc7f836e7d67d20" title="indices.optimize.json">indices.optimize.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2729,10 +2750,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_alias.json" class="js-directory-link" id="7c4d55dd18903fbe6a08229325f31825-aab8da146ecf2609b8687bddb4b973199434f543" title="indices.put_alias.json">indices.put_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.put_alias.json" class="js-directory-link" id="7c4d55dd18903fbe6a08229325f31825-aab8da146ecf2609b8687bddb4b973199434f543" title="indices.put_alias.json">indices.put_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2746,10 +2767,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_mapping.json" class="js-directory-link" id="250bd21a9bccfcf55d2e743ea58da37e-44aba72eed29523ef8cf01c450f2a5b228cb9bd2" title="indices.put_mapping.json">indices.put_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.put_mapping.json" class="js-directory-link" id="250bd21a9bccfcf55d2e743ea58da37e-44aba72eed29523ef8cf01c450f2a5b228cb9bd2" title="indices.put_mapping.json">indices.put_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2763,10 +2784,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_settings.json" class="js-directory-link" id="d6b150b68eeb6f484cdae6fec82c913f-b7ad400591acdccec26fa6088175e0b60911afa9" title="indices.put_settings.json">indices.put_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.put_settings.json" class="js-directory-link" id="d6b150b68eeb6f484cdae6fec82c913f-b7ad400591acdccec26fa6088175e0b60911afa9" title="indices.put_settings.json">indices.put_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2780,10 +2801,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_template.json" class="js-directory-link" id="481ea697fa69449ad04daf3c10691415-daa30fcc8fb41ebf5549351b7b26912f652d11db" title="indices.put_template.json">indices.put_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.put_template.json" class="js-directory-link" id="481ea697fa69449ad04daf3c10691415-daa30fcc8fb41ebf5549351b7b26912f652d11db" title="indices.put_template.json">indices.put_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2797,10 +2818,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.put_warmer.json" class="js-directory-link" id="7144ddc1e315d2eb87f6d7fa415b3027-4caa83a940ad50fe7645bfa91f04d189021309a3" title="indices.put_warmer.json">indices.put_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.put_warmer.json" class="js-directory-link" id="7144ddc1e315d2eb87f6d7fa415b3027-4caa83a940ad50fe7645bfa91f04d189021309a3" title="indices.put_warmer.json">indices.put_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2814,10 +2835,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.recovery.json" class="js-directory-link" id="7a1cc9a6701c8cfa3c52bbaffa9f22b8-2b94f1ad3d6920f905242ed843bcb6102a51afed" title="indices.recovery.json">indices.recovery.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.recovery.json" class="js-directory-link" id="7a1cc9a6701c8cfa3c52bbaffa9f22b8-2b94f1ad3d6920f905242ed843bcb6102a51afed" title="indices.recovery.json">indices.recovery.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2831,10 +2852,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.refresh.json" class="js-directory-link" id="3717be850ac7c14c749c955fb79f61d7-a8bfc95ab3ac12fc23c4649ec074194ad27ee9e2" title="indices.refresh.json">indices.refresh.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.refresh.json" class="js-directory-link" id="3717be850ac7c14c749c955fb79f61d7-a8bfc95ab3ac12fc23c4649ec074194ad27ee9e2" title="indices.refresh.json">indices.refresh.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2848,10 +2869,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.segments.json" class="js-directory-link" id="56a2f2774152e652738ca9703cf447dc-8beb5871c65392982e5472f601053f60e5ea09b2" title="indices.segments.json">indices.segments.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.segments.json" class="js-directory-link" id="56a2f2774152e652738ca9703cf447dc-8beb5871c65392982e5472f601053f60e5ea09b2" title="indices.segments.json">indices.segments.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2865,10 +2886,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.stats.json" class="js-directory-link" id="cb782133ac617be36b33b196df8059b5-e4bb414c88589dc58777dddfa0cedbb205c08686" title="indices.stats.json">indices.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.stats.json" class="js-directory-link" id="cb782133ac617be36b33b196df8059b5-e4bb414c88589dc58777dddfa0cedbb205c08686" title="indices.stats.json">indices.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2882,10 +2903,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.status.json" class="js-directory-link" id="2cc01e73929605ba4a1f29ef7bd89c47-45805ab2fe9b13f958afaa2113501d108c50390e" title="indices.status.json">indices.status.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.status.json" class="js-directory-link" id="2cc01e73929605ba4a1f29ef7bd89c47-45805ab2fe9b13f958afaa2113501d108c50390e" title="indices.status.json">indices.status.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2899,10 +2920,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.update_aliases.json" class="js-directory-link" id="655e7332a9c5cd438b45d4ff1cb30b85-2ca4be33819052a8b1a85db847847009a9c20347" title="indices.update_aliases.json">indices.update_aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.update_aliases.json" class="js-directory-link" id="655e7332a9c5cd438b45d4ff1cb30b85-2ca4be33819052a8b1a85db847847009a9c20347" title="indices.update_aliases.json">indices.update_aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2916,10 +2937,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.upgrade.json" class="js-directory-link" id="49572445346c6fe5f226279051b88082-250b7c3fb8930ecd81fc1847a090295b248df63a" title="indices.upgrade.json">indices.upgrade.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.upgrade.json" class="js-directory-link" id="49572445346c6fe5f226279051b88082-250b7c3fb8930ecd81fc1847a090295b248df63a" title="indices.upgrade.json">indices.upgrade.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2933,10 +2954,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/indices.validate_query.json" class="js-directory-link" id="abeaaf04f453c9902ecb8d3315d3d43d-0dc9a0d41c6460d17b5e9cc639f3b1d0befc087d" title="indices.validate_query.json">indices.validate_query.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/indices.validate_query.json" class="js-directory-link" id="abeaaf04f453c9902ecb8d3315d3d43d-64a36227e3de8f1f816e709d9885e3cb2c7332d8" title="indices.validate_query.json">indices.validate_query.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2950,10 +2971,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/info.json" class="js-directory-link" id="379da8ee275d0393f12cdff8542d368d-63754eb7f7c3ccae5da2b584be5ba2a90c71fa4a" title="info.json">info.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/info.json" class="js-directory-link" id="379da8ee275d0393f12cdff8542d368d-63754eb7f7c3ccae5da2b584be5ba2a90c71fa4a" title="info.json">info.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2967,10 +2988,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/mget.json" class="js-directory-link" id="7db3deffe9680ffd2cdb16a331aea2fa-cd5d9cc6358eea6135b1640ed090b9210b5a787e" title="mget.json">mget.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/mget.json" class="js-directory-link" id="7db3deffe9680ffd2cdb16a331aea2fa-cd5d9cc6358eea6135b1640ed090b9210b5a787e" title="mget.json">mget.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -2984,10 +3005,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/mlt.json" class="js-directory-link" id="85fe94abc6068cd67d547c5c09f278b3-05921c10cf8a0c76ce44ccba96e75dfc2bbf0505" title="mlt.json">mlt.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/mlt.json" class="js-directory-link" id="85fe94abc6068cd67d547c5c09f278b3-05921c10cf8a0c76ce44ccba96e75dfc2bbf0505" title="mlt.json">mlt.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3001,10 +3022,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/mpercolate.json" class="js-directory-link" id="9410cd2b17f09ec3ccfa9fbc452c0e98-a92e7c3f0350be543d888765d9eb47767597b2d4" title="mpercolate.json">mpercolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/mpercolate.json" class="js-directory-link" id="9410cd2b17f09ec3ccfa9fbc452c0e98-a92e7c3f0350be543d888765d9eb47767597b2d4" title="mpercolate.json">mpercolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3018,10 +3039,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/msearch.json" class="js-directory-link" id="41473f6391667dbfeb8f12856e6dbf9b-788a326b98dd676b46ea087b86adc63093779e8b" title="msearch.json">msearch.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/msearch.json" class="js-directory-link" id="41473f6391667dbfeb8f12856e6dbf9b-788a326b98dd676b46ea087b86adc63093779e8b" title="msearch.json">msearch.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3035,10 +3056,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/mtermvectors.json" class="js-directory-link" id="717daf7be8083a78bf284fe4a9a25223-e3c6cd3f414ab9f17c2307de437375b5c18db902" title="mtermvectors.json">mtermvectors.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/mtermvectors.json" class="js-directory-link" id="717daf7be8083a78bf284fe4a9a25223-e3c6cd3f414ab9f17c2307de437375b5c18db902" title="mtermvectors.json">mtermvectors.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3052,10 +3073,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/nodes.hot_threads.json" class="js-directory-link" id="0ef0e709908091e3498307d32d74fa69-c0ca4cece19923ac18a8867d2ca333c3c6d85ed7" title="nodes.hot_threads.json">nodes.hot_threads.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/nodes.hot_threads.json" class="js-directory-link" id="0ef0e709908091e3498307d32d74fa69-c0ca4cece19923ac18a8867d2ca333c3c6d85ed7" title="nodes.hot_threads.json">nodes.hot_threads.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3069,10 +3090,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/nodes.info.json" class="js-directory-link" id="827644931be55e9818fb73ba26553cba-03f04d75d84fe823613e57b654c67cd471a419a9" title="nodes.info.json">nodes.info.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/nodes.info.json" class="js-directory-link" id="827644931be55e9818fb73ba26553cba-03f04d75d84fe823613e57b654c67cd471a419a9" title="nodes.info.json">nodes.info.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3086,10 +3107,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/nodes.shutdown.json" class="js-directory-link" id="b87d2a5a6a497bc76aa25fb8a2e71226-50e1d13448a6e293a40fbcf0567c51fbc7aa5432" title="nodes.shutdown.json">nodes.shutdown.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/nodes.shutdown.json" class="js-directory-link" id="b87d2a5a6a497bc76aa25fb8a2e71226-50e1d13448a6e293a40fbcf0567c51fbc7aa5432" title="nodes.shutdown.json">nodes.shutdown.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3103,10 +3124,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/nodes.stats.json" class="js-directory-link" id="1402dc0afe821bc096932f4af7774b7b-a7b63b7681e586fb1ae259946d3250ba668a1807" title="nodes.stats.json">nodes.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/nodes.stats.json" class="js-directory-link" id="1402dc0afe821bc096932f4af7774b7b-a7b63b7681e586fb1ae259946d3250ba668a1807" title="nodes.stats.json">nodes.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3120,10 +3141,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/percolate.json" class="js-directory-link" id="4b2043d3c446183feab58857c7d22954-ee008c7c68ec85facbda4c8ac7fecf7fb5cf09f9" title="percolate.json">percolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/percolate.json" class="js-directory-link" id="4b2043d3c446183feab58857c7d22954-ee008c7c68ec85facbda4c8ac7fecf7fb5cf09f9" title="percolate.json">percolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3137,10 +3158,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/ping.json" class="js-directory-link" id="2c0ccb85c134546fc2419cd212d7c7a1-41310bb30d4942e3edb97d489c5613685227ca33" title="ping.json">ping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/ping.json" class="js-directory-link" id="2c0ccb85c134546fc2419cd212d7c7a1-41310bb30d4942e3edb97d489c5613685227ca33" title="ping.json">ping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3154,10 +3175,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/put_script.json" class="js-directory-link" id="3e5e341e9944ac912cd75b44d94ffb18-1a0d6ac5f74a3a6016759884301a1e0252b45f73" title="put_script.json">put_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/put_script.json" class="js-directory-link" id="3e5e341e9944ac912cd75b44d94ffb18-1a0d6ac5f74a3a6016759884301a1e0252b45f73" title="put_script.json">put_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3171,10 +3192,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/put_template.json" class="js-directory-link" id="eb9589368281828322f480b4696c4a51-845a368493e97af0b5a1a818454c0da795d8eb03" title="put_template.json">put_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/put_template.json" class="js-directory-link" id="eb9589368281828322f480b4696c4a51-845a368493e97af0b5a1a818454c0da795d8eb03" title="put_template.json">put_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3188,10 +3209,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/scroll.json" class="js-directory-link" id="b68a77ffff64b26fa9efb03e5f4fec69-07fdb0134de900dff7447cdc1027a09cd637d634" title="scroll.json">scroll.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/scroll.json" class="js-directory-link" id="b68a77ffff64b26fa9efb03e5f4fec69-07fdb0134de900dff7447cdc1027a09cd637d634" title="scroll.json">scroll.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3205,10 +3226,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/search.json" class="js-directory-link" id="36e64ee591eb44c77488faec76357456-d7a65bd74e0baf563c5176fd74e75288768f60f1" title="search.json">search.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/search.json" class="js-directory-link" id="36e64ee591eb44c77488faec76357456-d7a65bd74e0baf563c5176fd74e75288768f60f1" title="search.json">search.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3222,10 +3243,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/search_exists.json" class="js-directory-link" id="05525aaadd0ea9bb5405273c1ccbeb9c-a8970467d1c11870059a945a2a161271b42102e6" title="search_exists.json">search_exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/search_exists.json" class="js-directory-link" id="05525aaadd0ea9bb5405273c1ccbeb9c-a8970467d1c11870059a945a2a161271b42102e6" title="search_exists.json">search_exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3239,10 +3260,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/search_shards.json" class="js-directory-link" id="087e36570eccc7017ef612e4d4fcab82-8bd4a4084cb13c81542a3cadf6fb501c956e60c2" title="search_shards.json">search_shards.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/search_shards.json" class="js-directory-link" id="087e36570eccc7017ef612e4d4fcab82-8bd4a4084cb13c81542a3cadf6fb501c956e60c2" title="search_shards.json">search_shards.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3256,10 +3277,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/search_template.json" class="js-directory-link" id="271a84623de72292ff6257d567a959a8-a1122f19a1e80fc5506dd23edff72ab3dc00393f" title="search_template.json">search_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/search_template.json" class="js-directory-link" id="271a84623de72292ff6257d567a959a8-a1122f19a1e80fc5506dd23edff72ab3dc00393f" title="search_template.json">search_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3273,10 +3294,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.create.json" class="js-directory-link" id="3142f56582a6a4f221f2ca9613092485-6f3c4f9b390b06c21092b1905ce0ccd1a72e0e94" title="snapshot.create.json">snapshot.create.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.create.json" class="js-directory-link" id="3142f56582a6a4f221f2ca9613092485-6f3c4f9b390b06c21092b1905ce0ccd1a72e0e94" title="snapshot.create.json">snapshot.create.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3290,10 +3311,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.create_repository.json" class="js-directory-link" id="3c7efb7259ad685fcc61441956417466-a88aa5a1b98c90ce894d3535ddf58717dfcaf5d1" title="snapshot.create_repository.json">snapshot.create_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.create_repository.json" class="js-directory-link" id="3c7efb7259ad685fcc61441956417466-a88aa5a1b98c90ce894d3535ddf58717dfcaf5d1" title="snapshot.create_repository.json">snapshot.create_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3307,10 +3328,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.delete.json" class="js-directory-link" id="057c6616838d5438ead24db42bab5b2e-b0501535af2b53f912dc5c9f87464f7130c5e0e0" title="snapshot.delete.json">snapshot.delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.delete.json" class="js-directory-link" id="057c6616838d5438ead24db42bab5b2e-b0501535af2b53f912dc5c9f87464f7130c5e0e0" title="snapshot.delete.json">snapshot.delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3324,10 +3345,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.delete_repository.json" class="js-directory-link" id="9af95f6a49693f226af744dec7d88ed3-a23ca289a193ea0bead9d89bb668152939b30dee" title="snapshot.delete_repository.json">snapshot.delete_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.delete_repository.json" class="js-directory-link" id="9af95f6a49693f226af744dec7d88ed3-a23ca289a193ea0bead9d89bb668152939b30dee" title="snapshot.delete_repository.json">snapshot.delete_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3341,10 +3362,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.get.json" class="js-directory-link" id="651bdc0b78c2633f9a5da0947a67d317-46a5b2a7101100d72f4b84f80cc799a7db708261" title="snapshot.get.json">snapshot.get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.get.json" class="js-directory-link" id="651bdc0b78c2633f9a5da0947a67d317-46a5b2a7101100d72f4b84f80cc799a7db708261" title="snapshot.get.json">snapshot.get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3358,10 +3379,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.get_repository.json" class="js-directory-link" id="2dd6796f7524ee470c4ba617cb6be760-02b6a7b4ee67b26655fd68283b461a44bc4688fc" title="snapshot.get_repository.json">snapshot.get_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.get_repository.json" class="js-directory-link" id="2dd6796f7524ee470c4ba617cb6be760-02b6a7b4ee67b26655fd68283b461a44bc4688fc" title="snapshot.get_repository.json">snapshot.get_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3375,10 +3396,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.restore.json" class="js-directory-link" id="b2377ab03bc2e7f239f6f9d2b1689802-fb5ee8102aa62189b49af02acfbb3f1b26061ada" title="snapshot.restore.json">snapshot.restore.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.restore.json" class="js-directory-link" id="b2377ab03bc2e7f239f6f9d2b1689802-fb5ee8102aa62189b49af02acfbb3f1b26061ada" title="snapshot.restore.json">snapshot.restore.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3392,10 +3413,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.status.json" class="js-directory-link" id="e790b0dada2bf67f54709c5f222b8ef1-ebc9180cb527c8e3dc1a6cc78e327b8e8e82d2f9" title="snapshot.status.json">snapshot.status.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.status.json" class="js-directory-link" id="e790b0dada2bf67f54709c5f222b8ef1-ebc9180cb527c8e3dc1a6cc78e327b8e8e82d2f9" title="snapshot.status.json">snapshot.status.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3409,10 +3430,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/snapshot.verify_repository.json" class="js-directory-link" id="4b88bdf4b93ee8150855454ee6b250f4-0d9a97c10877b5494b9eb5074f2a0953ac7a9e70" title="snapshot.verify_repository.json">snapshot.verify_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/snapshot.verify_repository.json" class="js-directory-link" id="4b88bdf4b93ee8150855454ee6b250f4-0d9a97c10877b5494b9eb5074f2a0953ac7a9e70" title="snapshot.verify_repository.json">snapshot.verify_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3426,10 +3447,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/suggest.json" class="js-directory-link" id="ede60bf6805d74020a897b7189fd2c28-d737e251d045da09c86858a9ec112c5831a0ec3f" title="suggest.json">suggest.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/suggest.json" class="js-directory-link" id="ede60bf6805d74020a897b7189fd2c28-d737e251d045da09c86858a9ec112c5831a0ec3f" title="suggest.json">suggest.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3443,10 +3464,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/termvector.json" class="js-directory-link" id="007656edbf5dfa6498a00a62c187d2c6-116aea619bfbf0eeabb2aef183f01710e55d7bcb" title="termvector.json">termvector.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/termvector.json" class="js-directory-link" id="007656edbf5dfa6498a00a62c187d2c6-116aea619bfbf0eeabb2aef183f01710e55d7bcb" title="termvector.json">termvector.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3460,10 +3481,10 @@
         <tr>
           <td class="icon">
             <span class="octicon octicon-file-text"></span>
-            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/assets/spinners/octocat-spinner-32-e513294efa576953719e4e2de888dd9cf929b7d62ed8d05f25e731d02452ab6c.gif" width="16" />
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/v1.6.0/rest-api-spec/api/update.json" class="js-directory-link" id="2103efac9db966ed8688bc9b541c1638-2cfe7992ffde46c319620769a02d5d44e14d8757" title="update.json">update.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/1.6/rest-api-spec/api/update.json" class="js-directory-link" id="2103efac9db966ed8688bc9b541c1638-2cfe7992ffde46c319620769a02d5d44e14d8757" title="update.json">update.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
@@ -3510,7 +3531,7 @@
       <span class="mega-octicon octicon-mark-github" title="GitHub"></span>
 </a>
     <ul class="site-footer-links">
-      <li>&copy; 2015 <span title="0.04728s from github-fe122-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+      <li>&copy; 2015 <span title="0.11164s from github-fe138-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
         <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
         <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
         <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
@@ -3552,8 +3573,8 @@
     </div>
 
 
-      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-dea2e78f4b34a1f3429ade94f98bd25fad6bbe8d28635a93d9caeb68e3c2d258.js"></script>
-      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github/index-42e4be905d0eeef68d11167fbeb73eeaffd7b523509fd330a025c339a4488dc7.js"></script>
+      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-808fcfcd63c9ecba3e84453f540cb1cbafde48c6b30c1d51ebd4e67e88ff66bd.js"></script>
+      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github/index-f66b416610dec6e8a6a3108cbbeaf5c55898e39d95710a3fd195522d322c9dba.js"></script>
       
       
   </body>

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/scroll.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/scroll.json
@@ -1,6 +1,6 @@
 {
   "scroll": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_search/scroll",
@@ -12,10 +12,6 @@
         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "scroll": {
           "type" : "duration",
           "description" : "Specify how long a consistent view of the index should be maintained for scrolled search"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search.json
@@ -1,6 +1,6 @@
 {
   "search": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_search",
@@ -64,10 +64,6 @@
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
         },
-        "indices_boost": {
-          "type" : "list",
-          "description" : "Comma-separated list of index boosts"
-        },
         "lenient": {
           "type" : "boolean",
           "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
@@ -104,10 +100,6 @@
         "sort": {
           "type" : "list",
           "description" : "A comma-separated list of <field>:<direction> pairs"
-        },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition using the Query DSL (instead of using request body)"
         },
         "_source": {
           "type" : "list",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search_exists.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search_exists.json
@@ -1,6 +1,6 @@
 {
   "search_exists": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_search/exists",
@@ -42,9 +42,35 @@
           "type" : "string",
           "description" : "Specific routing value"
         },
-        "source": {
+        "q": {
           "type" : "string",
-          "description" : "The URL-encoded query definition (instead of using the request body)"
+          "description" : "Query in the Lucene query string syntax"
+        },
+        "analyzer": {
+          "type" : "string",
+          "description" : "The analyzer to use for the query string"
+        },
+        "analyze_wildcard": {
+          "type" : "boolean",
+          "description" : "Specify whether wildcard and prefix queries should be analyzed (default: false)"
+        },
+        "default_operator": {
+          "type" : "enum",
+          "options" : ["AND","OR"],
+          "default" : "OR",
+          "description" : "The default operator for query string query (AND or OR)"
+        },
+        "df": {
+          "type" : "string",
+          "description" : "The field to use as default where no field prefix is given in the query string"
+        },
+        "lenient": {
+          "type" : "boolean",
+          "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
+        },
+        "lowercase_expanded_terms": {
+          "type" : "boolean",
+          "description" : "Specify whether query terms should be lowercased"
         }
       }
     },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search_shards.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search_shards.json
@@ -1,6 +1,6 @@
 {
   "search_shards": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/{index}/{type}/_search_shards",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search_template.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search_template.json
@@ -1,6 +1,6 @@
 {
   "search_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_search/template",
@@ -16,10 +16,6 @@
         }
       },
       "params" : {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "ignore_unavailable": {
             "type" : "boolean",
             "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.create.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.create.json
@@ -1,6 +1,6 @@
 {
   "snapshot.create": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_snapshot/{repository}/{snapshot}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.create_repository.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.create_repository.json
@@ -1,6 +1,6 @@
 {
   "snapshot.create_repository": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_snapshot/{repository}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.delete.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.delete.json
@@ -1,6 +1,6 @@
 {
   "snapshot.delete": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_snapshot/{repository}/{snapshot}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.delete_repository.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.delete_repository.json
@@ -1,6 +1,6 @@
 {
   "snapshot.delete_repository": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_snapshot/{repository}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.get.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.get.json
@@ -1,6 +1,6 @@
 {
   "snapshot.get": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
       "path": "/_snapshot/{repository}/{snapshot}",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.get_repository.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.get_repository.json
@@ -1,6 +1,6 @@
 {
   "snapshot.get_repository": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
       "path": "/_snapshot",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.restore.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.restore.json
@@ -1,6 +1,6 @@
 {
   "snapshot.restore": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html",
     "methods": ["POST"],
     "url": {
       "path": "/_snapshot/{repository}/{snapshot}/_restore",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.status.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.status.json
@@ -1,6 +1,6 @@
 {
   "snapshot.status": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
       "path": "/_snapshot/_status",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.verify_repository.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/snapshot.verify_repository.json
@@ -1,6 +1,6 @@
 {
     "snapshot.verify_repository": {
-        "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+        "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
         "methods": ["POST"],
         "url": {
             "path": "/_snapshot/{repository}/_verify",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/suggest.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/suggest.json
@@ -1,6 +1,6 @@
 {
   "suggest": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_suggest",
@@ -33,10 +33,6 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
-        },
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition (instead of using request body)"
         }
       }
     },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/termvector.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/termvector.json
@@ -1,15 +1,15 @@
 {
   "termvector" : {
-    "documentation" : "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html",
+    "documentation" : "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
       "path" : "/{index}/{type}/_termvector",
       "paths" : ["/{index}/{type}/_termvector", "/{index}/{type}/{id}/_termvector"],
       "parts" : {
         "index" : {
-          "type" : "string",
-          "description" : "The index in which the document resides.",
-          "required" : true
+         "type" : "string",
+         "description" : "The index in which the document resides.",
+         "required" : true
         },
         "type" : {
           "type" : "string",
@@ -17,15 +17,11 @@
           "required" : true
         },
         "id" : {
-          "type" : "string",
-          "description" : "The id of the document, when not specified a doc param should be supplied."
-        }
+           "type" : "string",
+           "description" : "The id of the document."
+         }
       },
       "params": {
-        "source": {
-          "type" : "string",
-          "description" : "The URL-encoded request definition"
-        },
         "term_statistics" : {
           "type" : "boolean",
           "description" : "Specifies if total term frequency and document frequency should be returned.",
@@ -33,10 +29,10 @@
           "required" : false
         },
         "field_statistics" : {
-          "type" : "boolean",
-          "description" : "Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.",
-          "default" : true,
-          "required" : false
+           "type" : "boolean",
+           "description" : "Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.",
+           "default" : true,
+           "required" : false
         },
         "fields" : {
           "type" : "list",
@@ -84,7 +80,7 @@
       }
     },
     "body": {
-      "description" : "Define parameters and or supply a document to get termvectors for. See documentation.",
+      "description" : "Define parameters. See documentation.",
       "required" : false
     }
   }

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/update.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/update.json
@@ -1,6 +1,6 @@
 {
   "update": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html",
     "methods": ["POST"],
     "url": {
       "path": "/{index}/{type}/{id}/_update",
@@ -38,7 +38,7 @@
         },
         "parent": {
           "type": "string",
-          "description": "ID of the parent document"
+          "description": "ID of the parent document. Is is only used for routing and when for the upsert request"
         },
         "refresh": {
           "type": "boolean",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiGenerator.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiGenerator.cs
@@ -13,13 +13,14 @@ using CsQuery;
 using CsQuery.ExtensionMethods.Internal;
 using Newtonsoft.Json;
 using Xipton.Razor;
+using CodeGeneration.LowLevelClient.Overrides.Global;
 
 namespace CodeGeneration.LowLevelClient
 {
 	public static class ApiGenerator
 	{
-		private readonly static string _listingUrl = "https://github.com/elastic/elasticsearch/tree/v1.5.2/rest-api-spec/api";
-		private readonly static string _rawUrlPrefix = "https://raw.github.com/elastic/elasticsearch/v1.5.2/rest-api-spec/api/";
+		private readonly static string _listingUrl = "https://github.com/elastic/elasticsearch/tree/v1.6.0/rest-api-spec/api";
+		private readonly static string _rawUrlPrefix = "https://raw.github.com/elastic/elasticsearch/v1.6.0/rest-api-spec/api/";
 		private readonly static string _nestFolder = @"..\..\..\..\..\src\Nest\";
 		private readonly static string _esNetFolder = @"..\..\..\..\..\src\Elasticsearch.Net\";
 		private readonly static string _viewFolder = @"..\..\Views\";
@@ -148,6 +149,12 @@ namespace CodeGeneration.LowLevelClient
 			method.FullName =
 				Regex.Replace(method.FullName, m, (a) => a.Index != method.FullName.IndexOf(m) ? "" : m);
 
+			foreach (var param in GlobalQueryParameters.Parameters)
+			{
+				if (!method.Url.Params.ContainsKey(param.Key))
+					method.Url.Params.Add(param.Key, param.Value);
+			}
+
 			string manualOverride;
 			var key = method.QueryStringParamName.Replace("RequestParameters", "");
 			if (MethodNameOverrides.TryGetValue(key, out manualOverride))
@@ -183,7 +190,6 @@ namespace CodeGeneration.LowLevelClient
 						renameList = overrides.RenameQueryStringParams ?? renameList;
 					}
 				}
-
 
 				var globalQueryStringRenames = new Dictionary<string, string>
 				{

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiGenerator.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiGenerator.cs
@@ -19,8 +19,8 @@ namespace CodeGeneration.LowLevelClient
 {
 	public static class ApiGenerator
 	{
-		private readonly static string _listingUrl = "https://github.com/elastic/elasticsearch/tree/v1.6.0/rest-api-spec/api";
-		private readonly static string _rawUrlPrefix = "https://raw.github.com/elastic/elasticsearch/v1.6.0/rest-api-spec/api/";
+		private readonly static string _listingUrl = "https://github.com/elastic/elasticsearch/tree/1.6/rest-api-spec/api";
+		private readonly static string _rawUrlPrefix = "https://raw.github.com/elastic/elasticsearch/1.6/rest-api-spec/api/";
 		private readonly static string _nestFolder = @"..\..\..\..\..\src\Nest\";
 		private readonly static string _esNetFolder = @"..\..\..\..\..\src\Elasticsearch.Net\";
 		private readonly static string _viewFolder = @"..\..\Views\";

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/CodeGeneration.LowLevelClient.csproj
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/CodeGeneration.LowLevelClient.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Overrides\Descriptors\MultiTermVectorsDescriptorOverrides.cs" />
     <Compile Include="Overrides\Descriptors\SearchDescriptorOverrides.cs" />
     <Compile Include="Overrides\Descriptors\UpdateDescriptorOverrides.cs" />
+    <Compile Include="Overrides\Global\GlobalQueryParameters.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Domain\RestApiSpec.cs" />

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Global/GlobalQueryParameters.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Global/GlobalQueryParameters.cs
@@ -1,0 +1,35 @@
+﻿using CodeGeneration.LowLevelClient.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodeGeneration.LowLevelClient.Overrides.Global
+{
+	
+	public static class GlobalQueryParameters
+	{
+		/// <summary>
+		/// Query parameters that are available on all API endpoints, but are not specified in the REST spec
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html
+		/// </summary>
+		public static Dictionary<string, ApiQueryParameters> Parameters = new Dictionary<string, ApiQueryParameters>
+		{
+			{ "source", new ApiQueryParameters 
+				{ 
+					Description = "The URL-encoded request definition",
+					Type = "string",
+					OriginalQueryStringParamName = "source"  
+				} 
+			},
+			{ "filter_path", new ApiQueryParameters 
+				{
+					Description = "Comma separated list of filters used to reduce the response returned by Elasticsearch",
+					Type = "string",
+					OriginalQueryStringParamName = "filter_path"
+				}
+			}
+		};
+	}
+}

--- a/src/Elasticsearch.Net/Domain/Enums.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/Enums.Generated.cs
@@ -80,6 +80,15 @@ namespace Elasticsearch.Net
 	}
 	
 	
+	public enum DefaultOperator 
+	{
+		  [EnumMember(Value = "AND")]
+		And,
+		[EnumMember(Value = "OR")]
+		Or
+	}
+	
+	
 	public enum VersionType 
 	{
 		  [EnumMember(Value = "internal")]
@@ -90,15 +99,6 @@ namespace Elasticsearch.Net
 		ExternalGte,
 		[EnumMember(Value = "force")]
 		Force
-	}
-	
-	
-	public enum DefaultOperator 
-	{
-		  [EnumMember(Value = "AND")]
-		And,
-		[EnumMember(Value = "OR")]
-		Or
 	}
 	
 	
@@ -178,6 +178,8 @@ namespace Elasticsearch.Net
 		Nodes,
 		[EnumMember(Value = "routing_table")]
 		RoutingTable,
+		[EnumMember(Value = "routing_nodes")]
+		RoutingNodes,
 		[EnumMember(Value = "master_node")]
 		MasterNode,
 		[EnumMember(Value = "version")]
@@ -389,6 +391,16 @@ namespace Elasticsearch.Net
 			}
 			
 			
+			if (e is DefaultOperator)
+			{
+				switch((DefaultOperator)e)
+				{
+					case DefaultOperator.And: return "AND";
+					case DefaultOperator.Or: return "OR";
+				}
+			}
+			
+			
 			if (e is VersionType)
 			{
 				switch((VersionType)e)
@@ -397,16 +409,6 @@ namespace Elasticsearch.Net
 					case VersionType.External: return "external";
 					case VersionType.ExternalGte: return "external_gte";
 					case VersionType.Force: return "force";
-				}
-			}
-			
-			
-			if (e is DefaultOperator)
-			{
-				switch((DefaultOperator)e)
-				{
-					case DefaultOperator.And: return "AND";
-					case DefaultOperator.Or: return "OR";
 				}
 			}
 			
@@ -485,6 +487,7 @@ namespace Elasticsearch.Net
 					case ClusterStateMetric.Metadata: return "metadata";
 					case ClusterStateMetric.Nodes: return "nodes";
 					case ClusterStateMetric.RoutingTable: return "routing_table";
+					case ClusterStateMetric.RoutingNodes: return "routing_nodes";
 					case ClusterStateMetric.MasterNode: return "master_node";
 					case ClusterStateMetric.Version: return "version";
 				}

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -20,12 +20,32 @@ namespace Elasticsearch.Net
 	///</summary>
 	public class AbortBenchmarkRequestParameters : FluentRequestParameters<AbortBenchmarkRequestParameters> 
 	{
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public AbortBenchmarkRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public AbortBenchmarkRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Bulk
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html
 	///</pre>
 	///</summary>
 	public class BulkRequestParameters : FluentRequestParameters<BulkRequestParameters> 
@@ -90,12 +110,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public BulkRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public BulkRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatAliases
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html
 	///</pre>
 	///</summary>
 	public class CatAliasesRequestParameters : FluentRequestParameters<CatAliasesRequestParameters> 
@@ -150,12 +190,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatAliasesRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatAliasesRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatAllocation
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html
 	///</pre>
 	///</summary>
 	public class CatAllocationRequestParameters : FluentRequestParameters<CatAllocationRequestParameters> 
@@ -220,12 +280,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatAllocationRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatAllocationRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatCount
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html
 	///</pre>
 	///</summary>
 	public class CatCountRequestParameters : FluentRequestParameters<CatCountRequestParameters> 
@@ -280,12 +360,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatCountRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatCountRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatFielddata
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html
 	///</pre>
 	///</summary>
 	public class CatFielddataRequestParameters : FluentRequestParameters<CatFielddataRequestParameters> 
@@ -360,12 +460,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatFielddataRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatFielddataRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatHealth
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html
 	///</pre>
 	///</summary>
 	public class CatHealthRequestParameters : FluentRequestParameters<CatHealthRequestParameters> 
@@ -430,12 +550,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatHealthRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatHealthRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatHelp
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html
 	///</pre>
 	///</summary>
 	public class CatHelpRequestParameters : FluentRequestParameters<CatHelpRequestParameters> 
@@ -450,12 +590,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatHelpRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatHelpRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatIndices
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html
 	///</pre>
 	///</summary>
 	public class CatIndicesRequestParameters : FluentRequestParameters<CatIndicesRequestParameters> 
@@ -530,12 +690,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatIndicesRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatIndicesRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatMaster
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html
 	///</pre>
 	///</summary>
 	public class CatMasterRequestParameters : FluentRequestParameters<CatMasterRequestParameters> 
@@ -590,12 +770,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatMasterRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatMasterRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatNodes
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html
 	///</pre>
 	///</summary>
 	public class CatNodesRequestParameters : FluentRequestParameters<CatNodesRequestParameters> 
@@ -650,12 +850,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatNodesRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatNodesRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatPendingTasks
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html
 	///</pre>
 	///</summary>
 	public class CatPendingTasksRequestParameters : FluentRequestParameters<CatPendingTasksRequestParameters> 
@@ -710,12 +930,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatPendingTasksRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatPendingTasksRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatPlugins
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html
 	///</pre>
 	///</summary>
 	public class CatPluginsRequestParameters : FluentRequestParameters<CatPluginsRequestParameters> 
@@ -770,12 +1010,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatPluginsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatPluginsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatRecovery
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html
 	///</pre>
 	///</summary>
 	public class CatRecoveryRequestParameters : FluentRequestParameters<CatRecoveryRequestParameters> 
@@ -830,12 +1090,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatRecoveryRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatRecoveryRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatSegments
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html
 	///</pre>
 	///</summary>
 	public class CatSegmentsRequestParameters : FluentRequestParameters<CatSegmentsRequestParameters> 
@@ -870,12 +1150,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatSegmentsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatSegmentsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatShards
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html
 	///</pre>
 	///</summary>
 	public class CatShardsRequestParameters : FluentRequestParameters<CatShardsRequestParameters> 
@@ -930,12 +1230,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatShardsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatShardsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for CatThreadPool
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html
 	///</pre>
 	///</summary>
 	public class CatThreadPoolRequestParameters : FluentRequestParameters<CatThreadPoolRequestParameters> 
@@ -1000,22 +1320,62 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CatThreadPoolRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatThreadPoolRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ClearScroll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html
 	///</pre>
 	///</summary>
 	public class ClearScrollRequestParameters : FluentRequestParameters<ClearScrollRequestParameters> 
 	{
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClearScrollRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClearScrollRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ClusterGetSettings
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html
 	///</pre>
 	///</summary>
 	public class ClusterGetSettingsRequestParameters : FluentRequestParameters<ClusterGetSettingsRequestParameters> 
@@ -1050,12 +1410,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterGetSettingsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterGetSettingsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ClusterHealth
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html
 	///</pre>
 	///</summary>
 	public class ClusterHealthRequestParameters : FluentRequestParameters<ClusterHealthRequestParameters> 
@@ -1140,12 +1520,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterHealthRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterHealthRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ClusterPendingTasks
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html
 	///</pre>
 	///</summary>
 	public class ClusterPendingTasksRequestParameters : FluentRequestParameters<ClusterPendingTasksRequestParameters> 
@@ -1170,12 +1570,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterPendingTasksRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterPendingTasksRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ClusterPutSettings
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html
 	///</pre>
 	///</summary>
 	public class ClusterSettingsRequestParameters : FluentRequestParameters<ClusterSettingsRequestParameters> 
@@ -1210,12 +1630,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterSettingsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterSettingsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ClusterReroute
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html
 	///</pre>
 	///</summary>
 	public class ClusterRerouteRequestParameters : FluentRequestParameters<ClusterRerouteRequestParameters> 
@@ -1270,12 +1710,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterRerouteRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterRerouteRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ClusterState
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html
 	///</pre>
 	///</summary>
 	public class ClusterStateRequestParameters : FluentRequestParameters<ClusterStateRequestParameters> 
@@ -1340,12 +1800,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterStateRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterStateRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ClusterStats
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html
 	///</pre>
 	///</summary>
 	public class ClusterStatsRequestParameters : FluentRequestParameters<ClusterStatsRequestParameters> 
@@ -1370,12 +1850,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterStatsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterStatsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Count
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html
 	///</pre>
 	///</summary>
 	public class CountRequestParameters : FluentRequestParameters<CountRequestParameters> 
@@ -1441,12 +1941,92 @@ namespace Elasticsearch.Net
 		}
 		
 		
+		internal string _q { get; set; }
+		///<summary>Query in the Lucene query string syntax</summary>
+		public CountRequestParameters Q(string q)
+		{
+			this._q = q;
+			this.AddQueryString("q", this._q);
+			return this;
+		}
+		
+		
+		internal string _analyzer { get; set; }
+		///<summary>The analyzer to use for the query string</summary>
+		public CountRequestParameters Analyzer(string analyzer)
+		{
+			this._analyzer = analyzer;
+			this.AddQueryString("analyzer", this._analyzer);
+			return this;
+		}
+		
+		
+		internal bool _analyze_wildcard { get; set; }
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public CountRequestParameters AnalyzeWildcard(bool analyze_wildcard)
+		{
+			this._analyze_wildcard = analyze_wildcard;
+			this.AddQueryString("analyze_wildcard", this._analyze_wildcard);
+			return this;
+		}
+		
+		
+		internal DefaultOperator _default_operator { get; set; }
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public CountRequestParameters DefaultOperator(DefaultOperator default_operator)
+		{
+			this._default_operator = default_operator;
+			this.AddQueryString("default_operator", this._default_operator);
+			return this;
+		}
+		
+		
+		internal string _df { get; set; }
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public CountRequestParameters Df(string df)
+		{
+			this._df = df;
+			this.AddQueryString("df", this._df);
+			return this;
+		}
+		
+		
+		internal bool _lenient { get; set; }
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public CountRequestParameters Lenient(bool lenient)
+		{
+			this._lenient = lenient;
+			this.AddQueryString("lenient", this._lenient);
+			return this;
+		}
+		
+		
+		internal bool _lowercase_expanded_terms { get; set; }
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public CountRequestParameters LowercaseExpandedTerms(bool lowercase_expanded_terms)
+		{
+			this._lowercase_expanded_terms = lowercase_expanded_terms;
+			this.AddQueryString("lowercase_expanded_terms", this._lowercase_expanded_terms);
+			return this;
+		}
+		
+		
 		internal string _source { get; set; }
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>The URL-encoded request definition</summary>
 		public CountRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CountRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
 			return this;
 		}
 		
@@ -1455,21 +2035,11 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for CountPercolateGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
 	///</pre>
 	///</summary>
 	public class PercolateCountRequestParameters : FluentRequestParameters<PercolateCountRequestParameters> 
 	{
-		
-		internal string _source { get; set; }
-		///<summary>The URL-encoded request definition</summary>
-		public PercolateCountRequestParameters Source(string source)
-		{
-			this._source = source;
-			this.AddQueryString("source", this._source);
-			return this;
-		}
-		
 		
 		internal  string[] _routing { get; set; }
 		///<summary>A comma-separated list of specific routing values</summary>
@@ -1560,12 +2130,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public PercolateCountRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PercolateCountRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Delete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html
 	///</pre>
 	///</summary>
 	public class DeleteRequestParameters : FluentRequestParameters<DeleteRequestParameters> 
@@ -1650,12 +2240,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for DeleteByQuery
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html
 	///</pre>
 	///</summary>
 	public class DeleteByQueryRequestParameters : FluentRequestParameters<DeleteByQueryRequestParameters> 
@@ -1761,16 +2371,6 @@ namespace Elasticsearch.Net
 		}
 		
 		
-		internal string _source { get; set; }
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public DeleteByQueryRequestParameters Source(string source)
-		{
-			this._source = source;
-			this.AddQueryString("source", this._source);
-			return this;
-		}
-		
-		
 		internal string _timeout { get; set; }
 		///<summary>Explicit operation timeout</summary>
 		public DeleteByQueryRequestParameters Timeout(string timeout)
@@ -1780,12 +2380,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteByQueryRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteByQueryRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for DeleteScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public class DeleteScriptRequestParameters : FluentRequestParameters<DeleteScriptRequestParameters> 
@@ -1810,12 +2430,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteScriptRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteScriptRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for DeleteTemplate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html
 	///</pre>
 	///</summary>
 	public class DeleteTemplateRequestParameters : FluentRequestParameters<DeleteTemplateRequestParameters> 
@@ -1840,12 +2480,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteTemplateRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteTemplateRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Exists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public class DocumentExistsRequestParameters : FluentRequestParameters<DocumentExistsRequestParameters> 
@@ -1900,12 +2560,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DocumentExistsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DocumentExistsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ExplainGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html
 	///</pre>
 	///</summary>
 	public class ExplainRequestParameters : FluentRequestParameters<ExplainRequestParameters> 
@@ -2021,16 +2701,6 @@ namespace Elasticsearch.Net
 		}
 		
 		
-		internal string _source { get; set; }
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public ExplainRequestParameters Source(string source)
-		{
-			this._source = source;
-			this.AddQueryString("source", this._source);
-			return this;
-		}
-		
-		
 		internal  string[] _source_enabled { get; set; }
 		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
 		public ExplainRequestParameters SourceEnabled(params string[] source_enabled)
@@ -2070,12 +2740,112 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ExplainRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ExplainRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
+	}
+	
+	
+	///<summary>Request parameters descriptor for FieldStatsGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html
+	///</pre>
+	///</summary>
+	public class FieldStatsRequestParameters : FluentRequestParameters<FieldStatsRequestParameters> 
+	{
+		
+		internal IEnumerable<object> _fields { get; set; }
+		///<summary>A comma-separated list of fields for to get field statistics for (min value, max value, and more)</summary>
+		public FieldStatsRequestParameters Fields(params string[] fields)
+		{
+			this._fields = fields.Select(f=>(object)f);
+			this.AddQueryString("fields", this._fields);
+			return this;
+		}
+		
+		
+		internal Level _level { get; set; }
+		///<summary>Defines if field stats should be returned on a per index level or on a cluster wide level</summary>
+		public FieldStatsRequestParameters Level(Level level)
+		{
+			this._level = level;
+			this.AddQueryString("level", this._level);
+			return this;
+		}
+		
+		
+		internal bool _ignore_unavailable { get; set; }
+		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
+		public FieldStatsRequestParameters IgnoreUnavailable(bool ignore_unavailable)
+		{
+			this._ignore_unavailable = ignore_unavailable;
+			this.AddQueryString("ignore_unavailable", this._ignore_unavailable);
+			return this;
+		}
+		
+		
+		internal bool _allow_no_indices { get; set; }
+		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
+		public FieldStatsRequestParameters AllowNoIndices(bool allow_no_indices)
+		{
+			this._allow_no_indices = allow_no_indices;
+			this.AddQueryString("allow_no_indices", this._allow_no_indices);
+			return this;
+		}
+		
+		
+		internal ExpandWildcards _expand_wildcards { get; set; }
+		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+		public FieldStatsRequestParameters ExpandWildcards(ExpandWildcards expand_wildcards)
+		{
+			this._expand_wildcards = expand_wildcards;
+			this.AddQueryString("expand_wildcards", this._expand_wildcards);
+			return this;
+		}
+		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public FieldStatsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public FieldStatsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Get
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public class GetRequestParameters : FluentRequestParameters<GetRequestParameters> 
@@ -2200,12 +2970,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for GetScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public class GetScriptRequestParameters : FluentRequestParameters<GetScriptRequestParameters> 
@@ -2230,12 +3020,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetScriptRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetScriptRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for GetSource
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public class SourceRequestParameters : FluentRequestParameters<SourceRequestParameters> 
@@ -2350,12 +3160,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public SourceRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SourceRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for GetTemplate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html
 	///</pre>
 	///</summary>
 	public class GetTemplateRequestParameters : FluentRequestParameters<GetTemplateRequestParameters> 
@@ -2380,12 +3210,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetTemplateRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetTemplateRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Index
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html
 	///</pre>
 	///</summary>
 	public class IndexRequestParameters : FluentRequestParameters<IndexRequestParameters> 
@@ -2500,26 +3350,36 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
-	}
-	
-	
-	///<summary>Request parameters descriptor for IndicesAnalyzeGetForAll
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html
-	///</pre>
-	///</summary>
-	public class AnalyzeRequestParameters : FluentRequestParameters<AnalyzeRequestParameters> 
-	{
 		
 		internal string _source { get; set; }
 		///<summary>The URL-encoded request definition</summary>
-		public AnalyzeRequestParameters Source(string source)
+		public IndexRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
 			return this;
 		}
 		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndexRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
+	}
+	
+	
+	///<summary>Request parameters descriptor for IndicesAnalyzeGetForAll
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html
+	///</pre>
+	///</summary>
+	public class AnalyzeRequestParameters : FluentRequestParameters<AnalyzeRequestParameters> 
+	{
 		
 		internal string _analyzer { get; set; }
 		///<summary>The name of the analyzer to use</summary>
@@ -2610,12 +3470,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public AnalyzeRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public AnalyzeRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesClearCacheForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html
 	///</pre>
 	///</summary>
 	public class ClearCacheRequestParameters : FluentRequestParameters<ClearCacheRequestParameters> 
@@ -2750,12 +3630,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ClearCacheRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClearCacheRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesClose
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html
 	///</pre>
 	///</summary>
 	public class CloseIndexRequestParameters : FluentRequestParameters<CloseIndexRequestParameters> 
@@ -2810,12 +3710,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CloseIndexRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CloseIndexRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesCreate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html
 	///</pre>
 	///</summary>
 	public class CreateIndexRequestParameters : FluentRequestParameters<CreateIndexRequestParameters> 
@@ -2840,12 +3760,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CreateIndexRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CreateIndexRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesDelete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html
 	///</pre>
 	///</summary>
 	public class DeleteIndexRequestParameters : FluentRequestParameters<DeleteIndexRequestParameters> 
@@ -2870,12 +3810,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteIndexRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteIndexRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesDeleteAlias
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public class DeleteAliasRequestParameters : FluentRequestParameters<DeleteAliasRequestParameters> 
@@ -2900,12 +3860,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteAliasRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteAliasRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesDeleteMapping
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html
 	///</pre>
 	///</summary>
 	public class DeleteMappingRequestParameters : FluentRequestParameters<DeleteMappingRequestParameters> 
@@ -2920,12 +3900,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteMappingRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteMappingRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesDeleteWarmer
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public class DeleteWarmerRequestParameters : FluentRequestParameters<DeleteWarmerRequestParameters> 
@@ -2940,12 +3940,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteWarmerRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteWarmerRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesExists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html
 	///</pre>
 	///</summary>
 	public class IndexExistsRequestParameters : FluentRequestParameters<IndexExistsRequestParameters> 
@@ -2990,12 +4010,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public IndexExistsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndexExistsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesExistsAliasForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public class AliasExistsRequestParameters : FluentRequestParameters<AliasExistsRequestParameters> 
@@ -3040,12 +4080,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public AliasExistsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public AliasExistsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesExistsTemplateForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html
 	///</pre>
 	///</summary>
 	public class TemplateExistsRequestParameters : FluentRequestParameters<TemplateExistsRequestParameters> 
@@ -3070,12 +4130,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public TemplateExistsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TemplateExistsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesExistsType
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html
 	///</pre>
 	///</summary>
 	public class TypeExistsRequestParameters : FluentRequestParameters<TypeExistsRequestParameters> 
@@ -3120,12 +4200,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public TypeExistsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TypeExistsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesFlushForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html
 	///</pre>
 	///</summary>
 	public class FlushRequestParameters : FluentRequestParameters<FlushRequestParameters> 
@@ -3180,12 +4280,62 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public FlushRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public FlushRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
+	}
+	
+	
+	///<summary>Request parameters descriptor for IndicesFlushSyncedForAll
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
+	///</pre>
+	///</summary>
+	public class IndicesFlushSyncedRequestParameters : FluentRequestParameters<IndicesFlushSyncedRequestParameters> 
+	{
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public IndicesFlushSyncedRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndicesFlushSyncedRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html
 	///</pre>
 	///</summary>
 	public class GetIndexRequestParameters : FluentRequestParameters<GetIndexRequestParameters> 
@@ -3230,12 +4380,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetIndexRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetIndexRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesGetAliasForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public class GetAliasRequestParameters : FluentRequestParameters<GetAliasRequestParameters> 
@@ -3280,12 +4450,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetAliasRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetAliasRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesGetAliasesForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public class GetAliasesRequestParameters : FluentRequestParameters<GetAliasesRequestParameters> 
@@ -3310,12 +4500,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetAliasesRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetAliasesRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesGetFieldMappingForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html
 	///</pre>
 	///</summary>
 	public class GetFieldMappingRequestParameters : FluentRequestParameters<GetFieldMappingRequestParameters> 
@@ -3370,12 +4580,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetFieldMappingRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetFieldMappingRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesGetMappingForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html
 	///</pre>
 	///</summary>
 	public class GetMappingRequestParameters : FluentRequestParameters<GetMappingRequestParameters> 
@@ -3420,12 +4650,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetMappingRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetMappingRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesGetSettingsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html
 	///</pre>
 	///</summary>
 	public class GetIndexSettingsRequestParameters : FluentRequestParameters<GetIndexSettingsRequestParameters> 
@@ -3480,12 +4730,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetIndexSettingsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetIndexSettingsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesGetUpgradeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
 	///</pre>
 	///</summary>
 	public class UpgradeStatusRequestParameters : FluentRequestParameters<UpgradeStatusRequestParameters> 
@@ -3530,12 +4800,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public UpgradeStatusRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpgradeStatusRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesGetWarmerForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public class GetWarmerRequestParameters : FluentRequestParameters<GetWarmerRequestParameters> 
@@ -3580,12 +4870,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetWarmerRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetWarmerRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesOpen
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html
 	///</pre>
 	///</summary>
 	public class OpenIndexRequestParameters : FluentRequestParameters<OpenIndexRequestParameters> 
@@ -3640,12 +4950,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public OpenIndexRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public OpenIndexRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesOptimizeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html
 	///</pre>
 	///</summary>
 	public class OptimizeRequestParameters : FluentRequestParameters<OptimizeRequestParameters> 
@@ -3740,12 +5070,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public OptimizeRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public OptimizeRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesPutAlias
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public class PutAliasRequestParameters : FluentRequestParameters<PutAliasRequestParameters> 
@@ -3770,12 +5120,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public PutAliasRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutAliasRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesPutMapping
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html
 	///</pre>
 	///</summary>
 	public class PutMappingRequestParameters : FluentRequestParameters<PutMappingRequestParameters> 
@@ -3840,12 +5210,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public PutMappingRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutMappingRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesPutSettingsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html
 	///</pre>
 	///</summary>
 	public class UpdateSettingsRequestParameters : FluentRequestParameters<UpdateSettingsRequestParameters> 
@@ -3900,12 +5290,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public UpdateSettingsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpdateSettingsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesPutTemplateForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html
 	///</pre>
 	///</summary>
 	public class PutTemplateRequestParameters : FluentRequestParameters<PutTemplateRequestParameters> 
@@ -3950,12 +5360,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public PutTemplateRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutTemplateRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesPutWarmerForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public class PutWarmerRequestParameters : FluentRequestParameters<PutWarmerRequestParameters> 
@@ -4000,12 +5430,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public PutWarmerRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutWarmerRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesRecoveryForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html
 	///</pre>
 	///</summary>
 	public class RecoveryStatusRequestParameters : FluentRequestParameters<RecoveryStatusRequestParameters> 
@@ -4040,12 +5490,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public RecoveryStatusRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public RecoveryStatusRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesRefreshForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html
 	///</pre>
 	///</summary>
 	public class RefreshRequestParameters : FluentRequestParameters<RefreshRequestParameters> 
@@ -4100,12 +5570,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public RefreshRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public RefreshRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesSegmentsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html
 	///</pre>
 	///</summary>
 	public class SegmentsRequestParameters : FluentRequestParameters<SegmentsRequestParameters> 
@@ -4160,12 +5650,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public SegmentsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SegmentsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesStatsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html
 	///</pre>
 	///</summary>
 	public class IndicesStatsRequestParameters : FluentRequestParameters<IndicesStatsRequestParameters> 
@@ -4230,12 +5740,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public IndicesStatsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndicesStatsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesStatusForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html
 	///</pre>
 	///</summary>
 	public class IndicesStatusRequestParameters : FluentRequestParameters<IndicesStatusRequestParameters> 
@@ -4310,12 +5840,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public IndicesStatusRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndicesStatusRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesUpdateAliasesForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public class AliasRequestParameters : FluentRequestParameters<AliasRequestParameters> 
@@ -4340,12 +5890,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public AliasRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public AliasRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesUpgradeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
 	///</pre>
 	///</summary>
 	public class UpgradeRequestParameters : FluentRequestParameters<UpgradeRequestParameters> 
@@ -4390,12 +5960,42 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal bool _only_ancient_segments { get; set; }
+		///<summary>If true, only ancient (an older Lucene major release) segments will be upgraded</summary>
+		public UpgradeRequestParameters OnlyAncientSegments(bool only_ancient_segments)
+		{
+			this._only_ancient_segments = only_ancient_segments;
+			this.AddQueryString("only_ancient_segments", this._only_ancient_segments);
+			return this;
+		}
+		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public UpgradeRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpgradeRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for IndicesValidateQueryGetForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html
 	///</pre>
 	///</summary>
 	public class ValidateQueryRequestParameters : FluentRequestParameters<ValidateQueryRequestParameters> 
@@ -4451,16 +6051,6 @@ namespace Elasticsearch.Net
 		}
 		
 		
-		internal string _source { get; set; }
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public ValidateQueryRequestParameters Source(string source)
-		{
-			this._source = source;
-			this.AddQueryString("source", this._source);
-			return this;
-		}
-		
-		
 		internal string _q { get; set; }
 		///<summary>Query in the Lucene query string syntax</summary>
 		public ValidateQueryRequestParameters Q(string q)
@@ -4470,16 +6060,116 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _analyzer { get; set; }
+		///<summary>The analyzer to use for the query string</summary>
+		public ValidateQueryRequestParameters Analyzer(string analyzer)
+		{
+			this._analyzer = analyzer;
+			this.AddQueryString("analyzer", this._analyzer);
+			return this;
+		}
+		
+		
+		internal bool _analyze_wildcard { get; set; }
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public ValidateQueryRequestParameters AnalyzeWildcard(bool analyze_wildcard)
+		{
+			this._analyze_wildcard = analyze_wildcard;
+			this.AddQueryString("analyze_wildcard", this._analyze_wildcard);
+			return this;
+		}
+		
+		
+		internal DefaultOperator _default_operator { get; set; }
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public ValidateQueryRequestParameters DefaultOperator(DefaultOperator default_operator)
+		{
+			this._default_operator = default_operator;
+			this.AddQueryString("default_operator", this._default_operator);
+			return this;
+		}
+		
+		
+		internal string _df { get; set; }
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public ValidateQueryRequestParameters Df(string df)
+		{
+			this._df = df;
+			this.AddQueryString("df", this._df);
+			return this;
+		}
+		
+		
+		internal bool _lenient { get; set; }
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public ValidateQueryRequestParameters Lenient(bool lenient)
+		{
+			this._lenient = lenient;
+			this.AddQueryString("lenient", this._lenient);
+			return this;
+		}
+		
+		
+		internal bool _lowercase_expanded_terms { get; set; }
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public ValidateQueryRequestParameters LowercaseExpandedTerms(bool lowercase_expanded_terms)
+		{
+			this._lowercase_expanded_terms = lowercase_expanded_terms;
+			this.AddQueryString("lowercase_expanded_terms", this._lowercase_expanded_terms);
+			return this;
+		}
+		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public ValidateQueryRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ValidateQueryRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Info
 	///<pre>
-	///http://www.elasticsearch.org/guide/
+	///http://www.elastic.co/guide/
 	///</pre>
 	///</summary>
 	public class InfoRequestParameters : FluentRequestParameters<InfoRequestParameters> 
 	{
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public InfoRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public InfoRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
@@ -4490,26 +6180,36 @@ namespace Elasticsearch.Net
 	///</summary>
 	public class ListBenchmarksRequestParameters : FluentRequestParameters<ListBenchmarksRequestParameters> 
 	{
-	}
-	
-	
-	///<summary>Request parameters descriptor for MgetGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html
-	///</pre>
-	///</summary>
-	public class MultiGetRequestParameters : FluentRequestParameters<MultiGetRequestParameters> 
-	{
 		
 		internal string _source { get; set; }
 		///<summary>The URL-encoded request definition</summary>
-		public MultiGetRequestParameters Source(string source)
+		public ListBenchmarksRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
 			return this;
 		}
 		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ListBenchmarksRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
+	}
+	
+	
+	///<summary>Request parameters descriptor for MgetGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html
+	///</pre>
+	///</summary>
+	public class MultiGetRequestParameters : FluentRequestParameters<MultiGetRequestParameters> 
+	{
 		
 		internal IEnumerable<object> _fields { get; set; }
 		///<summary>A comma-separated list of fields to return in the response</summary>
@@ -4590,26 +6290,36 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
-	}
-	
-	
-	///<summary>Request parameters descriptor for MltGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html
-	///</pre>
-	///</summary>
-	public class MoreLikeThisRequestParameters : FluentRequestParameters<MoreLikeThisRequestParameters> 
-	{
 		
 		internal string _source { get; set; }
 		///<summary>The URL-encoded request definition</summary>
-		public MoreLikeThisRequestParameters Source(string source)
+		public MultiGetRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
 			return this;
 		}
 		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MultiGetRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
+	}
+	
+	
+	///<summary>Request parameters descriptor for MltGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html
+	///</pre>
+	///</summary>
+	public class MoreLikeThisRequestParameters : FluentRequestParameters<MoreLikeThisRequestParameters> 
+	{
 		
 		internal double _boost_terms { get; set; }
 		///<summary>The boost factor</summary>
@@ -4790,26 +6500,36 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
-	}
-	
-	
-	///<summary>Request parameters descriptor for MpercolateGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
-	///</pre>
-	///</summary>
-	public class MultiPercolateRequestParameters : FluentRequestParameters<MultiPercolateRequestParameters> 
-	{
 		
 		internal string _source { get; set; }
 		///<summary>The URL-encoded request definition</summary>
-		public MultiPercolateRequestParameters Source(string source)
+		public MoreLikeThisRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
 			return this;
 		}
 		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MoreLikeThisRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
+	}
+	
+	
+	///<summary>Request parameters descriptor for MpercolateGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
+	///</pre>
+	///</summary>
+	public class MultiPercolateRequestParameters : FluentRequestParameters<MultiPercolateRequestParameters> 
+	{
 		
 		internal bool _ignore_unavailable { get; set; }
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
@@ -4840,16 +6560,46 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public MultiPercolateRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MultiPercolateRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for MsearchGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html
 	///</pre>
 	///</summary>
 	public class MultiSearchRequestParameters : FluentRequestParameters<MultiSearchRequestParameters> 
 	{
+		
+		internal SearchType _search_type { get; set; }
+		///<summary>Search operation type</summary>
+		public MultiSearchRequestParameters SearchType(SearchType search_type)
+		{
+			this._search_type = search_type;
+			this.AddQueryString("search_type", this._search_type);
+			return this;
+		}
+		
 		
 		internal string _source { get; set; }
 		///<summary>The URL-encoded request definition</summary>
@@ -4861,12 +6611,12 @@ namespace Elasticsearch.Net
 		}
 		
 		
-		internal SearchType _search_type { get; set; }
-		///<summary>Search operation type</summary>
-		public MultiSearchRequestParameters SearchType(SearchType search_type)
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MultiSearchRequestParameters FilterPath(string filter_path)
 		{
-			this._search_type = search_type;
-			this.AddQueryString("search_type", this._search_type);
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
 			return this;
 		}
 		
@@ -4875,21 +6625,11 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for MtermvectorsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html
 	///</pre>
 	///</summary>
 	public class MultiTermVectorsRequestParameters : FluentRequestParameters<MultiTermVectorsRequestParameters> 
 	{
-		
-		internal string _source { get; set; }
-		///<summary>The URL-encoded request definition</summary>
-		public MultiTermVectorsRequestParameters Source(string source)
-		{
-			this._source = source;
-			this.AddQueryString("source", this._source);
-			return this;
-		}
-		
 		
 		internal bool _term_statistics { get; set; }
 		///<summary>Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body &quot;params&quot; or &quot;docs&quot;.</summary>
@@ -4990,12 +6730,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public MultiTermVectorsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MultiTermVectorsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for NodesHotThreadsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html
 	///</pre>
 	///</summary>
 	public class NodesHotThreadsRequestParameters : FluentRequestParameters<NodesHotThreadsRequestParameters> 
@@ -5050,12 +6810,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public NodesHotThreadsRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public NodesHotThreadsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for NodesInfoForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html
 	///</pre>
 	///</summary>
 	public class NodesInfoRequestParameters : FluentRequestParameters<NodesInfoRequestParameters> 
@@ -5080,12 +6860,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public NodesInfoRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public NodesInfoRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for NodesShutdownForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html
 	///</pre>
 	///</summary>
 	public class NodesShutdownRequestParameters : FluentRequestParameters<NodesShutdownRequestParameters> 
@@ -5110,12 +6910,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public NodesShutdownRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public NodesShutdownRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for NodesStatsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html
 	///</pre>
 	///</summary>
 	public class NodesStatsRequestParameters : FluentRequestParameters<NodesStatsRequestParameters> 
@@ -5190,26 +7010,36 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
-	}
-	
-	
-	///<summary>Request parameters descriptor for PercolateGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
-	///</pre>
-	///</summary>
-	public class PercolateRequestParameters : FluentRequestParameters<PercolateRequestParameters> 
-	{
 		
 		internal string _source { get; set; }
 		///<summary>The URL-encoded request definition</summary>
-		public PercolateRequestParameters Source(string source)
+		public NodesStatsRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
 			return this;
 		}
 		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public NodesStatsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
+	}
+	
+	
+	///<summary>Request parameters descriptor for PercolateGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
+	///</pre>
+	///</summary>
+	public class PercolateRequestParameters : FluentRequestParameters<PercolateRequestParameters> 
+	{
 		
 		internal  string[] _routing { get; set; }
 		///<summary>A comma-separated list of specific routing values</summary>
@@ -5330,22 +7160,62 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public PercolateRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PercolateRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Ping
 	///<pre>
-	///http://www.elasticsearch.org/guide/
+	///http://www.elastic.co/guide/
 	///</pre>
 	///</summary>
 	public class PingRequestParameters : FluentRequestParameters<PingRequestParameters> 
 	{
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public PingRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PingRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for PutScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public class PutScriptRequestParameters : FluentRequestParameters<PutScriptRequestParameters> 
@@ -5380,12 +7250,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public PutScriptRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutScriptRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for ScrollGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html
 	///</pre>
 	///</summary>
 	public class ScrollRequestParameters : FluentRequestParameters<ScrollRequestParameters> 
@@ -5400,12 +7290,22 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ScrollRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SearchGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html
 	///</pre>
 	///</summary>
 	public class SearchRequestParameters : FluentRequestParameters<SearchRequestParameters> 
@@ -5600,12 +7500,22 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SearchRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SearchExists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
 	///</pre>
 	///</summary>
 	public class SearchExistsRequestParameters : FluentRequestParameters<SearchExistsRequestParameters> 
@@ -5671,12 +7581,92 @@ namespace Elasticsearch.Net
 		}
 		
 		
+		internal string _q { get; set; }
+		///<summary>Query in the Lucene query string syntax</summary>
+		public SearchExistsRequestParameters Q(string q)
+		{
+			this._q = q;
+			this.AddQueryString("q", this._q);
+			return this;
+		}
+		
+		
+		internal string _analyzer { get; set; }
+		///<summary>The analyzer to use for the query string</summary>
+		public SearchExistsRequestParameters Analyzer(string analyzer)
+		{
+			this._analyzer = analyzer;
+			this.AddQueryString("analyzer", this._analyzer);
+			return this;
+		}
+		
+		
+		internal bool _analyze_wildcard { get; set; }
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public SearchExistsRequestParameters AnalyzeWildcard(bool analyze_wildcard)
+		{
+			this._analyze_wildcard = analyze_wildcard;
+			this.AddQueryString("analyze_wildcard", this._analyze_wildcard);
+			return this;
+		}
+		
+		
+		internal DefaultOperator _default_operator { get; set; }
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public SearchExistsRequestParameters DefaultOperator(DefaultOperator default_operator)
+		{
+			this._default_operator = default_operator;
+			this.AddQueryString("default_operator", this._default_operator);
+			return this;
+		}
+		
+		
+		internal string _df { get; set; }
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public SearchExistsRequestParameters Df(string df)
+		{
+			this._df = df;
+			this.AddQueryString("df", this._df);
+			return this;
+		}
+		
+		
+		internal bool _lenient { get; set; }
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public SearchExistsRequestParameters Lenient(bool lenient)
+		{
+			this._lenient = lenient;
+			this.AddQueryString("lenient", this._lenient);
+			return this;
+		}
+		
+		
+		internal bool _lowercase_expanded_terms { get; set; }
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public SearchExistsRequestParameters LowercaseExpandedTerms(bool lowercase_expanded_terms)
+		{
+			this._lowercase_expanded_terms = lowercase_expanded_terms;
+			this.AddQueryString("lowercase_expanded_terms", this._lowercase_expanded_terms);
+			return this;
+		}
+		
+		
 		internal string _source { get; set; }
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>The URL-encoded request definition</summary>
 		public SearchExistsRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SearchExistsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
 			return this;
 		}
 		
@@ -5685,7 +7675,7 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for SearchShardsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html
 	///</pre>
 	///</summary>
 	public class SearchShardsRequestParameters : FluentRequestParameters<SearchShardsRequestParameters> 
@@ -5750,26 +7740,36 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
-	}
-	
-	
-	///<summary>Request parameters descriptor for SearchTemplateGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html
-	///</pre>
-	///</summary>
-	public class SearchTemplateRequestParameters : FluentRequestParameters<SearchTemplateRequestParameters> 
-	{
 		
 		internal string _source { get; set; }
 		///<summary>The URL-encoded request definition</summary>
-		public SearchTemplateRequestParameters Source(string source)
+		public SearchShardsRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
 			return this;
 		}
 		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SearchShardsRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
+	}
+	
+	
+	///<summary>Request parameters descriptor for SearchTemplateGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html
+	///</pre>
+	///</summary>
+	public class SearchTemplateRequestParameters : FluentRequestParameters<SearchTemplateRequestParameters> 
+	{
 		
 		internal bool _ignore_unavailable { get; set; }
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
@@ -5840,12 +7840,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public SearchTemplateRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SearchTemplateRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotCreate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class SnapshotRequestParameters : FluentRequestParameters<SnapshotRequestParameters> 
@@ -5870,12 +7890,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public SnapshotRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SnapshotRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotCreateRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class CreateRepositoryRequestParameters : FluentRequestParameters<CreateRepositoryRequestParameters> 
@@ -5910,12 +7950,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public CreateRepositoryRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CreateRepositoryRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotDelete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class DeleteSnapshotRequestParameters : FluentRequestParameters<DeleteSnapshotRequestParameters> 
@@ -5930,12 +7990,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteSnapshotRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteSnapshotRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotDeleteRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class DeleteRepositoryRequestParameters : FluentRequestParameters<DeleteRepositoryRequestParameters> 
@@ -5960,12 +8040,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteRepositoryRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteRepositoryRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class GetSnapshotRequestParameters : FluentRequestParameters<GetSnapshotRequestParameters> 
@@ -5980,12 +8080,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetSnapshotRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetSnapshotRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotGetRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class GetRepositoryRequestParameters : FluentRequestParameters<GetRepositoryRequestParameters> 
@@ -6010,12 +8130,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public GetRepositoryRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetRepositoryRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotRestore
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class RestoreRequestParameters : FluentRequestParameters<RestoreRequestParameters> 
@@ -6040,12 +8180,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public RestoreRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public RestoreRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotStatus
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class SnapshotStatusRequestParameters : FluentRequestParameters<SnapshotStatusRequestParameters> 
@@ -6060,12 +8220,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public SnapshotStatusRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SnapshotStatusRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for SnapshotVerifyRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public class VerifyRepositoryRequestParameters : FluentRequestParameters<VerifyRepositoryRequestParameters> 
@@ -6090,12 +8270,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public VerifyRepositoryRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public VerifyRepositoryRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Suggest
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html
 	///</pre>
 	///</summary>
 	public class SuggestRequestParameters : FluentRequestParameters<SuggestRequestParameters> 
@@ -6152,11 +8352,21 @@ namespace Elasticsearch.Net
 		
 		
 		internal string _source { get; set; }
-		///<summary>The URL-encoded request definition (instead of using request body)</summary>
+		///<summary>The URL-encoded request definition</summary>
 		public SuggestRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SuggestRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
 			return this;
 		}
 		
@@ -6165,21 +8375,11 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for TermvectorGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html
 	///</pre>
 	///</summary>
 	public class TermvectorRequestParameters : FluentRequestParameters<TermvectorRequestParameters> 
 	{
-		
-		internal string _source { get; set; }
-		///<summary>The URL-encoded request definition</summary>
-		public TermvectorRequestParameters Source(string source)
-		{
-			this._source = source;
-			this.AddQueryString("source", this._source);
-			return this;
-		}
-		
 		
 		internal bool _term_statistics { get; set; }
 		///<summary>Specifies if total term frequency and document frequency should be returned.</summary>
@@ -6280,12 +8480,32 @@ namespace Elasticsearch.Net
 			return this;
 		}
 		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public TermvectorRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TermvectorRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
+			return this;
+		}
+		
 	}
 	
 	
 	///<summary>Request parameters descriptor for Update
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html
 	///</pre>
 	///</summary>
 	public class UpdateRequestParameters : FluentRequestParameters<UpdateRequestParameters> 
@@ -6312,7 +8532,7 @@ namespace Elasticsearch.Net
 		
 		
 		internal string _parent { get; set; }
-		///<summary>ID of the parent document</summary>
+		///<summary>ID of the parent document. Is is only used for routing and when for the upsert request</summary>
 		public UpdateRequestParameters Parent(string parent)
 		{
 			this._parent = parent;
@@ -6437,6 +8657,26 @@ namespace Elasticsearch.Net
 		{
 			this._version_type = version_type;
 			this.AddQueryString("version_type", this._version_type);
+			return this;
+		}
+		
+		
+		internal string _source { get; set; }
+		///<summary>The URL-encoded request definition</summary>
+		public UpdateRequestParameters Source(string source)
+		{
+			this._source = source;
+			this.AddQueryString("source", this._source);
+			return this;
+		}
+		
+		
+		internal string _filter_path { get; set; }
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpdateRequestParameters FilterPath(string filter_path)
+		{
+			this._filter_path = filter_path;
+			this.AddQueryString("filter_path", this._filter_path);
 			return this;
 		}
 		

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -4308,12 +4308,12 @@ namespace Elasticsearch.Net
 	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
 	///</pre>
 	///</summary>
-	public class IndicesFlushSyncedRequestParameters : FluentRequestParameters<IndicesFlushSyncedRequestParameters> 
+	public class SyncedFlushRequestParameters : FluentRequestParameters<SyncedFlushRequestParameters> 
 	{
 		
 		internal string _source { get; set; }
 		///<summary>The URL-encoded request definition</summary>
-		public IndicesFlushSyncedRequestParameters Source(string source)
+		public SyncedFlushRequestParameters Source(string source)
 		{
 			this._source = source;
 			this.AddQueryString("source", this._source);
@@ -4323,7 +4323,7 @@ namespace Elasticsearch.Net
 		
 		internal string _filter_path { get; set; }
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
-		public IndicesFlushSyncedRequestParameters FilterPath(string filter_path)
+		public SyncedFlushRequestParameters FilterPath(string filter_path)
 		{
 			this._filter_path = filter_path;
 			this.AddQueryString("filter_path", this._filter_path);

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -4305,7 +4305,7 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for IndicesFlushSyncedForAll
 	///<pre>
-	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html
 	///</pre>
 	///</summary>
 	public class SyncedFlushRequestParameters : FluentRequestParameters<SyncedFlushRequestParameters> 
@@ -6117,6 +6117,16 @@ namespace Elasticsearch.Net
 		{
 			this._lowercase_expanded_terms = lowercase_expanded_terms;
 			this.AddQueryString("lowercase_expanded_terms", this._lowercase_expanded_terms);
+			return this;
+		}
+		
+		
+		internal bool _rewrite { get; set; }
+		///<summary>Provide a more detailed explanation showing the actual Lucene query that will be executed.</summary>
+		public ValidateQueryRequestParameters Rewrite(bool rewrite)
+		{
+			this._rewrite = rewrite;
+			this.AddQueryString("rewrite", this._rewrite);
 			return this;
 		}
 		

--- a/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
@@ -161,7 +161,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -194,7 +194,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -228,7 +228,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -263,7 +263,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -297,7 +297,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -332,7 +332,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -368,7 +368,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -405,7 +405,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -441,7 +441,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -478,7 +478,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -516,7 +516,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -555,7 +555,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -593,7 +593,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -626,7 +626,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -660,7 +660,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -695,7 +695,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -729,7 +729,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -764,7 +764,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -800,7 +800,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -837,7 +837,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -873,7 +873,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -910,7 +910,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -948,7 +948,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -987,7 +987,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 	    ///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -1025,7 +1025,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1063,7 +1063,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1102,7 +1102,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1142,7 +1142,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1181,7 +1181,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -1221,7 +1221,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -1262,7 +1262,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -1304,7 +1304,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -1345,7 +1345,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1383,7 +1383,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1422,7 +1422,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1462,7 +1462,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1501,7 +1501,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1541,7 +1541,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1582,7 +1582,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1624,7 +1624,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1665,7 +1665,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1703,7 +1703,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1742,7 +1742,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1782,7 +1782,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1821,7 +1821,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1861,7 +1861,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1902,7 +1902,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1944,7 +1944,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1985,7 +1985,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2023,7 +2023,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2062,7 +2062,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2102,7 +2102,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2141,7 +2141,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2179,7 +2179,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2218,7 +2218,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2258,7 +2258,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2297,7 +2297,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2335,7 +2335,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2374,7 +2374,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2414,7 +2414,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2453,7 +2453,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2491,7 +2491,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2530,7 +2530,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2570,7 +2570,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2609,7 +2609,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -2649,7 +2649,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -2690,7 +2690,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -2732,7 +2732,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -2773,7 +2773,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2811,7 +2811,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2850,7 +2850,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2890,7 +2890,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2929,7 +2929,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2967,7 +2967,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3006,7 +3006,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3046,7 +3046,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3085,7 +3085,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3123,7 +3123,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3162,7 +3162,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3202,7 +3202,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3241,7 +3241,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3279,7 +3279,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3318,7 +3318,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3358,7 +3358,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3397,7 +3397,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3435,7 +3435,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3474,7 +3474,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3514,7 +3514,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3553,7 +3553,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -3593,7 +3593,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -3634,7 +3634,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -3676,7 +3676,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -3717,7 +3717,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3755,7 +3755,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3794,7 +3794,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3834,7 +3834,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3873,7 +3873,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -3913,7 +3913,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -3954,7 +3954,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -3996,7 +3996,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -4037,7 +4037,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4075,7 +4075,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4114,7 +4114,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4154,7 +4154,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4193,7 +4193,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -4233,7 +4233,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -4274,7 +4274,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -4316,7 +4316,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -4357,7 +4357,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4395,7 +4395,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4434,7 +4434,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4474,7 +4474,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4513,7 +4513,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">A comma-separated list of scroll IDs to clear</param>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
@@ -4548,7 +4548,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">A comma-separated list of scroll IDs to clear</param>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
@@ -4584,7 +4584,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">A comma-separated list of scroll IDs to clear</param>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
@@ -4621,7 +4621,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">A comma-separated list of scroll IDs to clear</param>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
@@ -4657,7 +4657,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">
@@ -4690,7 +4690,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">
@@ -4724,7 +4724,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">
@@ -4759,7 +4759,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">
@@ -4793,7 +4793,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4825,7 +4825,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4858,7 +4858,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4892,7 +4892,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4925,7 +4925,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4957,7 +4957,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -4990,7 +4990,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5024,7 +5024,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5057,7 +5057,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 	    ///</summary>
 		///<param name="index">Limit the information returned to a specific index</param>
 		///<param name="requestParameters">
@@ -5091,7 +5091,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 	    ///</summary>
 		///<param name="index">Limit the information returned to a specific index</param>
 		///<param name="requestParameters">
@@ -5126,7 +5126,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 	    ///</summary>
 		///<param name="index">Limit the information returned to a specific index</param>
 		///<param name="requestParameters">
@@ -5162,7 +5162,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 	    ///</summary>
 		///<param name="index">Limit the information returned to a specific index</param>
 		///<param name="requestParameters">
@@ -5197,7 +5197,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5229,7 +5229,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5262,7 +5262,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5296,7 +5296,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5329,7 +5329,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 	    ///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">
@@ -5362,7 +5362,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 	    ///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">
@@ -5396,7 +5396,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 	    ///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">
@@ -5431,7 +5431,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 	    ///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">
@@ -5465,7 +5465,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html</para>	
 	    ///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">
@@ -5498,7 +5498,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html</para>	
 	    ///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">
@@ -5532,7 +5532,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html</para>	
 	    ///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">
@@ -5567,7 +5567,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html</para>	
 	    ///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">
@@ -5601,7 +5601,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5633,7 +5633,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5666,7 +5666,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5700,7 +5700,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5733,7 +5733,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -5767,7 +5767,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -5802,7 +5802,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -5838,7 +5838,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -5873,7 +5873,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
@@ -5909,7 +5909,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
@@ -5946,7 +5946,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
@@ -5984,7 +5984,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
@@ -6021,7 +6021,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -6053,7 +6053,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -6086,7 +6086,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -6120,7 +6120,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -6153,7 +6153,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -6187,7 +6187,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -6222,7 +6222,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -6258,7 +6258,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -6293,7 +6293,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -6326,7 +6326,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -6360,7 +6360,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -6395,7 +6395,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -6429,7 +6429,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -6464,7 +6464,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -6500,7 +6500,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -6537,7 +6537,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -6573,7 +6573,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6610,7 +6610,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6648,7 +6648,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6687,7 +6687,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6725,7 +6725,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -6757,7 +6757,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -6790,7 +6790,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -6824,7 +6824,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -6857,7 +6857,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -6891,7 +6891,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -6926,7 +6926,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -6962,7 +6962,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -6997,7 +6997,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -7033,7 +7033,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -7070,7 +7070,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -7108,7 +7108,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -7145,7 +7145,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7181,7 +7181,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7218,7 +7218,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7256,7 +7256,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7293,7 +7293,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7331,7 +7331,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7370,7 +7370,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7410,7 +7410,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7449,7 +7449,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7486,7 +7486,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7524,7 +7524,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7563,7 +7563,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7601,7 +7601,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7640,7 +7640,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7680,7 +7680,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7721,7 +7721,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -7761,7 +7761,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -7805,7 +7805,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -7850,7 +7850,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -7896,7 +7896,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -7941,7 +7941,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="body">A query to restrict the operation specified with the Query DSL</param>
@@ -7976,7 +7976,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="body">A query to restrict the operation specified with the Query DSL</param>
@@ -8012,7 +8012,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="body">A query to restrict the operation specified with the Query DSL</param>
@@ -8049,7 +8049,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="body">A query to restrict the operation specified with the Query DSL</param>
@@ -8085,7 +8085,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of types to restrict the operation</param>
@@ -8122,7 +8122,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of types to restrict the operation</param>
@@ -8160,7 +8160,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of types to restrict the operation</param>
@@ -8199,7 +8199,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of types to restrict the operation</param>
@@ -8237,7 +8237,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -8273,7 +8273,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -8310,7 +8310,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -8348,7 +8348,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -8385,7 +8385,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -8419,7 +8419,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -8454,7 +8454,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -8490,7 +8490,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -8525,7 +8525,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -8569,7 +8569,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -8614,7 +8614,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -8660,7 +8660,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -8705,7 +8705,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -8743,7 +8743,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -8782,7 +8782,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -8822,7 +8822,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -8861,7 +8861,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -8900,7 +8900,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -8940,7 +8940,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -8981,7 +8981,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9017,11 +9017,555 @@ namespace Elasticsearch.Net
 			);
 		}
 		
+		///<summary>Represents a GET on /_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> FieldStatsGet<T>(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			var url = "_field_stats";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /_field_stats
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> FieldStatsGetAsync<T>(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			var url = "_field_stats";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> FieldStatsGet(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			var url = "_field_stats";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<DynamicDictionary>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /_field_stats
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> FieldStatsGetAsync(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			var url = "_field_stats";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<DynamicDictionary>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> FieldStatsGet<T>(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_field_stats".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/_field_stats
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> FieldStatsGetAsync<T>(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_field_stats".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> FieldStatsGet(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_field_stats".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<DynamicDictionary>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/_field_stats
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> FieldStatsGetAsync(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_field_stats".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<DynamicDictionary>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> FieldStats<T>(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			var url = "_field_stats";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /_field_stats
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> FieldStatsAsync<T>(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			var url = "_field_stats";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> FieldStats(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			var url = "_field_stats";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<DynamicDictionary>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /_field_stats
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> FieldStatsAsync(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			var url = "_field_stats";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<DynamicDictionary>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> FieldStats<T>(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_field_stats".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/_field_stats
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> FieldStatsAsync<T>(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_field_stats".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> FieldStats(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_field_stats".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<DynamicDictionary>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/_field_stats
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> FieldStatsAsync(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_field_stats".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new FieldStatsRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<DynamicDictionary>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
 		///<summary>Represents a GET on /{index}/{type}/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -9065,7 +9609,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -9110,7 +9654,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -9156,7 +9700,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -9201,7 +9745,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -9237,7 +9781,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -9274,7 +9818,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -9312,7 +9856,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -9349,7 +9893,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document; use `_all` to fetch the first document matching the ID across all types</param>
@@ -9387,7 +9931,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document; use `_all` to fetch the first document matching the ID across all types</param>
@@ -9426,7 +9970,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document; use `_all` to fetch the first document matching the ID across all types</param>
@@ -9466,7 +10010,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document; use `_all` to fetch the first document matching the ID across all types</param>
@@ -9505,7 +10049,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -9539,7 +10083,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -9574,7 +10118,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -9610,7 +10154,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -9645,7 +10189,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9682,7 +10226,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9720,7 +10264,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9759,7 +10303,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9797,7 +10341,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9836,7 +10380,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9876,7 +10420,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9917,7 +10461,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9957,7 +10501,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -9994,7 +10538,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -10032,7 +10576,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -10071,7 +10615,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -10109,7 +10653,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -10148,7 +10692,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -10188,7 +10732,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -10229,7 +10773,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -10269,7 +10813,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -10301,7 +10845,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -10334,7 +10878,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -10368,7 +10912,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -10401,7 +10945,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="requestParameters">
@@ -10435,7 +10979,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="requestParameters">
@@ -10470,7 +11014,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="requestParameters">
@@ -10506,7 +11050,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="requestParameters">
@@ -10541,7 +11085,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="body">The text on which the analysis should be performed</param>
 		///<param name="requestParameters">
@@ -10574,7 +11118,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="body">The text on which the analysis should be performed</param>
 		///<param name="requestParameters">
@@ -10608,7 +11152,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="body">The text on which the analysis should be performed</param>
 		///<param name="requestParameters">
@@ -10643,7 +11187,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="body">The text on which the analysis should be performed</param>
 		///<param name="requestParameters">
@@ -10677,7 +11221,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">The text on which the analysis should be performed</param>
@@ -10712,7 +11256,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">The text on which the analysis should be performed</param>
@@ -10748,7 +11292,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">The text on which the analysis should be performed</param>
@@ -10785,7 +11329,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">The text on which the analysis should be performed</param>
@@ -10821,7 +11365,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -10853,7 +11397,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -10886,7 +11430,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -10920,7 +11464,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -10953,7 +11497,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -10987,7 +11531,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -11022,7 +11566,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -11058,7 +11602,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -11093,7 +11637,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11125,7 +11669,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11158,7 +11702,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11192,7 +11736,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11225,7 +11769,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -11259,7 +11803,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -11294,7 +11838,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -11330,7 +11874,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -11365,7 +11909,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -11399,7 +11943,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -11434,7 +11978,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -11470,7 +12014,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -11505,7 +12049,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -11540,7 +12084,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -11576,7 +12120,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -11613,7 +12157,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -11649,7 +12193,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -11684,7 +12228,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -11720,7 +12264,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -11757,7 +12301,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -11793,7 +12337,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices</param>
 		///<param name="requestParameters">
@@ -11827,7 +12371,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices</param>
 		///<param name="requestParameters">
@@ -11862,7 +12406,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices</param>
 		///<param name="requestParameters">
@@ -11898,7 +12442,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices</param>
 		///<param name="requestParameters">
@@ -11933,7 +12477,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="name">A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.</param>
@@ -11969,7 +12513,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="name">A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.</param>
@@ -12006,7 +12550,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="name">A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.</param>
@@ -12044,7 +12588,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="name">A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.</param>
@@ -12081,7 +12625,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="type">A comma-separated list of document types to delete (supports wildcards); use `_all` to delete all document types in the specified indices.</param>
@@ -12117,7 +12661,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="type">A comma-separated list of document types to delete (supports wildcards); use `_all` to delete all document types in the specified indices.</param>
@@ -12154,7 +12698,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="type">A comma-separated list of document types to delete (supports wildcards); use `_all` to delete all document types in the specified indices.</param>
@@ -12192,7 +12736,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="type">A comma-separated list of document types to delete (supports wildcards); use `_all` to delete all document types in the specified indices.</param>
@@ -12229,7 +12773,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -12263,7 +12807,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -12298,7 +12842,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -12334,7 +12878,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -12369,7 +12913,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters.</param>
@@ -12405,7 +12949,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters.</param>
@@ -12442,7 +12986,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters.</param>
@@ -12480,7 +13024,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters.</param>
@@ -12517,7 +13061,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to check</param>
 		///<param name="requestParameters">
@@ -12557,7 +13101,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to check</param>
 		///<param name="requestParameters">
@@ -12598,7 +13142,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to check</param>
 		///<param name="requestParameters">
@@ -12640,7 +13184,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to check</param>
 		///<param name="requestParameters">
@@ -12681,7 +13225,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -12721,7 +13265,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -12762,7 +13306,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -12804,7 +13348,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -12845,7 +13389,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -12887,7 +13431,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -12930,7 +13474,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -12974,7 +13518,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -13017,7 +13561,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -13057,7 +13601,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -13098,7 +13642,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -13140,7 +13684,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -13181,7 +13725,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -13221,7 +13765,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -13262,7 +13806,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -13304,7 +13848,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -13345,7 +13889,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` to check the types across all indices</param>
 		///<param name="type">A comma-separated list of document types to check</param>
@@ -13387,7 +13931,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` to check the types across all indices</param>
 		///<param name="type">A comma-separated list of document types to check</param>
@@ -13430,7 +13974,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` to check the types across all indices</param>
 		///<param name="type">A comma-separated list of document types to check</param>
@@ -13474,7 +14018,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` to check the types across all indices</param>
 		///<param name="type">A comma-separated list of document types to check</param>
@@ -13517,7 +14061,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13549,7 +14093,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13582,7 +14126,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13616,7 +14160,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13649,7 +14193,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -13683,7 +14227,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -13718,7 +14262,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -13754,7 +14298,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -13789,7 +14333,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13821,7 +14365,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13854,7 +14398,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13888,7 +14432,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13921,7 +14465,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -13955,7 +14499,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -13990,7 +14534,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -14026,7 +14570,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -14057,11 +14601,555 @@ namespace Elasticsearch.Net
 			);
 		}
 		
+		///<summary>Represents a POST on /_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> IndicesFlushSyncedForAll<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			var url = "_flush/synced";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /_flush/synced
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedForAllAsync<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			var url = "_flush/synced";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedForAll(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			var url = "_flush/synced";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<DynamicDictionary>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /_flush/synced
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedForAllAsync(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			var url = "_flush/synced";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<DynamicDictionary>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> IndicesFlushSynced<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_flush/synced".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/_flush/synced
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedAsync<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_flush/synced".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSynced(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_flush/synced".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<DynamicDictionary>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a POST on /{index}/_flush/synced
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedAsync(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_flush/synced".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<DynamicDictionary>(
+				"POST", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> IndicesFlushSyncedGetForAll<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			var url = "_flush/synced";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /_flush/synced
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetForAllAsync<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			var url = "_flush/synced";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGetForAll(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			var url = "_flush/synced";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<DynamicDictionary>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /_flush/synced
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetForAllAsync(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			var url = "_flush/synced";
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<DynamicDictionary>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public ElasticsearchResponse<T> IndicesFlushSyncedGet<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_flush/synced".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/_flush/synced
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetAsync<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_flush/synced".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<T>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGet(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_flush/synced".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequest<DynamicDictionary>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
+		///<summary>Represents a GET on /{index}/_flush/synced
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetAsync(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		{
+			index.ThrowIfNullOrEmpty("index");
+			var url = "{0}/_flush/synced".F(Encoded(index));
+			IRequestParameters requestParams = null;
+				
+			if (requestParameters != null)
+			{
+				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+			}
+				
+
+
+			return this.DoRequestAsync<DynamicDictionary>(
+				"GET", url, data: null, 
+				requestParameters: requestParams
+			);
+		}
+		
 		///<summary>Represents a GET on /{index}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -14095,7 +15183,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -14130,7 +15218,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -14166,7 +15254,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -14201,7 +15289,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="feature">A comma-separated list of features</param>
@@ -14237,7 +15325,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="feature">A comma-separated list of features</param>
@@ -14274,7 +15362,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="feature">A comma-separated list of features</param>
@@ -14312,7 +15400,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="feature">A comma-separated list of features</param>
@@ -14349,7 +15437,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14381,7 +15469,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14414,7 +15502,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14448,7 +15536,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14481,7 +15569,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -14515,7 +15603,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -14550,7 +15638,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -14586,7 +15674,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -14621,7 +15709,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -14657,7 +15745,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -14694,7 +15782,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -14732,7 +15820,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -14769,7 +15857,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -14803,7 +15891,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -14838,7 +15926,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -14874,7 +15962,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -14909,7 +15997,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14941,7 +16029,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14974,7 +16062,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15008,7 +16096,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15041,7 +16129,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -15075,7 +16163,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -15110,7 +16198,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -15146,7 +16234,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -15181,7 +16269,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to filter</param>
@@ -15217,7 +16305,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to filter</param>
@@ -15254,7 +16342,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to filter</param>
@@ -15292,7 +16380,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to filter</param>
@@ -15329,7 +16417,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to filter</param>
 		///<param name="requestParameters">
@@ -15363,7 +16451,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to filter</param>
 		///<param name="requestParameters">
@@ -15398,7 +16486,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to filter</param>
 		///<param name="requestParameters">
@@ -15434,7 +16522,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="name">A comma-separated list of alias names to filter</param>
 		///<param name="requestParameters">
@@ -15469,7 +16557,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="field">A comma-separated list of fields</param>
 		///<param name="requestParameters">
@@ -15503,7 +16591,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="field">A comma-separated list of fields</param>
 		///<param name="requestParameters">
@@ -15538,7 +16626,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="field">A comma-separated list of fields</param>
 		///<param name="requestParameters">
@@ -15574,7 +16662,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="field">A comma-separated list of fields</param>
 		///<param name="requestParameters">
@@ -15609,7 +16697,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -15645,7 +16733,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -15682,7 +16770,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -15720,7 +16808,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -15757,7 +16845,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -15793,7 +16881,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -15830,7 +16918,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -15868,7 +16956,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -15905,7 +16993,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -15943,7 +17031,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -15982,7 +17070,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -16022,7 +17110,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -16061,7 +17149,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16093,7 +17181,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16126,7 +17214,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16160,7 +17248,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16193,7 +17281,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -16227,7 +17315,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -16262,7 +17350,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -16298,7 +17386,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -16333,7 +17421,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="requestParameters">
@@ -16367,7 +17455,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="requestParameters">
@@ -16402,7 +17490,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="requestParameters">
@@ -16438,7 +17526,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="requestParameters">
@@ -16473,7 +17561,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -16509,7 +17597,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -16546,7 +17634,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -16584,7 +17672,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -16621,7 +17709,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16653,7 +17741,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16686,7 +17774,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16720,7 +17808,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16753,7 +17841,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -16787,7 +17875,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -16822,7 +17910,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -16858,7 +17946,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -16893,7 +17981,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="name">The name of the settings that should be included</param>
@@ -16929,7 +18017,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="name">The name of the settings that should be included</param>
@@ -16966,7 +18054,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="name">The name of the settings that should be included</param>
@@ -17004,7 +18092,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="name">The name of the settings that should be included</param>
@@ -17041,7 +18129,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the settings that should be included</param>
 		///<param name="requestParameters">
@@ -17075,7 +18163,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the settings that should be included</param>
 		///<param name="requestParameters">
@@ -17110,7 +18198,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the settings that should be included</param>
 		///<param name="requestParameters">
@@ -17146,7 +18234,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the settings that should be included</param>
 		///<param name="requestParameters">
@@ -17181,7 +18269,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17213,7 +18301,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17246,7 +18334,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17280,7 +18368,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17313,7 +18401,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -17347,7 +18435,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -17382,7 +18470,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -17418,7 +18506,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -17453,7 +18541,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17485,7 +18573,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17518,7 +18606,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17552,7 +18640,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17585,7 +18673,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17619,7 +18707,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17654,7 +18742,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17690,7 +18778,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17725,7 +18813,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17757,7 +18845,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17790,7 +18878,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17824,7 +18912,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17857,7 +18945,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17891,7 +18979,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17926,7 +19014,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17962,7 +19050,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17997,7 +19085,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
@@ -18033,7 +19121,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
@@ -18070,7 +19158,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
@@ -18108,7 +19196,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
@@ -18145,7 +19233,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
 		///<param name="requestParameters">
@@ -18179,7 +19267,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
 		///<param name="requestParameters">
@@ -18214,7 +19302,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
 		///<param name="requestParameters">
@@ -18250,7 +19338,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
 		///<param name="requestParameters">
@@ -18285,7 +19373,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -18323,7 +19411,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -18362,7 +19450,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -18402,7 +19490,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -18441,7 +19529,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18475,7 +19563,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18510,7 +19598,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18546,7 +19634,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18581,7 +19669,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18613,7 +19701,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18646,7 +19734,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18680,7 +19768,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18713,7 +19801,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -18747,7 +19835,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -18782,7 +19870,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -18818,7 +19906,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -18853,7 +19941,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18885,7 +19973,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18918,7 +20006,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18952,7 +20040,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18985,7 +20073,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -19019,7 +20107,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -19054,7 +20142,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -19090,7 +20178,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -19125,7 +20213,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -19162,7 +20250,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -19200,7 +20288,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -19239,7 +20327,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -19277,7 +20365,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -19314,7 +20402,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -19352,7 +20440,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -19391,7 +20479,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -19429,7 +20517,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -19466,7 +20554,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -19504,7 +20592,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -19543,7 +20631,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -19581,7 +20669,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -19616,7 +20704,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -19652,7 +20740,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -19689,7 +20777,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -19725,7 +20813,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -19762,7 +20850,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -19800,7 +20888,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -19839,7 +20927,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -19877,7 +20965,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -19912,7 +21000,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -19948,7 +21036,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -19985,7 +21073,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 	    ///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -20021,7 +21109,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 	    ///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">
@@ -20054,7 +21142,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 	    ///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">
@@ -20088,7 +21176,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 	    ///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">
@@ -20123,7 +21211,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 	    ///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">
@@ -20157,7 +21245,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
@@ -20192,7 +21280,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
@@ -20228,7 +21316,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
@@ -20265,7 +21353,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
@@ -20301,7 +21389,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -20336,7 +21424,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -20372,7 +21460,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -20409,7 +21497,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -20445,7 +21533,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -20480,7 +21568,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -20516,7 +21604,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -20553,7 +21641,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -20589,7 +21677,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -20624,7 +21712,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -20660,7 +21748,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -20697,7 +21785,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -20733,7 +21821,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -20770,7 +21858,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -20808,7 +21896,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -20847,7 +21935,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -20885,7 +21973,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -20924,7 +22012,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -20964,7 +22052,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -21005,7 +22093,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -21045,7 +22133,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -21080,7 +22168,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -21116,7 +22204,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -21153,7 +22241,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -21189,7 +22277,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -21226,7 +22314,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -21264,7 +22352,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -21303,7 +22391,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -21341,7 +22429,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -21380,7 +22468,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -21420,7 +22508,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -21461,7 +22549,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -21501,7 +22589,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -21533,7 +22621,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -21566,7 +22654,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -21600,7 +22688,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -21633,7 +22721,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -21667,7 +22755,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -21702,7 +22790,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -21738,7 +22826,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -21773,7 +22861,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -21805,7 +22893,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -21838,7 +22926,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -21872,7 +22960,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -21905,7 +22993,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -21939,7 +23027,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -21974,7 +23062,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22010,7 +23098,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22045,7 +23133,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22077,7 +23165,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22110,7 +23198,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22144,7 +23232,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22177,7 +23265,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22211,7 +23299,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22246,7 +23334,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22282,7 +23370,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22317,7 +23405,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22349,7 +23437,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22382,7 +23470,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22416,7 +23504,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22449,7 +23537,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22483,7 +23571,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22518,7 +23606,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22554,7 +23642,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22589,7 +23677,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22621,7 +23709,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22654,7 +23742,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22688,7 +23776,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -22721,7 +23809,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
 		///<param name="requestParameters">
@@ -22755,7 +23843,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
 		///<param name="requestParameters">
@@ -22790,7 +23878,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
 		///<param name="requestParameters">
@@ -22826,7 +23914,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
 		///<param name="requestParameters">
@@ -22861,7 +23949,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22895,7 +23983,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22930,7 +24018,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -22966,7 +24054,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23001,7 +24089,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
@@ -23037,7 +24125,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
@@ -23074,7 +24162,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
@@ -23112,7 +24200,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
@@ -23149,7 +24237,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23181,7 +24269,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23214,7 +24302,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23248,7 +24336,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23281,7 +24369,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23315,7 +24403,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23350,7 +24438,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23386,7 +24474,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23421,7 +24509,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">
@@ -23454,7 +24542,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">
@@ -23488,7 +24576,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">
@@ -23523,7 +24611,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 	    ///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">
@@ -23557,7 +24645,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23589,7 +24677,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23622,7 +24710,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23656,7 +24744,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23689,7 +24777,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23723,7 +24811,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23758,7 +24846,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23794,7 +24882,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23829,7 +24917,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23861,7 +24949,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23894,7 +24982,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23928,7 +25016,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -23961,7 +25049,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -23995,7 +25083,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -24030,7 +25118,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -24066,7 +25154,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -24101,7 +25189,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -24137,7 +25225,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -24174,7 +25262,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -24212,7 +25300,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -24249,7 +25337,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">
@@ -24282,7 +25370,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">
@@ -24316,7 +25404,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">
@@ -24351,7 +25439,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">
@@ -24385,7 +25473,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
@@ -24420,7 +25508,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
@@ -24456,7 +25544,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
@@ -24493,7 +25581,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
@@ -24529,7 +25617,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -24566,7 +25654,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -24604,7 +25692,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -24643,7 +25731,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -24681,7 +25769,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/</para>	
+	    ///<para>See also: http://www.elastic.co/guide/</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -24713,7 +25801,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/</para>	
+	    ///<para>See also: http://www.elastic.co/guide/</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -24746,7 +25834,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/</para>	
+	    ///<para>See also: http://www.elastic.co/guide/</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -24780,7 +25868,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/</para>	
+	    ///<para>See also: http://www.elastic.co/guide/</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -25233,7 +26321,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -25265,7 +26353,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -25298,7 +26386,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -25332,7 +26420,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -25365,7 +26453,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -25399,7 +26487,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -25434,7 +26522,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -25470,7 +26558,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -25505,7 +26593,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -25541,7 +26629,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -25578,7 +26666,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -25616,7 +26704,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -25653,7 +26741,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">
@@ -25686,7 +26774,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">
@@ -25720,7 +26808,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">
@@ -25755,7 +26843,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">
@@ -25789,7 +26877,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
@@ -25824,7 +26912,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
@@ -25860,7 +26948,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
@@ -25897,7 +26985,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
@@ -25933,7 +27021,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -25970,7 +27058,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -26008,7 +27096,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -26047,7 +27135,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -26085,7 +27173,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -26123,7 +27211,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -26162,7 +27250,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -26202,7 +27290,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -26241,7 +27329,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -26280,7 +27368,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -26320,7 +27408,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -26361,7 +27449,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -26401,7 +27489,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -26433,7 +27521,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -26466,7 +27554,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -26500,7 +27588,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -26533,7 +27621,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="requestParameters">
@@ -26567,7 +27655,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="requestParameters">
@@ -26602,7 +27690,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="requestParameters">
@@ -26638,7 +27726,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="requestParameters">
@@ -26673,7 +27761,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -26709,7 +27797,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -26746,7 +27834,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -26784,7 +27872,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -26821,7 +27909,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
 		///<param name="requestParameters">
@@ -26854,7 +27942,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
 		///<param name="requestParameters">
@@ -26888,7 +27976,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
 		///<param name="requestParameters">
@@ -26923,7 +28011,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
 		///<param name="requestParameters">
@@ -26957,7 +28045,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
@@ -26992,7 +28080,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
@@ -27028,7 +28116,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
@@ -27065,7 +28153,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
@@ -27101,7 +28189,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -27138,7 +28226,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -27176,7 +28264,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -27215,7 +28303,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -27253,7 +28341,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -27285,7 +28373,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -27318,7 +28406,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -27352,7 +28440,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -27385,7 +28473,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="requestParameters">
@@ -27419,7 +28507,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="requestParameters">
@@ -27454,7 +28542,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="requestParameters">
@@ -27490,7 +28578,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="requestParameters">
@@ -27525,7 +28613,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -27561,7 +28649,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -27598,7 +28686,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -27636,7 +28724,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -27673,7 +28761,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -27706,7 +28794,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -27740,7 +28828,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -27775,7 +28863,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -27809,7 +28897,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
@@ -27844,7 +28932,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
@@ -27880,7 +28968,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
@@ -27917,7 +29005,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
@@ -27953,7 +29041,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -27990,7 +29078,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -28028,7 +29116,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -28067,7 +29155,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -28105,7 +29193,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28137,7 +29225,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28170,7 +29258,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28204,7 +29292,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28237,7 +29325,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -28271,7 +29359,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -28306,7 +29394,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -28342,7 +29430,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -28377,7 +29465,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28413,7 +29501,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28450,7 +29538,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28488,7 +29576,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28525,7 +29613,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
@@ -28558,7 +29646,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
@@ -28592,7 +29680,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
@@ -28627,7 +29715,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
@@ -28661,7 +29749,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
@@ -28696,7 +29784,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
@@ -28732,7 +29820,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
@@ -28769,7 +29857,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
@@ -28805,7 +29893,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28842,7 +29930,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28880,7 +29968,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28919,7 +30007,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -28957,7 +30045,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -28989,7 +30077,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29022,7 +30110,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29056,7 +30144,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29089,7 +30177,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -29123,7 +30211,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -29158,7 +30246,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -29194,7 +30282,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -29229,7 +30317,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29261,7 +30349,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29294,7 +30382,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29328,7 +30416,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29361,7 +30449,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -29395,7 +30483,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -29430,7 +30518,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -29466,7 +30554,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -29501,7 +30589,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
 		///<param name="requestParameters">
@@ -29535,7 +30623,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
 		///<param name="requestParameters">
@@ -29570,7 +30658,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
 		///<param name="requestParameters">
@@ -29606,7 +30694,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
 		///<param name="requestParameters">
@@ -29641,7 +30729,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
@@ -29677,7 +30765,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
@@ -29714,7 +30802,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
@@ -29752,7 +30840,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
@@ -29789,7 +30877,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29821,7 +30909,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29854,7 +30942,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29888,7 +30976,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -29921,7 +31009,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to perform the operation on; use `_local` to perform the operation on the node you&#39;re connected to, leave empty to perform the operation on all nodes</param>
 		///<param name="requestParameters">
@@ -29955,7 +31043,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to perform the operation on; use `_local` to perform the operation on the node you&#39;re connected to, leave empty to perform the operation on all nodes</param>
 		///<param name="requestParameters">
@@ -29990,7 +31078,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to perform the operation on; use `_local` to perform the operation on the node you&#39;re connected to, leave empty to perform the operation on all nodes</param>
 		///<param name="requestParameters">
@@ -30026,7 +31114,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to perform the operation on; use `_local` to perform the operation on the node you&#39;re connected to, leave empty to perform the operation on all nodes</param>
 		///<param name="requestParameters">
@@ -30061,7 +31149,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -30093,7 +31181,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -30126,7 +31214,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -30160,7 +31248,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -30193,7 +31281,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -30227,7 +31315,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -30262,7 +31350,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -30298,7 +31386,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -30333,7 +31421,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -30367,7 +31455,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -30402,7 +31490,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -30438,7 +31526,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -30473,7 +31561,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -30509,7 +31597,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -30546,7 +31634,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -30584,7 +31672,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -30621,7 +31709,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index_metric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#39;t used if `indices` (or `all`) metric isn&#39;t specified.</param>
@@ -30657,7 +31745,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index_metric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#39;t used if `indices` (or `all`) metric isn&#39;t specified.</param>
@@ -30694,7 +31782,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index_metric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#39;t used if `indices` (or `all`) metric isn&#39;t specified.</param>
@@ -30732,7 +31820,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index_metric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#39;t used if `indices` (or `all`) metric isn&#39;t specified.</param>
@@ -30769,7 +31857,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -30807,7 +31895,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -30846,7 +31934,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -30886,7 +31974,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 	    ///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -30925,7 +32013,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -30961,7 +32049,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -30998,7 +32086,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31036,7 +32124,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31073,7 +32161,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31111,7 +32199,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31150,7 +32238,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31190,7 +32278,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31229,7 +32317,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31266,7 +32354,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31304,7 +32392,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31343,7 +32431,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31381,7 +32469,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31420,7 +32508,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31460,7 +32548,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31501,7 +32589,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 	    ///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -31541,7 +32629,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/</para>	
+	    ///<para>See also: http://www.elastic.co/guide/</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -31573,7 +32661,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/</para>	
+	    ///<para>See also: http://www.elastic.co/guide/</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -31606,7 +32694,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/</para>	
+	    ///<para>See also: http://www.elastic.co/guide/</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -31640,7 +32728,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/</para>	
+	    ///<para>See also: http://www.elastic.co/guide/</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -31673,7 +32761,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -31710,7 +32798,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -31748,7 +32836,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -31787,7 +32875,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -31825,7 +32913,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -31862,7 +32950,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -31900,7 +32988,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -31939,7 +33027,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 	    ///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -31977,7 +33065,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -32012,7 +33100,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -32048,7 +33136,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -32085,7 +33173,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -32121,7 +33209,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -32156,7 +33244,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -32192,7 +33280,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -32229,7 +33317,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 	    ///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -32265,7 +33353,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -32297,7 +33385,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -32330,7 +33418,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -32364,7 +33452,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -32397,7 +33485,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="requestParameters">
@@ -32431,7 +33519,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="requestParameters">
@@ -32466,7 +33554,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="requestParameters">
@@ -32502,7 +33590,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="requestParameters">
@@ -32537,7 +33625,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">
@@ -32570,7 +33658,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">
@@ -32604,7 +33692,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">
@@ -32639,7 +33727,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">
@@ -32673,7 +33761,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
@@ -32708,7 +33796,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
@@ -32744,7 +33832,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
@@ -32781,7 +33869,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 	    ///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
@@ -32817,7 +33905,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -32849,7 +33937,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -32882,7 +33970,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -32916,7 +34004,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -32949,7 +34037,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -32983,7 +34071,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -33018,7 +34106,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -33054,7 +34142,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -33089,7 +34177,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -33125,7 +34213,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -33162,7 +34250,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -33200,7 +34288,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -33237,7 +34325,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">
@@ -33270,7 +34358,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">
@@ -33304,7 +34392,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">
@@ -33339,7 +34427,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">
@@ -33373,7 +34461,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
@@ -33408,7 +34496,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
@@ -33444,7 +34532,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
@@ -33481,7 +34569,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
@@ -33517,7 +34605,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -33554,7 +34642,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -33592,7 +34680,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -33631,7 +34719,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -33669,7 +34757,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -33708,7 +34796,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -33748,7 +34836,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -33789,7 +34877,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -33829,7 +34917,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -33870,7 +34958,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -33912,7 +35000,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -33955,7 +35043,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -33997,7 +35085,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -34040,7 +35128,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -34084,7 +35172,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -34129,7 +35217,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -34173,7 +35261,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -34211,7 +35299,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -34250,7 +35338,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -34290,7 +35378,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -34329,7 +35417,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -34369,7 +35457,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -34410,7 +35498,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -34452,7 +35540,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -34493,7 +35581,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -34535,7 +35623,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -34578,7 +35666,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -34622,7 +35710,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -34665,7 +35753,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -34697,7 +35785,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -34730,7 +35818,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -34764,7 +35852,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -34797,7 +35885,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -34831,7 +35919,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -34866,7 +35954,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -34902,7 +35990,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -34937,7 +36025,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -34973,7 +36061,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -35010,7 +36098,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -35048,7 +36136,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -35085,7 +36173,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -35117,7 +36205,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -35150,7 +36238,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -35184,7 +36272,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -35217,7 +36305,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -35251,7 +36339,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -35286,7 +36374,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -35322,7 +36410,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -35357,7 +36445,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -35393,7 +36481,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -35430,7 +36518,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -35468,7 +36556,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -35505,7 +36593,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -35537,7 +36625,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -35570,7 +36658,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -35604,7 +36692,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -35637,7 +36725,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -35671,7 +36759,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -35706,7 +36794,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -35742,7 +36830,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -35777,7 +36865,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -35813,7 +36901,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -35850,7 +36938,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -35888,7 +36976,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -35925,7 +37013,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">
@@ -35958,7 +37046,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">
@@ -35992,7 +37080,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">
@@ -36027,7 +37115,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">
@@ -36061,7 +37149,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
@@ -36096,7 +37184,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
@@ -36132,7 +37220,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
@@ -36169,7 +37257,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
@@ -36205,7 +37293,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -36242,7 +37330,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -36280,7 +37368,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -36319,7 +37407,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -36357,7 +37445,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36394,7 +37482,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36432,7 +37520,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36471,7 +37559,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36509,7 +37597,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36546,7 +37634,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36584,7 +37672,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36623,7 +37711,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36661,7 +37749,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -36696,7 +37784,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -36732,7 +37820,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -36769,7 +37857,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -36805,7 +37893,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -36840,7 +37928,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -36876,7 +37964,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -36913,7 +38001,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -36949,7 +38037,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -36985,7 +38073,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -37022,7 +38110,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -37060,7 +38148,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -37097,7 +38185,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -37131,7 +38219,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -37166,7 +38254,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -37202,7 +38290,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -37237,7 +38325,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -37273,7 +38361,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -37310,7 +38398,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -37348,7 +38436,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -37385,7 +38473,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -37417,7 +38505,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -37450,7 +38538,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -37484,7 +38572,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -37517,7 +38605,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -37551,7 +38639,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -37586,7 +38674,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -37622,7 +38710,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -37657,7 +38745,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -37694,7 +38782,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -37732,7 +38820,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -37771,7 +38859,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -37809,7 +38897,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -37841,7 +38929,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -37874,7 +38962,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -37908,7 +38996,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -37941,7 +39029,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -37975,7 +39063,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -38010,7 +39098,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -38046,7 +39134,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -38081,7 +39169,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -38117,7 +39205,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -38154,7 +39242,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -38192,7 +39280,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -38229,7 +39317,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -38263,7 +39351,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -38298,7 +39386,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -38334,7 +39422,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 	    ///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -38369,7 +39457,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="body">The request definition</param>
 		///<param name="requestParameters">
@@ -38402,7 +39490,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="body">The request definition</param>
 		///<param name="requestParameters">
@@ -38436,7 +39524,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="body">The request definition</param>
 		///<param name="requestParameters">
@@ -38471,7 +39559,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="body">The request definition</param>
 		///<param name="requestParameters">
@@ -38505,7 +39593,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The request definition</param>
@@ -38540,7 +39628,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The request definition</param>
@@ -38576,7 +39664,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The request definition</param>
@@ -38613,7 +39701,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The request definition</param>
@@ -38649,7 +39737,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -38681,7 +39769,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -38714,7 +39802,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -38748,7 +39836,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -38781,7 +39869,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -38815,7 +39903,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -38850,7 +39938,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -38886,7 +39974,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -38921,7 +40009,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -38957,7 +40045,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -38994,7 +40082,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -39032,7 +40120,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -39069,11 +40157,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="id">The id of the document.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39107,11 +40195,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="id">The id of the document.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39146,11 +40234,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="id">The id of the document.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39186,11 +40274,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="id">The id of the document.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39225,11 +40313,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39262,11 +40350,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39300,11 +40388,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39339,11 +40427,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39377,12 +40465,12 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="id">The id of the document.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39416,12 +40504,12 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="id">The id of the document.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39456,12 +40544,12 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="id">The id of the document.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39497,12 +40585,12 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 	    ///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="id">The id of the document.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -39537,7 +40625,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -39576,7 +40664,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -39616,7 +40704,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -39657,7 +40745,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html</para>	
 	    ///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>

--- a/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
@@ -14615,14 +14615,14 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> IndicesFlushSyncedForAll<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesFlushSyncedForAll<T>(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			var url = "_flush/synced";
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14647,14 +14647,14 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedForAllAsync<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedForAllAsync<T>(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			var url = "_flush/synced";
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14681,14 +14681,14 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedForAll(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedForAll(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			var url = "_flush/synced";
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14715,14 +14715,14 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedForAllAsync(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedForAllAsync(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			var url = "_flush/synced";
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14748,7 +14748,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> IndicesFlushSynced<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesFlushSynced<T>(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			index.ThrowIfNullOrEmpty("index");
 			var url = "{0}/_flush/synced".F(Encoded(index));
@@ -14756,7 +14756,7 @@ namespace Elasticsearch.Net
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14782,7 +14782,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedAsync<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedAsync<T>(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			index.ThrowIfNullOrEmpty("index");
 			var url = "{0}/_flush/synced".F(Encoded(index));
@@ -14790,7 +14790,7 @@ namespace Elasticsearch.Net
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14818,7 +14818,7 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSynced(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSynced(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			index.ThrowIfNullOrEmpty("index");
 			var url = "{0}/_flush/synced".F(Encoded(index));
@@ -14826,7 +14826,7 @@ namespace Elasticsearch.Net
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14854,7 +14854,7 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedAsync(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedAsync(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			index.ThrowIfNullOrEmpty("index");
 			var url = "{0}/_flush/synced".F(Encoded(index));
@@ -14862,7 +14862,7 @@ namespace Elasticsearch.Net
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14887,14 +14887,14 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> IndicesFlushSyncedGetForAll<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesFlushSyncedGetForAll<T>(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			var url = "_flush/synced";
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14919,14 +14919,14 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetForAllAsync<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetForAllAsync<T>(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			var url = "_flush/synced";
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14953,14 +14953,14 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGetForAll(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGetForAll(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			var url = "_flush/synced";
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -14987,14 +14987,14 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetForAllAsync(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetForAllAsync(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			var url = "_flush/synced";
 			IRequestParameters requestParams = null;
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -15020,7 +15020,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public ElasticsearchResponse<T> IndicesFlushSyncedGet<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesFlushSyncedGet<T>(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			index.ThrowIfNullOrEmpty("index");
 			var url = "{0}/_flush/synced".F(Encoded(index));
@@ -15028,7 +15028,7 @@ namespace Elasticsearch.Net
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -15054,7 +15054,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
-		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetAsync<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetAsync<T>(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			index.ThrowIfNullOrEmpty("index");
 			var url = "{0}/_flush/synced".F(Encoded(index));
@@ -15062,7 +15062,7 @@ namespace Elasticsearch.Net
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -15090,7 +15090,7 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGet(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGet(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			index.ThrowIfNullOrEmpty("index");
 			var url = "{0}/_flush/synced".F(Encoded(index));
@@ -15098,7 +15098,7 @@ namespace Elasticsearch.Net
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 
@@ -15126,7 +15126,7 @@ namespace Elasticsearch.Net
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
-		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetAsync(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetAsync(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null)
 		{
 			index.ThrowIfNullOrEmpty("index");
 			var url = "{0}/_flush/synced".F(Encoded(index));
@@ -15134,7 +15134,7 @@ namespace Elasticsearch.Net
 				
 			if (requestParameters != null)
 			{
-				requestParams = requestParameters(new IndicesFlushSyncedRequestParameters());
+				requestParams = requestParameters(new SyncedFlushRequestParameters());
 			}
 				
 

--- a/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticsearchClient.Generated.cs
@@ -14605,7 +14605,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14637,7 +14637,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14670,7 +14670,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14704,7 +14704,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14737,7 +14737,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -14771,7 +14771,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -14806,7 +14806,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -14842,7 +14842,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -14877,7 +14877,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14909,7 +14909,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14942,7 +14942,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14976,7 +14976,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15009,7 +15009,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -15043,7 +15043,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -15078,7 +15078,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -15114,7 +15114,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">

--- a/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
@@ -7588,7 +7588,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7605,7 +7605,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7623,7 +7623,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7642,7 +7642,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7660,7 +7660,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7678,7 +7678,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7697,7 +7697,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7717,7 +7717,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7736,7 +7736,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7753,7 +7753,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7771,7 +7771,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7790,7 +7790,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7808,7 +7808,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7826,7 +7826,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7845,7 +7845,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7865,7 +7865,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">

--- a/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
@@ -104,7 +104,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -122,7 +122,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -141,7 +141,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -161,7 +161,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -180,7 +180,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -199,7 +199,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -219,7 +219,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -240,7 +240,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -260,7 +260,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -280,7 +280,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -301,7 +301,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -323,7 +323,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -344,7 +344,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -362,7 +362,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -381,7 +381,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -401,7 +401,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -420,7 +420,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -439,7 +439,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -459,7 +459,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -480,7 +480,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
@@ -500,7 +500,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -520,7 +520,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -541,7 +541,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -563,7 +563,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html</para>	
 		///</summary>
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
@@ -584,7 +584,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -601,7 +601,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -619,7 +619,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -638,7 +638,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -656,7 +656,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -674,7 +674,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -693,7 +693,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -713,7 +713,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -732,7 +732,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -749,7 +749,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -767,7 +767,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -786,7 +786,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -804,7 +804,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -822,7 +822,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -841,7 +841,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -861,7 +861,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -880,7 +880,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -897,7 +897,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -915,7 +915,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -934,7 +934,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -952,7 +952,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -970,7 +970,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -989,7 +989,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1009,7 +1009,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1028,7 +1028,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1045,7 +1045,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1063,7 +1063,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1082,7 +1082,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1100,7 +1100,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1117,7 +1117,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1135,7 +1135,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1154,7 +1154,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1172,7 +1172,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1189,7 +1189,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1207,7 +1207,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1226,7 +1226,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1244,7 +1244,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1261,7 +1261,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1279,7 +1279,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1298,7 +1298,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1316,7 +1316,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1334,7 +1334,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1353,7 +1353,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1373,7 +1373,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1392,7 +1392,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1409,7 +1409,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1427,7 +1427,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1446,7 +1446,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1464,7 +1464,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1481,7 +1481,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1499,7 +1499,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1518,7 +1518,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1536,7 +1536,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1553,7 +1553,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1571,7 +1571,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1590,7 +1590,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1608,7 +1608,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1625,7 +1625,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1643,7 +1643,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1662,7 +1662,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1680,7 +1680,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1697,7 +1697,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1715,7 +1715,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1734,7 +1734,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1752,7 +1752,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1770,7 +1770,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1789,7 +1789,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1809,7 +1809,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1828,7 +1828,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1845,7 +1845,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1863,7 +1863,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1882,7 +1882,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1900,7 +1900,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1918,7 +1918,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1937,7 +1937,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1957,7 +1957,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -1976,7 +1976,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -1993,7 +1993,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2011,7 +2011,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2030,7 +2030,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2048,7 +2048,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -2066,7 +2066,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -2085,7 +2085,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -2105,7 +2105,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to limit the returned information</param>
 		///<param name="requestParameters">
@@ -2124,7 +2124,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2141,7 +2141,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2159,7 +2159,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2178,7 +2178,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2196,7 +2196,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">A comma-separated list of scroll IDs to clear</param>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
@@ -2215,7 +2215,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">A comma-separated list of scroll IDs to clear</param>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
@@ -2235,7 +2235,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">A comma-separated list of scroll IDs to clear</param>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
@@ -2256,7 +2256,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">A comma-separated list of scroll IDs to clear</param>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
@@ -2276,7 +2276,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">
@@ -2294,7 +2294,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">
@@ -2313,7 +2313,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">
@@ -2333,7 +2333,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">
@@ -2352,7 +2352,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2369,7 +2369,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2387,7 +2387,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2406,7 +2406,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2424,7 +2424,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2441,7 +2441,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2459,7 +2459,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2478,7 +2478,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2496,7 +2496,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 		///</summary>
 		///<param name="index">Limit the information returned to a specific index</param>
 		///<param name="requestParameters">
@@ -2514,7 +2514,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 		///</summary>
 		///<param name="index">Limit the information returned to a specific index</param>
 		///<param name="requestParameters">
@@ -2533,7 +2533,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 		///</summary>
 		///<param name="index">Limit the information returned to a specific index</param>
 		///<param name="requestParameters">
@@ -2553,7 +2553,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html</para>	
 		///</summary>
 		///<param name="index">Limit the information returned to a specific index</param>
 		///<param name="requestParameters">
@@ -2572,7 +2572,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2589,7 +2589,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2607,7 +2607,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2626,7 +2626,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2644,7 +2644,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 		///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">
@@ -2662,7 +2662,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 		///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">
@@ -2681,7 +2681,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 		///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">
@@ -2701,7 +2701,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html</para>	
 		///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">
@@ -2720,7 +2720,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html</para>	
 		///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">
@@ -2738,7 +2738,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html</para>	
 		///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">
@@ -2757,7 +2757,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html</para>	
 		///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">
@@ -2777,7 +2777,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html</para>	
 		///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">
@@ -2796,7 +2796,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2813,7 +2813,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2831,7 +2831,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2850,7 +2850,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -2868,7 +2868,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -2886,7 +2886,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -2905,7 +2905,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -2925,7 +2925,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -2944,7 +2944,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
@@ -2963,7 +2963,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
@@ -2983,7 +2983,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
@@ -3004,7 +3004,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
@@ -3024,7 +3024,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3041,7 +3041,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3059,7 +3059,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3078,7 +3078,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3096,7 +3096,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -3114,7 +3114,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -3133,7 +3133,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -3153,7 +3153,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -3172,7 +3172,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -3190,7 +3190,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -3209,7 +3209,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -3229,7 +3229,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -3248,7 +3248,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -3267,7 +3267,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -3287,7 +3287,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -3308,7 +3308,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -3328,7 +3328,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -3348,7 +3348,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -3369,7 +3369,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -3391,7 +3391,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -3412,7 +3412,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3429,7 +3429,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3447,7 +3447,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3466,7 +3466,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -3484,7 +3484,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -3502,7 +3502,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -3521,7 +3521,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -3541,7 +3541,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -3560,7 +3560,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -3579,7 +3579,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -3599,7 +3599,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -3620,7 +3620,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -3640,7 +3640,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3659,7 +3659,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3679,7 +3679,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3700,7 +3700,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3720,7 +3720,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3740,7 +3740,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3761,7 +3761,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3783,7 +3783,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3804,7 +3804,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3824,7 +3824,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3845,7 +3845,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3867,7 +3867,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3888,7 +3888,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3909,7 +3909,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3931,7 +3931,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3954,7 +3954,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated.</param>
 		///<param name="type">The type of the document being count percolated.</param>
@@ -3976,7 +3976,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -3996,7 +3996,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4017,7 +4017,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4039,7 +4039,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4060,7 +4060,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="body">A query to restrict the operation specified with the Query DSL</param>
@@ -4079,7 +4079,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="body">A query to restrict the operation specified with the Query DSL</param>
@@ -4099,7 +4099,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="body">A query to restrict the operation specified with the Query DSL</param>
@@ -4120,7 +4120,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="body">A query to restrict the operation specified with the Query DSL</param>
@@ -4140,7 +4140,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of types to restrict the operation</param>
@@ -4160,7 +4160,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of types to restrict the operation</param>
@@ -4181,7 +4181,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of types to restrict the operation</param>
@@ -4203,7 +4203,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of types to restrict the operation</param>
@@ -4224,7 +4224,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -4243,7 +4243,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -4263,7 +4263,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -4284,7 +4284,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -4304,7 +4304,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -4322,7 +4322,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -4341,7 +4341,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -4361,7 +4361,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -4380,7 +4380,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -4400,7 +4400,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -4421,7 +4421,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -4443,7 +4443,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -4464,7 +4464,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4484,7 +4484,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4505,7 +4505,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4527,7 +4527,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4548,7 +4548,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4569,7 +4569,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4591,7 +4591,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4614,7 +4614,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4632,11 +4632,307 @@ namespace Elasticsearch.Net
 		
 		Task<ElasticsearchResponse<DynamicDictionary>> ExplainAsync(string index, string type, string id, object body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null);
 		
+		///<summary>Represents a GET on /_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> FieldStatsGet<T>(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /_field_stats
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> FieldStatsGetAsync<T>(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> FieldStatsGet(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /_field_stats
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> FieldStatsGetAsync(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> FieldStatsGet<T>(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/_field_stats
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> FieldStatsGetAsync<T>(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> FieldStatsGet(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/_field_stats
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> FieldStatsGetAsync(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> FieldStats<T>(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /_field_stats
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> FieldStatsAsync<T>(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> FieldStats(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /_field_stats
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> FieldStatsAsync(Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> FieldStats<T>(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/_field_stats
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> FieldStatsAsync<T>(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/_field_stats
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> FieldStats(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/_field_stats
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> FieldStatsAsync(string index, Func<FieldStatsRequestParameters, FieldStatsRequestParameters> requestParameters = null);
+		
 		///<summary>Represents a GET on /{index}/{type}/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -4656,7 +4952,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -4677,7 +4973,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -4699,7 +4995,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -4720,7 +5016,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -4739,7 +5035,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -4759,7 +5055,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -4780,7 +5076,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -4800,7 +5096,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document; use `_all` to fetch the first document matching the ID across all types</param>
@@ -4820,7 +5116,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document; use `_all` to fetch the first document matching the ID across all types</param>
@@ -4841,7 +5137,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document; use `_all` to fetch the first document matching the ID across all types</param>
@@ -4863,7 +5159,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document; use `_all` to fetch the first document matching the ID across all types</param>
@@ -4884,7 +5180,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -4902,7 +5198,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -4921,7 +5217,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -4941,7 +5237,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="requestParameters">
@@ -4960,7 +5256,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -4980,7 +5276,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5001,7 +5297,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5023,7 +5319,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5044,7 +5340,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5065,7 +5361,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5087,7 +5383,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5110,7 +5406,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5132,7 +5428,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5152,7 +5448,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5173,7 +5469,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5195,7 +5491,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5216,7 +5512,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5237,7 +5533,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5259,7 +5555,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5282,7 +5578,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -5304,7 +5600,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5321,7 +5617,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5339,7 +5635,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5358,7 +5654,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5376,7 +5672,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="requestParameters">
@@ -5394,7 +5690,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="requestParameters">
@@ -5413,7 +5709,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="requestParameters">
@@ -5433,7 +5729,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="requestParameters">
@@ -5452,7 +5748,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="body">The text on which the analysis should be performed</param>
 		///<param name="requestParameters">
@@ -5470,7 +5766,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="body">The text on which the analysis should be performed</param>
 		///<param name="requestParameters">
@@ -5489,7 +5785,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="body">The text on which the analysis should be performed</param>
 		///<param name="requestParameters">
@@ -5509,7 +5805,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="body">The text on which the analysis should be performed</param>
 		///<param name="requestParameters">
@@ -5528,7 +5824,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">The text on which the analysis should be performed</param>
@@ -5547,7 +5843,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">The text on which the analysis should be performed</param>
@@ -5567,7 +5863,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">The text on which the analysis should be performed</param>
@@ -5588,7 +5884,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html</para>	
 		///</summary>
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">The text on which the analysis should be performed</param>
@@ -5608,7 +5904,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5625,7 +5921,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5643,7 +5939,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5662,7 +5958,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5680,7 +5976,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -5698,7 +5994,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -5717,7 +6013,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -5737,7 +6033,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -5756,7 +6052,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5773,7 +6069,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5791,7 +6087,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5810,7 +6106,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -5828,7 +6124,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -5846,7 +6142,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -5865,7 +6161,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -5885,7 +6181,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index name to limit the operation</param>
 		///<param name="requestParameters">
@@ -5904,7 +6200,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -5922,7 +6218,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -5941,7 +6237,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -5961,7 +6257,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -5980,7 +6276,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -5999,7 +6295,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -6019,7 +6315,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -6040,7 +6336,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -6060,7 +6356,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -6079,7 +6375,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -6099,7 +6395,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -6120,7 +6416,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
@@ -6140,7 +6436,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices</param>
 		///<param name="requestParameters">
@@ -6158,7 +6454,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices</param>
 		///<param name="requestParameters">
@@ -6177,7 +6473,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices</param>
 		///<param name="requestParameters">
@@ -6197,7 +6493,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices</param>
 		///<param name="requestParameters">
@@ -6216,7 +6512,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="name">A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.</param>
@@ -6235,7 +6531,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="name">A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.</param>
@@ -6255,7 +6551,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="name">A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.</param>
@@ -6276,7 +6572,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="name">A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.</param>
@@ -6296,7 +6592,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="type">A comma-separated list of document types to delete (supports wildcards); use `_all` to delete all document types in the specified indices.</param>
@@ -6315,7 +6611,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="type">A comma-separated list of document types to delete (supports wildcards); use `_all` to delete all document types in the specified indices.</param>
@@ -6335,7 +6631,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="type">A comma-separated list of document types to delete (supports wildcards); use `_all` to delete all document types in the specified indices.</param>
@@ -6356,7 +6652,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names (supports wildcards); use `_all` for all indices</param>
 		///<param name="type">A comma-separated list of document types to delete (supports wildcards); use `_all` to delete all document types in the specified indices.</param>
@@ -6376,7 +6672,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -6394,7 +6690,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -6413,7 +6709,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -6433,7 +6729,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -6452,7 +6748,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters.</param>
@@ -6471,7 +6767,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters.</param>
@@ -6491,7 +6787,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters.</param>
@@ -6512,7 +6808,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters.</param>
@@ -6532,7 +6828,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to check</param>
 		///<param name="requestParameters">
@@ -6550,7 +6846,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to check</param>
 		///<param name="requestParameters">
@@ -6569,7 +6865,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to check</param>
 		///<param name="requestParameters">
@@ -6589,7 +6885,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to check</param>
 		///<param name="requestParameters">
@@ -6608,7 +6904,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -6626,7 +6922,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -6645,7 +6941,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -6665,7 +6961,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -6684,7 +6980,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -6703,7 +6999,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -6723,7 +7019,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -6744,7 +7040,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -6764,7 +7060,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -6782,7 +7078,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -6801,7 +7097,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -6821,7 +7117,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -6840,7 +7136,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -6858,7 +7154,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -6877,7 +7173,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -6897,7 +7193,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -6916,7 +7212,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` to check the types across all indices</param>
 		///<param name="type">A comma-separated list of document types to check</param>
@@ -6935,7 +7231,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` to check the types across all indices</param>
 		///<param name="type">A comma-separated list of document types to check</param>
@@ -6955,7 +7251,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` to check the types across all indices</param>
 		///<param name="type">A comma-separated list of document types to check</param>
@@ -6976,7 +7272,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` to check the types across all indices</param>
 		///<param name="type">A comma-separated list of document types to check</param>
@@ -6996,7 +7292,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7013,7 +7309,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7031,7 +7327,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7050,7 +7346,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7068,7 +7364,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7086,7 +7382,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7105,7 +7401,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7125,7 +7421,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7144,7 +7440,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7161,7 +7457,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7179,7 +7475,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7198,7 +7494,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7216,7 +7512,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7234,7 +7530,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7253,7 +7549,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7273,7 +7569,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
 		///<param name="requestParameters">
@@ -7288,11 +7584,307 @@ namespace Elasticsearch.Net
 		
 		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushGetAsync(string index, Func<FlushRequestParameters, FlushRequestParameters> requestParameters = null);
 		
+		///<summary>Represents a POST on /_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> IndicesFlushSyncedForAll<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /_flush/synced
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> IndicesFlushSyncedForAllAsync<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedForAll(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /_flush/synced
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedForAllAsync(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> IndicesFlushSynced<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/_flush/synced
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> IndicesFlushSyncedAsync<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> IndicesFlushSynced(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a POST on /{index}/_flush/synced
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedAsync(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> IndicesFlushSyncedGetForAll<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /_flush/synced
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetForAllAsync<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGetForAll(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /_flush/synced
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetForAllAsync(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		ElasticsearchResponse<T> IndicesFlushSyncedGet<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/_flush/synced
+		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
+		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
+		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetAsync<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/_flush/synced
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGet(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
+		///<summary>Represents a GET on /{index}/_flush/synced
+		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names; use `_all` or empty string for all indices</param>
+		///<param name="requestParameters">
+		///Optional function to specify any additional request parameters 
+		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
+		///</param>
+		///<returns>Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
+		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
+		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
+		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
+		///</returns>
+		
+		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetAsync(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		
 		///<summary>Represents a GET on /{index}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -7310,7 +7902,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -7329,7 +7921,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -7349,7 +7941,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -7368,7 +7960,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="feature">A comma-separated list of features</param>
@@ -7387,7 +7979,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="feature">A comma-separated list of features</param>
@@ -7407,7 +7999,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="feature">A comma-separated list of features</param>
@@ -7428,7 +8020,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="feature">A comma-separated list of features</param>
@@ -7448,7 +8040,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7465,7 +8057,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7483,7 +8075,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7502,7 +8094,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7520,7 +8112,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -7538,7 +8130,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -7557,7 +8149,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -7577,7 +8169,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to return</param>
 		///<param name="requestParameters">
@@ -7596,7 +8188,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -7615,7 +8207,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -7635,7 +8227,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -7656,7 +8248,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to return</param>
@@ -7676,7 +8268,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -7694,7 +8286,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -7713,7 +8305,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -7733,7 +8325,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -7752,7 +8344,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7769,7 +8361,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7787,7 +8379,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7806,7 +8398,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -7824,7 +8416,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -7842,7 +8434,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -7861,7 +8453,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -7881,7 +8473,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="requestParameters">
@@ -7900,7 +8492,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to filter</param>
@@ -7919,7 +8511,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to filter</param>
@@ -7939,7 +8531,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to filter</param>
@@ -7960,7 +8552,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to filter aliases</param>
 		///<param name="name">A comma-separated list of alias names to filter</param>
@@ -7980,7 +8572,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to filter</param>
 		///<param name="requestParameters">
@@ -7998,7 +8590,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to filter</param>
 		///<param name="requestParameters">
@@ -8017,7 +8609,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to filter</param>
 		///<param name="requestParameters">
@@ -8037,7 +8629,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="name">A comma-separated list of alias names to filter</param>
 		///<param name="requestParameters">
@@ -8056,7 +8648,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="field">A comma-separated list of fields</param>
 		///<param name="requestParameters">
@@ -8074,7 +8666,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="field">A comma-separated list of fields</param>
 		///<param name="requestParameters">
@@ -8093,7 +8685,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="field">A comma-separated list of fields</param>
 		///<param name="requestParameters">
@@ -8113,7 +8705,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="field">A comma-separated list of fields</param>
 		///<param name="requestParameters">
@@ -8132,7 +8724,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -8151,7 +8743,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -8171,7 +8763,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -8192,7 +8784,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -8212,7 +8804,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -8231,7 +8823,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -8251,7 +8843,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -8272,7 +8864,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="field">A comma-separated list of fields</param>
@@ -8292,7 +8884,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -8312,7 +8904,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -8333,7 +8925,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -8355,7 +8947,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -8376,7 +8968,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -8393,7 +8985,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -8411,7 +9003,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -8430,7 +9022,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -8448,7 +9040,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -8466,7 +9058,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -8485,7 +9077,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -8505,7 +9097,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="requestParameters">
@@ -8524,7 +9116,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="requestParameters">
@@ -8542,7 +9134,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="requestParameters">
@@ -8561,7 +9153,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="requestParameters">
@@ -8581,7 +9173,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="type">A comma-separated list of document types</param>
 		///<param name="requestParameters">
@@ -8600,7 +9192,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -8619,7 +9211,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -8639,7 +9231,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -8660,7 +9252,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names</param>
 		///<param name="type">A comma-separated list of document types</param>
@@ -8680,7 +9272,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -8697,7 +9289,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -8715,7 +9307,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -8734,7 +9326,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -8752,7 +9344,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -8770,7 +9362,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -8789,7 +9381,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -8809,7 +9401,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -8828,7 +9420,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="name">The name of the settings that should be included</param>
@@ -8847,7 +9439,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="name">The name of the settings that should be included</param>
@@ -8867,7 +9459,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="name">The name of the settings that should be included</param>
@@ -8888,7 +9480,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="name">The name of the settings that should be included</param>
@@ -8908,7 +9500,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="name">The name of the settings that should be included</param>
 		///<param name="requestParameters">
@@ -8926,7 +9518,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="name">The name of the settings that should be included</param>
 		///<param name="requestParameters">
@@ -8945,7 +9537,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="name">The name of the settings that should be included</param>
 		///<param name="requestParameters">
@@ -8965,7 +9557,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html</para>	
 		///</summary>
 		///<param name="name">The name of the settings that should be included</param>
 		///<param name="requestParameters">
@@ -8984,7 +9576,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9001,7 +9593,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9019,7 +9611,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9038,7 +9630,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9056,7 +9648,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -9074,7 +9666,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -9093,7 +9685,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -9113,7 +9705,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="requestParameters">
@@ -9132,7 +9724,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9149,7 +9741,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9167,7 +9759,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9186,7 +9778,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9204,7 +9796,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9222,7 +9814,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9241,7 +9833,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9261,7 +9853,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9280,7 +9872,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9297,7 +9889,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9315,7 +9907,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9334,7 +9926,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9352,7 +9944,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9370,7 +9962,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9389,7 +9981,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9409,7 +10001,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9428,7 +10020,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
@@ -9447,7 +10039,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
@@ -9467,7 +10059,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
@@ -9488,7 +10080,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
@@ -9508,7 +10100,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
 		///<param name="requestParameters">
@@ -9526,7 +10118,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
 		///<param name="requestParameters">
@@ -9545,7 +10137,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
 		///<param name="requestParameters">
@@ -9565,7 +10157,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer (supports wildcards); leave empty to get all warmers</param>
 		///<param name="requestParameters">
@@ -9584,7 +10176,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -9604,7 +10196,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -9625,7 +10217,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -9647,7 +10239,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -9668,7 +10260,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -9686,7 +10278,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -9705,7 +10297,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -9725,7 +10317,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -9744,7 +10336,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9761,7 +10353,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9779,7 +10371,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9798,7 +10390,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9816,7 +10408,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9834,7 +10426,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9853,7 +10445,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9873,7 +10465,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9892,7 +10484,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9909,7 +10501,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9927,7 +10519,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9946,7 +10538,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -9964,7 +10556,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -9982,7 +10574,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -10001,7 +10593,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -10021,7 +10613,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -10040,7 +10632,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -10060,7 +10652,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -10081,7 +10673,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -10103,7 +10695,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -10124,7 +10716,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -10144,7 +10736,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -10165,7 +10757,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -10187,7 +10779,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.</param>
 		///<param name="name">The name of the alias to be created or updated</param>
@@ -10208,7 +10800,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -10228,7 +10820,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -10249,7 +10841,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -10271,7 +10863,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -10292,7 +10884,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -10311,7 +10903,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -10331,7 +10923,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -10352,7 +10944,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -10372,7 +10964,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -10392,7 +10984,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -10413,7 +11005,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -10435,7 +11027,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.</param>
 		///<param name="type">The name of the document type</param>
@@ -10456,7 +11048,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -10475,7 +11067,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -10495,7 +11087,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -10516,7 +11108,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html</para>	
 		///</summary>
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
@@ -10536,7 +11128,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 		///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">
@@ -10554,7 +11146,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 		///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">
@@ -10573,7 +11165,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 		///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">
@@ -10593,7 +11185,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 		///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">
@@ -10612,7 +11204,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
@@ -10631,7 +11223,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
@@ -10651,7 +11243,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
@@ -10672,7 +11264,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
@@ -10692,7 +11284,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -10711,7 +11303,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -10731,7 +11323,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -10752,7 +11344,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -10772,7 +11364,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -10791,7 +11383,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -10811,7 +11403,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -10832,7 +11424,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html</para>	
 		///</summary>
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
@@ -10852,7 +11444,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -10871,7 +11463,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -10891,7 +11483,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -10912,7 +11504,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -10932,7 +11524,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -10952,7 +11544,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -10973,7 +11565,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -10995,7 +11587,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -11016,7 +11608,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -11037,7 +11629,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -11059,7 +11651,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -11082,7 +11674,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -11104,7 +11696,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -11123,7 +11715,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -11143,7 +11735,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -11164,7 +11756,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="name">The name of the warmer</param>
 		///<param name="body">The search request definition for the warmer (query, filters, facets, sorting, etc)</param>
@@ -11184,7 +11776,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -11204,7 +11796,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -11225,7 +11817,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -11247,7 +11839,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="name">The name of the warmer</param>
@@ -11268,7 +11860,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -11289,7 +11881,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -11311,7 +11903,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -11334,7 +11926,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types</param>
@@ -11356,7 +11948,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11373,7 +11965,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11391,7 +11983,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11410,7 +12002,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11428,7 +12020,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11446,7 +12038,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11465,7 +12057,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11485,7 +12077,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11504,7 +12096,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11521,7 +12113,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11539,7 +12131,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11558,7 +12150,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11576,7 +12168,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11594,7 +12186,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11613,7 +12205,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11633,7 +12225,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11652,7 +12244,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11669,7 +12261,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11687,7 +12279,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11706,7 +12298,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11724,7 +12316,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11742,7 +12334,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11761,7 +12353,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11781,7 +12373,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11800,7 +12392,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11817,7 +12409,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11835,7 +12427,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11854,7 +12446,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11872,7 +12464,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11890,7 +12482,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11909,7 +12501,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11929,7 +12521,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -11948,7 +12540,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11965,7 +12557,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -11983,7 +12575,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12002,7 +12594,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12020,7 +12612,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
 		///<param name="requestParameters">
@@ -12038,7 +12630,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
 		///<param name="requestParameters">
@@ -12057,7 +12649,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
 		///<param name="requestParameters">
@@ -12077,7 +12669,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
 		///<param name="requestParameters">
@@ -12096,7 +12688,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12114,7 +12706,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12133,7 +12725,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12153,7 +12745,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12172,7 +12764,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
@@ -12191,7 +12783,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
@@ -12211,7 +12803,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
@@ -12232,7 +12824,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="metric">Limit the information returned the specific metrics.</param>
@@ -12252,7 +12844,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12269,7 +12861,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12287,7 +12879,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12306,7 +12898,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12324,7 +12916,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12342,7 +12934,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12361,7 +12953,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12381,7 +12973,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12400,7 +12992,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">
@@ -12418,7 +13010,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">
@@ -12437,7 +13029,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">
@@ -12457,7 +13049,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html</para>	
 		///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">
@@ -12476,7 +13068,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12493,7 +13085,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12511,7 +13103,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12530,7 +13122,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12548,7 +13140,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12566,7 +13158,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12585,7 +13177,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12605,7 +13197,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12624,7 +13216,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12641,7 +13233,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12659,7 +13251,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12678,7 +13270,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -12696,7 +13288,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12714,7 +13306,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12733,7 +13325,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12753,7 +13345,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -12772,7 +13364,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -12791,7 +13383,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -12811,7 +13403,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -12832,7 +13424,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -12852,7 +13444,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">
@@ -12870,7 +13462,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">
@@ -12889,7 +13481,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">
@@ -12909,7 +13501,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">
@@ -12928,7 +13520,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
@@ -12947,7 +13539,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
@@ -12967,7 +13559,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
@@ -12988,7 +13580,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
@@ -13008,7 +13600,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -13028,7 +13620,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -13049,7 +13641,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -13071,7 +13663,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
@@ -13092,7 +13684,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/</para>	
+		///<para>See also: http://www.elastic.co/guide/</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13109,7 +13701,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/</para>	
+		///<para>See also: http://www.elastic.co/guide/</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13127,7 +13719,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/</para>	
+		///<para>See also: http://www.elastic.co/guide/</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13146,7 +13738,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/</para>	
+		///<para>See also: http://www.elastic.co/guide/</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13392,7 +13984,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13409,7 +14001,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13427,7 +14019,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13446,7 +14038,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -13464,7 +14056,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -13482,7 +14074,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -13501,7 +14093,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -13521,7 +14113,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -13540,7 +14132,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -13559,7 +14151,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -13579,7 +14171,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -13600,7 +14192,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -13620,7 +14212,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">
@@ -13638,7 +14230,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">
@@ -13657,7 +14249,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">
@@ -13677,7 +14269,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">
@@ -13696,7 +14288,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
@@ -13715,7 +14307,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
@@ -13735,7 +14327,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
@@ -13756,7 +14348,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
@@ -13776,7 +14368,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -13796,7 +14388,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -13817,7 +14409,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -13839,7 +14431,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -13860,7 +14452,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -13880,7 +14472,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -13901,7 +14493,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -13923,7 +14515,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -13944,7 +14536,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -13965,7 +14557,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -13987,7 +14579,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -14010,7 +14602,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document (use `_all` to fetch the first document matching the ID across all types)</param>
@@ -14032,7 +14624,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14049,7 +14641,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14067,7 +14659,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14086,7 +14678,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14104,7 +14696,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="requestParameters">
@@ -14122,7 +14714,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="requestParameters">
@@ -14141,7 +14733,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="requestParameters">
@@ -14161,7 +14753,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="requestParameters">
@@ -14180,7 +14772,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -14199,7 +14791,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -14219,7 +14811,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -14240,7 +14832,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -14260,7 +14852,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
 		///<param name="requestParameters">
@@ -14278,7 +14870,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
 		///<param name="requestParameters">
@@ -14297,7 +14889,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
 		///<param name="requestParameters">
@@ -14317,7 +14909,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
 		///<param name="requestParameters">
@@ -14336,7 +14928,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
@@ -14355,7 +14947,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
@@ -14375,7 +14967,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
@@ -14396,7 +14988,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="body">The percolate request definitions (header &amp; body pair), separated by newlines</param>
@@ -14416,7 +15008,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -14436,7 +15028,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -14457,7 +15049,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -14479,7 +15071,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being count percolated to use as default</param>
 		///<param name="type">The type of the document being percolated to use as default.</param>
@@ -14500,7 +15092,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14517,7 +15109,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14535,7 +15127,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14554,7 +15146,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14572,7 +15164,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="requestParameters">
@@ -14590,7 +15182,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="requestParameters">
@@ -14609,7 +15201,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="requestParameters">
@@ -14629,7 +15221,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="requestParameters">
@@ -14648,7 +15240,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -14667,7 +15259,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -14687,7 +15279,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -14708,7 +15300,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -14728,7 +15320,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -14746,7 +15338,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -14765,7 +15357,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -14785,7 +15377,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">
@@ -14804,7 +15396,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
@@ -14823,7 +15415,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
@@ -14843,7 +15435,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
@@ -14864,7 +15456,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
@@ -14884,7 +15476,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -14904,7 +15496,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -14925,7 +15517,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -14947,7 +15539,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="type">A comma-separated list of document types to use as default</param>
@@ -14968,7 +15560,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -14985,7 +15577,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15003,7 +15595,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15022,7 +15614,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15040,7 +15632,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -15058,7 +15650,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -15077,7 +15669,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -15097,7 +15689,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="requestParameters">
@@ -15116,7 +15708,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15135,7 +15727,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15155,7 +15747,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15176,7 +15768,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15196,7 +15788,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
@@ -15214,7 +15806,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
@@ -15233,7 +15825,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
@@ -15253,7 +15845,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">
@@ -15272,7 +15864,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
@@ -15291,7 +15883,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
@@ -15311,7 +15903,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
@@ -15332,7 +15924,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
@@ -15352,7 +15944,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15372,7 +15964,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15393,7 +15985,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15415,7 +16007,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -15436,7 +16028,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15453,7 +16045,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15471,7 +16063,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15490,7 +16082,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15508,7 +16100,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -15526,7 +16118,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -15545,7 +16137,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -15565,7 +16157,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -15584,7 +16176,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15601,7 +16193,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15619,7 +16211,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15638,7 +16230,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15656,7 +16248,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -15674,7 +16266,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -15693,7 +16285,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -15713,7 +16305,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -15732,7 +16324,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
 		///<param name="requestParameters">
@@ -15750,7 +16342,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
 		///<param name="requestParameters">
@@ -15769,7 +16361,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
 		///<param name="requestParameters">
@@ -15789,7 +16381,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
 		///<param name="requestParameters">
@@ -15808,7 +16400,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
@@ -15827,7 +16419,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
@@ -15847,7 +16439,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
@@ -15868,7 +16460,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">A comma-separated list of metrics you wish returned. Leave empty to return all.</param>
@@ -15888,7 +16480,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15905,7 +16497,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15923,7 +16515,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15942,7 +16534,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -15960,7 +16552,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to perform the operation on; use `_local` to perform the operation on the node you&#39;re connected to, leave empty to perform the operation on all nodes</param>
 		///<param name="requestParameters">
@@ -15978,7 +16570,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to perform the operation on; use `_local` to perform the operation on the node you&#39;re connected to, leave empty to perform the operation on all nodes</param>
 		///<param name="requestParameters">
@@ -15997,7 +16589,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to perform the operation on; use `_local` to perform the operation on the node you&#39;re connected to, leave empty to perform the operation on all nodes</param>
 		///<param name="requestParameters">
@@ -16017,7 +16609,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to perform the operation on; use `_local` to perform the operation on the node you&#39;re connected to, leave empty to perform the operation on all nodes</param>
 		///<param name="requestParameters">
@@ -16036,7 +16628,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16053,7 +16645,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16071,7 +16663,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16090,7 +16682,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16108,7 +16700,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -16126,7 +16718,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -16145,7 +16737,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -16165,7 +16757,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="requestParameters">
@@ -16184,7 +16776,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -16202,7 +16794,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -16221,7 +16813,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -16241,7 +16833,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="requestParameters">
@@ -16260,7 +16852,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -16279,7 +16871,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -16299,7 +16891,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -16320,7 +16912,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -16340,7 +16932,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index_metric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#39;t used if `indices` (or `all`) metric isn&#39;t specified.</param>
@@ -16359,7 +16951,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index_metric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#39;t used if `indices` (or `all`) metric isn&#39;t specified.</param>
@@ -16379,7 +16971,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index_metric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#39;t used if `indices` (or `all`) metric isn&#39;t specified.</param>
@@ -16400,7 +16992,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
 		///<param name="index_metric">Limit the information returned for `indices` metric to the specific index metrics. Isn&#39;t used if `indices` (or `all`) metric isn&#39;t specified.</param>
@@ -16420,7 +17012,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -16440,7 +17032,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -16461,7 +17053,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -16483,7 +17075,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html</para>	
 		///</summary>
 		///<param name="node_id">A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</param>
 		///<param name="metric">Limit the information returned to the specified metrics</param>
@@ -16504,7 +17096,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16523,7 +17115,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16543,7 +17135,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16564,7 +17156,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16584,7 +17176,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16604,7 +17196,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16625,7 +17217,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16647,7 +17239,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16668,7 +17260,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16688,7 +17280,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16709,7 +17301,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16731,7 +17323,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16752,7 +17344,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16773,7 +17365,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16795,7 +17387,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16818,7 +17410,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html</para>	
 		///</summary>
 		///<param name="index">The index of the document being percolated.</param>
 		///<param name="type">The type of the document being percolated.</param>
@@ -16840,7 +17432,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/</para>	
+		///<para>See also: http://www.elastic.co/guide/</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16857,7 +17449,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/</para>	
+		///<para>See also: http://www.elastic.co/guide/</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16875,7 +17467,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/</para>	
+		///<para>See also: http://www.elastic.co/guide/</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16894,7 +17486,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/</para>	
+		///<para>See also: http://www.elastic.co/guide/</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -16912,7 +17504,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -16932,7 +17524,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -16953,7 +17545,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -16975,7 +17567,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -16996,7 +17588,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -17016,7 +17608,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -17037,7 +17629,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -17059,7 +17651,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para>	
 		///</summary>
 		///<param name="lang">Script language</param>
 		///<param name="id">Script ID</param>
@@ -17080,7 +17672,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -17099,7 +17691,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -17119,7 +17711,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -17140,7 +17732,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -17160,7 +17752,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -17179,7 +17771,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -17199,7 +17791,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -17220,7 +17812,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html</para>	
 		///</summary>
 		///<param name="id">Template ID</param>
 		///<param name="body">The document</param>
@@ -17240,7 +17832,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17257,7 +17849,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17275,7 +17867,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17294,7 +17886,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17312,7 +17904,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="requestParameters">
@@ -17330,7 +17922,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="requestParameters">
@@ -17349,7 +17941,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="requestParameters">
@@ -17369,7 +17961,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="requestParameters">
@@ -17388,7 +17980,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">
@@ -17406,7 +17998,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">
@@ -17425,7 +18017,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">
@@ -17445,7 +18037,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">
@@ -17464,7 +18056,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
@@ -17483,7 +18075,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
@@ -17503,7 +18095,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
@@ -17524,7 +18116,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html</para>	
 		///</summary>
 		///<param name="scroll_id">The scroll ID</param>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
@@ -17544,7 +18136,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17561,7 +18153,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17579,7 +18171,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17598,7 +18190,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -17616,7 +18208,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17634,7 +18226,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17653,7 +18245,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17673,7 +18265,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -17692,7 +18284,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -17711,7 +18303,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -17731,7 +18323,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -17752,7 +18344,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -17772,7 +18364,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">
@@ -17790,7 +18382,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">
@@ -17809,7 +18401,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">
@@ -17829,7 +18421,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">
@@ -17848,7 +18440,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
@@ -17867,7 +18459,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
@@ -17887,7 +18479,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
@@ -17908,7 +18500,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
@@ -17928,7 +18520,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -17948,7 +18540,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -17969,7 +18561,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -17991,7 +18583,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -18012,7 +18604,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -18030,7 +18622,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -18049,7 +18641,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -18069,7 +18661,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">
@@ -18088,7 +18680,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -18107,7 +18699,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -18127,7 +18719,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -18148,7 +18740,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -18168,7 +18760,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -18188,7 +18780,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -18209,7 +18801,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -18231,7 +18823,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -18252,7 +18844,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18269,7 +18861,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18287,7 +18879,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18306,7 +18898,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18324,7 +18916,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -18342,7 +18934,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -18361,7 +18953,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -18381,7 +18973,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">
@@ -18400,7 +18992,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -18419,7 +19011,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -18439,7 +19031,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -18460,7 +19052,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -18480,7 +19072,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18497,7 +19089,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18515,7 +19107,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18534,7 +19126,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18552,7 +19144,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18570,7 +19162,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18589,7 +19181,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18609,7 +19201,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18628,7 +19220,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -18647,7 +19239,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -18667,7 +19259,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -18688,7 +19280,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -18708,7 +19300,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18725,7 +19317,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18743,7 +19335,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18762,7 +19354,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18780,7 +19372,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18798,7 +19390,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18817,7 +19409,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18837,7 +19429,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="requestParameters">
@@ -18856,7 +19448,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -18875,7 +19467,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -18895,7 +19487,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -18916,7 +19508,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -18936,7 +19528,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18953,7 +19545,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18971,7 +19563,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -18990,7 +19582,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -19008,7 +19600,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -19026,7 +19618,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -19045,7 +19637,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -19065,7 +19657,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -19084,7 +19676,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -19103,7 +19695,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -19123,7 +19715,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -19144,7 +19736,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -19164,7 +19756,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">
@@ -19182,7 +19774,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">
@@ -19201,7 +19793,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">
@@ -19221,7 +19813,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">
@@ -19240,7 +19832,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
@@ -19259,7 +19851,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
@@ -19279,7 +19871,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
@@ -19300,7 +19892,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
@@ -19320,7 +19912,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -19340,7 +19932,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -19361,7 +19953,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -19383,7 +19975,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
@@ -19404,7 +19996,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19424,7 +20016,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19445,7 +20037,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19467,7 +20059,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19488,7 +20080,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19508,7 +20100,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19529,7 +20121,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19551,7 +20143,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19572,7 +20164,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -19591,7 +20183,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -19611,7 +20203,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -19632,7 +20224,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -19652,7 +20244,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -19671,7 +20263,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -19691,7 +20283,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -19712,7 +20304,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
@@ -19732,7 +20324,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19751,7 +20343,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19771,7 +20363,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19792,7 +20384,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -19812,7 +20404,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -19830,7 +20422,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -19849,7 +20441,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -19869,7 +20461,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -19888,7 +20480,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -19907,7 +20499,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -19927,7 +20519,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -19948,7 +20540,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -19968,7 +20560,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -19985,7 +20577,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20003,7 +20595,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20022,7 +20614,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20040,7 +20632,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -20058,7 +20650,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -20077,7 +20669,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -20097,7 +20689,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A comma-separated list of repository names</param>
 		///<param name="requestParameters">
@@ -20116,7 +20708,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -20136,7 +20728,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -20157,7 +20749,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -20179,7 +20771,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A snapshot name</param>
@@ -20200,7 +20792,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20217,7 +20809,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20235,7 +20827,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20254,7 +20846,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20272,7 +20864,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -20290,7 +20882,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -20309,7 +20901,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -20329,7 +20921,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -20348,7 +20940,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -20367,7 +20959,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -20387,7 +20979,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -20408,7 +21000,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="snapshot">A comma-separated list of snapshot names</param>
@@ -20428,7 +21020,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -20446,7 +21038,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -20465,7 +21057,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -20485,7 +21077,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para>	
 		///</summary>
 		///<param name="repository">A repository name</param>
 		///<param name="requestParameters">
@@ -20504,7 +21096,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="body">The request definition</param>
 		///<param name="requestParameters">
@@ -20522,7 +21114,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="body">The request definition</param>
 		///<param name="requestParameters">
@@ -20541,7 +21133,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="body">The request definition</param>
 		///<param name="requestParameters">
@@ -20561,7 +21153,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="body">The request definition</param>
 		///<param name="requestParameters">
@@ -20580,7 +21172,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The request definition</param>
@@ -20599,7 +21191,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The request definition</param>
@@ -20619,7 +21211,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The request definition</param>
@@ -20640,7 +21232,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="body">The request definition</param>
@@ -20660,7 +21252,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20677,7 +21269,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20695,7 +21287,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20714,7 +21306,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
@@ -20732,7 +21324,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -20750,7 +21342,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -20769,7 +21361,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -20789,7 +21381,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html</para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">
@@ -20808,7 +21400,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -20827,7 +21419,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -20847,7 +21439,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -20868,7 +21460,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
@@ -20888,11 +21480,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="id">The id of the document.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20908,11 +21500,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="id">The id of the document.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20929,11 +21521,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="id">The id of the document.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20951,11 +21543,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
+		///<param name="id">The id of the document.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20972,11 +21564,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -20992,11 +21584,11 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -21013,11 +21605,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -21035,11 +21627,11 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -21056,12 +21648,12 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="id">The id of the document.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -21077,12 +21669,12 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="id">The id of the document.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -21099,12 +21691,12 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="id">The id of the document.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -21122,12 +21714,12 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html</para>	
 		///</summary>
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="type">The type of the document.</param>
-		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
-		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
+		///<param name="id">The id of the document.</param>
+		///<param name="body">Define parameters. See documentation.</param>
 		///<param name="requestParameters">
 		///Optional function to specify any additional request parameters 
 		///<para>Querystring values, connection configuration specific to this request, deserialization state.</para>
@@ -21144,7 +21736,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -21165,7 +21757,7 @@ namespace Elasticsearch.Net
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
 		///<para> - If T is of type byte[] deserialization will be shortcircuited</para>
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -21187,7 +21779,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>
@@ -21210,7 +21802,7 @@ namespace Elasticsearch.Net
 		///<para> - Dynamic dictionary is a special dynamic type that allows json to be traversed safely</para>
 		///<para> - i.e result.Response.hits.hits[0].property.nested["nested_deeper"]</para>
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
-		///<para>See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html</para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html</para>	
 		///</summary>
 		///<param name="index">The name of the index</param>
 		///<param name="type">The type of the document</param>

--- a/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticsearchClient.Generated.cs
@@ -7599,7 +7599,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
 		
-		ElasticsearchResponse<T> IndicesFlushSyncedForAll<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		ElasticsearchResponse<T> IndicesFlushSyncedForAll<T>(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a POST on /_flush/synced
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -7616,7 +7616,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
 		
-		Task<ElasticsearchResponse<T>> IndicesFlushSyncedForAllAsync<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		Task<ElasticsearchResponse<T>> IndicesFlushSyncedForAllAsync<T>(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a POST on /_flush/synced
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -7635,7 +7635,7 @@ namespace Elasticsearch.Net
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
 		
-		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedForAll(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedForAll(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a POST on /_flush/synced
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -7654,7 +7654,7 @@ namespace Elasticsearch.Net
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
 		
-		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedForAllAsync(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedForAllAsync(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a POST on /{index}/_flush/synced
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -7672,7 +7672,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
 		
-		ElasticsearchResponse<T> IndicesFlushSynced<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		ElasticsearchResponse<T> IndicesFlushSynced<T>(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a POST on /{index}/_flush/synced
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -7690,7 +7690,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
 		
-		Task<ElasticsearchResponse<T>> IndicesFlushSyncedAsync<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		Task<ElasticsearchResponse<T>> IndicesFlushSyncedAsync<T>(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a POST on /{index}/_flush/synced
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -7710,7 +7710,7 @@ namespace Elasticsearch.Net
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
 		
-		ElasticsearchResponse<DynamicDictionary> IndicesFlushSynced(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		ElasticsearchResponse<DynamicDictionary> IndicesFlushSynced(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a POST on /{index}/_flush/synced
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -7730,7 +7730,7 @@ namespace Elasticsearch.Net
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
 		
-		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedAsync(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedAsync(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /_flush/synced
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -7747,7 +7747,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
 		
-		ElasticsearchResponse<T> IndicesFlushSyncedGetForAll<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		ElasticsearchResponse<T> IndicesFlushSyncedGetForAll<T>(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /_flush/synced
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -7764,7 +7764,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
 		
-		Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetForAllAsync<T>(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetForAllAsync<T>(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /_flush/synced
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -7783,7 +7783,7 @@ namespace Elasticsearch.Net
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
 		
-		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGetForAll(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGetForAll(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /_flush/synced
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -7802,7 +7802,7 @@ namespace Elasticsearch.Net
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
 		
-		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetForAllAsync(Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetForAllAsync(Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /{index}/_flush/synced
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -7820,7 +7820,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
 		
-		ElasticsearchResponse<T> IndicesFlushSyncedGet<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		ElasticsearchResponse<T> IndicesFlushSyncedGet<T>(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /{index}/_flush/synced
 		///<para></para>Returns: A task that'll return an ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.
@@ -7838,7 +7838,7 @@ namespace Elasticsearch.Net
 		///<para> - If T is of type VoidResponse the response stream will be ignored completely</para>
 		///</returns>
 		
-		Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetAsync<T>(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		Task<ElasticsearchResponse<T>> IndicesFlushSyncedGetAsync<T>(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /{index}/_flush/synced
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the response body deserialized as DynamicDictionary
@@ -7858,7 +7858,7 @@ namespace Elasticsearch.Net
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
 		
-		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGet(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		ElasticsearchResponse<DynamicDictionary> IndicesFlushSyncedGet(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /{index}/_flush/synced
 		///<para></para>Returns: Task that'll return an ElasticsearchResponse&lt;T$gt; holding the response body deserialized as DynamicDictionary
@@ -7878,7 +7878,7 @@ namespace Elasticsearch.Net
 		///<para> - can be safely dispatched to a nullable type even if intermediate properties do not exist</para>
 		///</returns>
 		
-		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetAsync(string index, Func<IndicesFlushSyncedRequestParameters, IndicesFlushSyncedRequestParameters> requestParameters = null);
+		Task<ElasticsearchResponse<DynamicDictionary>> IndicesFlushSyncedGetAsync(string index, Func<SyncedFlushRequestParameters, SyncedFlushRequestParameters> requestParameters = null);
 		
 		///<summary>Represents a GET on /{index}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; holding the reponse body deserialized as T.

--- a/src/Nest/DSL/FieldStatsDescriptor.cs
+++ b/src/Nest/DSL/FieldStatsDescriptor.cs
@@ -1,0 +1,38 @@
+﻿using Elasticsearch.Net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nest
+{
+	public interface IFieldStatsRequest : IIndicesOptionalExplicitAllPath<FieldStatsRequestParameters>
+	{
+	}
+
+	public partial class FieldStatsRequest : IndicesOptionalExplicitAllPathBase<FieldStatsRequestParameters>, IFieldStatsRequest
+	{
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo)
+		{
+			FieldStatsPathInfo.Update(settings, pathInfo);
+		}
+	}
+
+	internal static class FieldStatsPathInfo
+	{
+		public static void Update(IConnectionSettingsValues settings, ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo)
+		{
+			pathInfo.HttpMethod = PathInfoHttpMethod.GET;
+		}
+	}
+
+	public partial class FieldStatsDescriptor 
+		: IndicesOptionalExplicitAllPathDescriptor<FieldStatsDescriptor, FieldStatsRequestParameters>
+		, IFieldStatsRequest
+	{
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo)
+		{
+			FieldStatsPathInfo.Update(settings, pathInfo);	
+		}
+	}
+}

--- a/src/Nest/DSL/Query/Functions/FieldValueFactorDescriptor.cs
+++ b/src/Nest/DSL/Query/Functions/FieldValueFactorDescriptor.cs
@@ -40,9 +40,18 @@ namespace Nest
 		[JsonProperty("missing")]
 		internal double? _Missing { get; set; }
 
+		[JsonProperty("default")]
+		internal object _Default { get; set; }
+
 		public FieldValueFactorDescriptor<T> Field(Expression<Func<T, object>> field)
 		{
 			this._Field = field;
+			return this;
+		}
+
+		public FieldValueFactorDescriptor<T> Default(object defaultValue)
+		{
+			this._Default = defaultValue;
 			return this;
 		}
 

--- a/src/Nest/DSL/SyncedFlushDescriptor.cs
+++ b/src/Nest/DSL/SyncedFlushDescriptor.cs
@@ -18,7 +18,7 @@ namespace Nest
 		}
 	}
 
-	public partial class SyncedFlushRequest : IndicesOptionalExplicitAllPathBase<SyncedFlushRequestParameters>
+	public partial class SyncedFlushRequest : IndicesOptionalExplicitAllPathBase<SyncedFlushRequestParameters>, ISyncedFlushRequest
 	{
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<SyncedFlushRequestParameters> pathInfo)
 		{

--- a/src/Nest/DSL/SyncedFlushDescriptor.cs
+++ b/src/Nest/DSL/SyncedFlushDescriptor.cs
@@ -1,0 +1,39 @@
+﻿using Elasticsearch.Net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nest
+{
+	public interface ISyncedFlushRequest : IIndicesOptionalExplicitAllPath<SyncedFlushRequestParameters>
+	{
+	}
+
+	internal static class SyncedFlushPathInfo
+	{
+		public static void Update(IConnectionSettingsValues settings, ElasticsearchPathInfo<SyncedFlushRequestParameters> pathInfo)
+		{
+			pathInfo.HttpMethod = PathInfoHttpMethod.POST;
+		}
+	}
+
+	public partial class SyncedFlushRequest : IndicesOptionalExplicitAllPathBase<SyncedFlushRequestParameters>
+	{
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<SyncedFlushRequestParameters> pathInfo)
+		{
+			SyncedFlushPathInfo.Update(settings, pathInfo);
+		}
+	}
+	
+	[DescriptorFor("IndicesFlushSynced")]
+	public partial class SyncedFlushDescriptor 
+		: IndicesOptionalExplicitAllPathDescriptor<SyncedFlushDescriptor, SyncedFlushRequestParameters>
+		, ISyncedFlushRequest
+	{
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<SyncedFlushRequestParameters> pathInfo)
+		{
+			SyncedFlushPathInfo.Update(settings, pathInfo);
+		}
+	}
+}

--- a/src/Nest/DSL/_Descriptors.generated.cs
+++ b/src/Nest/DSL/_Descriptors.generated.cs
@@ -21,6 +21,22 @@ namespace Nest
 	{
 		
 	
+
+		///<summary>The URL-encoded request definition</summary>
+		public AbortBenchmarkDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public AbortBenchmarkDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 		
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<AbortBenchmarkRequestParameters> pathInfo)
 		{
@@ -33,7 +49,7 @@ namespace Nest
 	
 	///<summary>descriptor for Bulk
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html
 	///</pre>
 	///</summary>
 	public partial class BulkDescriptor 
@@ -88,13 +104,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public BulkDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public BulkDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatAliases
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html
 	///</pre>
 	///</summary>
 	public partial class CatAliasesDescriptor 
@@ -141,13 +173,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatAliasesDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatAliasesDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatAllocation
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html
 	///</pre>
 	///</summary>
 	public partial class CatAllocationDescriptor 
@@ -202,13 +250,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatAllocationDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatAllocationDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatCount
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html
 	///</pre>
 	///</summary>
 	public partial class CatCountDescriptor 
@@ -255,13 +319,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatCountDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatCountDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatFielddata
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html
 	///</pre>
 	///</summary>
 	public partial class CatFielddataDescriptor 
@@ -335,13 +415,29 @@ namespace Nest
 			return this;
 		}
 			
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatFielddataDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatFielddataDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatHealth
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html
 	///</pre>
 	///</summary>
 	public partial class CatHealthDescriptor 
@@ -396,13 +492,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatHealthDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatHealthDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatHelp
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html
 	///</pre>
 	///</summary>
 	public partial class CatHelpDescriptor  : BaseRequest<CatHelpRequestParameters>
@@ -414,6 +526,22 @@ namespace Nest
 		public CatHelpDescriptor Help(bool help = true)
 		{
 			this.Request.RequestParameters.Help(help);
+			return this;
+		}
+		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatHelpDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatHelpDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
 		}
 		
@@ -429,7 +557,7 @@ namespace Nest
 	
 	///<summary>descriptor for CatIndices
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html
 	///</pre>
 	///</summary>
 	public partial class CatIndicesDescriptor 
@@ -492,13 +620,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatIndicesDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatIndicesDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatMaster
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html
 	///</pre>
 	///</summary>
 	public partial class CatMasterDescriptor 
@@ -545,13 +689,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatMasterDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatMasterDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatNodes
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html
 	///</pre>
 	///</summary>
 	public partial class CatNodesDescriptor 
@@ -598,13 +758,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatNodesDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatNodesDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatPendingTasks
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html
 	///</pre>
 	///</summary>
 	public partial class CatPendingTasksDescriptor 
@@ -651,13 +827,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatPendingTasksDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatPendingTasksDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatPlugins
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html
 	///</pre>
 	///</summary>
 	public partial class CatPluginsDescriptor 
@@ -704,13 +896,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatPluginsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatPluginsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatRecovery
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html
 	///</pre>
 	///</summary>
 	public partial class CatRecoveryDescriptor 
@@ -757,13 +965,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatRecoveryDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatRecoveryDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatSegments
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html
 	///</pre>
 	///</summary>
 	public partial class CatSegmentsDescriptor 
@@ -794,13 +1018,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatSegmentsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatSegmentsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatShards
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html
 	///</pre>
 	///</summary>
 	public partial class CatShardsDescriptor 
@@ -847,13 +1087,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatShardsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatShardsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for CatThreadPool
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html
 	///</pre>
 	///</summary>
 	public partial class CatThreadPoolDescriptor 
@@ -908,26 +1164,58 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CatThreadPoolDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CatThreadPoolDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ClearScroll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html
 	///</pre>
 	///</summary>
 	public partial class ClearScrollDescriptor 
 	{
 		
 	
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClearScrollDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClearScrollDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ClusterGetSettings
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html
 	///</pre>
 	///</summary>
 	public partial class ClusterGetSettingsDescriptor 
@@ -958,13 +1246,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterGetSettingsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterGetSettingsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ClusterHealth
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html
 	///</pre>
 	///</summary>
 	public partial class ClusterHealthDescriptor 
@@ -1035,13 +1339,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterHealthDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterHealthDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ClusterPendingTasks
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html
 	///</pre>
 	///</summary>
 	public partial class ClusterPendingTasksDescriptor 
@@ -1064,13 +1384,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterPendingTasksDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterPendingTasksDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ClusterPutSettings
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html
 	///</pre>
 	///</summary>
 	public partial class ClusterSettingsDescriptor 
@@ -1101,13 +1437,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterSettingsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterSettingsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ClusterReroute
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html
 	///</pre>
 	///</summary>
 	public partial class ClusterRerouteDescriptor 
@@ -1154,13 +1506,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterRerouteDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterRerouteDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ClusterState
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html
 	///</pre>
 	///</summary>
 	public partial class ClusterStateDescriptor 
@@ -1215,13 +1583,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterStateDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterStateDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ClusterStats
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html
 	///</pre>
 	///</summary>
 	public partial class ClusterStatsDescriptor 
@@ -1244,13 +1628,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClusterStatsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClusterStatsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for Count
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html
 	///</pre>
 	///</summary>
 	public partial class CountDescriptor<T> 
@@ -1306,10 +1706,74 @@ namespace Nest
 		}
 		
 
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>Query in the Lucene query string syntax</summary>
+		public CountDescriptor<T> Q(string q)
+		{
+			this.Request.RequestParameters.Q(q);
+			return this;
+		}
+		
+
+		///<summary>The analyzer to use for the query string</summary>
+		public CountDescriptor<T> Analyzer(string analyzer)
+		{
+			this.Request.RequestParameters.Analyzer(analyzer);
+			return this;
+		}
+		
+
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public CountDescriptor<T> AnalyzeWildcard(bool analyze_wildcard = true)
+		{
+			this.Request.RequestParameters.AnalyzeWildcard(analyze_wildcard);
+			return this;
+		}
+		
+
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public CountDescriptor<T> DefaultOperator(DefaultOperator default_operator)
+		{
+			this.Request.RequestParameters.DefaultOperator(default_operator);
+			return this;
+		}
+		
+
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public CountDescriptor<T> Df(string df)
+		{
+			this.Request.RequestParameters.Df(df);
+			return this;
+		}
+		
+
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public CountDescriptor<T> Lenient(bool lenient = true)
+		{
+			this.Request.RequestParameters.Lenient(lenient);
+			return this;
+		}
+		
+
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public CountDescriptor<T> LowercaseExpandedTerms(bool lowercase_expanded_terms = true)
+		{
+			this.Request.RequestParameters.LowercaseExpandedTerms(lowercase_expanded_terms);
+			return this;
+		}
+		
+
+		///<summary>The URL-encoded request definition</summary>
 		public CountDescriptor<T> Source(string source)
 		{
 			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CountDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
 		}
 		
@@ -1319,21 +1783,13 @@ namespace Nest
 	
 	///<summary>descriptor for CountPercolateGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
 	///</pre>
 	///</summary>
 	public partial class PercolateCountDescriptor<T> 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public PercolateCountDescriptor<T> Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>A comma-separated list of specific routing values</summary>
 		public PercolateCountDescriptor<T> Routing(params string[] routing)
@@ -1406,13 +1862,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public PercolateCountDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PercolateCountDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for Delete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html
 	///</pre>
 	///</summary>
 	public partial class DeleteDescriptor<T> 
@@ -1483,13 +1955,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for DeleteByQuery
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html
 	///</pre>
 	///</summary>
 	public partial class DeleteByQueryDescriptor<T> 
@@ -1577,7 +2065,15 @@ namespace Nest
 		}
 		
 
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>Explicit operation timeout</summary>
+		public DeleteByQueryDescriptor<T> Timeout(string timeout)
+		{
+			this.Request.RequestParameters.Timeout(timeout);
+			return this;
+		}
+		
+
+		///<summary>The URL-encoded request definition</summary>
 		public DeleteByQueryDescriptor<T> Source(string source)
 		{
 			this.Request.RequestParameters.Source(source);
@@ -1585,10 +2081,10 @@ namespace Nest
 		}
 		
 
-		///<summary>Explicit operation timeout</summary>
-		public DeleteByQueryDescriptor<T> Timeout(string timeout)
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteByQueryDescriptor<T> FilterPath(string filter_path)
 		{
-			this.Request.RequestParameters.Timeout(timeout);
+			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
 		}
 		
@@ -1598,7 +2094,7 @@ namespace Nest
 	
 	///<summary>descriptor for DeleteScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public partial class DeleteScriptDescriptor 
@@ -1621,13 +2117,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteScriptDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteScriptDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for DeleteTemplate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html
 	///</pre>
 	///</summary>
 	public partial class DeleteTemplateDescriptor 
@@ -1650,13 +2162,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteTemplateDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteTemplateDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for Exists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class DocumentExistsDescriptor<T> 
@@ -1703,13 +2231,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DocumentExistsDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DocumentExistsDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ExplainGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html
 	///</pre>
 	///</summary>
 	public partial class ExplainDescriptor<T> 
@@ -1816,14 +2360,6 @@ namespace Nest
 		}
 		
 
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public ExplainDescriptor<T> Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
-
 		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
 		[Obsolete("Scheduled to be removed in 2.0, use EnableSource instead")]
 		public ExplainDescriptor<T> SourceEnabled(params string[] source_enabled)
@@ -1878,13 +2414,115 @@ namespace Nest
 			return this;
 		}
 			
+
+		///<summary>The URL-encoded request definition</summary>
+		public ExplainDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ExplainDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
+	
+	}
+	
+	
+	///<summary>descriptor for FieldStatsGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html
+	///</pre>
+	///</summary>
+	public partial class FieldStatsDescriptor  : BaseRequest<FieldStatsRequestParameters>
+	{
+		
+	
+
+		///<summary>A comma-separated list of fields for to get field statistics for (min value, max value, and more)</summary>
+		public FieldStatsDescriptor Fields(params string[] fields)
+		{
+			this.Request.RequestParameters.Fields(fields);
+			return this;
+		}
+		
+			
+		///<summary>A comma-separated list of fields for to get field statistics for (min value, max value, and more)</summary>
+		public FieldStatsDescriptor Fields<T>(params Expression<Func<T, object>>[] typedPathLookups) where T : class
+		{
+			if (!typedPathLookups.HasAny())
+				return this;
+
+			this.Request.RequestParameters._Fields(typedPathLookups);
+			return this;
+		}
+			
+
+		///<summary>Defines if field stats should be returned on a per index level or on a cluster wide level</summary>
+		public FieldStatsDescriptor Level(Level level)
+		{
+			this.Request.RequestParameters.Level(level);
+			return this;
+		}
+		
+
+		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
+		public FieldStatsDescriptor IgnoreUnavailable(bool ignore_unavailable = true)
+		{
+			this.Request.RequestParameters.IgnoreUnavailable(ignore_unavailable);
+			return this;
+		}
+		
+
+		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
+		public FieldStatsDescriptor AllowNoIndices(bool allow_no_indices = true)
+		{
+			this.Request.RequestParameters.AllowNoIndices(allow_no_indices);
+			return this;
+		}
+		
+
+		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+		public FieldStatsDescriptor ExpandWildcards(ExpandWildcards expand_wildcards)
+		{
+			this.Request.RequestParameters.ExpandWildcards(expand_wildcards);
+			return this;
+		}
+		
+
+		///<summary>The URL-encoded request definition</summary>
+		public FieldStatsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public FieldStatsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
+		
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo)
+		{
+			throw new NotImplementedException();
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for Get
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class GetDescriptor<T> 
@@ -2021,13 +2659,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for GetScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public partial class GetScriptDescriptor 
@@ -2050,13 +2704,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetScriptDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetScriptDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for GetSource
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class SourceDescriptor<T> 
@@ -2174,13 +2844,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public SourceDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SourceDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for GetTemplate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html
 	///</pre>
 	///</summary>
 	public partial class GetTemplateDescriptor 
@@ -2203,13 +2889,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetTemplateDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetTemplateDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for Index
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html
 	///</pre>
 	///</summary>
 	public partial class IndexDescriptor<T> 
@@ -2304,27 +3006,35 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public IndexDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndexDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesAnalyzeGetForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html
 	///</pre>
 	///</summary>
 	public partial class AnalyzeDescriptor 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public AnalyzeDescriptor Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>The name of the analyzer to use</summary>
 		public AnalyzeDescriptor Analyzer(string analyzer)
@@ -2406,13 +3116,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public AnalyzeDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public AnalyzeDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesClearCacheForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html
 	///</pre>
 	///</summary>
 	public partial class ClearCacheDescriptor 
@@ -2534,13 +3260,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public ClearCacheDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ClearCacheDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesClose
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html
 	///</pre>
 	///</summary>
 	public partial class CloseIndexDescriptor 
@@ -2587,13 +3329,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CloseIndexDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CloseIndexDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesCreate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html
 	///</pre>
 	///</summary>
 	public partial class CreateIndexDescriptor 
@@ -2616,13 +3374,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CreateIndexDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CreateIndexDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesDelete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html
 	///</pre>
 	///</summary>
 	public partial class DeleteIndexDescriptor 
@@ -2645,13 +3419,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteIndexDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteIndexDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesDeleteAlias
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class DeleteAliasDescriptor<T> 
@@ -2674,13 +3464,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteAliasDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteAliasDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesDeleteMapping
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html
 	///</pre>
 	///</summary>
 	public partial class DeleteMappingDescriptor<T> 
@@ -2695,13 +3501,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteMappingDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteMappingDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesDeleteWarmer
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public partial class DeleteWarmerDescriptor 
@@ -2716,13 +3538,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteWarmerDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteWarmerDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesExists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html
 	///</pre>
 	///</summary>
 	public partial class IndexExistsDescriptor 
@@ -2761,13 +3599,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public IndexExistsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndexExistsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesExistsAliasForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class AliasExistsDescriptor 
@@ -2806,13 +3660,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public AliasExistsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public AliasExistsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesExistsTemplateForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html
 	///</pre>
 	///</summary>
 	public partial class TemplateExistsDescriptor 
@@ -2835,13 +3705,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public TemplateExistsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TemplateExistsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesExistsType
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html
 	///</pre>
 	///</summary>
 	public partial class TypeExistsDescriptor 
@@ -2880,13 +3766,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public TypeExistsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TypeExistsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesFlushForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html
 	///</pre>
 	///</summary>
 	public partial class FlushDescriptor 
@@ -2933,13 +3835,64 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public FlushDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public FlushDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
+	
+	}
+	
+	
+	///<summary>descriptor for IndicesFlushSyncedForAll
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
+	///</pre>
+	///</summary>
+	public partial class IndicesFlushSyncedDescriptor  : BaseRequest<IndicesFlushSyncedRequestParameters>
+	{
+		
+	
+
+		///<summary>The URL-encoded request definition</summary>
+		public IndicesFlushSyncedDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndicesFlushSyncedDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
+		
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<IndicesFlushSyncedRequestParameters> pathInfo)
+		{
+			throw new NotImplementedException();
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html
 	///</pre>
 	///</summary>
 	public partial class GetIndexDescriptor 
@@ -2978,13 +3931,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetIndexDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetIndexDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesGetAliasForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class GetAliasDescriptor 
@@ -3023,13 +3992,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetAliasDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetAliasDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesGetAliasesForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class GetAliasesDescriptor 
@@ -3052,13 +4037,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetAliasesDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetAliasesDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesGetFieldMappingForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html
 	///</pre>
 	///</summary>
 	public partial class GetFieldMappingDescriptor<T> 
@@ -3105,13 +4106,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetFieldMappingDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetFieldMappingDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesGetMappingForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html
 	///</pre>
 	///</summary>
 	public partial class GetMappingDescriptor<T> 
@@ -3150,13 +4167,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetMappingDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetMappingDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesGetSettingsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html
 	///</pre>
 	///</summary>
 	public partial class GetIndexSettingsDescriptor 
@@ -3203,13 +4236,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetIndexSettingsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetIndexSettingsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesGetUpgradeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
 	///</pre>
 	///</summary>
 	public partial class UpgradeStatusDescriptor 
@@ -3248,13 +4297,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public UpgradeStatusDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpgradeStatusDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesGetWarmerForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public partial class GetWarmerDescriptor 
@@ -3293,13 +4358,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetWarmerDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetWarmerDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesOpen
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html
 	///</pre>
 	///</summary>
 	public partial class OpenIndexDescriptor 
@@ -3346,13 +4427,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public OpenIndexDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public OpenIndexDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesOptimizeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html
 	///</pre>
 	///</summary>
 	public partial class OptimizeDescriptor 
@@ -3431,13 +4528,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public OptimizeDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public OptimizeDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesPutAlias
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class PutAliasDescriptor 
@@ -3460,13 +4573,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public PutAliasDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutAliasDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesPutMapping
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html
 	///</pre>
 	///</summary>
 	public partial class PutMappingDescriptor<T> 
@@ -3521,13 +4650,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public PutMappingDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutMappingDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesPutSettingsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html
 	///</pre>
 	///</summary>
 	public partial class UpdateSettingsDescriptor 
@@ -3574,13 +4719,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public UpdateSettingsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpdateSettingsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesPutTemplateForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html
 	///</pre>
 	///</summary>
 	public partial class PutTemplateDescriptor 
@@ -3619,13 +4780,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public PutTemplateDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutTemplateDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesPutWarmerForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public partial class PutWarmerDescriptor 
@@ -3664,13 +4841,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public PutWarmerDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutWarmerDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesRecoveryForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html
 	///</pre>
 	///</summary>
 	public partial class RecoveryStatusDescriptor 
@@ -3701,13 +4894,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public RecoveryStatusDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public RecoveryStatusDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesRefreshForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html
 	///</pre>
 	///</summary>
 	public partial class RefreshDescriptor 
@@ -3754,13 +4963,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public RefreshDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public RefreshDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesSegmentsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html
 	///</pre>
 	///</summary>
 	public partial class SegmentsDescriptor 
@@ -3807,13 +5032,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public SegmentsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SegmentsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesStatsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html
 	///</pre>
 	///</summary>
 	public partial class IndicesStatsDescriptor 
@@ -3901,13 +5142,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public IndicesStatsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndicesStatsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesStatusForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html
 	///</pre>
 	///</summary>
 	public partial class IndicesStatusDescriptor 
@@ -3970,13 +5227,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public IndicesStatusDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public IndicesStatusDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesUpdateAliasesForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class AliasDescriptor 
@@ -3999,13 +5272,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public AliasDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public AliasDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesUpgradeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
 	///</pre>
 	///</summary>
 	public partial class UpgradeDescriptor 
@@ -4044,13 +5333,37 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>If true, only ancient (an older Lucene major release) segments will be upgraded</summary>
+		public UpgradeDescriptor OnlyAncientSegments(bool only_ancient_segments = true)
+		{
+			this.Request.RequestParameters.OnlyAncientSegments(only_ancient_segments);
+			return this;
+		}
+		
+
+		///<summary>The URL-encoded request definition</summary>
+		public UpgradeDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpgradeDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for IndicesValidateQueryGetForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html
 	///</pre>
 	///</summary>
 	public partial class ValidateQueryDescriptor<T> 
@@ -4098,7 +5411,63 @@ namespace Nest
 		}
 		
 
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>Query in the Lucene query string syntax</summary>
+		public ValidateQueryDescriptor<T> Q(string q)
+		{
+			this.Request.RequestParameters.Q(q);
+			return this;
+		}
+		
+
+		///<summary>The analyzer to use for the query string</summary>
+		public ValidateQueryDescriptor<T> Analyzer(string analyzer)
+		{
+			this.Request.RequestParameters.Analyzer(analyzer);
+			return this;
+		}
+		
+
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public ValidateQueryDescriptor<T> AnalyzeWildcard(bool analyze_wildcard = true)
+		{
+			this.Request.RequestParameters.AnalyzeWildcard(analyze_wildcard);
+			return this;
+		}
+		
+
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public ValidateQueryDescriptor<T> DefaultOperator(DefaultOperator default_operator)
+		{
+			this.Request.RequestParameters.DefaultOperator(default_operator);
+			return this;
+		}
+		
+
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public ValidateQueryDescriptor<T> Df(string df)
+		{
+			this.Request.RequestParameters.Df(df);
+			return this;
+		}
+		
+
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public ValidateQueryDescriptor<T> Lenient(bool lenient = true)
+		{
+			this.Request.RequestParameters.Lenient(lenient);
+			return this;
+		}
+		
+
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public ValidateQueryDescriptor<T> LowercaseExpandedTerms(bool lowercase_expanded_terms = true)
+		{
+			this.Request.RequestParameters.LowercaseExpandedTerms(lowercase_expanded_terms);
+			return this;
+		}
+		
+
+		///<summary>The URL-encoded request definition</summary>
 		public ValidateQueryDescriptor<T> Source(string source)
 		{
 			this.Request.RequestParameters.Source(source);
@@ -4106,10 +5475,10 @@ namespace Nest
 		}
 		
 
-		///<summary>Query in the Lucene query string syntax</summary>
-		public ValidateQueryDescriptor<T> Q(string q)
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ValidateQueryDescriptor<T> FilterPath(string filter_path)
 		{
-			this.Request.RequestParameters.Q(q);
+			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
 		}
 		
@@ -4119,13 +5488,29 @@ namespace Nest
 	
 	///<summary>descriptor for Info
 	///<pre>
-	///http://www.elasticsearch.org/guide/
+	///http://www.elastic.co/guide/
 	///</pre>
 	///</summary>
 	public partial class InfoDescriptor 
 	{
 		
 	
+
+		///<summary>The URL-encoded request definition</summary>
+		public InfoDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public InfoDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
@@ -4139,6 +5524,22 @@ namespace Nest
 	{
 		
 	
+
+		///<summary>The URL-encoded request definition</summary>
+		public ListBenchmarksDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ListBenchmarksDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 		
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<ListBenchmarksRequestParameters> pathInfo)
 		{
@@ -4151,21 +5552,13 @@ namespace Nest
 	
 	///<summary>descriptor for MgetGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html
 	///</pre>
 	///</summary>
 	public partial class MultiGetDescriptor 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public MultiGetDescriptor Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>A comma-separated list of fields to return in the response</summary>
 		public MultiGetDescriptor Fields(params string[] fields)
@@ -4264,27 +5657,35 @@ namespace Nest
 			return this;
 		}
 			
+
+		///<summary>The URL-encoded request definition</summary>
+		public MultiGetDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MultiGetDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for MltGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html
 	///</pre>
 	///</summary>
 	public partial class MoreLikeThisDescriptor<T> 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public MoreLikeThisDescriptor<T> Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>The boost factor</summary>
 		public MoreLikeThisDescriptor<T> BoostTerms(double boost_terms)
@@ -4440,27 +5841,35 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public MoreLikeThisDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MoreLikeThisDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for MpercolateGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
 	///</pre>
 	///</summary>
 	public partial class MultiPercolateDescriptor 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public MultiPercolateDescriptor Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public MultiPercolateDescriptor IgnoreUnavailable(bool ignore_unavailable = true)
@@ -4485,19 +5894,43 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public MultiPercolateDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MultiPercolateDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for MsearchGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html
 	///</pre>
 	///</summary>
 	public partial class MultiSearchDescriptor 
 	{
 		
 	
+
+		///<summary>Search operation type</summary>
+		public MultiSearchDescriptor SearchType(SearchType search_type)
+		{
+			this.Request.RequestParameters.SearchType(search_type);
+			return this;
+		}
+		
 
 		///<summary>The URL-encoded request definition</summary>
 		public MultiSearchDescriptor Source(string source)
@@ -4507,10 +5940,10 @@ namespace Nest
 		}
 		
 
-		///<summary>Search operation type</summary>
-		public MultiSearchDescriptor SearchType(SearchType search_type)
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MultiSearchDescriptor FilterPath(string filter_path)
 		{
-			this.Request.RequestParameters.SearchType(search_type);
+			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
 		}
 		
@@ -4520,21 +5953,13 @@ namespace Nest
 	
 	///<summary>descriptor for MtermvectorsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html
 	///</pre>
 	///</summary>
 	public partial class MultiTermVectorsDescriptor<T> 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public MultiTermVectorsDescriptor<T> Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body &quot;params&quot; or &quot;docs&quot;.</summary>
 		public MultiTermVectorsDescriptor<T> TermStatistics(bool term_statistics = true)
@@ -4626,13 +6051,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public MultiTermVectorsDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public MultiTermVectorsDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for NodesHotThreadsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html
 	///</pre>
 	///</summary>
 	public partial class NodesHotThreadsDescriptor 
@@ -4679,13 +6120,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public NodesHotThreadsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public NodesHotThreadsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for NodesInfoForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html
 	///</pre>
 	///</summary>
 	public partial class NodesInfoDescriptor 
@@ -4708,13 +6165,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public NodesInfoDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public NodesInfoDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for NodesShutdownForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html
 	///</pre>
 	///</summary>
 	public partial class NodesShutdownDescriptor 
@@ -4737,13 +6210,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public NodesShutdownDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public NodesShutdownDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for NodesStatsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html
 	///</pre>
 	///</summary>
 	public partial class NodesStatsDescriptor 
@@ -4839,27 +6328,35 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public NodesStatsDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public NodesStatsDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for PercolateGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
 	///</pre>
 	///</summary>
 	public partial class PercolateDescriptor<T> 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public PercolateDescriptor<T> Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>A comma-separated list of specific routing values</summary>
 		public PercolateDescriptor<T> Routing(params string[] routing)
@@ -4956,26 +6453,58 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public PercolateDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PercolateDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for Ping
 	///<pre>
-	///http://www.elasticsearch.org/guide/
+	///http://www.elastic.co/guide/
 	///</pre>
 	///</summary>
 	public partial class PingDescriptor 
 	{
 		
 	
+
+		///<summary>The URL-encoded request definition</summary>
+		public PingDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PingDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for PutScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public partial class PutScriptDescriptor 
@@ -5006,13 +6535,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public PutScriptDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public PutScriptDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for ScrollGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html
 	///</pre>
 	///</summary>
 	public partial class ScrollDescriptor<T> 
@@ -5027,13 +6572,21 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ScrollDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SearchGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html
 	///</pre>
 	///</summary>
 	public partial class SearchDescriptor<T> 
@@ -5201,13 +6754,21 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SearchDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SearchExists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
 	///</pre>
 	///</summary>
 	public partial class SearchExistsDescriptor<T> 
@@ -5263,10 +6824,74 @@ namespace Nest
 		}
 		
 
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>Query in the Lucene query string syntax</summary>
+		public SearchExistsDescriptor<T> Q(string q)
+		{
+			this.Request.RequestParameters.Q(q);
+			return this;
+		}
+		
+
+		///<summary>The analyzer to use for the query string</summary>
+		public SearchExistsDescriptor<T> Analyzer(string analyzer)
+		{
+			this.Request.RequestParameters.Analyzer(analyzer);
+			return this;
+		}
+		
+
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public SearchExistsDescriptor<T> AnalyzeWildcard(bool analyze_wildcard = true)
+		{
+			this.Request.RequestParameters.AnalyzeWildcard(analyze_wildcard);
+			return this;
+		}
+		
+
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public SearchExistsDescriptor<T> DefaultOperator(DefaultOperator default_operator)
+		{
+			this.Request.RequestParameters.DefaultOperator(default_operator);
+			return this;
+		}
+		
+
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public SearchExistsDescriptor<T> Df(string df)
+		{
+			this.Request.RequestParameters.Df(df);
+			return this;
+		}
+		
+
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public SearchExistsDescriptor<T> Lenient(bool lenient = true)
+		{
+			this.Request.RequestParameters.Lenient(lenient);
+			return this;
+		}
+		
+
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public SearchExistsDescriptor<T> LowercaseExpandedTerms(bool lowercase_expanded_terms = true)
+		{
+			this.Request.RequestParameters.LowercaseExpandedTerms(lowercase_expanded_terms);
+			return this;
+		}
+		
+
+		///<summary>The URL-encoded request definition</summary>
 		public SearchExistsDescriptor<T> Source(string source)
 		{
 			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SearchExistsDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
 		}
 		
@@ -5276,7 +6901,7 @@ namespace Nest
 	
 	///<summary>descriptor for SearchShardsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html
 	///</pre>
 	///</summary>
 	public partial class SearchShardsDescriptor<T> 
@@ -5331,27 +6956,35 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public SearchShardsDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SearchShardsDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SearchTemplateGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html
 	///</pre>
 	///</summary>
 	public partial class SearchTemplateDescriptor<T> 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public SearchTemplateDescriptor<T> Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public SearchTemplateDescriptor<T> IgnoreUnavailable(bool ignore_unavailable = true)
@@ -5408,13 +7041,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public SearchTemplateDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SearchTemplateDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotCreate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class SnapshotDescriptor 
@@ -5437,13 +7086,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public SnapshotDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SnapshotDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotCreateRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class CreateRepositoryDescriptor 
@@ -5474,13 +7139,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public CreateRepositoryDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public CreateRepositoryDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotDelete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class DeleteSnapshotDescriptor 
@@ -5495,13 +7176,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteSnapshotDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteSnapshotDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotDeleteRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class DeleteRepositoryDescriptor 
@@ -5524,13 +7221,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public DeleteRepositoryDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public DeleteRepositoryDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class GetSnapshotDescriptor 
@@ -5545,13 +7258,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetSnapshotDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetSnapshotDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotGetRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class GetRepositoryDescriptor 
@@ -5574,13 +7303,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public GetRepositoryDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public GetRepositoryDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotRestore
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class RestoreDescriptor 
@@ -5603,13 +7348,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public RestoreDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public RestoreDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotStatus
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class SnapshotStatusDescriptor 
@@ -5624,13 +7385,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public SnapshotStatusDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SnapshotStatusDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for SnapshotVerifyRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class VerifyRepositoryDescriptor 
@@ -5653,13 +7430,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public VerifyRepositoryDescriptor Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public VerifyRepositoryDescriptor FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for Suggest
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html
 	///</pre>
 	///</summary>
 	public partial class SuggestDescriptor<T> 
@@ -5707,10 +7500,18 @@ namespace Nest
 		}
 		
 
-		///<summary>The URL-encoded request definition (instead of using request body)</summary>
+		///<summary>The URL-encoded request definition</summary>
 		public SuggestDescriptor<T> Source(string source)
 		{
 			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public SuggestDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
 		}
 		
@@ -5720,21 +7521,13 @@ namespace Nest
 	
 	///<summary>descriptor for TermvectorGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html
 	///</pre>
 	///</summary>
 	public partial class TermvectorDescriptor<T> 
 	{
 		
 	
-
-		///<summary>The URL-encoded request definition</summary>
-		public TermvectorDescriptor<T> Source(string source)
-		{
-			this.Request.RequestParameters.Source(source);
-			return this;
-		}
-		
 
 		///<summary>Specifies if total term frequency and document frequency should be returned.</summary>
 		public TermvectorDescriptor<T> TermStatistics(bool term_statistics = true)
@@ -5826,13 +7619,29 @@ namespace Nest
 			return this;
 		}
 		
+
+		///<summary>The URL-encoded request definition</summary>
+		public TermvectorDescriptor<T> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TermvectorDescriptor<T> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
+			return this;
+		}
+		
 	
 	}
 	
 	
 	///<summary>descriptor for Update
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html
 	///</pre>
 	///</summary>
 	public partial class UpdateDescriptor<TDocument,TPartialDocument> 
@@ -5856,7 +7665,7 @@ namespace Nest
 		}
 		
 
-		///<summary>ID of the parent document</summary>
+		///<summary>ID of the parent document. Is is only used for routing and when for the upsert request</summary>
 		public UpdateDescriptor<TDocument,TPartialDocument> Parent(string parent)
 		{
 			this.Request.RequestParameters.Parent(parent);
@@ -5956,6 +7765,22 @@ namespace Nest
 		public UpdateDescriptor<TDocument,TPartialDocument> VersionType(VersionType version_type)
 		{
 			this.Request.RequestParameters.VersionType(version_type);
+			return this;
+		}
+		
+
+		///<summary>The URL-encoded request definition</summary>
+		public UpdateDescriptor<TDocument,TPartialDocument> Source(string source)
+		{
+			this.Request.RequestParameters.Source(source);
+			return this;
+		}
+		
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpdateDescriptor<TDocument,TPartialDocument> FilterPath(string filter_path)
+		{
+			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
 		}
 		

--- a/src/Nest/DSL/_Descriptors.generated.cs
+++ b/src/Nest/DSL/_Descriptors.generated.cs
@@ -3851,7 +3851,7 @@ namespace Nest
 	
 	///<summary>descriptor for IndicesFlushSyncedForAll
 	///<pre>
-	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html
 	///</pre>
 	///</summary>
 	public partial class SyncedFlushDescriptor 
@@ -5451,6 +5451,14 @@ namespace Nest
 		public ValidateQueryDescriptor<T> LowercaseExpandedTerms(bool lowercase_expanded_terms = true)
 		{
 			this.Request.RequestParameters.LowercaseExpandedTerms(lowercase_expanded_terms);
+			return this;
+		}
+		
+
+		///<summary>Provide a more detailed explanation showing the actual Lucene query that will be executed.</summary>
+		public ValidateQueryDescriptor<T> Rewrite(bool rewrite = true)
+		{
+			this.Request.RequestParameters.Rewrite(rewrite);
 			return this;
 		}
 		

--- a/src/Nest/DSL/_Descriptors.generated.cs
+++ b/src/Nest/DSL/_Descriptors.generated.cs
@@ -3860,13 +3860,13 @@ namespace Nest
 	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
 	///</pre>
 	///</summary>
-	public partial class IndicesFlushSyncedDescriptor  : BaseRequest<IndicesFlushSyncedRequestParameters>
+	public partial class SyncedFlushDescriptor 
 	{
 		
 	
 
 		///<summary>The URL-encoded request definition</summary>
-		public IndicesFlushSyncedDescriptor Source(string source)
+		public SyncedFlushDescriptor Source(string source)
 		{
 			this.Request.RequestParameters.Source(source);
 			return this;
@@ -3874,16 +3874,10 @@ namespace Nest
 		
 
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
-		public IndicesFlushSyncedDescriptor FilterPath(string filter_path)
+		public SyncedFlushDescriptor FilterPath(string filter_path)
 		{
 			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
-		}
-		
-		
-		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<IndicesFlushSyncedRequestParameters> pathInfo)
-		{
-			throw new NotImplementedException();
 		}
 		
 	

--- a/src/Nest/DSL/_Descriptors.generated.cs
+++ b/src/Nest/DSL/_Descriptors.generated.cs
@@ -2439,7 +2439,7 @@ namespace Nest
 	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html
 	///</pre>
 	///</summary>
-	public partial class FieldStatsDescriptor  : BaseRequest<FieldStatsRequestParameters>
+	public partial class FieldStatsDescriptor 
 	{
 		
 	
@@ -2508,12 +2508,6 @@ namespace Nest
 		{
 			this.Request.RequestParameters.FilterPath(filter_path);
 			return this;
-		}
-		
-		
-		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo)
-		{
-			throw new NotImplementedException();
 		}
 		
 	

--- a/src/Nest/DSL/_Requests.generated.cs
+++ b/src/Nest/DSL/_Requests.generated.cs
@@ -3576,7 +3576,7 @@ namespace Nest
 	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
 	///</pre>
 	///</summary>
-	public partial class IndicesFlushSyncedRequest  : BasePathRequest<IndicesFlushSyncedRequestParameters>
+	public partial class SyncedFlushRequest 
 			{
 		
 		///<summary>The URL-encoded request definition</summary>
@@ -3594,12 +3594,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
 		}
 		
-
-		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<IndicesFlushSyncedRequestParameters> pathInfo)
-		{
-			throw new NotImplementedException();
-		}
-
 	}
 	
 		

--- a/src/Nest/DSL/_Requests.generated.cs
+++ b/src/Nest/DSL/_Requests.generated.cs
@@ -21,6 +21,22 @@ namespace Nest
 	///</summary>
 	public partial class AbortBenchmarkRequest  : BasePathRequest<AbortBenchmarkRequestParameters>
 			{
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<AbortBenchmarkRequestParameters> pathInfo)
 		{
@@ -32,7 +48,7 @@ namespace Nest
 		
 	///<summary>Request parameters for Bulk
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-bulk.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-bulk.html
 	///</pre>
 	///</summary>
 	public partial class BulkRequest 
@@ -85,12 +101,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatAliases
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-alias.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-alias.html
 	///</pre>
 	///</summary>
 	public partial class CatAliasesRequest 
@@ -135,12 +167,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatAllocation
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-allocation.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-allocation.html
 	///</pre>
 	///</summary>
 	public partial class CatAllocationRequest 
@@ -193,12 +241,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatCount
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-count.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-count.html
 	///</pre>
 	///</summary>
 	public partial class CatCountRequest 
@@ -243,12 +307,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatFielddata
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html
 	///</pre>
 	///</summary>
 	public partial class CatFielddataRequest 
@@ -309,12 +389,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("fields", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatHealth
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-health.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-health.html
 	///</pre>
 	///</summary>
 	public partial class CatHealthRequest 
@@ -367,12 +463,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatHelp
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat.html
 	///</pre>
 	///</summary>
 	public partial class CatHelpRequest  : BasePathRequest<CatHelpRequestParameters>
@@ -383,6 +495,22 @@ namespace Nest
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("help"); } 
 			set { this.Request.RequestParameters.AddQueryString("help", value); }
+		}
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
 		}
 		
 
@@ -396,7 +524,7 @@ namespace Nest
 		
 	///<summary>Request parameters for CatIndices
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-indices.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-indices.html
 	///</pre>
 	///</summary>
 	public partial class CatIndicesRequest 
@@ -457,12 +585,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatMaster
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-master.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-master.html
 	///</pre>
 	///</summary>
 	public partial class CatMasterRequest 
@@ -507,12 +651,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatNodes
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-nodes.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-nodes.html
 	///</pre>
 	///</summary>
 	public partial class CatNodesRequest 
@@ -557,12 +717,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatPendingTasks
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-pending-tasks.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-pending-tasks.html
 	///</pre>
 	///</summary>
 	public partial class CatPendingTasksRequest 
@@ -607,12 +783,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatPlugins
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-plugins.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html
 	///</pre>
 	///</summary>
 	public partial class CatPluginsRequest 
@@ -657,12 +849,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatRecovery
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-recovery.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-recovery.html
 	///</pre>
 	///</summary>
 	public partial class CatRecoveryRequest 
@@ -707,12 +915,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatSegments
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html
 	///</pre>
 	///</summary>
 	public partial class CatSegmentsRequest 
@@ -741,12 +965,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatShards
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cat-shards.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cat-shards.html
 	///</pre>
 	///</summary>
 	public partial class CatShardsRequest 
@@ -791,12 +1031,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("v", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for CatThreadPool
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html
 	///</pre>
 	///</summary>
 	public partial class CatThreadPoolRequest 
@@ -849,22 +1105,54 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("full_id", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ClearScroll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html
 	///</pre>
 	///</summary>
 	public partial class ClearScrollRequest 
 			{
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ClusterGetSettings
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html
 	///</pre>
 	///</summary>
 	public partial class ClusterGetSettingsRequest 
@@ -893,12 +1181,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ClusterHealth
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-health.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-health.html
 	///</pre>
 	///</summary>
 	public partial class ClusterHealthRequest 
@@ -967,12 +1271,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("wait_for_status", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ClusterPendingTasks
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-pending.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-pending.html
 	///</pre>
 	///</summary>
 	public partial class ClusterPendingTasksRequest 
@@ -993,12 +1313,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ClusterPutSettings
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-update-settings.html
 	///</pre>
 	///</summary>
 	public partial class ClusterSettingsRequest 
@@ -1027,12 +1363,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ClusterReroute
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-reroute.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-reroute.html
 	///</pre>
 	///</summary>
 	public partial class ClusterRerouteRequest 
@@ -1077,12 +1429,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ClusterState
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-state.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-state.html
 	///</pre>
 	///</summary>
 	public partial class ClusterStateRequest 
@@ -1135,12 +1503,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ClusterStats
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-stats.html
 	///</pre>
 	///</summary>
 	public partial class ClusterStatsRequest 
@@ -1161,12 +1545,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("human", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Count
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html
 	///</pre>
 	///</summary>
 	public partial class CountRequest<T> 
@@ -1220,23 +1620,61 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public string Source 
+		///<summary>Query in the Lucene query string syntax</summary>
+		public string Q 
 		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("q"); } 
+			set { this.Request.RequestParameters.AddQueryString("q", value); }
 		}
 		
-	}
-	
 		
-	///<summary>Request parameters for CountPercolateGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
-	///</pre>
-	///</summary>
-	public partial class PercolateCountRequest<TDocument> 
-			{
+		///<summary>The analyzer to use for the query string</summary>
+		public string Analyzer 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("analyzer"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyzer", value); }
+		}
+		
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public bool AnalyzeWildcard 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("analyze_wildcard"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyze_wildcard", value); }
+		}
+		
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public DefaultOperator DefaultOperator 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<DefaultOperator>("default_operator"); } 
+			set { this.Request.RequestParameters.AddQueryString("default_operator", value); }
+		}
+		
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public string Df 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("df"); } 
+			set { this.Request.RequestParameters.AddQueryString("df", value); }
+		}
+		
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public bool Lenient 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lenient"); } 
+			set { this.Request.RequestParameters.AddQueryString("lenient", value); }
+		}
+		
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public bool LowercaseExpandedTerms 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lowercase_expanded_terms"); } 
+			set { this.Request.RequestParameters.AddQueryString("lowercase_expanded_terms", value); }
+		}
+		
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -1245,6 +1683,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for CountPercolateGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
+	///</pre>
+	///</summary>
+	public partial class PercolateCountRequest<TDocument> 
+			{
 		
 		///<summary>A comma-separated list of specific routing values</summary>
 		public  string[] Routing 
@@ -1317,12 +1773,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Delete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html
 	///</pre>
 	///</summary>
 	public partial class DeleteRequest<T> 
@@ -1391,12 +1863,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for DeleteByQuery
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html
 	///</pre>
 	///</summary>
 	public partial class DeleteByQueryRequest<T> 
@@ -1482,14 +1970,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public string Source 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
-		}
-		
-		
 		///<summary>Explicit operation timeout</summary>
 		public string Timeout 
 		{ 
@@ -1497,12 +1977,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for DeleteScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public partial class DeleteScriptRequest 
@@ -1523,12 +2019,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for DeleteTemplate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html
 	///</pre>
 	///</summary>
 	public partial class DeleteTemplateRequest 
@@ -1549,12 +2061,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Exists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class DocumentExistsRequest<T> 
@@ -1599,12 +2127,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("routing", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ExplainGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html
 	///</pre>
 	///</summary>
 	public partial class ExplainRequest<T> 
@@ -1698,14 +2242,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public string Source 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
-		}
-		
-		
 		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
 		[Obsolete("Scheduled to be removed in 2.0, use EnableSource instead")]
 		public  string[] SourceEnabled 
@@ -1738,12 +2274,100 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("_source_include", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for FieldStatsGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html
+	///</pre>
+	///</summary>
+	public partial class FieldStatsRequest  : BasePathRequest<FieldStatsRequestParameters>
+			{
+		
+		///<summary>A comma-separated list of fields for to get field statistics for (min value, max value, and more)</summary>
+		public IList<PropertyPathMarker> Fields 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<IList<PropertyPathMarker>>("fields"); } 
+			set { this.Request.RequestParameters.AddQueryString("fields", value); }
+		}
+		
+		
+		///<summary>Defines if field stats should be returned on a per index level or on a cluster wide level</summary>
+		public Level Level 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<Level>("level"); } 
+			set { this.Request.RequestParameters.AddQueryString("level", value); }
+		}
+		
+		
+		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
+		public bool IgnoreUnavailable 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("ignore_unavailable"); } 
+			set { this.Request.RequestParameters.AddQueryString("ignore_unavailable", value); }
+		}
+		
+		
+		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
+		public bool AllowNoIndices 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("allow_no_indices"); } 
+			set { this.Request.RequestParameters.AddQueryString("allow_no_indices", value); }
+		}
+		
+		
+		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+		public ExpandWildcards ExpandWildcards 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<ExpandWildcards>("expand_wildcards"); } 
+			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
+		}
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo)
+		{
+			throw new NotImplementedException();
+		}
+
 	}
 	
 		
 	///<summary>Request parameters for Get
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class GetRequest<T> 
@@ -1845,12 +2469,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for GetScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public partial class GetScriptRequest 
@@ -1871,12 +2511,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for GetSource
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class SourceRequest<T> 
@@ -1970,12 +2626,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for GetTemplate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-template.html
 	///</pre>
 	///</summary>
 	public partial class GetTemplateRequest 
@@ -1996,12 +2668,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Index
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-index_.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-index_.html
 	///</pre>
 	///</summary>
 	public partial class IndexRequest<TDocument> 
@@ -2094,16 +2782,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for IndicesAnalyzeGetForAll
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-analyze.html
-	///</pre>
-	///</summary>
-	public partial class AnalyzeRequest 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -2112,6 +2790,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for IndicesAnalyzeGetForAll
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-analyze.html
+	///</pre>
+	///</summary>
+	public partial class AnalyzeRequest 
+			{
 		
 		///<summary>The name of the analyzer to use</summary>
 		public string Analyzer 
@@ -2184,12 +2880,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("format", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesClearCacheForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-clearcache.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-clearcache.html
 	///</pre>
 	///</summary>
 	public partial class ClearCacheRequest 
@@ -2298,12 +3010,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("query_cache", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesClose
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html
 	///</pre>
 	///</summary>
 	public partial class CloseIndexRequest 
@@ -2348,12 +3076,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesCreate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-create-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-create-index.html
 	///</pre>
 	///</summary>
 	public partial class CreateIndexRequest 
@@ -2374,12 +3118,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesDelete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-index.html
 	///</pre>
 	///</summary>
 	public partial class DeleteIndexRequest 
@@ -2400,12 +3160,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesDeleteAlias
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class DeleteAliasRequest 
@@ -2426,12 +3202,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesDeleteMapping
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html
 	///</pre>
 	///</summary>
 	public partial class DeleteMappingRequest<T> 
@@ -2444,12 +3236,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesDeleteWarmer
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public partial class DeleteWarmerRequest 
@@ -2462,12 +3270,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesExists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-exists.html
 	///</pre>
 	///</summary>
 	public partial class IndexExistsRequest 
@@ -2504,12 +3328,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesExistsAliasForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class AliasExistsRequest 
@@ -2546,12 +3386,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesExistsTemplateForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html
 	///</pre>
 	///</summary>
 	public partial class TemplateExistsRequest 
@@ -2572,12 +3428,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesExistsType
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-types-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-types-exists.html
 	///</pre>
 	///</summary>
 	public partial class TypeExistsRequest 
@@ -2614,12 +3486,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesFlushForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-flush.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-flush.html
 	///</pre>
 	///</summary>
 	public partial class FlushRequest 
@@ -2664,12 +3552,60 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for IndicesFlushSyncedForAll
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
+	///</pre>
+	///</summary>
+	public partial class IndicesFlushSyncedRequest  : BasePathRequest<IndicesFlushSyncedRequestParameters>
+			{
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+
+		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<IndicesFlushSyncedRequestParameters> pathInfo)
+		{
+			throw new NotImplementedException();
+		}
+
 	}
 	
 		
 	///<summary>Request parameters for IndicesGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-index.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-index.html
 	///</pre>
 	///</summary>
 	public partial class GetIndexRequest 
@@ -2706,12 +3642,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetAliasForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class GetAliasRequest 
@@ -2748,12 +3700,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetAliasesForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class GetAliasesRequest 
@@ -2774,12 +3742,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetFieldMappingForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html
 	///</pre>
 	///</summary>
 	public partial class GetFieldMappingRequest<T> 
@@ -2824,12 +3808,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetMappingForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html
 	///</pre>
 	///</summary>
 	public partial class GetMappingRequest<T> 
@@ -2866,12 +3866,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetSettingsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-settings.html
 	///</pre>
 	///</summary>
 	public partial class GetIndexSettingsRequest 
@@ -2916,12 +3932,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetUpgradeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
 	///</pre>
 	///</summary>
 	public partial class UpgradeStatusRequest 
@@ -2958,12 +3990,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("human", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetWarmerForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public partial class GetWarmerRequest 
@@ -3000,12 +4048,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesOpen
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-open-close.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-open-close.html
 	///</pre>
 	///</summary>
 	public partial class OpenIndexRequest 
@@ -3050,12 +4114,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesOptimizeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-optimize.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-optimize.html
 	///</pre>
 	///</summary>
 	public partial class OptimizeRequest 
@@ -3132,12 +4212,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("force", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesPutAlias
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class PutAliasRequest 
@@ -3158,12 +4254,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesPutMapping
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html
 	///</pre>
 	///</summary>
 	public partial class PutMappingRequest<T> 
@@ -3216,12 +4328,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesPutSettingsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-update-settings.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-update-settings.html
 	///</pre>
 	///</summary>
 	public partial class UpdateSettingsRequest 
@@ -3266,12 +4394,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("flat_settings", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesPutTemplateForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-templates.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-templates.html
 	///</pre>
 	///</summary>
 	public partial class PutTemplateRequest 
@@ -3308,12 +4452,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("flat_settings", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesPutWarmerForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-warmers.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-warmers.html
 	///</pre>
 	///</summary>
 	public partial class PutWarmerRequest 
@@ -3350,12 +4510,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesRecoveryForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html
 	///</pre>
 	///</summary>
 	public partial class RecoveryStatusRequest 
@@ -3384,12 +4560,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("human", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesRefreshForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-refresh.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-refresh.html
 	///</pre>
 	///</summary>
 	public partial class RefreshRequest 
@@ -3434,12 +4626,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("operation_threading", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesSegmentsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-segments.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-segments.html
 	///</pre>
 	///</summary>
 	public partial class SegmentsRequest 
@@ -3484,12 +4692,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("operation_threading", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesStatsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-stats.html
 	///</pre>
 	///</summary>
 	public partial class IndicesStatsRequest 
@@ -3542,12 +4766,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("level", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesStatusForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-status.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-status.html
 	///</pre>
 	///</summary>
 	public partial class IndicesStatusRequest 
@@ -3608,12 +4848,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("snapshot", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesUpdateAliasesForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-aliases.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-aliases.html
 	///</pre>
 	///</summary>
 	public partial class AliasRequest 
@@ -3634,12 +4890,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesUpgradeForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
 	///</pre>
 	///</summary>
 	public partial class UpgradeRequest 
@@ -3676,12 +4948,36 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("wait_for_completion", value); }
 		}
 		
+		
+		///<summary>If true, only ancient (an older Lucene major release) segments will be upgraded</summary>
+		public bool OnlyAncientSegments 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("only_ancient_segments"); } 
+			set { this.Request.RequestParameters.AddQueryString("only_ancient_segments", value); }
+		}
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesValidateQueryGetForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html
 	///</pre>
 	///</summary>
 	public partial class ValidateQueryRequest<T> 
@@ -3727,14 +5023,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public string Source 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
-		}
-		
-		
 		///<summary>Query in the Lucene query string syntax</summary>
 		public string Q 
 		{ 
@@ -3742,16 +5030,96 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("q", value); }
 		}
 		
+		
+		///<summary>The analyzer to use for the query string</summary>
+		public string Analyzer 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("analyzer"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyzer", value); }
+		}
+		
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public bool AnalyzeWildcard 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("analyze_wildcard"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyze_wildcard", value); }
+		}
+		
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public DefaultOperator DefaultOperator 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<DefaultOperator>("default_operator"); } 
+			set { this.Request.RequestParameters.AddQueryString("default_operator", value); }
+		}
+		
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public string Df 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("df"); } 
+			set { this.Request.RequestParameters.AddQueryString("df", value); }
+		}
+		
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public bool Lenient 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lenient"); } 
+			set { this.Request.RequestParameters.AddQueryString("lenient", value); }
+		}
+		
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public bool LowercaseExpandedTerms 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lowercase_expanded_terms"); } 
+			set { this.Request.RequestParameters.AddQueryString("lowercase_expanded_terms", value); }
+		}
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Info
 	///<pre>
-	///http://www.elasticsearch.org/guide/
+	///http://www.elastic.co/guide/
 	///</pre>
 	///</summary>
 	public partial class InfoRequest 
 			{
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
@@ -3762,6 +5130,22 @@ namespace Nest
 	///</summary>
 	public partial class ListBenchmarksRequest  : BasePathRequest<ListBenchmarksRequestParameters>
 			{
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 
 		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<ListBenchmarksRequestParameters> pathInfo)
 		{
@@ -3773,19 +5157,11 @@ namespace Nest
 		
 	///<summary>Request parameters for MgetGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-get.html
 	///</pre>
 	///</summary>
 	public partial class MultiGetRequest 
 			{
-		
-		///<summary>The URL-encoded request definition</summary>
-		public string Source 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
-		}
-		
 		
 		///<summary>A comma-separated list of fields to return in the response</summary>
 		public IList<PropertyPathMarker> Fields 
@@ -3851,16 +5227,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("_source_include", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for MltGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html
-	///</pre>
-	///</summary>
-	public partial class MoreLikeThisRequest<T> 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -3869,6 +5235,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for MltGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html
+	///</pre>
+	///</summary>
+	public partial class MoreLikeThisRequest<T> 
+			{
 		
 		///<summary>The boost factor</summary>
 		public double BoostTerms 
@@ -4013,16 +5397,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("stop_words", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for MpercolateGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
-	///</pre>
-	///</summary>
-	public partial class MultiPercolateRequest 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -4031,6 +5405,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for MpercolateGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
+	///</pre>
+	///</summary>
+	public partial class MultiPercolateRequest 
+			{
 		
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public bool IgnoreUnavailable 
@@ -4055,16 +5447,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for MsearchGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-multi-search.html
-	///</pre>
-	///</summary>
-	public partial class MultiSearchRequest 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -4073,6 +5455,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for MsearchGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-multi-search.html
+	///</pre>
+	///</summary>
+	public partial class MultiSearchRequest 
+			{
 		
 		///<summary>Search operation type</summary>
 		public SearchType SearchType 
@@ -4081,16 +5481,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("search_type", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for MtermvectorsGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-multi-termvectors.html
-	///</pre>
-	///</summary>
-	public partial class MultiTermVectorsRequest 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -4099,6 +5489,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for MtermvectorsGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-multi-termvectors.html
+	///</pre>
+	///</summary>
+	public partial class MultiTermVectorsRequest 
+			{
 		
 		///<summary>Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body &quot;params&quot; or &quot;docs&quot;.</summary>
 		public bool TermStatistics 
@@ -4179,12 +5587,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("realtime", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for NodesHotThreadsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-hot-threads.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-hot-threads.html
 	///</pre>
 	///</summary>
 	public partial class NodesHotThreadsRequest 
@@ -4229,12 +5653,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for NodesInfoForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-info.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-info.html
 	///</pre>
 	///</summary>
 	public partial class NodesInfoRequest 
@@ -4255,12 +5695,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("human", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for NodesShutdownForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-shutdown.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-shutdown.html
 	///</pre>
 	///</summary>
 	public partial class NodesShutdownRequest 
@@ -4281,12 +5737,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("exit", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for NodesStatsForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/cluster-nodes-stats.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/cluster-nodes-stats.html
 	///</pre>
 	///</summary>
 	public partial class NodesStatsRequest 
@@ -4347,16 +5819,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("types", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for PercolateGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-percolate.html
-	///</pre>
-	///</summary>
-	public partial class PercolateRequest<TDocument> 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -4365,6 +5827,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for PercolateGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-percolate.html
+	///</pre>
+	///</summary>
+	public partial class PercolateRequest<TDocument> 
+			{
 		
 		///<summary>A comma-separated list of specific routing values</summary>
 		public  string[] Routing 
@@ -4461,22 +5941,54 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Ping
 	///<pre>
-	///http://www.elasticsearch.org/guide/
+	///http://www.elastic.co/guide/
 	///</pre>
 	///</summary>
 	public partial class PingRequest 
 			{
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for PutScript
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
 	///</pre>
 	///</summary>
 	public partial class PutScriptRequest 
@@ -4505,12 +6017,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ScrollGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-scroll.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-scroll.html
 	///</pre>
 	///</summary>
 	public partial class ScrollRequest 
@@ -4523,12 +6051,20 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SearchGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html
 	///</pre>
 	///</summary>
 	public partial class SearchRequest<T> 
@@ -4685,12 +6221,20 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("query_cache", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SearchExists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
 	///</pre>
 	///</summary>
 	public partial class SearchExistsRequest<T> 
@@ -4744,11 +6288,75 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>Query in the Lucene query string syntax</summary>
+		public string Q 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("q"); } 
+			set { this.Request.RequestParameters.AddQueryString("q", value); }
+		}
+		
+		
+		///<summary>The analyzer to use for the query string</summary>
+		public string Analyzer 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("analyzer"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyzer", value); }
+		}
+		
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public bool AnalyzeWildcard 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("analyze_wildcard"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyze_wildcard", value); }
+		}
+		
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public DefaultOperator DefaultOperator 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<DefaultOperator>("default_operator"); } 
+			set { this.Request.RequestParameters.AddQueryString("default_operator", value); }
+		}
+		
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public string Df 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("df"); } 
+			set { this.Request.RequestParameters.AddQueryString("df", value); }
+		}
+		
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public bool Lenient 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lenient"); } 
+			set { this.Request.RequestParameters.AddQueryString("lenient", value); }
+		}
+		
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public bool LowercaseExpandedTerms 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lowercase_expanded_terms"); } 
+			set { this.Request.RequestParameters.AddQueryString("lowercase_expanded_terms", value); }
+		}
+		
+		
+		///<summary>The URL-encoded request definition</summary>
 		public string Source 
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
 		}
 		
 	}
@@ -4756,7 +6364,7 @@ namespace Nest
 		
 	///<summary>Request parameters for SearchShardsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html
 	///</pre>
 	///</summary>
 	public partial class SearchShardsRequest<T> 
@@ -4809,16 +6417,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for SearchTemplateGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html
-	///</pre>
-	///</summary>
-	public partial class SearchTemplateRequest<T> 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -4827,6 +6425,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for SearchTemplateGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html
+	///</pre>
+	///</summary>
+	public partial class SearchTemplateRequest<T> 
+			{
 		
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public bool IgnoreUnavailable 
@@ -4883,12 +6499,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("search_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotCreate
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class SnapshotRequest 
@@ -4909,12 +6541,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("wait_for_completion", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotCreateRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class CreateRepositoryRequest 
@@ -4943,12 +6591,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("verify", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotDelete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class DeleteSnapshotRequest 
@@ -4961,12 +6625,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotDeleteRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class DeleteRepositoryRequest 
@@ -4987,12 +6667,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class GetSnapshotRequest 
@@ -5005,12 +6701,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotGetRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class GetRepositoryRequest 
@@ -5031,12 +6743,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotRestore
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class RestoreRequest 
@@ -5057,12 +6785,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("wait_for_completion", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotStatus
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class SnapshotStatusRequest 
@@ -5075,12 +6819,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SnapshotVerifyRepository
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
 	///</pre>
 	///</summary>
 	public partial class VerifyRepositoryRequest 
@@ -5101,12 +6861,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Suggest
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-suggesters.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-suggesters.html
 	///</pre>
 	///</summary>
 	public partial class SuggestRequest 
@@ -5152,24 +6928,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded request definition (instead of using request body)</summary>
-		public string Source 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
-		}
-		
-	}
-	
-		
-	///<summary>Request parameters for TermvectorGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html
-	///</pre>
-	///</summary>
-	public partial class TermvectorRequest<T> 
-			{
-		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
 		{ 
@@ -5177,6 +6935,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for TermvectorGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html
+	///</pre>
+	///</summary>
+	public partial class TermvectorRequest<T> 
+			{
 		
 		///<summary>Specifies if total term frequency and document frequency should be returned.</summary>
 		public bool TermStatistics 
@@ -5257,12 +7033,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("realtime", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Update
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-update.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-update.html
 	///</pre>
 	///</summary>
 	public partial class UpdateRequest<TDocument,TPartialDocument> 
@@ -5284,7 +7076,7 @@ namespace Nest
 		}
 		
 		
-		///<summary>ID of the parent document</summary>
+		///<summary>ID of the parent document. Is is only used for routing and when for the upsert request</summary>
 		public string Parent 
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<string>("parent"); } 
@@ -5387,12 +7179,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Count
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-count.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-count.html
 	///</pre>
 	///</summary>
 	public partial class CountRequest 
@@ -5446,11 +7254,75 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>Query in the Lucene query string syntax</summary>
+		public string Q 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("q"); } 
+			set { this.Request.RequestParameters.AddQueryString("q", value); }
+		}
+		
+		
+		///<summary>The analyzer to use for the query string</summary>
+		public string Analyzer 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("analyzer"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyzer", value); }
+		}
+		
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public bool AnalyzeWildcard 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("analyze_wildcard"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyze_wildcard", value); }
+		}
+		
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public DefaultOperator DefaultOperator 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<DefaultOperator>("default_operator"); } 
+			set { this.Request.RequestParameters.AddQueryString("default_operator", value); }
+		}
+		
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public string Df 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("df"); } 
+			set { this.Request.RequestParameters.AddQueryString("df", value); }
+		}
+		
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public bool Lenient 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lenient"); } 
+			set { this.Request.RequestParameters.AddQueryString("lenient", value); }
+		}
+		
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public bool LowercaseExpandedTerms 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lowercase_expanded_terms"); } 
+			set { this.Request.RequestParameters.AddQueryString("lowercase_expanded_terms", value); }
+		}
+		
+		
+		///<summary>The URL-encoded request definition</summary>
 		public string Source 
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
 		}
 		
 	}
@@ -5458,7 +7330,7 @@ namespace Nest
 		
 	///<summary>Request parameters for Delete
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete.html
 	///</pre>
 	///</summary>
 	public partial class DeleteRequest 
@@ -5527,12 +7399,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for DeleteByQuery
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-delete-by-query.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-delete-by-query.html
 	///</pre>
 	///</summary>
 	public partial class DeleteByQueryRequest 
@@ -5618,14 +7506,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public string Source 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
-		}
-		
-		
 		///<summary>Explicit operation timeout</summary>
 		public string Timeout 
 		{ 
@@ -5633,12 +7513,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Exists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class DocumentExistsRequest 
@@ -5683,12 +7579,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("routing", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for ExplainGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-explain.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-explain.html
 	///</pre>
 	///</summary>
 	public partial class ExplainRequest 
@@ -5782,14 +7694,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public string Source 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
-		}
-		
-		
 		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
 		[Obsolete("Scheduled to be removed in 2.0, use EnableSource instead")]
 		public  string[] SourceEnabled 
@@ -5822,12 +7726,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("_source_include", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for Get
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class GetRequest 
@@ -5929,12 +7849,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for GetSource
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-get.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-get.html
 	///</pre>
 	///</summary>
 	public partial class SourceRequest 
@@ -6028,12 +7964,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("version_type", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesDeleteMapping
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-delete-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-delete-mapping.html
 	///</pre>
 	///</summary>
 	public partial class DeleteMappingRequest 
@@ -6046,12 +7998,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("master_timeout", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetFieldMappingForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-field-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-field-mapping.html
 	///</pre>
 	///</summary>
 	public partial class GetFieldMappingRequest 
@@ -6096,12 +8064,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesGetMappingForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-get-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-get-mapping.html
 	///</pre>
 	///</summary>
 	public partial class GetMappingRequest 
@@ -6138,12 +8122,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("local", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesPutMapping
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/indices-put-mapping.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/indices-put-mapping.html
 	///</pre>
 	///</summary>
 	public partial class PutMappingRequest 
@@ -6196,12 +8196,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for IndicesValidateQueryGetForAll
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-validate.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-validate.html
 	///</pre>
 	///</summary>
 	public partial class ValidateQueryRequest 
@@ -6247,14 +8263,6 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
-		public string Source 
-		{ 
-			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
-			set { this.Request.RequestParameters.AddQueryString("source", value); }
-		}
-		
-		
 		///<summary>Query in the Lucene query string syntax</summary>
 		public string Q 
 		{ 
@@ -6262,16 +8270,54 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("q", value); }
 		}
 		
-	}
-	
 		
-	///<summary>Request parameters for MltGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-more-like-this.html
-	///</pre>
-	///</summary>
-	public partial class MoreLikeThisRequest 
-			{
+		///<summary>The analyzer to use for the query string</summary>
+		public string Analyzer 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("analyzer"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyzer", value); }
+		}
+		
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public bool AnalyzeWildcard 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("analyze_wildcard"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyze_wildcard", value); }
+		}
+		
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public DefaultOperator DefaultOperator 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<DefaultOperator>("default_operator"); } 
+			set { this.Request.RequestParameters.AddQueryString("default_operator", value); }
+		}
+		
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public string Df 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("df"); } 
+			set { this.Request.RequestParameters.AddQueryString("df", value); }
+		}
+		
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public bool Lenient 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lenient"); } 
+			set { this.Request.RequestParameters.AddQueryString("lenient", value); }
+		}
+		
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public bool LowercaseExpandedTerms 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lowercase_expanded_terms"); } 
+			set { this.Request.RequestParameters.AddQueryString("lowercase_expanded_terms", value); }
+		}
+		
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -6280,6 +8326,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for MltGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-more-like-this.html
+	///</pre>
+	///</summary>
+	public partial class MoreLikeThisRequest 
+			{
 		
 		///<summary>The boost factor</summary>
 		public double BoostTerms 
@@ -6424,12 +8488,28 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("stop_words", value); }
 		}
 		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SearchGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-search.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-search.html
 	///</pre>
 	///</summary>
 	public partial class SearchRequest 
@@ -6586,12 +8666,20 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("query_cache", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
 	}
 	
 		
 	///<summary>Request parameters for SearchExists
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
 	///</pre>
 	///</summary>
 	public partial class SearchExistsRequest 
@@ -6645,11 +8733,75 @@ namespace Nest
 		}
 		
 		
-		///<summary>The URL-encoded query definition (instead of using the request body)</summary>
+		///<summary>Query in the Lucene query string syntax</summary>
+		public string Q 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("q"); } 
+			set { this.Request.RequestParameters.AddQueryString("q", value); }
+		}
+		
+		
+		///<summary>The analyzer to use for the query string</summary>
+		public string Analyzer 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("analyzer"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyzer", value); }
+		}
+		
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public bool AnalyzeWildcard 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("analyze_wildcard"); } 
+			set { this.Request.RequestParameters.AddQueryString("analyze_wildcard", value); }
+		}
+		
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public DefaultOperator DefaultOperator 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<DefaultOperator>("default_operator"); } 
+			set { this.Request.RequestParameters.AddQueryString("default_operator", value); }
+		}
+		
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public string Df 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("df"); } 
+			set { this.Request.RequestParameters.AddQueryString("df", value); }
+		}
+		
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public bool Lenient 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lenient"); } 
+			set { this.Request.RequestParameters.AddQueryString("lenient", value); }
+		}
+		
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public bool LowercaseExpandedTerms 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lowercase_expanded_terms"); } 
+			set { this.Request.RequestParameters.AddQueryString("lowercase_expanded_terms", value); }
+		}
+		
+		
+		///<summary>The URL-encoded request definition</summary>
 		public string Source 
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
 		}
 		
 	}
@@ -6657,7 +8809,7 @@ namespace Nest
 		
 	///<summary>Request parameters for SearchShardsGet
 	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html
 	///</pre>
 	///</summary>
 	public partial class SearchShardsRequest 
@@ -6710,16 +8862,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("expand_wildcards", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for SearchTemplateGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html
-	///</pre>
-	///</summary>
-	public partial class SearchTemplateRequest 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -6728,6 +8870,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for SearchTemplateGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html
+	///</pre>
+	///</summary>
+	public partial class SearchTemplateRequest 
+			{
 		
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public bool IgnoreUnavailable 
@@ -6784,16 +8944,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("search_type", value); }
 		}
 		
-	}
-	
-		
-	///<summary>Request parameters for TermvectorGet
-	///<pre>
-	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/docs-termvectors.html
-	///</pre>
-	///</summary>
-	public partial class TermvectorRequest 
-			{
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source 
@@ -6802,6 +8952,24 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("source", value); }
 		}
 		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
+		}
+		
+	}
+	
+		
+	///<summary>Request parameters for TermvectorGet
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/1.6/docs-termvectors.html
+	///</pre>
+	///</summary>
+	public partial class TermvectorRequest 
+			{
 		
 		///<summary>Specifies if total term frequency and document frequency should be returned.</summary>
 		public bool TermStatistics 
@@ -6880,6 +9048,22 @@ namespace Nest
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("realtime"); } 
 			set { this.Request.RequestParameters.AddQueryString("realtime", value); }
+		}
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("source"); } 
+			set { this.Request.RequestParameters.AddQueryString("source", value); }
+		}
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<string>("filter_path"); } 
+			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
 		}
 		
 	}

--- a/src/Nest/DSL/_Requests.generated.cs
+++ b/src/Nest/DSL/_Requests.generated.cs
@@ -2298,7 +2298,7 @@ namespace Nest
 	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html
 	///</pre>
 	///</summary>
-	public partial class FieldStatsRequest  : BasePathRequest<FieldStatsRequestParameters>
+	public partial class FieldStatsRequest 
 			{
 		
 		///<summary>A comma-separated list of fields for to get field statistics for (min value, max value, and more)</summary>
@@ -2356,12 +2356,6 @@ namespace Nest
 			set { this.Request.RequestParameters.AddQueryString("filter_path", value); }
 		}
 		
-
-		protected override void UpdatePathInfo(IConnectionSettingsValues settings, ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo)
-		{
-			throw new NotImplementedException();
-		}
-
 	}
 	
 		

--- a/src/Nest/DSL/_Requests.generated.cs
+++ b/src/Nest/DSL/_Requests.generated.cs
@@ -3567,7 +3567,7 @@ namespace Nest
 		
 	///<summary>Request parameters for IndicesFlushSyncedForAll
 	///<pre>
-	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html
 	///</pre>
 	///</summary>
 	public partial class SyncedFlushRequest 
@@ -5064,6 +5064,14 @@ namespace Nest
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lowercase_expanded_terms"); } 
 			set { this.Request.RequestParameters.AddQueryString("lowercase_expanded_terms", value); }
+		}
+		
+		
+		///<summary>Provide a more detailed explanation showing the actual Lucene query that will be executed.</summary>
+		public bool Rewrite 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("rewrite"); } 
+			set { this.Request.RequestParameters.AddQueryString("rewrite", value); }
 		}
 		
 		
@@ -8304,6 +8312,14 @@ namespace Nest
 		{ 
 			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("lowercase_expanded_terms"); } 
 			set { this.Request.RequestParameters.AddQueryString("lowercase_expanded_terms", value); }
+		}
+		
+		
+		///<summary>Provide a more detailed explanation showing the actual Lucene query that will be executed.</summary>
+		public bool Rewrite 
+		{ 
+			get { return this.Request.RequestParameters.GetQueryStringValue<bool>("rewrite"); } 
+			set { this.Request.RequestParameters.AddQueryString("rewrite", value); }
 		}
 		
 		

--- a/src/Nest/Domain/Cat/CatPluginsRecord.cs
+++ b/src/Nest/Domain/Cat/CatPluginsRecord.cs
@@ -5,6 +5,9 @@ namespace Nest
 	[JsonObject]
 	public class CatPluginsRecord : ICatRecord
 	{
+		[JsonProperty("id")]
+		public string Id { get; set; }
+
 		[JsonProperty("name")]
 		public string Name  { get; set; }
 
@@ -23,6 +26,7 @@ namespace Nest
 		[JsonProperty("url")]
 		public string Url { get; set; }
 
-
+		[JsonProperty("description")]
+		public string Description { get; set; }
 	}
 }

--- a/src/Nest/Domain/Cat/CatSegmentsRecord.cs
+++ b/src/Nest/Domain/Cat/CatSegmentsRecord.cs
@@ -21,6 +21,9 @@ namespace Nest
 		[JsonProperty("ip")]
 		public string Ip { get; set; }
 
+		[JsonProperty("id")]
+		public string Id { get; set; }
+
 		[JsonProperty("segment")]
 		public string Segment { get; set; }
 

--- a/src/Nest/Domain/Cat/CatShardsRecord.cs
+++ b/src/Nest/Domain/Cat/CatShardsRecord.cs
@@ -26,7 +26,157 @@ namespace Nest
 		[JsonProperty("ip")]
 		public string Ip { get; set; }
 
+		[JsonProperty("id")]
+		public string Id { get; set; }
+
 		[JsonProperty("node")]
 		public string Node { get; set; }
+
+		[JsonProperty("completion.size")]
+		public string CompletionSize { get; set; }
+
+		[JsonProperty("fielddata.memory_size")]
+		public string FielddataMemorySize { get; set; }
+
+		[JsonProperty("fielddata.evictions")]
+		public string FielddataEvictions { get; set; }
+
+		[JsonProperty("filter_cache.memory_size")]
+		public string FilterCacheMemorySize { get; set; }
+		
+		[JsonProperty("flush.total")]
+		public string FlushTotal { get; set; }
+
+		[JsonProperty("flush.total_time")]
+		public string FlushTotalTime { get; set; }
+
+		[JsonProperty("get.current")]
+		public string GetCurrent { get; set; }
+
+		[JsonProperty("get.time")]
+		public string GetTime { get; set; }
+
+		[JsonProperty("get.total")]
+		public string GetTotal { get; set; }
+
+		[JsonProperty("get.exists_time")]
+		public string GetExistsTime { get; set; }
+
+		[JsonProperty("get.exists_total")]
+		public string GetExistsTotal { get; set; }
+
+		[JsonProperty("get.missing_time")]
+		public string GetMissingTime { get; set; }
+
+		[JsonProperty("get.missing_total")]
+		public string GetMissingTotal { get; set; }
+
+		[JsonProperty("id_cache.memory_size")]
+		public string IdCacheMemorySize { get; set; }
+
+		[JsonProperty("indexing.delete_current")]
+		public string IndexingDeleteCurrent { get; set; }
+
+		[JsonProperty("indexing.delete_time")]
+		public string IndexingDeleteTime { get; set; }
+
+		[JsonProperty("indexing.delete_total")]
+		public string IndexingDeleteTotal { get; set; }
+
+		[JsonProperty("indexing.index_current")]
+		public string IndexingIndexCurrent { get; set; }
+
+		[JsonProperty("indexing.index_time")]
+		public string IndexingIndexTime { get; set; }
+
+		[JsonProperty("indexing.index_total")]
+		public string IndexingIndexTotal { get; set; }
+
+		[JsonProperty("merges.current")]
+		public string MergesCurrent { get; set; }
+
+		[JsonProperty("merges.current_docs")]
+		public string MergesCurrentDocs { get; set; }
+
+		[JsonProperty("merges.current_size")]
+		public string MergesCurrentSize { get; set; }
+		
+		[JsonProperty("merges.total_docs")]
+		public string MergesTotalDocs { get; set; }
+		
+		[JsonProperty("merges.total_size")]
+		public string MergesTotalSize { get; set; }
+	
+		[JsonProperty("merges.total_time")]
+		public string MergesTotalTime { get; set; }
+	
+		[JsonProperty("percolate.current")]
+		public string PercolateCurrent { get; set; }
+		
+		[JsonProperty("percolate.memory_size")]
+		public string PercolateMemorySize { get; set; }
+		
+		[JsonProperty("percolate.queries")]
+		public string PercolateQueries { get; set; }
+	
+		[JsonProperty("percolate.time")]
+		public string PercolateTime { get; set; }
+		
+		[JsonProperty("percolate.total")]
+		public string PercolateTotal { get; set; }
+		
+		[JsonProperty("refresh.total")]
+		public string RefreshTotal { get; set; }
+		
+		[JsonProperty("refresh.time")]
+		public string RefreshTime { get; set; }
+		
+		[JsonProperty("search.fetch_current")]
+		public string SearchFetchCurrent { get; set; }
+		
+		[JsonProperty("search.fetch_time")]
+		public string SearchFetchTime { get; set; }
+		
+		[JsonProperty("search.fetch_total")]
+		public string SearchFetchTotal { get; set; }
+		
+		[JsonProperty("search.open_contexts")]
+		public string SearchOpenContexts { get; set; }
+		
+		[JsonProperty("search.query_current")]
+		public string SearchQueryCurrent { get; set; }
+		
+		[JsonProperty("search.query_time")]
+		public string SearchQueryTime { get; set; }
+		
+		[JsonProperty("search.query_total")]
+		public string SearchQueryTotal { get; set; }
+		
+		[JsonProperty("segments.count")]
+		public string SegmentsCount { get; set; }
+		
+		[JsonProperty("segments.memory")]
+		public string SegmentsMemory { get; set; }
+		
+		[JsonProperty("segments.index_writer_memory")]
+		public string SegmentsIndexWriterMemory { get; set; }
+		
+		[JsonProperty("segments.index_writer_max_memory")]
+		public string SegmentsIndexWriterMaxMemory { get; set; }
+		
+		[JsonProperty("segments.version_map_memory")]
+		public string SegmentsVersionMapMemory { get; set; }
+		
+		[JsonProperty("segments.fixed_bitset_memory")]
+		public string SegmentsFixedBitsetMemory { get; set; }
+		
+		[JsonProperty("warmer.current")]
+		public string WarmerCurrent { get; set; }
+		
+		[JsonProperty("warmer.total")]
+		public string WarmerTotal { get; set; }
+		
+		[JsonProperty("warmer.total_time")]
+		public string WarmerTotalTime { get; set; }
 	}
 }

--- a/src/Nest/Domain/Hit/ValidationExplanation.cs
+++ b/src/Nest/Domain/Hit/ValidationExplanation.cs
@@ -10,10 +10,14 @@ namespace Nest
 	{
 		[JsonProperty(PropertyName = "index")]
 		public string Index { get; internal set; }
-		[JsonProperty(PropertyName = "description")]
+
+		[JsonProperty(PropertyName = "valid")]
 		public bool Valid { get; internal set; }
+		
 		[JsonProperty(PropertyName = "error")]
 		public string Error { get; internal set; }
 		
+		[JsonProperty(PropertyName = "explanation")]
+		public string Explanation { get; internal set; }
 	}
 }

--- a/src/Nest/Domain/Mapping/Descriptors/DateMappingDescriptor.cs
+++ b/src/Nest/Domain/Mapping/Descriptors/DateMappingDescriptor.cs
@@ -94,5 +94,11 @@ namespace Nest
 			this._Mapping.DocValues = docValues;
 			return this;
 		}
+
+		public DateMappingDescriptor<T> NumericResolution(NumericResolutionUnit unit)
+		{
+			this._Mapping.NumericResolution = unit;
+			return this;
+		}
 	}
 }

--- a/src/Nest/Domain/Mapping/Types/DateMapping.cs
+++ b/src/Nest/Domain/Mapping/Types/DateMapping.cs
@@ -41,5 +41,8 @@ namespace Nest
 
 		[JsonProperty("doc_values")]
 		public bool? DocValues { get; set; }
+
+		[JsonProperty("numeric_resolution")]
+		public NumericResolutionUnit NumericResolution { get; set; }
 	}
 }

--- a/src/Nest/Domain/RequestParametersExtensions.Generated.cs
+++ b/src/Nest/Domain/RequestParametersExtensions.Generated.cs
@@ -64,6 +64,18 @@ namespace Nest
 		}
 		
 		
+		///<summary>A comma-separated list of fields for to get field statistics for (min value, max value, and more)</summary>
+			internal static FieldStatsRequestParameters _Fields<T>(
+				this FieldStatsRequestParameters qs,
+				IEnumerable<Expression<Func<T, object>>>  fields)
+			where T : class
+		{
+			var _fields = fields.Select(e=>(PropertyPathMarker)e);
+			qs.AddQueryString("fields", _fields);
+			return qs;
+		}
+		
+		
 		///<summary>A comma-separated list of fields to return in the response</summary>
 			internal static GetRequestParameters _Fields<T>(
 				this GetRequestParameters qs,

--- a/src/Nest/Domain/Responses/FieldStatsResponse.cs
+++ b/src/Nest/Domain/Responses/FieldStatsResponse.cs
@@ -1,0 +1,55 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nest
+{
+	[JsonObject]
+	public interface IFieldStatsResponse : IResponse
+	{
+		[JsonProperty("_shards")]
+		ShardsMetaData Shards { get; set; }
+
+		[JsonProperty("indices")]
+		Dictionary<string, FieldStats> Indices { get; set; }
+	}
+
+	public class FieldStatsResponse : BaseResponse, IFieldStatsResponse
+	{
+		public ShardsMetaData Shards { get; set; }
+		public Dictionary<string, FieldStats> Indices { get; set; }
+	}
+
+	[JsonObject]
+	public class FieldStats
+	{
+		[JsonProperty("fields")]
+		public Dictionary<string, FieldStatsField> Fields { get; set; }
+	}
+
+	public class FieldStatsField
+	{
+		[JsonProperty("max_doc")]
+		public long MaxDoc { get; set; }
+
+		[JsonProperty("doc_count")]
+		public long DocCount { get; set; }
+
+		[JsonProperty("density")]
+		public long Density { get; set; }
+
+		[JsonProperty("sum_doc_freq")]
+		public long SumDocumentFrequency { get; set; }
+
+		[JsonProperty("sum_total_term_freq")]
+		public long SumTotalTermFrequency { get; set; }
+
+		[JsonProperty("min_value")]
+		public string MinValue { get; set; }
+
+		[JsonProperty("max_value")]
+		public string MaxValue { get; set; }
+	}
+}

--- a/src/Nest/ElasticClient-FieldStats.cs
+++ b/src/Nest/ElasticClient-FieldStats.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public partial class ElasticClient
+	{
+		public IFieldStatsResponse FieldStats(Func<FieldStatsDescriptor, FieldStatsDescriptor> selector)
+		{
+			return this.Dispatcher.Dispatch<FieldStatsDescriptor, FieldStatsRequestParameters, FieldStatsResponse>(
+				selector,
+				(p, d) => this.RawDispatch.FieldStatsDispatch<FieldStatsResponse>(p)
+			);
+		}
+
+		public IFieldStatsResponse FieldStats(IFieldStatsRequest request)
+		{
+			return this.Dispatcher.Dispatch<IFieldStatsRequest, FieldStatsRequestParameters, FieldStatsResponse>(
+				request,
+				(p, d) => this.RawDispatch.FieldStatsDispatch<FieldStatsResponse>(p)
+			);
+		}
+
+		public Task<IFieldStatsResponse> FieldStatsAsync(Func<FieldStatsDescriptor, FieldStatsDescriptor> selector)
+		{
+			return this.Dispatcher.DispatchAsync<FieldStatsDescriptor, FieldStatsRequestParameters, FieldStatsResponse, IFieldStatsResponse>(
+				selector,
+				(p, d) => this.RawDispatch.FieldStatsDispatchAsync<FieldStatsResponse>(p)
+			);
+		}
+
+		public Task<IFieldStatsResponse> FieldStatsAsync(IFieldStatsRequest request)
+		{
+			return this.Dispatcher.DispatchAsync<IFieldStatsRequest, FieldStatsRequestParameters, FieldStatsResponse, IFieldStatsResponse>(
+				request,
+				(p, d) => this.RawDispatch.FieldStatsDispatchAsync<FieldStatsResponse>(p)
+			);
+		}
+	}
+}

--- a/src/Nest/ElasticClient-Flush.cs
+++ b/src/Nest/ElasticClient-Flush.cs
@@ -43,5 +43,40 @@ namespace Nest
 			);
 		}
 
+		/// <inheritdoc />
+		public IShardsOperationResponse SyncedFlush(Func<SyncedFlushDescriptor, SyncedFlushDescriptor> selector)
+		{
+			return this.Dispatcher.Dispatch<SyncedFlushDescriptor, SyncedFlushRequestParameters, ShardsOperationResponse>(
+				selector,
+				(p, d) => this.RawDispatch.IndicesFlushSyncedDispatch<ShardsOperationResponse>(p)
+			);
+		}
+
+		/// <inheritdoc />
+		public IShardsOperationResponse SyncedFlush(ISyncedFlushRequest flushRequest)
+		{
+			return this.Dispatcher.Dispatch<ISyncedFlushRequest, SyncedFlushRequestParameters, ShardsOperationResponse>(
+				flushRequest,
+				(p, d) => this.RawDispatch.IndicesFlushSyncedDispatch<ShardsOperationResponse>(p)
+			);
+		}
+
+		/// <inheritdoc />
+		public Task<IShardsOperationResponse> SyncedFlushAsync(Func<SyncedFlushDescriptor, SyncedFlushDescriptor> selector)
+		{
+			return this.Dispatcher.DispatchAsync<SyncedFlushDescriptor, SyncedFlushRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+				selector,
+				(p, d) => this.RawDispatch.IndicesFlushSyncedDispatchAsync<ShardsOperationResponse>(p)
+			);
+		}
+
+		/// <inheritdoc />
+		public Task<IShardsOperationResponse> SyncedFlushAsync(ISyncedFlushRequest flushRequest)
+		{
+			return this.Dispatcher.DispatchAsync<ISyncedFlushRequest, SyncedFlushRequestParameters, ShardsOperationResponse, IShardsOperationResponse>(
+				flushRequest,
+				(p, d) => this.RawDispatch.IndicesFlushSyncedDispatchAsync<ShardsOperationResponse>(p)
+			);
+		}
 	}
 }

--- a/src/Nest/Enums/NumericResolutionUnit.cs
+++ b/src/Nest/Enums/NumericResolutionUnit.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Nest
+{
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum NumericResolutionUnit
+	{
+		[EnumMember(Value = "milliseconds")]
+		Milliseconds,
+		[EnumMember(Value = "seconds")]
+		Seconds
+	}
+}

--- a/src/Nest/IElasticClient.cs
+++ b/src/Nest/IElasticClient.cs
@@ -1786,5 +1786,11 @@ namespace Nest
 		ICatResponse<CatSegmentsRecord> CatSegments(ICatSegmentsRequest request);
 		Task<ICatResponse<CatSegmentsRecord>> CatSegmentsAsync(Func<CatSegmentsDescriptor, CatSegmentsDescriptor> selector = null);
 		Task<ICatResponse<CatSegmentsRecord>> CatSegmentsAsync(ICatSegmentsRequest request);
+
+		/// <inheritdoc />
+		IFieldStatsResponse FieldStats(Func<FieldStatsDescriptor, FieldStatsDescriptor> selector);
+		IFieldStatsResponse FieldStats(IFieldStatsRequest request);
+		Task<IFieldStatsResponse> FieldStatsAsync(Func<FieldStatsDescriptor, FieldStatsDescriptor> selector);
+		Task<IFieldStatsResponse> FieldStatsAsync(IFieldStatsRequest request);
 	}
 }

--- a/src/Nest/IElasticClient.cs
+++ b/src/Nest/IElasticClient.cs
@@ -492,6 +492,25 @@ namespace Nest
 		Task<IShardsOperationResponse> FlushAsync(IFlushRequest flushRequest);
 
 		/// <summary>
+		/// The Synced Flush API allows an administrator to initiate a synced flush manually. 
+		/// This can be particularly useful for a planned (rolling) cluster restart where you 
+		/// can stop indexing and don’t want to wait the default 5 minutes for idle indices to 
+		/// be sync-flushed automatically.
+		/// </summary>
+		/// <param name="selector">A descriptor that describes the parameters for the synced flush operation</param>
+		/// <returns></returns>
+		IShardsOperationResponse SyncedFlush(Func<SyncedFlushDescriptor, SyncedFlushDescriptor> selector);
+
+		/// <inheritdoc />
+		IShardsOperationResponse SyncedFlush(ISyncedFlushRequest flushRequest);
+
+		/// <inheritdoc />
+		Task<IShardsOperationResponse> SyncedFlushAsync(Func<SyncedFlushDescriptor, SyncedFlushDescriptor> selector);
+
+		/// <inheritdoc />
+		Task<IShardsOperationResponse> SyncedFlushAsync(ISyncedFlushRequest flushRequest);
+
+		/// <summary>
 		/// The get settings API allows to retrieve settings of index/indices.
 		/// <para> </para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-settings.html
 		/// </summary>

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Domain\Responses\ClusterStatsResponse.cs" />
     <Compile Include="Domain\Responses\ClusterPendingTasksResponse.cs" />
     <Compile Include="Domain\Responses\DeleteAliasResponse.cs" />
+    <Compile Include="Domain\Responses\FieldStatsResponse.cs" />
     <Compile Include="Domain\Responses\GetIndexResponse.cs" />
     <Compile Include="Domain\Responses\DeleteScriptResponse.cs" />
     <Compile Include="Domain\Responses\DeleteSearchTemplateResponse.cs" />
@@ -237,6 +238,7 @@
     <Compile Include="DSL\Aggregations\TopHitsAggregationDescriptor.cs" />
     <Compile Include="DSL\Aggregations\GeoBoundsAggregationDescriptor.cs" />
     <Compile Include="DSL\Aggregations\ReverseNestedAggregationDescriptor.cs" />
+    <Compile Include="DSL\FieldStatsDescriptor.cs" />
     <Compile Include="DSL\Filter\IndicesFilterDescriptor.cs" />
     <Compile Include="Domain\DSL\NoMatchShortcut.cs" />
     <Compile Include="DSL\SyncedFlushDescriptor.cs" />
@@ -251,6 +253,7 @@
     <Compile Include="DSL\Filter\GeoHashCellFilterDescriptor.cs" />
     <Compile Include="DSL\DeleteScriptDescriptor.cs" />
     <Compile Include="ElasticClient-GetIndex.cs" />
+    <Compile Include="ElasticClient-FieldStats.cs" />
     <Compile Include="Enums\GeoOrientation.cs" />
     <Compile Include="Enums\GeoPrecisionUnit.cs" />
     <Compile Include="Enums\GetIndexFeature.cs" />

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -239,6 +239,7 @@
     <Compile Include="DSL\Aggregations\ReverseNestedAggregationDescriptor.cs" />
     <Compile Include="DSL\Filter\IndicesFilterDescriptor.cs" />
     <Compile Include="Domain\DSL\NoMatchShortcut.cs" />
+    <Compile Include="DSL\SyncedFlushDescriptor.cs" />
     <Compile Include="DSL\Query\Functions\WeightFunction.cs" />
     <Compile Include="DSL\Search\IGlobalInnerHit.cs" />
     <Compile Include="DSL\Search\IInnerHitsContainer.cs" />

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -406,6 +406,7 @@
     <Compile Include="Enums\GeoShapeRelation.cs" />
     <Compile Include="Enums\HighlighterType.cs" />
     <Compile Include="Enums\NormsLoading.cs" />
+    <Compile Include="Enums\NumericResolutionUnit.cs" />
     <Compile Include="Enums\RangeExecution.cs" />
     <Compile Include="Enums\RoutingAllocationEnableOption.cs" />
     <Compile Include="Enums\ScriptLang.cs" />

--- a/src/Nest/RawDispatch.generated.cs
+++ b/src/Nest/RawDispatch.generated.cs
@@ -1110,6 +1110,52 @@ namespace Nest
 		}
 		
 		
+		internal ElasticsearchResponse<T> FieldStatsDispatch<T>(ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo )
+		{
+			switch(pathInfo.HttpMethod)
+			{
+				case PathInfoHttpMethod.GET:
+					//GET /{index}/_field_stats
+					if (!pathInfo.Index.IsNullOrEmpty())
+						return this.Raw.FieldStatsGet<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+					//GET /_field_stats
+					return this.Raw.FieldStatsGet<T>(u => pathInfo.RequestParameters);
+
+				case PathInfoHttpMethod.POST:
+					//POST /{index}/_field_stats
+					if (!pathInfo.Index.IsNullOrEmpty())
+						return this.Raw.FieldStats<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+					//POST /_field_stats
+					return this.Raw.FieldStats<T>(u => pathInfo.RequestParameters);
+
+			}
+			throw new DispatchException("Could not dispatch IElasticClient.FieldStats() into any of the following paths: \r\n - /_field_stats\r\n - /{index}/_field_stats");
+		}
+		
+		
+		internal Task<ElasticsearchResponse<T>> FieldStatsDispatchAsync<T>(ElasticsearchPathInfo<FieldStatsRequestParameters> pathInfo )
+		{
+			switch(pathInfo.HttpMethod)
+			{
+				case PathInfoHttpMethod.GET:
+					//GET /{index}/_field_stats
+					if (!pathInfo.Index.IsNullOrEmpty())
+						return this.Raw.FieldStatsGetAsync<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+					//GET /_field_stats
+					return this.Raw.FieldStatsGetAsync<T>(u => pathInfo.RequestParameters);
+
+				case PathInfoHttpMethod.POST:
+					//POST /{index}/_field_stats
+					if (!pathInfo.Index.IsNullOrEmpty())
+						return this.Raw.FieldStatsAsync<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+					//POST /_field_stats
+					return this.Raw.FieldStatsAsync<T>(u => pathInfo.RequestParameters);
+
+			}
+			throw new DispatchException("Could not dispatch IElasticClient.FieldStats() into any of the following paths: \r\n - /_field_stats\r\n - /{index}/_field_stats");
+		}
+		
+		
 		internal ElasticsearchResponse<T> GetDispatch<T>(ElasticsearchPathInfo<GetRequestParameters> pathInfo )
 		{
 			switch(pathInfo.HttpMethod)
@@ -1777,6 +1823,52 @@ namespace Nest
 
 			}
 			throw new DispatchException("Could not dispatch IElasticClient.IndicesFlush() into any of the following paths: \r\n - /_flush\r\n - /{index}/_flush");
+		}
+		
+		
+		internal ElasticsearchResponse<T> IndicesFlushSyncedDispatch<T>(ElasticsearchPathInfo<IndicesFlushSyncedRequestParameters> pathInfo )
+		{
+			switch(pathInfo.HttpMethod)
+			{
+				case PathInfoHttpMethod.POST:
+					//POST /{index}/_flush/synced
+					if (!pathInfo.Index.IsNullOrEmpty())
+						return this.Raw.IndicesFlushSynced<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+					//POST /_flush/synced
+					return this.Raw.IndicesFlushSyncedForAll<T>(u => pathInfo.RequestParameters);
+
+				case PathInfoHttpMethod.GET:
+					//GET /{index}/_flush/synced
+					if (!pathInfo.Index.IsNullOrEmpty())
+						return this.Raw.IndicesFlushSyncedGet<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+					//GET /_flush/synced
+					return this.Raw.IndicesFlushSyncedGetForAll<T>(u => pathInfo.RequestParameters);
+
+			}
+			throw new DispatchException("Could not dispatch IElasticClient.IndicesFlushSynced() into any of the following paths: \r\n - /_flush/synced\r\n - /{index}/_flush/synced");
+		}
+		
+		
+		internal Task<ElasticsearchResponse<T>> IndicesFlushSyncedDispatchAsync<T>(ElasticsearchPathInfo<IndicesFlushSyncedRequestParameters> pathInfo )
+		{
+			switch(pathInfo.HttpMethod)
+			{
+				case PathInfoHttpMethod.POST:
+					//POST /{index}/_flush/synced
+					if (!pathInfo.Index.IsNullOrEmpty())
+						return this.Raw.IndicesFlushSyncedAsync<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+					//POST /_flush/synced
+					return this.Raw.IndicesFlushSyncedForAllAsync<T>(u => pathInfo.RequestParameters);
+
+				case PathInfoHttpMethod.GET:
+					//GET /{index}/_flush/synced
+					if (!pathInfo.Index.IsNullOrEmpty())
+						return this.Raw.IndicesFlushSyncedGetAsync<T>(pathInfo.Index,u => pathInfo.RequestParameters);
+					//GET /_flush/synced
+					return this.Raw.IndicesFlushSyncedGetForAllAsync<T>(u => pathInfo.RequestParameters);
+
+			}
+			throw new DispatchException("Could not dispatch IElasticClient.IndicesFlushSynced() into any of the following paths: \r\n - /_flush/synced\r\n - /{index}/_flush/synced");
 		}
 		
 		

--- a/src/Nest/RawDispatch.generated.cs
+++ b/src/Nest/RawDispatch.generated.cs
@@ -1826,7 +1826,7 @@ namespace Nest
 		}
 		
 		
-		internal ElasticsearchResponse<T> IndicesFlushSyncedDispatch<T>(ElasticsearchPathInfo<IndicesFlushSyncedRequestParameters> pathInfo )
+		internal ElasticsearchResponse<T> IndicesFlushSyncedDispatch<T>(ElasticsearchPathInfo<SyncedFlushRequestParameters> pathInfo )
 		{
 			switch(pathInfo.HttpMethod)
 			{
@@ -1849,7 +1849,7 @@ namespace Nest
 		}
 		
 		
-		internal Task<ElasticsearchResponse<T>> IndicesFlushSyncedDispatchAsync<T>(ElasticsearchPathInfo<IndicesFlushSyncedRequestParameters> pathInfo )
+		internal Task<ElasticsearchResponse<T>> IndicesFlushSyncedDispatchAsync<T>(ElasticsearchPathInfo<SyncedFlushRequestParameters> pathInfo )
 		{
 			switch(pathInfo.HttpMethod)
 			{

--- a/src/Tests/Nest.Tests.Integration/Core/FieldStatsTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/FieldStatsTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using FluentAssertions;
+
+namespace Nest.Tests.Integration.Core
+{
+	[TestFixture]
+	public class FieldStatsTests : IntegrationTests
+	{
+		private void Assert(FieldStatsField fields)
+		{
+			fields.DocCount.Should().BeGreaterThan(0);
+			fields.MaxDoc.Should().BeGreaterThan(0);
+			fields.Density.Should().BeGreaterThan(0);
+			fields.SumDocumentFrequency.Should().BeGreaterThan(0);
+			fields.MinValue.Should().NotBeNullOrEmpty();
+			fields.MaxValue.Should().NotBeNullOrEmpty();
+		}
+
+		[Test]
+		[SkipVersion("0 - 1.5.9", "Field stats added in ES 1.6")]
+		public void FieldStatsClusterLevel()
+		{
+			var r = this.Client.FieldStats(fs => fs.Fields("name", "country"));
+			r.IsValid.Should().BeTrue();
+			r.Shards.Should().NotBeNull();
+			r.Shards.Successful.Should().BeGreaterThan(0);
+			r.Indices.Should().NotBeEmpty();
+			r.Indices.Should().ContainKey("_all");
+			var all = r.Indices["_all"];
+			all.Fields.Should().NotBeNull();
+			all.Fields.Should().ContainKey("name");
+			var nameFieldStats = all.Fields["name"];
+			Assert(nameFieldStats);
+			all.Fields.Should().ContainKey("country");
+			var countryFieldStats = all.Fields["country"];
+			Assert(countryFieldStats);
+		}
+
+		[Test]
+		[SkipVersion("0 - 1.5.9", "Field stats added in ES 1.6")]
+		public void FieldStatsIndicesLevel()
+		{
+			var r = this.Client.FieldStats(fs => fs
+				.Index(ElasticsearchConfiguration.DefaultIndex)
+				.Fields("name")
+				.Level(Elasticsearch.Net.Level.Indices)
+			);
+			r.IsValid.Should().BeTrue();
+			r.Shards.Should().NotBeNull();
+			r.Shards.Successful.Should().BeGreaterThan(0);
+			r.Indices.Should().NotBeEmpty();
+			r.Indices.Should().ContainKey(ElasticsearchConfiguration.DefaultIndex);
+			var defaultIndex = r.Indices[ElasticsearchConfiguration.DefaultIndex];
+			defaultIndex.Fields.Should().NotBeNull();
+			defaultIndex.Fields.Should().ContainKey("name");
+			Assert(defaultIndex.Fields["name"]);
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Integration/Core/Repository/CreateRepositoryTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/Repository/CreateRepositoryTests.cs
@@ -80,7 +80,6 @@ namespace Nest.Tests.Integration.Core.Repository
 			var backupName = ElasticsearchConfiguration.NewUniqueIndexName();
 			var snapshotResponse = this.Client.Snapshot(repositoryName, backupName, selector: f => f
 				.Index(ElasticsearchConfiguration.NewUniqueIndexName())
-				.IgnoreUnavailable()
 				.Partial());
 			snapshotResponse.IsValid.Should().BeTrue();
 			snapshotResponse.Accepted.Should().BeTrue();

--- a/src/Tests/Nest.Tests.Integration/Core/Repository/RestoreTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/Repository/RestoreTests.cs
@@ -46,7 +46,7 @@ namespace Nest.Tests.Integration.Core.Repository
 
 			var bulkResponse = this.Client.Bulk(d => descriptor);
 
-			this.Client.CreateRepository(_repositoryName, r => r
+			var result = this.Client.CreateRepository(_repositoryName, r => r
 				.FileSystem(@"local\\path", o => o
 					.Compress()
 					.ConcurrentStreams(10)));
@@ -80,7 +80,7 @@ namespace Nest.Tests.Integration.Core.Repository
 				.RenamePattern(d + "_(.+)")
 				.RenameReplacement(d + "_restored_$1")
 				.Index(_indexName)
-				.IgnoreUnavailable(true));
+			);
 
 			_restoredIndexName = _indexName.Replace(d + "_", d + "_restored_");
 			restoreResponse.IsValid.Should().BeTrue();
@@ -109,7 +109,6 @@ namespace Nest.Tests.Integration.Core.Repository
 			var snapshotResponse = this.Client.Snapshot(_repositoryName, _snapshotName, selector: f => f
 				.Index(_indexName)
 				.WaitForCompletion(true)
-				.IgnoreUnavailable()
 				.Partial());
 			snapshotResponse.IsValid.Should().BeTrue();
 
@@ -119,9 +118,9 @@ namespace Nest.Tests.Integration.Core.Repository
 				.RenamePattern(d + "_(.+)")
 				.RenameReplacement(d + "_restored_$1")
 				.Index(_indexName)
-				.IgnoreUnavailable(true)
 				.IndexSettings(descriptor => descriptor
-					.RefreshInterval("123s"))
+					.RefreshInterval("123s")
+				)
 				.IgnoreIndexSettings(UpdatableSettings.BlocksWrite));
 
 			restoreResponse.IsValid.Should().BeTrue();
@@ -200,7 +199,7 @@ namespace Nest.Tests.Integration.Core.Repository
 				.RenamePattern(d + "_(.+)")
 				.RenameReplacement(d + "_restored_$1")
 				.Index(_indexName)
-				.IgnoreUnavailable(true));
+			);
 
 			bool restoreCompleted = false;
 			var restoreObserver = new RestoreObserver(

--- a/src/Tests/Nest.Tests.Integration/Indices/SyncedFlushTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Indices/SyncedFlushTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Nest.Tests.MockData.Domain;
+
+namespace Nest.Tests.Integration.Indices
+{
+	[TestFixture]
+	public class SyncedFlushTests : IntegrationTests
+	{
+		private void Assert(IShardsOperationResponse response)
+		{
+			response.IsValid.Should().BeTrue();
+			response.Shards.Should().NotBeNull();
+			response.Shards.Successful.Should().BeGreaterThan(0);
+		}
+
+		[Test]
+		[SkipVersion("0 - 1.5.9", "Synced Flush added in ES 1.6")]
+		public void SyncedFlushAll()
+		{
+			var r = this.Client.SyncedFlush(sf => sf.AllIndices());
+			Assert(r);
+		}
+
+		[Test]
+		[SkipVersion("0 - 1.5.9", "Synced Flush added in ES 1.6")]
+		public void SyncedFlushIndex()
+		{
+			var r = this.Client.SyncedFlush(f => f.Index(ElasticsearchConfiguration.DefaultIndex));
+			Assert(r);
+		}
+
+		[Test]
+		[SkipVersion("0 - 1.5.9", "Synced Flush added in ES 1.6")]
+		public void SyncedFlushIndices()
+		{
+			var r = this.Client.SyncedFlush(f => f
+				.Indices(ElasticsearchConfiguration.DefaultIndex, ElasticsearchConfiguration.DefaultIndex + "_clone")
+			);
+			Assert(r);
+		}
+
+		[Test]
+		[SkipVersion("0 - 1.5.9", "Synced Flush added in ES 1.6")]
+		public void SyncedFlushTyped()
+		{
+			var r = this.Client.SyncedFlush(f => f.Index<ElasticsearchProject>());
+			Assert(r);
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Core\Exists\SearchExistsTests.cs" />
     <Compile Include="Core\Explain\ExplainTests.cs" />
     <Compile Include="Core\Exists\AliasExists.cs" />
+    <Compile Include="Core\FieldStatsTests.cs" />
     <Compile Include="Core\GetFieldMapping\GetFieldMappingTests.cs" />
     <Compile Include="Core\MultiPercolate\MultiPercolateTests.cs" />
     <Compile Include="Core\Percolate\PercolateTests.cs" />

--- a/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Core\Exists\TypeExistsTests.cs" />
     <Compile Include="Indices\GetIndexTests.cs" />
     <Compile Include="Indices\StatusTests.cs" />
+    <Compile Include="Indices\SyncedFlushTests.cs" />
     <Compile Include="Indices\UpgradeTests.cs" />
     <Compile Include="IntegrationTests.cs" />
     <Compile Include="Cluster\HealthTests.cs" />

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Properties/DateProperty.json
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Properties/DateProperty.json
@@ -11,7 +11,9 @@
         "boost": 1.3,
         "null_value": "1986-03-08T00:00:00",
         "include_in_all": true,
-        "ignore_malformed": true
+        "ignore_malformed": true,
+        "doc_values": true,
+        "numeric_resolution": "seconds"
       }
     }
   }

--- a/src/Tests/Nest.Tests.Unit/Core/Map/Properties/PropertiesTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Core/Map/Properties/PropertiesTests.cs
@@ -92,6 +92,8 @@ namespace Nest.Tests.Unit.Core.Map.Properties
 						.PrecisionStep(4)
 						.Store()
 						.Boost(1.3)
+						.DocValues()
+						.NumericResolution(NumericResolutionUnit.Seconds)
 					)
 				)
 			);

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/FunctionScoreQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/FunctionScoreQueryJson.cs
@@ -20,7 +20,13 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 							f => f.Linear(x => x.FloatValue, d => d.Scale("0.3")),
 							f => f.Exp(x => x.DoubleValue, d => d.Scale("0.5")),
 							f => f.BoostFactor(2.0),
-							f => f.FieldValueFactor(op => op.Field(ff => ff.DoubleValue).Factor(2.5).Modifier(FieldValueFactorModifier.SquareRoot).Missing(1.0))
+							f => f.FieldValueFactor(op => op
+								.Field(ff => ff.DoubleValue)
+								.Factor(2.5)
+								.Modifier(FieldValueFactorModifier.SquareRoot)
+								.Missing(1.0)
+								.Default(0.0)
+							)
 						)
 						.ScoreMode(FunctionScoreMode.Sum)
 						.BoostMode(FunctionBoostMode.Replace)
@@ -40,7 +46,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
                             {linear: { floatValue : { scale: '0.3'}}},
                             {exp:    { doubleValue: { scale: '0.5'}}}, 
                             {boost_factor: 2.0 },
-							{field_value_factor: { field: 'doubleValue', factor: 2.5, modifier: 'sqrt', missing: 1.0}}
+							{field_value_factor: { field: 'doubleValue', factor: 2.5, modifier: 'sqrt', missing: 1.0, default: 0.0}}
                         ],				
 						query : { match_all : {} },
                         score_mode: 'sum',


### PR DESCRIPTION
This PR adds full support for Elasticsearch 1.6 features:

 - Response filtering via `filter_path` query param on all endpoints (closes #1444)
 - Synced flush API (closes #1445)
 - Field stats API (closes #1446)
 - Explanation on validate API response (closes #1447)
 - Add `numeric_resolution` to date mapping (closes #1449)
 - Add `default` option to FieldValueFactor (closes #1450)
 - Add node id to _cat API responses (closes #1451)

**Note:** Global parameters like `source` were removed from the REST spec since it's implied that they should exist on all endpoints.  This is also the case for the new `filter_path` parameter.  I came up with [this solution](https://github.com/elastic/elasticsearch-net/blob/fix/1.6-compatibility/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Global/GlobalQueryParameters.cs#L11) for adding them via our code generator.