### PR TITLE
Added Parent and Routing fields to the Hit class

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/StatefulDeserialization/ConcreteTypeConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/StatefulDeserialization/ConcreteTypeConverter.cs
@@ -171,6 +171,8 @@ namespace Nest
 			hitDynamic.Type = d._type;
 			hitDynamic.Version = d._version;
 			hitDynamic.Id = d._id;
+			hitDynamic.Parent = d._parent;
+			hitDynamic.Routing = d._routing;
 			hitDynamic.Sorts = d.sort;
 			hitDynamic._Highlight = d.highlight is Dictionary<string, List<string>> ? d.highlight : null;
 			hitDynamic.Explanation = d._explanation is Explanation ? d._explanation : null;

--- a/src/Nest/Search/Search/Hits/Hit.cs
+++ b/src/Nest/Search/Search/Hits/Hit.cs
@@ -14,6 +14,8 @@ namespace Nest
 		long? Version { get; }
 		double Score { get; }
 		string Id { get; }
+		string Parent { get; }
+		string Routing { get; }
 		IEnumerable<object> Sorts { get; }
 		HighlightFieldDictionary Highlights { get; }
 		Explanation Explanation { get; }
@@ -49,6 +51,12 @@ namespace Nest
 
 		[JsonProperty(PropertyName = "_id")]
 		public string Id { get; internal set; }
+
+		[JsonProperty(PropertyName = "_parent")]
+		public string Parent { get; internal set; }
+
+		[JsonProperty(PropertyName = "_routing")]
+		public string Routing { get; internal set; }
 
 		[JsonProperty(PropertyName = "sort")]
 		public IEnumerable<object> Sorts { get; internal set; }


### PR DESCRIPTION
I noticed that the `_parent` and `_routing` fields for search responses were not being mapped to the Hit class. This commit simply adds the mapping for those two fields.