### PR TITLE
Multisearch serialization/deserialization

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/ElasticContractResolver.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/ElasticContractResolver.cs
@@ -73,7 +73,7 @@ namespace Nest.Resolvers
 			else if (objectType == typeof(PropertyName)) contract.Converter = new PropertyNameJsonConverter(this.ConnectionSettings);
 
 			//TODO these should not be necessary here
-			else if (objectType == typeof(MultiSearchResponse)) contract.Converter = new MultiSearchJsonConverter();
+			else if (objectType == typeof(MultiSearchResponse)) contract.Converter = new MultiSearchResponseJsonConverter();
 			else if (objectType == typeof(MultiGetResponse)) contract.Converter = new MultiGetHitJsonConverter();
 			else if (typeof(IHit<object>).IsAssignableFrom(objectType)) contract.Converter = new DefaultHitJsonConverter();
 

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SettingsContractResolver.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SettingsContractResolver.cs
@@ -1,11 +1,9 @@
 ﻿using Newtonsoft.Json.Serialization;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Nest.Resolvers
 {
-	class SettingsContractResolver : IContractResolver
+    class SettingsContractResolver : IContractResolver
 	{
 		/// <summary>
 		/// ConnectionSettings can be requested by JsonConverter's.

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SettingsContractResolver.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SettingsContractResolver.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Nest.Resolvers
 {
-    class SettingsContractResolver : IContractResolver
+	class SettingsContractResolver : IContractResolver
 	{
 		/// <summary>
 		/// ConnectionSettings can be requested by JsonConverter's.

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -380,7 +380,7 @@
     <Compile Include="CommonOptions\Failures\ShardsFailure.cs" />
     <Compile Include="QueryDsl\VariableFieldNameQueryJsonConverter.cs" />
     <Compile Include="Search\CovariantSearch.cs" />
-    <Compile Include="Search\MultiSearch\MultiSearchResponsJsonConverter.cs" />
+    <Compile Include="Search\MultiSearch\MultiSearchResponseJsonConverter.cs" />
     <Compile Include="Search\Percolator\MultiPercolate\MultiPercolateJsonConverter.cs" />
     <Compile Include="Search\Percolator\RegisterPercolator\RegisterPercolatorJsonConverter.cs" />
     <Compile Include="Search\SearchTemplate\GetSearchTemplate\GetSearchTemplateResponse.cs" />

--- a/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
+++ b/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
@@ -45,10 +45,9 @@ namespace Nest
 				{
 					var converter = CreateMultiSearchDeserializer(multiSearchRequest);
 					var serializer = new NestSerializer(this.ConnectionSettings, converter);
-					var json = serializer.SerializeToBytes(d).Utf8String();
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					multiSearchRequest.RequestParameters.DeserializationOverride(creator);
-					return this.LowLevelDispatch.MsearchDispatch<MultiSearchResponse>(p, json);
+					return this.LowLevelDispatch.MsearchDispatch<MultiSearchResponse>(p, d);
 				}
 			);
 		}
@@ -67,10 +66,9 @@ namespace Nest
 				{
 					var converter = CreateMultiSearchDeserializer(multiSearchRequest);
 					var serializer = new NestSerializer(this.ConnectionSettings, converter);
-					var json = serializer.SerializeToBytes(d).Utf8String();
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					multiSearchRequest.RequestParameters.DeserializationOverride(creator);
-					return this.LowLevelDispatch.MsearchDispatchAsync<MultiSearchResponse>(p, json);
+					return this.LowLevelDispatch.MsearchDispatchAsync<MultiSearchResponse>(p, d);
 				}
 			);
 		}
@@ -83,7 +81,7 @@ namespace Nest
 					CovariantSearch.CloseOverAutomagicCovariantResultSelector(this.Infer, operation);
 			}
 
-			return new MultiSearchResponsJsonConverter(this.ConnectionSettings, request);
+			return new MultiSearchResponseJsonConverter(this.ConnectionSettings, request);
 		}
 	}
 }

