### PR TITLE
JsonProperty now taken into account when inferring properies

### DIFF
--- a/src/Elasticsearch.Net/Serialization/ElasticsearchDefaultSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/ElasticsearchDefaultSerializer.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -53,7 +54,9 @@ namespace Elasticsearch.Net
 			}
 		}
 
-		public static string RemoveNewLinesAndTabs(string input)
+		public string CreatePropertyName(MemberInfo memberInfo) => null;
+
+		private static string RemoveNewLinesAndTabs(string input)
 		{
 			return new string(input
 				.Where(c => c != '\r' && c != '\n')

--- a/src/Elasticsearch.Net/Serialization/IElasticsearchSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/IElasticsearchSerializer.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,6 +12,8 @@ namespace Elasticsearch.Net
 		Task<T> DeserializeAsync<T>(Stream responseStream, CancellationToken cancellationToken = default(CancellationToken));
 
 		void Serialize(object data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.Indented);
+
+		string CreatePropertyName(MemberInfo memberInfo);
 	}
 
 	public static class ElasticsearchSerializerExtensions

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettings.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettings.cs
@@ -87,7 +87,7 @@ namespace Nest
 		/// The default serializer for requests and responses
 		/// </summary>
 		/// <returns></returns>
-		protected override IElasticsearchSerializer DefaultSerializer() => new NestSerializer(this);
+		protected override IElasticsearchSerializer DefaultSerializer() => new JsonNetSerializer(this);
 
 		/// <summary>
 		/// This calls SetDefaultTypenameInferrer with an implementation that will pluralize type names. This used to be the default prior to Nest 0.90

--- a/src/Nest/CommonAbstractions/Infer/Field/FieldResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/FieldResolver.cs
@@ -34,7 +34,7 @@ namespace Nest
 			if (att != null && !att.Name.IsNullOrEmpty())
 				return att.Name;
 
-			return _settings.DefaultFieldNameInferrer(name);
+			return _settings.Serializer?.CreatePropertyName(info) ?? _settings.DefaultFieldNameInferrer(name);
 		}
 
 		public string Resolve(Expression expression)

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	public class NestSerializer : IElasticsearchSerializer
+	public class JsonNetSerializer : IElasticsearchSerializer
 	{
 		private static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
 
@@ -17,12 +18,12 @@ namespace Nest
 		private readonly Dictionary<SerializationFormatting, JsonSerializer> _defaultSerializers;
 		private readonly JsonSerializer _defaultSerializer;
 
-		public NestSerializer(IConnectionSettingsValues settings) : this(settings, null) { }
+		public JsonNetSerializer(IConnectionSettingsValues settings) : this(settings, null) { }
 
 		/// <summary>
 		/// this constructor is only here for stateful (de)serialization 
 		/// </summary>
-		public NestSerializer(IConnectionSettingsValues settings, JsonConverter stateFullConverter)
+		public JsonNetSerializer(IConnectionSettingsValues settings, JsonConverter stateFullConverter)
 		{
 			this._settings = settings;
 
@@ -47,6 +48,12 @@ namespace Nest
 				writer.Flush();
 				jsonWriter.Flush();
 			}
+		}
+
+		public string CreatePropertyName(MemberInfo memberInfo)
+		{
+			var jsonProperty = memberInfo.GetCustomAttribute<JsonPropertyAttribute>(true);
+			return jsonProperty?.PropertyName;
 		}
 
 		public virtual T Deserialize<T>(Stream stream)

--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-MultiGet.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-MultiGet.cs
@@ -55,7 +55,7 @@ namespace Nest
 				this.LowLevelDispatch.MgetDispatchAsync<MultiGetResponse>
 			);
 		private MultiGetResponse DeserializeMultiGetResponse(IApiCallDetails response, Stream stream, JsonConverter converter)=>
-			new NestSerializer(this.ConnectionSettings, converter).Deserialize<MultiGetResponse>(stream);
+			new JsonNetSerializer(this.ConnectionSettings, converter).Deserialize<MultiGetResponse>(stream);
 
 		private JsonConverter CreateCovariantMultiGetConverter(IMultiGetRequest descriptor) => new MultiGetHitJsonConverter(descriptor);
 

--- a/src/Nest/Mapping/AttributeBased/ElasticsearchPropertyAttribute.cs
+++ b/src/Nest/Mapping/AttributeBased/ElasticsearchPropertyAttribute.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
 
