### PR TITLE
PingTimeout does not use a time unit.

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -245,7 +245,7 @@ namespace Elasticsearch.Net.Connection
 			}
 		}
 
-		private string SniffPath => "_nodes/_all/settings?flat_settings&timeout=" + this.PingTimeout;
+		private string SniffPath => "_nodes/_all/settings?flat_settings&timeout=" + this.PingTimeout.TotalMilliseconds + "ms";
 
 		public IEnumerable<Node> SniffNodes => this._connectionPool.CreateView().ToList().OrderBy(n =>  n.MasterEligable ? n.Uri.Port : int.MaxValue);
 

--- a/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
+++ b/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
@@ -37,8 +37,8 @@ namespace Elasticsearch.Net.Connection.Sniff
 		public string build { get; set; }
 		public IDictionary<string, object> settings { get; set; }
 
-		internal bool MasterEligable => !((this.settings?.ContainsKey("node.master")).GetValueOrDefault(false) && ((bool)this.settings["node.master"]) == false);
-		internal bool HoldsData => !((this.settings?.ContainsKey("node.data")).GetValueOrDefault(false) && ((bool)this.settings["node.data"]) == false);
+		internal bool MasterEligable => !((this.settings?.ContainsKey("node.master")).GetValueOrDefault(false) && Convert.ToBoolean(this.settings["node.master"]) == false);
+		internal bool HoldsData => !((this.settings?.ContainsKey("node.data")).GetValueOrDefault(false) && Convert.ToBoolean(this.settings["node.data"]) == false);
 	}
 
 }


### PR DESCRIPTION
Since Elasticsearch 2.0, time units are obligatory.  
This causes connection pooling not to work because of a null reference exception in the `Sniff` method.

I would have liked to use `TimeUnitExpression` but that belongs to `Nest` only.  Maybe it should be moved to `Elasticsearch.net`?