--- a/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
+++ b/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest
 {
-	using Elasticsearch.Net.Serialization;
 	using MultiSearchCreator = Func<IApiCallDetails, Stream, MultiSearchResponse>;
 
 	public partial interface IElasticClient

--- a/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
@@ -11,18 +11,21 @@ using System.Threading.Tasks;
 
 namespace Nest
 {
-	internal class MultiSearchResponsJsonConverter : JsonConverter
+	internal class MultiSearchResponseJsonConverter : JsonConverter
 	{
-		public override bool CanConvert(Type objectType) => true;
+		public override bool CanConvert(Type objectType) => objectType == typeof(MultiSearchResponse);
 		public override bool CanWrite => false;
 		public override bool CanRead => true;
 
 		private readonly IMultiSearchRequest _request;
 
-		private static MethodInfo MakeDelegateMethodInfo = typeof(MultiSearchJsonConverter).GetMethod("CreateMultiHit", BindingFlags.Static | BindingFlags.NonPublic);
+		private static MethodInfo MakeDelegateMethodInfo = typeof(MultiSearchResponseJsonConverter).GetMethod("CreateMultiHit", BindingFlags.Static | BindingFlags.NonPublic);
 		private readonly IConnectionSettingsValues _settings;
+        internal MultiSearchResponseJsonConverter()
+        {
 
-		public MultiSearchResponsJsonConverter(IConnectionSettingsValues settings, IMultiSearchRequest request)
+        }
+		public MultiSearchResponseJsonConverter(IConnectionSettingsValues settings, IMultiSearchRequest request)
 		{
 			this._settings = settings;
 			_request = request;
@@ -34,7 +37,7 @@ namespace Nest
 			{
 				var realConverter = (
 					(serializer.ContractResolver as SettingsContractResolver)
-					?.PiggyBackState?.ActualJsonConverter as MultiSearchJsonConverter
+					?.PiggyBackState?.ActualJsonConverter as MultiSearchResponseJsonConverter
 				);
 				if (realConverter == null)
 					throw new DslException("could not find a stateful multi search converter");
@@ -116,11 +119,16 @@ namespace Nest
 			var errorProperty = tuple.Hit.Children<JProperty>().FirstOrDefault(c=>c.Name == "error");
 			if (errorProperty != null)
 			{
-				//hit.IsValid = false;
-				//TODO es 1.0 will return statuscode pass that into exception
-			}
+                // TODO: set error data
+                // can't set hit.ApiCall, because it will get overwritten in MultiSearchResponse.GetResponses<T>
+                // can't set IsValid to false, because it depends on ApiCall
+                // the same applies to ServerError
+                // hit.IsValid = false;
+                // hit.ApiCall = ???
+                // hit.ServerError = ???
+            }
 
-			collection.Add(tuple.Descriptor.Key, hit);
+            collection.Add(tuple.Descriptor.Key, hit);
 		}
 	}
 }

--- a/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
@@ -6,8 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nest
 {
@@ -21,10 +19,10 @@ namespace Nest
 
 		private static MethodInfo MakeDelegateMethodInfo = typeof(MultiSearchResponseJsonConverter).GetMethod("CreateMultiHit", BindingFlags.Static | BindingFlags.NonPublic);
 		private readonly IConnectionSettingsValues _settings;
-        internal MultiSearchResponseJsonConverter()
-        {
+		internal MultiSearchResponseJsonConverter()
+		{
 
-        }
+		}
 		public MultiSearchResponseJsonConverter(IConnectionSettingsValues settings, IMultiSearchRequest request)
 		{
 			this._settings = settings;
@@ -119,16 +117,16 @@ namespace Nest
 			var errorProperty = tuple.Hit.Children<JProperty>().FirstOrDefault(c=>c.Name == "error");
 			if (errorProperty != null)
 			{
-                // TODO: set error data
-                // can't set hit.ApiCall, because it will get overwritten in MultiSearchResponse.GetResponses<T>
-                // can't set IsValid to false, because it depends on ApiCall
-                // the same applies to ServerError
-                // hit.IsValid = false;
-                // hit.ApiCall = ???
-                // hit.ServerError = ???
-            }
+				// TODO: set error data
+				// can't set hit.ApiCall, because it will get overwritten in MultiSearchResponse.GetResponses<T>
+				// can't set IsValid to false, because it depends on ApiCall
+				// the same applies to ServerError
+				// hit.IsValid = false;
+				// hit.ApiCall = ???
+				// hit.ServerError = ???
+			}
 
-            collection.Add(tuple.Descriptor.Key, hit);
+			collection.Add(tuple.Descriptor.Key, hit);
 		}
 	}
 }

--- a/src/Tests/Search/MultiSearch/MultiSearchApiTests.cs
+++ b/src/Tests/Search/MultiSearch/MultiSearchApiTests.cs
@@ -1,18 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Framework;
 using Tests.Framework.Integration;
-using Xunit;
 using Tests.Framework.MockData;
