### PR TITLE
Add custom converter for UpgradeStatusResponse

### DIFF
--- a/src/Nest/Domain/Responses/UpgradeStatusResponse.cs
+++ b/src/Nest/Domain/Responses/UpgradeStatusResponse.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,14 +7,23 @@ using System.Text;
 
 namespace Nest
 {
+	[JsonObject(MemberSerialization.OptIn)]
+	[JsonConverter(typeof(UpgradeStatusResponseConverter))]
 	public interface IUpgradeStatusResponse : IResponse
 	{
+		long SizeInBytes { get; set; }
+		string SizeToUpgradeInBytes { get; set; }
+		string SizeToUpgradeAncientInBytes { get; set; }
 		Dictionary<string, UpgradeStatus> Upgrades { get; set; }
+
 	}
 
 	public class UpgradeStatusResponse : BaseResponse, IUpgradeStatusResponse
 	{
 		[JsonConverter(typeof(DictionaryKeysAreNotPropertyNamesJsonConverter))]
 		public Dictionary<string, UpgradeStatus> Upgrades { get; set; }
+		public long SizeInBytes { get; set; }
+		public string SizeToUpgradeInBytes { get; set; }
+		public string SizeToUpgradeAncientInBytes { get; set; }
 	}
 }

--- a/src/Nest/Domain/Status/UpgradeStatus.cs
+++ b/src/Nest/Domain/Status/UpgradeStatus.cs
@@ -19,5 +19,8 @@ namespace Nest
 
 		[JsonProperty("size_to_upgrade_in_bytes")]
 		public string SizeToUpgradeInBytes { get; set; }
+
+		[JsonProperty("size_to_upgrade_ancient_in_bytes")]
+		public string SizeToUpgradeAncientInBytes { get; set; }
 	}
 }

--- a/src/Nest/ElasticClient-Upgrade.cs
+++ b/src/Nest/ElasticClient-Upgrade.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 
 namespace Nest
 {
-	using UpgradeStatusResponseConverter = Func<IElasticsearchResponse, Stream, UpgradeStatusResponse>;
-
 	public partial class ElasticClient
 	{
 		public IUpgradeResponse Upgrade(IUpgradeRequest upgradeRequest)
@@ -50,9 +48,7 @@ namespace Nest
 		{
 			return this.Dispatcher.Dispatch<IUpgradeStatusRequest, UpgradeStatusRequestParameters, UpgradeStatusResponse>(
 				upgradeStatusRequest,
-				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatch<UpgradeStatusResponse>(
-					p.DeserializationState(new UpgradeStatusResponseConverter((r, s) => DeserializeUpgradeStatusResponse(r, s)))
-				)
+				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatch<UpgradeStatusResponse>(p)
 			);	
 		}
 
@@ -61,9 +57,7 @@ namespace Nest
 			upgradeStatusDescriptor = upgradeStatusDescriptor ?? (s => s);
 			return this.Dispatcher.Dispatch<UpgradeStatusDescriptor, UpgradeStatusRequestParameters, UpgradeStatusResponse>(
 				upgradeStatusDescriptor,
-				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatch<UpgradeStatusResponse>(
-					p.DeserializationState(new UpgradeStatusResponseConverter((r, s) => DeserializeUpgradeStatusResponse(r, s)))
-				)
+				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatch<UpgradeStatusResponse>(p)
 			);
 		}
 
@@ -71,9 +65,7 @@ namespace Nest
 		{
 			return this.Dispatcher.DispatchAsync<IUpgradeStatusRequest, UpgradeStatusRequestParameters, UpgradeStatusResponse, IUpgradeStatusResponse>(
 				upgradeStatusRequest,
-				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatchAsync<UpgradeStatusResponse>(
-					p.DeserializationState(new UpgradeStatusResponseConverter((r, s) => DeserializeUpgradeStatusResponse(r, s)))
-				)
+				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatchAsync<UpgradeStatusResponse>(p)
 			);
 		}
 
@@ -82,18 +74,8 @@ namespace Nest
 			upgradeStatusDescriptor = upgradeStatusDescriptor ?? (s => s);
 			return this.Dispatcher.DispatchAsync<UpgradeStatusDescriptor, UpgradeStatusRequestParameters, UpgradeStatusResponse, IUpgradeStatusResponse>(
 				upgradeStatusDescriptor,
-				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatchAsync<UpgradeStatusResponse>(
-					p.DeserializationState(new UpgradeStatusResponseConverter((r, s) => DeserializeUpgradeStatusResponse(r, s)))
-				)
+				(p, d) => this.RawDispatch.IndicesGetUpgradeDispatchAsync<UpgradeStatusResponse>(p)
 			);
-		}
-
-		private UpgradeStatusResponse DeserializeUpgradeStatusResponse(IElasticsearchResponse response, Stream stream)
-		{
-			return new UpgradeStatusResponse
-			{
-				Upgrades = this.Serializer.Deserialize<Dictionary<string, UpgradeStatus>>(stream)
-			};
 		}
 	}
 }

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -1005,6 +1005,7 @@
     <Compile Include="Resolvers\Converters\TokenizerCollectionConverter.cs" />
     <Compile Include="Resolvers\Converters\TypeNameMarkerConverter.cs" />
     <Compile Include="Resolvers\Converters\GeoPrecisionConverter.cs" />
