### PR TITLE
Fix #1484 Added document metadata to multitermvectors response

### DIFF
--- a/src/Nest/Domain/Responses/MultiTermVectorResponse.cs
+++ b/src/Nest/Domain/Responses/MultiTermVectorResponse.cs
@@ -5,21 +5,26 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-    public interface IMultiTermVectorResponse : IResponse
-    {
-        IEnumerable<TermVectorResponse> Documents { get; }
-    }
+	public interface IMultiTermVectorResponse : IResponse
+	{
+		[Obsolete("In 1.x this property does not return metadata for the documents, switch to .Docs or upgrade to 2.0 when its release")]
+		IEnumerable<TermVectorResponse> Documents { get; }
+		IEnumerable<MultiTermVectorHit> Docs { get; }
+	}
 
-    [JsonObject]
-    public class MultiTermVectorResponse : BaseResponse, IMultiTermVectorResponse
-    {
-        public MultiTermVectorResponse()
-        {
-            IsValid = true;
-            Documents = new List<TermVectorResponse>();
-        }
+	[JsonObject]
+	public class MultiTermVectorResponse : BaseResponse, IMultiTermVectorResponse
+	{
+		public MultiTermVectorResponse()
+		{
+			IsValid = true;
+			Docs = new List<MultiTermVectorHit>();
+		}
 
-        [JsonProperty("docs")]
-        public IEnumerable<TermVectorResponse> Documents { get; internal set; }
-    }
+		[Obsolete("In 1.x this property does not return metadata for the documents, switch to .Docs or upgrade to 2.0 when its release")]
+		public IEnumerable<TermVectorResponse> Documents { get { return this.Docs; } }
+
+		[JsonProperty("docs")]
+		public IEnumerable<MultiTermVectorHit> Docs { get; internal set; }
+	}
 }

--- a/src/Nest/Domain/Responses/TermVectorResponse.cs
+++ b/src/Nest/Domain/Responses/TermVectorResponse.cs
@@ -5,25 +5,54 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-    public interface ITermVectorResponse : IResponse
-    {
-        bool Found { get; }
-        IDictionary<string, TermVector> TermVectors { get; }
-    }
+	public interface ITermVectorResponse : IResponse
+	{
+		bool Found { get; }
+		IDictionary<string, TermVector> TermVectors { get; }
+	}
 
-    [JsonObject]
-    public class TermVectorResponse : BaseResponse, ITermVectorResponse
-    {
-        public TermVectorResponse()
-        {
-            IsValid = true;
-            TermVectors = new Dictionary<string, TermVector>();
-        }
+	public interface IMultiTermVectorHit : ITermVectorResponse
+	{
+		string Index { get; }
+		string Type { get; }
+		string Id { get; }
+		long Version { get; }
+		long Took { get; }
+	}
 
-        [JsonProperty("found")]
-        public bool Found { get; internal set; }
+	[JsonObject]
+	public class TermVectorResponse : BaseResponse, ITermVectorResponse
+	{
+		public TermVectorResponse()
+		{
+			IsValid = true;
+			TermVectors = new Dictionary<string, TermVector>();
+		}
 
-        [JsonProperty("term_vectors")]
-        public IDictionary<string, TermVector> TermVectors { get; internal set; }
-    }
+		[JsonProperty("found")]
+		public bool Found { get; internal set; }
+
+
+		[JsonProperty("term_vectors")]
+		public IDictionary<string, TermVector> TermVectors { get; internal set; }
+	}
+
+	public class MultiTermVectorHit : TermVectorResponse, IMultiTermVectorHit
+	{
+		[JsonProperty("_index")]
+		public string Index { get; internal set; }
+
+		[JsonProperty("_type")]
+		public string Type { get; internal set; }
+
+		[JsonProperty("_id")]
+		public string Id { get; internal set; }
+
+		[JsonProperty("_version")]
+		public long Version { get; internal set; }
+
+		[JsonProperty("took")]
+		public long Took { get; internal set; }
+		
+	}
 }

--- a/src/Tests/Nest.Tests.Integration/Core/TermVectors/MultiTermVectorsTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/TermVectors/MultiTermVectorsTests.cs
@@ -44,11 +44,17 @@ namespace Nest.Tests.Integration.Core.TermVectors
 
 			result.IsValid.Should().BeTrue();
 
-			result.Documents.Should().NotBeNull();
-			result.Documents.Count().Should().Be(2);
+			result.Docs.Should().NotBeNull();
+			result.Docs.Count().Should().Be(2);
 
-			foreach (var document in result.Documents)
+			foreach (var document in result.Docs)
 			{
+				document.Index.Should().NotBeNullOrWhiteSpace();
+				document.Type.Should().NotBeNullOrWhiteSpace();
+				document.Id.Should().NotBeNullOrWhiteSpace();
+				document.Version.Should().BeGreaterThan(0);
+				document.Took.Should().BeGreaterThan(0);
+
 				document.TermVectors.Count().Should().Be(1);
 				document.TermVectors.First().Key.Should().Be("content");
 			}


### PR DESCRIPTION
Obsoleted `.Documents` in favor of `.Docs` in 1.x. 

In `2.0` we'll switch back to `.Documents`