### PR TITLE
UriInfo class is improperly parsing URIs

### DIFF
--- a/src/Elasticsearch.Net/Purify/Purify.cs
+++ b/src/Elasticsearch.Net/Purify/Purify.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace Purify
@@ -180,8 +181,20 @@ namespace Purify
 				var pathEnd = queryPos == -1 ? fragPos : queryPos;
 				if (pathEnd == -1)
 					pathEnd = source.Length + 1;
+
+				if (start < pathEnd - 1 && source[start] == ':')
+				{
+					var portLength = uri.Port.ToString(CultureInfo.InvariantCulture).Length;
+					start += portLength + 1;
+				}
+
 				Path = queryPos > -1 ? source.Substring(start, pathEnd - start) : source.Substring(start);
-				Query = fragPos > -1 ? source.Substring(queryPos, fragPos - queryPos) : source.Substring(queryPos);
+
+				Query = fragPos > -1
+					? source.Substring(queryPos, fragPos - queryPos)
+					: queryPos > -1
+						? source.Substring(queryPos, (source.Length - queryPos))
+						: null;
 			}
 		}
 	}


### PR DESCRIPTION
It looks like commit 5b0bd6c refactored this class and lost pieces of the code that respect port numbers as well as the absence of query strings in the given URI.

This was causing `System.ArgumentOutOfRangeException : StartIndex cannot be less than zero.` exceptions to be thrown from projects targeting .NET 4.6.

I just took the same code in the UriInfo class prior to commit 5b0bd6c and re-added it to the refactored class.