+    <Compile Include="Resolvers\Converters\UpgradeStatusResponseConverter.cs" />
     <Compile Include="Resolvers\Converters\UriJsonConverter.cs" />
     <Compile Include="Resolvers\Converters\WarmerMappingConverter.cs" />
     <Compile Include="Resolvers\Converters\ShardsSegmentConverter.cs" />

--- a/src/Nest/Resolvers/Converters/UpgradeStatusResponseConverter.cs
+++ b/src/Nest/Resolvers/Converters/UpgradeStatusResponseConverter.cs
@@ -1,0 +1,77 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nest.Resolvers.Converters
+{
+	public class UpgradeStatusResponseConverter : JsonConverter
+	{
+
+		public override bool CanConvert(Type objectType)
+		{
+			return true;
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var response = new UpgradeStatusResponse();
+			reader.Read();
+			if (reader.TokenType == JsonToken.EndObject)
+				return response;
+			bool newResponse = false;
+			if ((reader.Value as string) == "size_in_bytes")
+			{
+				newResponse = true;
+				reader.Read();
+				response.SizeInBytes = (long)reader.Value;
+				reader.Read();
+				reader.Read();
+				response.SizeToUpgradeInBytes = reader.Value.ToString();
+				reader.Read();
+				reader.Read();
+				response.SizeToUpgradeAncientInBytes = reader.Value.ToString();
+				reader.Read();
+				if (reader.TokenType != JsonToken.EndObject)
+				{
+					reader.Read();
+					reader.Read();
+				}
+			}
+			var upgrades = new Dictionary<string, UpgradeStatus>();
+			while(true)
+			{
+				var status = new UpgradeStatus();
+				var index = reader.Value as string;
+				reader.Read();
+				reader.Read();
+				reader.Read();
+				status.SizeInBytes = (long)reader.Value;
+				reader.Read();
+				reader.Read();
+				status.SizeToUpgradeInBytes = reader.Value.ToString();
+				if (newResponse)
+				{
+					reader.Read();
+					reader.Read();
+					status.SizeToUpgradeAncientInBytes = reader.Value.ToString();
+				}
+				upgrades.Add(index, status);
+				reader.Read();
+				reader.Read();
+				if (reader.TokenType == JsonToken.EndObject)
+					break;
+			}
+			reader.Read();
+			response.Upgrades = upgrades;
+			return response;
+		}
+
+		public override bool CanWrite { get { return false; } }
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}


### PR DESCRIPTION
The _upgrade response has changed in ES 1.6.  This commit adds a custom
JSON converter in order to support the ES <= 1.5 response as well as the
newer 1.6 response.

ES <= 1.5.x
```json
{
   "nest_test_data-11800": {
      "size_in_bytes": 153183,
      "size_to_upgrade_in_bytes": 0
   }
}
```

versus

ES 1.6
```json
{
   "size_in_bytes": 153218,
   "size_to_upgrade_in_bytes": 0,
   "size_to_upgrade_ancient_in_bytes": 0,
   "indices": {
      "nest_test_data-10872": {
         "size_in_bytes": 153218,
         "size_to_upgrade_in_bytes": 0,
         "size_to_upgrade_ancient_in_bytes": 0
      }
   }
}
```


I hate writing code like this, and adding another custom converter, but I don't see another way around it for now.  Please review @Mpdreamz.