### PR TITLE
Fix SniffPath format issues against 2.0

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -244,7 +244,7 @@ namespace Elasticsearch.Net.Connection
 			}
 		}
 
-		private string SniffPath => "_nodes/_all/settings?flat_settings&timeout=" + this.PingTimeout;
+		private string SniffPath => $"_nodes/_all/settings?flat_settings&timeout={this.PingTimeout.TotalSeconds}s";
 
 		public IEnumerable<Node> SniffNodes => this._connectionPool.CreateView().ToList().OrderBy(n =>  n.MasterEligable ? n.Uri.Port : int.MaxValue);
 


### PR DESCRIPTION
The generated sniff path URL had timeout=00:00:02 by default. 

Elastic complained about no unit specified for timeout, making the call actually fail because it returned no nodes. 

I changed this to specify TotalSeconds seconds and now it "works for me". No formal testing has been performed.