### PR TITLE
Index.url.cs added to Tests.csproj

### DIFF
--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -97,8 +97,8 @@
     <Compile Include="ClientConcepts\HighLevel\Inferrence\Id\IdsInference.cs" />
     <Compile Include="ClientConcepts\HighLevel\Inferrence\Indices\IndicesPaths.cs" />
     <Compile Include="CodeStandards\Descriptors.cs" />
+    <Compile Include="Document\Single\Index\Index.url.cs" />
     <Compile Include="Document\Single\Index\Indexing.doc.cs" />
-    <Compile Include="Document\Single\Index\Indexing.url.cs" />
     <Compile Include="Framework\CrudExample.cs" />
     <Compile Include="Framework\MockResponses\SniffingResponse.cs" />
     <Compile Include="Framework\UrlTests.cs" />


### PR DESCRIPTION
Ups ... Tests.csproj was referencing Indexing.url.cs instead of Index.url.cs.

![1](https://cloud.githubusercontent.com/assets/2392583/10117694/afa53bba-645f-11e5-8547-93097fc33d2b.PNG)

![2](https://cloud.githubusercontent.com/assets/2392583/10117696/b34b49c6-645f-11e5-94a4-66ce5f705f7d.PNG)