-namespace Nest 
+namespace Nest
 {
 	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
@@ -27,10 +27,10 @@ namespace Nest
 		public SimilarityOption Similarity { get { return Self.Similarity.GetValueOrDefault(); } set { Self.Similarity = value; } }
 		public bool Store { get { return Self.Store.GetValueOrDefault(); } set { Self.Store = value; } }
 
-        protected ElasticsearchPropertyAttribute(string typeName)
-        {
-            Self.Type = typeName;
-        }
+		protected ElasticsearchPropertyAttribute(string typeName)
+		{
+			Self.Type = typeName;
+		}
 
 		protected ElasticsearchPropertyAttribute(Type type)
 		{

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -718,7 +718,7 @@
     <Compile Include="Mapping\Types\Core\Date\NumericResolutionUnit.cs" />
     <Compile Include="Modules\Scripting\ScriptLang.cs" />
     <Compile Include="Aggregations\Bucket\Terms\TermsAggregationCollectMode.cs" />
-    <Compile Include="CommonAbstractions\SerializationBehavior\NestSerializer.cs" />
+    <Compile Include="CommonAbstractions\SerializationBehavior\JsonNetSerializer.cs" />
     <Compile Include="CommonOptions\Geo\GeoDistanceType.cs" />
     <Compile Include="CommonAbstractions\LowLevelDispatch\IHighLevelToLowLevelDispatcher.cs" />
     <Compile Include="CommonAbstractions\Extensions\ExceptionExtensions.cs" />

--- a/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
+++ b/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
@@ -41,7 +41,7 @@ namespace Nest
 				(p, d) =>
 				{
 					var converter = CreateMultiSearchDeserializer(p);
-					var serializer = new NestSerializer(this.ConnectionSettings, converter);
+					var serializer = new JsonNetSerializer(this.ConnectionSettings, converter);
 					var json = serializer.SerializeToBytes(p).Utf8String();
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);
@@ -63,7 +63,7 @@ namespace Nest
 				(p, d) =>
 				{
 					var converter = CreateMultiSearchDeserializer(p);
-					var serializer = new NestSerializer(this.ConnectionSettings, converter);
+					var serializer = new JsonNetSerializer(this.ConnectionSettings, converter);
 					var json = serializer.SerializeToBytes(p).Utf8String();
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);

--- a/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
@@ -59,7 +59,7 @@ namespace Nest
 
 				if (concreteTypeSelector != null)
 				{
-					var elasticSerializer = new NestSerializer(this._settings);
+					var elasticSerializer = new JsonNetSerializer(this._settings);
 					var state = typeof(ConcreteTypeConverter<>).CreateGenericInstance(baseType, concreteTypeSelector) as JsonConverter;
 					if (state != null)
 					{

--- a/src/Nest/Search/Search/ElasticClient-Search.cs
+++ b/src/Nest/Search/Search/ElasticClient-Search.cs
@@ -123,7 +123,7 @@ namespace Nest
 			where TResult : class =>
 			!response.Success
 				? null
-				: new NestSerializer(this.ConnectionSettings, new ConcreteTypeConverter<TResult>(d.TypeSelector))
+				: new JsonNetSerializer(this.ConnectionSettings, new ConcreteTypeConverter<TResult>(d.TypeSelector))
 					.Deserialize<SearchResponse<TResult>>(stream);
 
 	}

--- a/src/Nest/Search/SearchTemplate/ElasticClient-SearchTemplate.cs
+++ b/src/Nest/Search/SearchTemplate/ElasticClient-SearchTemplate.cs
@@ -99,7 +99,7 @@ namespace Nest
 		{
 			var converter = this.CreateCovariantSearchSelector<T, TResult>(d);
 			var dict = response.Success
-				? new NestSerializer(this.ConnectionSettings, converter).Deserialize<SearchResponse<TResult>>(stream)
+				? new JsonNetSerializer(this.ConnectionSettings, converter).Deserialize<SearchResponse<TResult>>(stream)
 				: null;
 			return dict;
 		}

--- a/src/Tests/ClientConcepts/HighLevel/Inferrence/FieldNames/FieldInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inferrence/FieldNames/FieldInference.doc.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using Nest;
+using Newtonsoft.Json;
 using Tests.Framework;
 using Tests.Framework.MockData;
 using static Tests.Framework.RoundTripper;
@@ -126,7 +127,52 @@ namespace Tests.ClientConcepts.HighLevel.Inferrence.FieldNames
 			var suffix = "unanalyzed";
 			Expect("metadata.var.unanalyzed").WhenSerializing(Field<Project>(p => p.Metadata[variable].Suffix(suffix)));
 			Expect("metadata.var.created.unanalyzed").WhenSerializing(Field<Project>(p => p.Metadata[variable].Created.Suffix(suffix)));
+		}
 
+		/** Annotations 
+		* 
+		* When using NEST's property attributes you can specify a new name for the properties
+		*/
+		public class BuiltIn
+		{
+			[String(Name="naam")]
+			public string Name { get; set; }
+		}
+		[U] public void BuiltInAnnotiatons()
+		{
+			Expect("naam").WhenSerializing(Field<BuiltIn>(p=>p.Name));
+		}
+		
+		/** 
+		* Starting with NEST 2.x we also ask the serializer if it can resolve the property to a name.
+		* Here we ask the default JsonNetSerializer and it takes JsonProperty into account
+		*/
+		public class SerializerSpecific
+		{
+			[JsonProperty("nameInJson")]
+			public string Name { get; set; }
+		}
+		[U] public void SerializerSpecificAnnotations()
+		{
+			Expect("nameInJson").WhenSerializing(Field<SerializerSpecific>(p=>p.Name));
+		}
+
+		/** 
+		* If both are specified NEST takes precedence though 
+		*/
+		public class Both
+		{
+			[String(Name="naam")]
+			[JsonProperty("nameInJson")]
+			public string Name { get; set; }
+		}
+		[U] public void NestAttributeTakesPrecedence()
+		{
+			Expect("naam").WhenSerializing(Field<Both>(p=>p.Name));
+			Expect(new
+			{
+				naam = "Martijn Laarman"
+			}).WhenSerializing(new Both { Name = "Martijn Laarman" });
 		}
 	}
 }

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using Nest;
+using Newtonsoft.Json;
 using Tests.Framework;
 using static Tests.Framework.RoundTripper;
 
