### PR TITLE
Crud tests for scripting module

### DIFF
--- a/src/Tests/Modules/Scripting/ScriptingCrudTests.cs
+++ b/src/Tests/Modules/Scripting/ScriptingCrudTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Xunit;
+
+namespace Tests.Modules.Scripting
+{
+	[Collection(IntegrationContext.Indexing)]
+	public class ScriptingCrudTests
+		: CrudTestBase<IPutScriptResponse, IGetScriptResponse, IPutScriptResponse>
+	{
+		public ScriptingCrudTests(IndexingCluster cluster, EndpointUsage usage) : base(cluster, usage) {}
+
+		protected override bool SupportsDeletes => true;
+
+		protected override LazyResponses Create() => Calls<PutScriptDescriptor, PutScriptRequest, IPutScriptRequest, IPutScriptResponse>(
+			CreateInitializer,
+			CreateFluent,
+			fluent: (s, c, f) => c.PutScript(_lang, s, f),
+			fluentAsync: (s, c, f) => c.PutScriptAsync(_lang, s, f),
+			request: (s, c, r) => c.PutScript(r),
+			requestAsync: (s, c, r) => c.PutScriptAsync(r)
+		);
+
+		private string _lang = "groovy";
+
+		protected PutScriptRequest CreateInitializer(string id) =>
+			new PutScriptRequest(_lang, id) {Script = "1+1"};
+
+		protected IPutScriptRequest CreateFluent(string id, PutScriptDescriptor d) => d.Script("1+1");
+
+		protected override LazyResponses Read() => Calls<GetScriptDescriptor, GetScriptRequest, IGetScriptRequest, IGetScriptResponse>(
+			ReadInitializer,
+			ReadFluent,
+			fluent: (s, c, f) => c.GetScript(_lang, s, f),
+			fluentAsync: (s, c, f) => c.GetScriptAsync(_lang, s, f),
+			request: (s, c, r) => c.GetScript(r),
+			requestAsync: (s, c, r) => c.GetScriptAsync(r)
+        );
+
+		protected GetScriptRequest ReadInitializer(string id) => new GetScriptRequest(_lang, id);
+
+		protected IGetScriptRequest ReadFluent(string id, GetScriptDescriptor d) => d;
+
+		protected override LazyResponses Update() => Calls<PutScriptDescriptor, PutScriptRequest, IPutScriptRequest, IPutScriptResponse>(
+			UpdateInitializer,
+			UpdateFluent,
+			fluent: (s, c, f) => c.PutScript(_lang, s, f),
+			fluentAsync: (s, c, f) => c.PutScriptAsync(_lang, s, f),
+			request: (s, c, r) => c.PutScript(r),
+			requestAsync: (s, c, r) => c.PutScriptAsync(r)
+		);
+
+		private string _updatedScript = "2+2";
+
+		protected PutScriptRequest UpdateInitializer(string id) =>
+			new PutScriptRequest(_lang, id) { Script = _updatedScript};
+
+		protected IPutScriptRequest UpdateFluent(string id, PutScriptDescriptor d) => d.Script(_updatedScript);
+
+		protected override LazyResponses Delete() => Calls<DeleteScriptDescriptor, DeleteScriptRequest, IDeleteScriptRequest, IDeleteScriptResponse>(
+			DeleteInitializer,
+			DeleteFluent,
+			fluent: (s, c, f) => c.DeleteScript(_lang, s, f),
+			fluentAsync: (s, c, f) => c.DeleteScriptAsync(_lang, s, f),
+			request: (s, c, r) => c.DeleteScript(r),
+			requestAsync: (s, c, r) => c.DeleteScriptAsync(r)
+		);
+
+		protected DeleteScriptRequest DeleteInitializer(string id) => new DeleteScriptRequest(_lang, id);
+
+		protected IDeleteScriptRequest DeleteFluent(string id, DeleteScriptDescriptor d) => d;
+
+		[I] protected async Task ScriptIsUpdated() => await this.AssertOnGetAfterUpdate(r =>
+			r.Script.Should().Be(_updatedScript)
+		);
+
+		[I] protected async Task ScriptIsDeleted() => await this.AssertOnGetAfterDelete(r =>
+			r.IsValid.Should().BeFalse()
+		);
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -236,6 +236,10 @@
     <Compile Include="Indices\Warmers\GetWarmer\GetWarmerUrlTests.cs" />
     <Compile Include="Indices\Warmers\PutWarmer\PutWarmerUrlTests.cs" />
     <Compile Include="Mapping\Types\String.cs" />
+    <Compile Include="Modules\Scripting\DeleteScript\DeleteScriptUrlTests.cs" />
+    <Compile Include="Modules\Scripting\GetScript\GetScriptUrlTests.cs" />
+    <Compile Include="Modules\Scripting\PutScript\PutScriptUrlTests.cs" />
+    <Compile Include="Modules\Scripting\ScriptingCrudTests.cs" />
     <Compile Include="Search\Count\CountUrlTests.cs" />
     <Compile Include="Search\Explain\ExplainUrlTests.cs" />
     <Compile Include="Search\FieldStats\FieldStatsUrlTests.cs" />
@@ -303,7 +307,6 @@
     <Folder Include="Aggregations\Pipeline\" />
     <Folder Include="Document\Single\Source\" />
     <Folder Include="Migration\" />
-    <Folder Include="Modules\" />
     <Folder Include="Plugins\Analysis\Phonetic\" />
     <Folder Include="QueryDsl\" />
     <Folder Include="Setup\" />


### PR DESCRIPTION
Hi,

PR contains crud tests for scripts https://github.com/elastic/elasticsearch-net/issues/1586.
Don't know why `DeleteCallsIsValid` don't pass. Any ideas?

Any feedback appreciated.