### PR TITLE
Sniffing connection pool is now disposable

### DIFF
--- a/src/Elasticsearch.Net/ConnectionPool/SniffingConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/SniffingConnectionPool.cs
@@ -100,7 +100,6 @@ namespace Elasticsearch.Net.ConnectionPool
 	            if (disposing)
 	            {
 	                _readerWriter.Dispose();
-	                _isDisposed = true;
 	            }
 	            _isDisposed = true;
 	        }

--- a/src/Elasticsearch.Net/ConnectionPool/SniffingConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/SniffingConnectionPool.cs
@@ -89,11 +89,22 @@ namespace Elasticsearch.Net.ConnectionPool
 
 	    public void Dispose()
 	    {
-            CheckDisposed();
-            
-            _readerWriter.Dispose();
-            _isDisposed = true;
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+	    protected virtual void Dispose(bool disposing)
+	    {
+	        if (!_isDisposed)
+	        {
+	            if (disposing)
+	            {
+	                _readerWriter.Dispose();
+	                _isDisposed = true;
+	            }
+	            _isDisposed = true;
+	        }
+	    }
 
 	    private void CheckDisposed()
 	    {

--- a/src/Tests/Elasticsearch.Net.Tests.Unit/ConnectionPools/Sniffing/SniffingConnectionPoolTests.cs
+++ b/src/Tests/Elasticsearch.Net.Tests.Unit/ConnectionPools/Sniffing/SniffingConnectionPoolTests.cs
@@ -535,7 +535,39 @@ namespace Elasticsearch.Net.Tests.Unit.ConnectionPools.Sniffing
 				sniffException.Should().NotBeNull();
 			}
 		}
-		
 
+	    [Test]
+	    public void ShouldBeDisposable()
+	    {
+            var uris = new[]
+            {
+                new Uri("http://localhost:9200"),
+                new Uri("http://localhost:9201"),
+                new Uri("http://localhost:9202")
+            };
+            var connectionPool = new SniffingConnectionPool(uris, randomizeOnStartup: false);
+
+            Assert.That(connectionPool, Is.InstanceOf<IDisposable>());
+        }
+
+	    [Test]
+	    public void ShouldNotBeUsableAfterDispose()
+	    {
+            var uris = new[]
+            {
+                new Uri("http://localhost:9200"),
+                new Uri("http://localhost:9201"),
+                new Uri("http://localhost:9202")
+            };
+            var connectionPool = new SniffingConnectionPool(uris, randomizeOnStartup: false);
+	        connectionPool.Dispose();
+
+	        Assert.Throws<ObjectDisposedException>(() => connectionPool.MarkAlive(uris.First()));
+            Assert.Throws<ObjectDisposedException>(() => connectionPool.MarkDead(uris.First(), null, null));
+            Assert.Throws<ObjectDisposedException>(() => connectionPool.UpdateNodeList(uris));
+	        int seed;
+	        bool shouldPingHint;
+            Assert.Throws<ObjectDisposedException>(() => connectionPool.GetNext(null, out seed, out shouldPingHint));
+        }
 	}
 }


### PR DESCRIPTION
The `SniffingConnectionPool` contains a `ReaderWriterLockSlim`, which implements `IDisposable`. Because the connection pool wholly owns the lock, their lifetimes are linked. The `SniffingConnectionPool` should therefore allow deterministic disposal of the `ReaderWriterLockSlim` by implementing `IDisposable`.

The tests ensure that the interface is implemented, and that the pool is unusable after disposal. Could see no way of asserting that the lock is definitely disposed.