@@ -303,6 +304,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 			public bool IsManager { get; set; }
 
 			[Nested(Path = "employees")]
+			[JsonProperty("empl")]
 			public List<Employee> Employees { get; set; }
 		}
 
@@ -376,7 +378,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 								numeric_resolution = "seconds",
 								type = "date"
 							},
-							employees = new
+							empl = new
 							{
 								path = "employees",
 								properties = new

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -61,7 +61,7 @@ namespace Tests.Framework
 
 		public static IElasticClient GetFixedReturnClient(object responseJson)
 		{
-			var serializer = new NestSerializer(new ConnectionSettings());
+			var serializer = new JsonNetSerializer(new ConnectionSettings());
 			byte[] fixedResult;
 			using (var ms = new MemoryStream())
 			{

--- a/src/Tests/Mapping/Types/Geo/GeoPoint/GeoPointMappingTests.cs
+++ b/src/Tests/Mapping/Types/Geo/GeoPoint/GeoPointMappingTests.cs
@@ -22,7 +22,7 @@ namespace Tests.Mapping.Types.Geo.GeoPoint
 		[GeoPoint]
 		public string Minimal { get; set; }
 
-        public GeoLocation Inferred { get; set; }
+		public GeoLocation Inferred { get; set; }
 	}
 
 	public class GeoPointMappingTests : TypeMappingTestBase<GeoPointTest>
@@ -50,11 +50,11 @@ namespace Tests.Mapping.Types.Geo.GeoPoint
 				{
 					type = "geo_point"
 				},
-                inferred = new
-                {
-                    type = "geo_point"
-                }
-            }
+				inferred = new
+				{
+					type = "geo_point"
+				}
+			}
 		};
 
 		protected override Func<PropertiesDescriptor<GeoPointTest>, IPromise<IProperties>> FluentProperties => p => p
@@ -75,8 +75,8 @@ namespace Tests.Mapping.Types.Geo.GeoPoint
 			.GeoPoint(b => b
 				.Name(o => o.Minimal)
 			)
-            .GeoPoint(b => b
-                .Name(o => o.Inferred)
-            );
-    }
+			.GeoPoint(b => b
+				.Name(o => o.Inferred)
+			);
+	}
 }


### PR DESCRIPTION
Now we ask the configured `IElasticsearchSerializer` if it can resolve the `MemberInfo` to a fieldname.

Precedence:

* NEST mapping attributes
* Ask serializer (default looks for JsonProperty)
* PropertyNameInferrer(MemberInfo.Name) (default camelCase)

also renamed NestSerializer to JsonNetSerializer, 