### PR TITLE
Fix minor typo in xmldoc comments

### DIFF
--- a/src/Nest/Domain/Property.cs
+++ b/src/Nest/Domain/Property.cs
@@ -7,7 +7,7 @@ namespace Nest.Resolvers
 	{
 		/// <summary>
 		/// Create a strongly typed string representation of the path to a property
-		/// <para>i.e p => p.Arrary.First().SubProperty.Field will return 'array.subProperty.field'</para>
+		/// <para>i.e p => p.Array.First().SubProperty.Field will return 'array.subProperty.field'</para>
 		/// </summary>
 		/// <typeparam name="T">The type of the object</typeparam>
 		/// <param name="path">The path we want to specify</param>
@@ -20,7 +20,7 @@ namespace Nest.Resolvers
 		
 		/// <summary>
 		/// Create a strongly typed string representation of the name to a property
-		/// <para>i.e p => p.Arrary.First().SubProperty.Field will return 'field'</para>
+		/// <para>i.e p => p.Array.First().SubProperty.Field will return 'field'</para>
 		/// </summary>
 		/// <typeparam name="T">The type of the object</typeparam>
 		/// <param name="path">The path we want to specify</param>


### PR DESCRIPTION
Hi all, 

Noticed the following while looking at some intellisense using NEST:

![image](https://cloud.githubusercontent.com/assets/2148318/10004116/076cb20a-607e-11e5-9434-d9c50d8f4339.png)

Figured I'd patch up the typo quickly and contribute something back, however minor, to this awesome library.

Resolves #1568.