### PR TITLE
IdsQueryDescriptor.Values(params long[] values) isn't assigning to Values correctly

### DIFF
--- a/src/Nest/QueryDsl/TermLevel/Ids/IdsQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Ids/IdsQuery.cs
@@ -40,7 +40,7 @@ namespace Nest
 		public IdsQueryDescriptor Type(IEnumerable<string> values) => Type(values.ToArray());
 
 		public IdsQueryDescriptor Values(params long[] values) =>
-			Assign(a => a.Values.Select(v => v.ToString(CultureInfo.InvariantCulture)).ToArray());
+			Assign(a => a.Values = values.Select(v => v.ToString(CultureInfo.InvariantCulture)).ToArray());
 
 		public IdsQueryDescriptor Values(IEnumerable<long> values) =>
 			Values(values.Select(v => v.ToString(CultureInfo.InvariantCulture)).ToArray());


### PR DESCRIPTION
The `Values(params long[] values)` method in the IdsQueryDescriptor wasn't setting the `IIdsQuery.Values` property with the passed in array of long. This was causing a NullReference exception to be thrown when calling this method.