### PR TITLE
- re-add Score property to IHit interface

### DIFF
--- a/src/Nest/Search/Search/Hits/Hit.cs
+++ b/src/Nest/Search/Search/Hits/Hit.cs
@@ -14,6 +14,7 @@ namespace Nest
 		string Index { get; }
 		string Type { get; }
 		long? Version { get; }
+		double Score { get; }
 		string Id { get; }
 		IEnumerable<object> Sorts { get; }
 		HighlightFieldDictionary Highlights { get; }


### PR DESCRIPTION
Cannot find any reasons for removing it.
This prevents getting Score by interface.