### PR TITLE
Improve "Service Unavailable" error reporting

### DIFF
--- a/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandler.cs
+++ b/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandler.cs
@@ -106,7 +106,7 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 				return this.StreamToTypedResponse<T>(streamResponse, requestState, bytes);
 
 			// If error read error 
-			error = GetErrorFromStream<T>(streamResponse.Response);
+			error = GetErrorFromStream<T>(streamResponse.Response, streamResponse.HttpStatusCode ?? 0);
 			var typedResponse = ElasticsearchResponse.CloneFrom<T>(streamResponse, default(T));
 			this.SetStringOrByteResult(typedResponse, bytes);
 			return typedResponse;

--- a/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerAsync.cs
+++ b/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerAsync.cs
@@ -131,7 +131,7 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 				var typedResponse = ElasticsearchResponse.CloneFrom<T>(streamResponse, default(T));
 				if (!isValidResponse)
 				{
-					response.Error = GetErrorFromStream<T>(gotStream.Result);
+					response.Error = GetErrorFromStream<T>(gotStream.Result, streamResponse.HttpStatusCode ?? 0);
 					this.SetStringOrByteResult(typedResponse, response.Bytes);
 					if (gotStream.Result != null) gotStream.Result.Close();
 					response.Response = typedResponse;

--- a/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerBase.cs
+++ b/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerBase.cs
@@ -211,11 +211,20 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 			response.Response = rawResponse;
 		}
 
-		protected ElasticsearchServerError GetErrorFromStream<T>(Stream stream)
+		protected ElasticsearchServerError GetErrorFromStream<T>(Stream stream, int httpStatusCode=0)
 		{
 			try
 			{
 				var e = this._serializer.Deserialize<OneToOneServerException>(stream);
+				if (e?.status == 0)
+				{
+					// Service unavailable isn't reported as a regular error, and
+					// thus won't be serialized as such. This workaround improves
+					// the errormessage for these errors.
+					e.status = httpStatusCode;
+					if (e.status == 503 && e.error.IsNullOrEmpty())
+						e.error = "ServiceUnavailableException[Service Unavaliable. Try again later.]";
+				}
 				return ElasticsearchServerError.Create(e);
 			}
 			// ReSharper disable once EmptyGeneralCatchClause


### PR DESCRIPTION
Service Unavailable can happen before shards are updates (creating
a new index, and then query it before it's created). These errors
are not reported as regular errors, and receives a very generic
errormessage. This commit improves the error message for these errors.

Closes #1596