### PR TITLE
fix #1296 map get response on the update response

### DIFF
--- a/src/Nest/Domain/Responses/UpdateResponse.cs
+++ b/src/Nest/Domain/Responses/UpdateResponse.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Nest.Domain;
+using Newtonsoft.Json;
 
 namespace Nest
 {
@@ -9,6 +11,10 @@ namespace Nest
 		string Type { get; }
 		string Id { get; }
 		string Version { get; }
+		GetFromUpdate Get { get;  }
+
+		T Source<T>() where T : class;
+		FieldSelection<T> Fields<T>() where T : class;
 	}
 
 	[JsonObject]
@@ -25,5 +31,36 @@ namespace Nest
 		public string Id { get; private set; }
 		[JsonProperty(PropertyName = "_version")]
 		public string Version { get; private set; }
+
+		[JsonProperty(PropertyName = "get")]
+		public GetFromUpdate Get { get; private set; }
+
+		public T Source<T>() where T : class
+		{
+			if (this.Get == null) return null;
+			return this.Get.Source.As<T>();
+		}
+
+		public FieldSelection<T> Fields<T>() where T : class
+		{
+			if (this.Get == null) return null;
+			return new FieldSelection<T>(this.Settings, this.Get._fields);
+		}
+	}
+
+	[JsonObject]
+	public class GetFromUpdate
+	{
+		[JsonProperty(PropertyName = "found")]
+		public bool Found { get; set; }
+
+		[JsonProperty(PropertyName = "_source")]
+		internal IDocument Source { get; set; }
+
+
+		[JsonProperty(PropertyName = "fields")]
+		internal IDictionary<string, object> _fields { get; set; }
+
+
 	}
 }


### PR DESCRIPTION
Update API allows you to get the `_source` or `fields` in one go, this was blatantly missing from our mappings thanks @jcachat for reporting.

For backwards compat reasons this object is untyped.