### PR TITLE
Build error in 2.0 due to missing file

### DIFF
--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -1007,7 +1007,6 @@
     <Compile Include="Resolvers\Converters\TypeNameMarkerConverter.cs" />
     <Compile Include="Resolvers\Converters\GeoPrecisionConverter.cs" />
     <Compile Include="Resolvers\Converters\UpgradeStatusResponseConverter.cs" />
-    <Compile Include="Resolvers\Converters\UriJsonConverter.cs" />
     <Compile Include="Resolvers\Converters\WarmerMappingConverter.cs" />
     <Compile Include="Resolvers\Converters\ShardsSegmentConverter.cs" />
     <Compile Include="Resolvers\Converters\MultiGetHitConverter.cs" />


### PR DESCRIPTION
File \src\Nest\Resolvers\Converters\UriJsonConverter.cs was in Nest.csproj but wasn't on disk.

I started #1477 from branch 2.0 and noticed this little error.