### PR TITLE
1500 - Change TypeTable in WordDelimiterTokenFilter from string to Li…

### DIFF
--- a/src/Nest/Domain/Analysis/TokenFilter/WordDelimiterTokenFilter.cs
+++ b/src/Nest/Domain/Analysis/TokenFilter/WordDelimiterTokenFilter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using System;
 
 namespace Nest
 {
@@ -47,8 +48,11 @@ namespace Nest
         [JsonProperty("protected_words_path ")]
         public string ProtectedWordsPath { get; set; }
 
-        [JsonProperty("type_table")]
+        [Obsolete("Please switch to TypeTableList property", true)]
         public string TypeTable { get; set; }
+
+        [JsonProperty("type_table")]
+        public List<string> TypeTableList { get; set; }
 
         [JsonProperty("type_table_path")]
         public string TypeTablePath { get; set; }


### PR DESCRIPTION
Change TypeTable in WordDelimiterTokenFilter from string to List<string>

The field "type_table" in token filter of type "word_delimiter' should be an array of strings or a object.

Ex:

```json
{
  "settings": {
    "index": {
      "number_of_replicas": 1,
      "number_of_shards": 5,
      "analysis": {
        "analyzer": {
          "default": {
            "tokenizer": "keyword",
            "filter": [
              "wordelimiter"
            ],
            "type": "custom"
          }
        },
        "filter": {
          "wordelimiter": {
            "preserve_original": true,
            "type_table": [
              "# => ALPHA",
              "@ => ALPHA",
              ". => ALPHA"
            ],
            "type": "word_delimiter"
          }
        }
      }
    }
  }
}
```