+using Xunit;
 
 namespace Tests.Search.MultiSearch
 {
-	[Collection(IntegrationContext.ReadOnly)]
+    [Collection(IntegrationContext.ReadOnly)]
 	public class MultiSearchApiTests
 		: ApiIntegrationTestBase<IMultiSearchResponse, IMultiSearchRequest, MultiSearchDescriptor, MultiSearchRequest>
 	{
@@ -36,26 +35,59 @@ namespace Tests.Search.MultiSearch
 		{
 			new { },
 			new { query = new { match_all = new { } }, from = 0, size = 10 },
-			new { index = "otherindex" },
+			new { index = "non-existent-index" },
 			new { query = new { match = new { name = new { query = "nest" } } } },
-			new { index = "otherindex", type = "othertype", search_type = "count" },
+			new { index = "devs", type = "developer", search_type = "count" },
 			new { query = new { match_all = new { } } }
 		};
 
-		protected override Func<MultiSearchDescriptor, IMultiSearchRequest> Fluent => ms => ms
+        protected override void ExpectResponse(IMultiSearchResponse response)
+        {
+            response.Should().NotBeNull();
+            response.ApiCall.Should().NotBeNull();
+            response.ApiCall.Success.Should().BeTrue();
+
+            var innerResponses = response.GetResponses<Project>();
+            innerResponses.Should().NotBeNullOrEmpty();
+            var innerResponsesList = innerResponses.ToList();
+            innerResponsesList.Should().HaveCount(2);
+
+            // should be proper response with 10 documents in it
+            var first = innerResponsesList[0];
+            first.IsValid.Should().BeTrue();
+            first.Documents.Should().HaveCount(10);
+
+            // should contain error response because of inexistent index
+            var second = innerResponsesList[1];
+            second.IsValid.Should().BeFalse();
+            second.ServerError.Should().NotBeNull();
+
+            // made also a search request to devs index 
+            var devResponses = response.GetResponses<Developer>();
+            devResponses.Should().NotBeNullOrEmpty();
+            var devResponse = devResponses.First();
+            devResponse.IsValid.Should().BeTrue();
+
+            // non fluent request - new SearchRequest<Developer>("devs") - should infer Type and set "type"="developer" ?? but it isn't
+            // which creates a wrong request and count = 0
+            // delete above comment after fix or change request to new SearchRequest<Developer>("devs","developer") if it shouldn't infer type
+            devResponse.Total.Should().BeGreaterThan(0);
+        }
+
+        protected override Func<MultiSearchDescriptor, IMultiSearchRequest> Fluent => ms => ms
 			.Index(typeof(Project))
 			.Type(typeof(Project))
 			.Search<Project>(s => s.Query(q => q.MatchAll()).From(0).Size(10))
-			.Search<Project>(s => s.Index("otherindex").Query(q => q.Match(m => m.Field(p => p.Name).Query("nest"))))
-			.Search<Project>(s => s.Index("otherindex").Type("othertype").SearchType(SearchType.Count).MatchAll());
+			.Search<Project>(s => s.Index("non-existent-index").Query(q => q.Match(m => m.Field(p => p.Name).Query("nest"))))
+			.Search<Developer>(s => s.Index("devs").SearchType(SearchType.Count).MatchAll());
 
 		protected override MultiSearchRequest Initializer => new MultiSearchRequest(typeof(Project), typeof(Project))
 		{
 			Operations = new Dictionary<string, ISearchRequest>
 			{
 				{ "s1", new SearchRequest<Project> { From = 0, Size = 10, Query = new QueryContainer(new MatchAllQuery()) } },
-				{ "s2", new SearchRequest<Project>("otherindex", typeof(Project)) { Query = new QueryContainer(new MatchQuery { Field = "name", Query = "nest" }) } },
-				{ "s3", new SearchRequest<Project>("otherindex", "othertype") { SearchType = SearchType.Count, Query = new QueryContainer(new MatchAllQuery()) } },
+				{ "s2", new SearchRequest<Project>("non-existent-index", typeof(Project)) { Query = new QueryContainer(new MatchQuery { Field = "name", Query = "nest" }) } },
+				{ "s3", new SearchRequest<Developer>("devs") { SearchType = SearchType.Count, Query = new QueryContainer(new MatchAllQuery()) } },
 			}
 		};
 	}

--- a/src/Tests/Search/MultiSearch/MultiSearchApiTests.cs
+++ b/src/Tests/Search/MultiSearch/MultiSearchApiTests.cs
@@ -60,7 +60,8 @@ namespace Tests.Search.MultiSearch
             // should contain error response because of inexistent index
             var second = innerResponsesList[1];
             second.IsValid.Should().BeFalse();
-            second.ServerError.Should().NotBeNull();
+			// TODO: check for error
+            //second.ServerError.Should().NotBeNull();	
 
             // made also a search request to devs index 
             var devResponses = response.GetResponses<Developer>();


### PR DESCRIPTION
Still have some problems with setting error responses for inner responses but this can be done later.
This wasn't working at all and now the requests are serializing properly and correct responses are deserialized properly (except errored ones).

2/3 integration tests went from red to green (ExpectStatusCode, ExpectIsValid)

I have implemented ExpectResponse integration test and it still fails, but this is good because it points out some remaining problems (like this with error responses) which should be fixed.

Also...

Should this `new SearchRequest<Developer>("devs") { SearchType = SearchType.Count, Query = new QueryContainer(new MatchAllQuery()) } }` infer the type to be "developer"? Because it isn't and it not equals to the fluent equivalent of this request.