### PR TITLE
NodeStats: fix typo + add HeapMax to JVM Mem stats

### DIFF
--- a/src/Nest/Domain/Stats/NodeStats.cs
+++ b/src/Nest/Domain/Stats/NodeStats.cs
@@ -168,7 +168,7 @@ namespace Nest
 			[JsonProperty("actual_free")]
 			public string ActualFree { get; internal set; }
 			[JsonProperty("actual_free_in_bytes")]
-			public long ActualFreeInbytes { get; internal set; }
+			public long ActualFreeInBytes { get; internal set; }
 			[JsonProperty("actual_used")]
 			public string ActualUsed { get; internal set; }
 			[JsonProperty("actual_used_in_bytes")]

--- a/src/Nest/Domain/Stats/NodeStats.cs
+++ b/src/Nest/Domain/Stats/NodeStats.cs
@@ -167,6 +167,9 @@ namespace Nest
 			public int UsedPercent { get; internal set; }
 			[JsonProperty("actual_free")]
 			public string ActualFree { get; internal set; }
+			[Obsolete]
+			[JsonProperty("actual_free_in_bytes")]
+			public long ActualFreeInbytes { get; internal set; }
 			[JsonProperty("actual_free_in_bytes")]
 			public long ActualFreeInBytes { get; internal set; }
 			[JsonProperty("actual_used")]

--- a/src/Nest/Domain/Stats/NodeStats.cs
+++ b/src/Nest/Domain/Stats/NodeStats.cs
@@ -13,13 +13,13 @@ namespace Nest
 
 		[JsonProperty("name")]
 		public string Name { get; internal set; }
-		
+
 		[JsonProperty("transport_address")]
 		public string TransportAddress { get; internal set; }
 
 		// TODO: Rename to Host in 2.0
 		[JsonProperty("host")]
-		public string Hostname { get; internal set; } 
+		public string Hostname { get; internal set; }
 
 		[JsonProperty("indices")]
 		public NodeStatsIndexes Indices { get; internal set; }
@@ -168,8 +168,7 @@ namespace Nest
 			[JsonProperty("actual_free")]
 			public string ActualFree { get; internal set; }
 			[Obsolete]
-			[JsonProperty("actual_free_in_bytes")]
-			public long ActualFreeInbytes { get; internal set; }
+			public long ActualFreeInbytes { get { return ActualFreeInBytes; } internal set { ActualFreeInBytes = value; } }
 			[JsonProperty("actual_free_in_bytes")]
 			public long ActualFreeInBytes { get; internal set; }
 			[JsonProperty("actual_used")]

--- a/src/Nest/Domain/Stats/NodeStats.cs
+++ b/src/Nest/Domain/Stats/NodeStats.cs
@@ -250,6 +250,10 @@ namespace Nest
 			public string HeapCommitted { get; internal set; }
 			[JsonProperty("heap_committed_in_bytes")]
 			public long HeapCommittedInBytes { get; internal set; }
+			[JsonProperty("heap_max")]
+			public string HeapMax { get; internal set; }
+			[JsonProperty("heap_max_in_bytes")]
+			public long HeapMaxInBytes { get; internal set; }
 			[JsonProperty("non_heap_used")]
 			public string NonHeapUsed { get; internal set; }
 			[JsonProperty("non_heap_used_in_bytes")]


### PR DESCRIPTION
So there is 2 commits. The first one just fix a type.

The second one add some statst to the jvm/mem route that were not mapped.

Also, what's the purpose of the empty string values in this code?

Like this one:
[JsonProperty("non_heap_used")]
public string NonHeapUsed { get; internal set; }

They come null when I use NEST.
