### PR TITLE
PercolateDescriptor serialization bug fix and addition of Score to PercolateResponse

### DIFF
--- a/src/Nest/DSL/MultiPercolate/IPercolateOperation.cs
+++ b/src/Nest/DSL/MultiPercolate/IPercolateOperation.cs
@@ -18,7 +18,7 @@ namespace Nest
 		[JsonProperty(PropertyName = "track_scores")]
 		bool? TrackScores { get; set; }
 
-		[JsonProperty(PropertyName = "score")]
+		[JsonProperty(PropertyName = "sort")]
 		[JsonConverter(typeof(DictionaryKeysAreNotPropertyNamesJsonConverter))]
 		IDictionary<PropertyPathMarker, ISort> Sort { get; set; }
 

--- a/src/Nest/Domain/Responses/PercolateResponse.cs
+++ b/src/Nest/Domain/Responses/PercolateResponse.cs
@@ -64,7 +64,9 @@ namespace Nest
 		[JsonProperty(PropertyName = "_id")]
 		public string Id { get; set; }
 		[JsonProperty(PropertyName = "highlight")]
-		public Dictionary<string, IList<string>> Highlight { get; set; }
+        public Dictionary<string, IList<string>> Highlight { get; set; }
+        [JsonProperty(PropertyName = "_score")]
+        public double Score { get; set; }
 		
 	}
 


### PR DESCRIPTION
When serializing the PercolateDescriptor, the sort property was
incorrectly being serialized as 'score' and not 'sort'. This is now
fixed.

When Percolating with a query, size and trackscores=true, the raw
response contains a score, but the PercolateResponse class does not.
This is now fixed/added.