### PR TITLE
Fix for CatAliases API #1591

### DIFF
--- a/src/Nest/DSL/PutAliasDescriptor.cs
+++ b/src/Nest/DSL/PutAliasDescriptor.cs
@@ -14,6 +14,10 @@ namespace Nest
 	{
 		[JsonProperty("routing")]
 		string Routing { get; set; }
+		[JsonProperty("search_routing")]
+		string SearchRouting { get; set; }
+		[JsonProperty("index_routing")]
+		string IndexRouting { get; set; }
 
 		[JsonProperty("filter")]
 		[JsonConverter(typeof(CompositeJsonConverter<ReadAsTypeConverter<FilterContainer>, CustomJsonConverter>))]
@@ -35,6 +39,8 @@ namespace Nest
 		public PutAliasRequest(string index, string name) : base(index, name) { }
 
 		public string Routing { get; set; }
+		public string SearchRouting { get; set; }
+		public string IndexRouting { get; set; }
 
 		public IFilterContainer Filter { get; set; }
 
@@ -51,11 +57,25 @@ namespace Nest
 	{
 		IPutAliasRequest Self { get { return this; } }
 		string IPutAliasRequest.Routing { get; set; }
+		string IPutAliasRequest.SearchRouting { get; set; }
+		string IPutAliasRequest.IndexRouting { get; set; }
 		IFilterContainer IPutAliasRequest.Filter { get; set; }
 		
 		public PutAliasDescriptor Routing(string routing)
 		{
 			Self.Routing = routing;
+			return this;
+		}
+
+		public PutAliasDescriptor SearchRouting(string searchRouting)
+		{
+			Self.SearchRouting = searchRouting;
+			return this;
+		}
+
+		public PutAliasDescriptor IndexRouting(string indexRouting)
+		{
+			Self.IndexRouting = indexRouting;
 			return this;
 		}
 

--- a/src/Nest/Domain/Cat/CatAliasesRecord.cs
+++ b/src/Nest/Domain/Cat/CatAliasesRecord.cs
@@ -14,10 +14,10 @@ namespace Nest
 		[JsonProperty("filter")]
 		public string Filter { get; set; }
 
-		[JsonProperty("indexRouting")]
+		[JsonProperty("routing.index")]
 		public string IndexRouting { get; set; }
 
-		[JsonProperty("searchRouting")]
+		[JsonProperty("routing.search")]
 		public string SearchRouting { get; set; }
 	}
 }

--- a/src/Tests/Elasticsearch.Net.Tests.Unit/Elasticsearch.Net.Tests.Unit.csproj
+++ b/src/Tests/Elasticsearch.Net.Tests.Unit/Elasticsearch.Net.Tests.Unit.csproj
@@ -234,7 +234,4 @@
       <Paket>True</Paket>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
 </Project>

--- a/src/Tests/Elasticsearch.Net.Tests.Unit/Elasticsearch.Net.Tests.Unit.csproj
+++ b/src/Tests/Elasticsearch.Net.Tests.Unit/Elasticsearch.Net.Tests.Unit.csproj
@@ -234,4 +234,7 @@
       <Paket>True</Paket>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Reproduce\Reproduce1457Tests.cs" />
     <Compile Include="Reproduce\Reproduce1474Tests.cs" />
     <Compile Include="Reproduce\Reproduce1515Tests.cs" />
+    <Compile Include="Reproduce\Reproduce1591Tests.cs" />
     <Compile Include="Reproduce\Reproduce769Tests.cs" />
     <Compile Include="Reproduce\Reproduce945Tests.cs" />
     <Compile Include="Reproduce\Reproduce953Tests.cs" />
@@ -446,5 +447,8 @@
       <Private>True</Private>
       <Paket>True</Paket>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -448,7 +448,4 @@
       <Paket>True</Paket>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
 </Project>

--- a/src/Tests/Nest.Tests.Integration/Reproduce/Reproduce1591Tests.cs
+++ b/src/Tests/Nest.Tests.Integration/Reproduce/Reproduce1591Tests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nest.Tests.Integration.Reproduce
+{
+	[TestFixture]
+	public class Reproduce1591Tests : IntegrationTests
+	{
+		private readonly string _aliasName = Guid.NewGuid().ToString();
+		private readonly string _indexName = Guid.NewGuid().ToString();
+
+		[SetUp]
+		public void SetUp()
+		{
+			Client.CreateIndex(_indexName);
+		}
+
+		[TearDown]
+		public void Teardown()
+		{
+			Client.DeleteIndex(_indexName);
+		}
+
+		[Test]
+		public void Test()
+		{
+			var putAliasResponse = Client.PutAlias(d => d
+				.Index(_indexName)
+				.Name(_aliasName)
+				.IndexRouting("indexrouting")
+				.SearchRouting("searchrouting"));
+
+			putAliasResponse.IsValid.Should().BeTrue();
+
+			var catResponse = Client.CatAliases(d => d.V()).Records
+				.FirstOrDefault(x => x.Index == _indexName);
+
+			catResponse.Should().NotBeNull();
+			catResponse.Alias.Should().Be(_aliasName);
+			catResponse.IndexRouting.Should().Be("indexrouting");
+			catResponse.SearchRouting.Should().Be("searchrouting");
+		}
+	}
+}


### PR DESCRIPTION
Hi,

This PR fixes #1591.
One more thing fixed - there was no way to specify `search_routing` and `index_routing` parameters when [creating alias](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html#aliases-routing). 