### PR TITLE
Allow 3rd party to sign HTTP requests

### DIFF
--- a/src/Elasticsearch.Net/Connection/Configuration/IRequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IRequestConfiguration.cs
@@ -2,6 +2,7 @@ using Elasticsearch.Net.Connection.Security;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 namespace Elasticsearch.Net.Connection.Configuration
 {
@@ -61,5 +62,11 @@ namespace Elasticsearch.Net.Connection.Configuration
 		/// <para>Note: HTTP pipelining must also be enabled in Elasticsearch for this to work properly.</para>
 		/// </summary>
 		bool EnableHttpPipelining { get; set; }
+
+		/// <summary>
+		/// An action that is called prior to sending an HTTP request to allow
+		/// a client to sign the HTTP request.
+		/// </summary>
+		Action<HttpWebRequest, byte[]> RequestSigner { get; set; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/RequestConfiguration.cs
@@ -1,6 +1,7 @@
 using Elasticsearch.Net.Connection.Security;
 using System;
 using System.Collections.Generic;
+using System.Net;
 
 namespace Elasticsearch.Net.Connection.Configuration
 {
@@ -16,5 +17,6 @@ namespace Elasticsearch.Net.Connection.Configuration
 		public IEnumerable<int> AllowedStatusCodes { get; set; }
 		public BasicAuthorizationCredentials BasicAuthorizationCredentials { get; set; }
 		public bool EnableHttpPipelining { get; set; }
+		public Action<HttpWebRequest, byte[]> RequestSigner { get; set; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/Configuration/RequestConfigurationDescriptor.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/RequestConfigurationDescriptor.cs
@@ -1,6 +1,7 @@
 using Elasticsearch.Net.Connection.Security;
 using System;
 using System.Collections.Generic;
+using System.Net;
 
 namespace Elasticsearch.Net.Connection.Configuration
 {
@@ -27,6 +28,8 @@ namespace Elasticsearch.Net.Connection.Configuration
 		BasicAuthorizationCredentials IRequestConfiguration.BasicAuthorizationCredentials { get; set; }
 
 		bool IRequestConfiguration.EnableHttpPipelining { get; set; }
+
+		Action<HttpWebRequest, byte[]> IRequestConfiguration.RequestSigner { get; set; }
 
 		public RequestConfigurationDescriptor RequestTimeout(int requestTimeoutInMilliseconds)
 		{
@@ -99,6 +102,12 @@ namespace Elasticsearch.Net.Connection.Configuration
 		public RequestConfigurationDescriptor EnableHttpPipelining(bool enable = true)
 		{
 			Self.EnableHttpPipelining = enable;
+			return this;
+		}
+
+		public RequestConfigurationDescriptor RequestSigner(Action<HttpWebRequest, byte[]> signer)
+		{
+			Self.RequestSigner = signer;
 			return this;
 		}
 	}

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -161,7 +161,16 @@ namespace Elasticsearch.Net.Connection
 			this.SetBasicAuthenticationIfNeeded(uri, request, requestSpecificConfig);
 			this.SetProxyIfNeeded(request);
 			this.AlterServicePoint(request.ServicePoint);
+			this.SignRequest(request, data, requestSpecificConfig);
 			return request;
+		}
+
+		private void SignRequest(HttpWebRequest request, byte[] data, IRequestConfiguration requestSpecificConfig)
+		{
+			if (requestSpecificConfig.RequestSigner != null)
+			{
+				requestSpecificConfig.RequestSigner(request, data);
+			}
 		}
 
 		private void SetProxyIfNeeded(HttpWebRequest myReq)


### PR DESCRIPTION
This is necessary to implement [AWS authentication](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/what-is-amazon-elasticsearch-service.html#signing-requests)