### PR TITLE
Overriding of json net no longer a concern of connectionsettings

### DIFF
--- a/src/Nest/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
@@ -16,7 +16,5 @@ namespace Nest
 		string DefaultIndex { get; }
 		Func<string, string> DefaultFieldNameInferrer { get; }
 		Func<Type, string> DefaultTypeNameInferrer { get; }
-		Action<JsonSerializerSettings> ModifyJsonSerializerSettings { get; }
-		ReadOnlyCollection<Func<Type, JsonConverter>> ContractConverters { get; }
 	}
 }

--- a/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
@@ -23,7 +23,7 @@ namespace Nest
 
 		//this contract is only used to resolve properties in class WE OWN.
 		//these are not subject to change depending on what the user passes as connectionsettings
-		private static ElasticContractResolver _jsonContract = new ElasticContractResolver(new ConnectionSettings());
+		private static ElasticContractResolver _jsonContract = new ElasticContractResolver(new ConnectionSettings(), null);
 
 		public delegate T ObjectActivator<out T>(params object[] args);
 

--- a/src/Nest/CommonAbstractions/SerializationBehavior/ElasticContractResolver.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/ElasticContractResolver.cs
@@ -12,6 +12,7 @@ namespace Nest
 {
 	public class ElasticContractResolver : DefaultContractResolver
 	{
+		private readonly IList<Func<Type, JsonConverter>> _contractConverters;
 		public static JsonSerializer Empty { get; } = new JsonSerializer();
 
 
@@ -25,8 +26,9 @@ namespace Nest
 		/// </summary>
 		internal JsonConverterPiggyBackState PiggyBackState { get; set; }
 
-		public ElasticContractResolver(IConnectionSettingsValues connectionSettings)
+		public ElasticContractResolver(IConnectionSettingsValues connectionSettings, IList<Func<Type, JsonConverter>> contractConverters)
 		{
+			this._contractConverters = contractConverters;
 			this.ConnectionSettings = connectionSettings;
 		}
 
@@ -48,9 +50,9 @@ namespace Nest
 			else if (ApplyExactContractJsonAttribute(objectType, contract)) return contract;
 			else if (ApplyContractJsonAttribute(objectType, contract)) return contract;
 
-			if (this.ConnectionSettings.ContractConverters.HasAny())
+			if (this._contractConverters.HasAny())
 			{
-				foreach (var c in this.ConnectionSettings.ContractConverters)
+				foreach (var c in this._contractConverters)
 				{
 					var converter = c(objectType);
 					if (converter == null)

--- a/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
@@ -59,21 +59,12 @@ namespace Nest
 
 				if (concreteTypeSelector != null)
 				{
-					var elasticSerializer = new JsonNetSerializer(this._settings);
 					var state = typeof(ConcreteTypeConverter<>).CreateGenericInstance(baseType, concreteTypeSelector) as JsonConverter;
 					if (state != null)
 					{
-						var settings = elasticSerializer.CreateSettings(SerializationFormatting.None, piggyBackJsonConverter: state);
+						var elasticSerializer = new JsonNetSerializer(this._settings, state);
 
-						var jsonSerializer = new JsonSerializer()
-						{
-							NullValueHandling = settings.NullValueHandling,
-							DefaultValueHandling = settings.DefaultValueHandling,
-							ContractResolver = settings.ContractResolver,
-						};
-						foreach (var converter in settings.Converters.EmptyIfNull())
-							jsonSerializer.Converters.Add(converter);
-						generic.Invoke(null, new object[] { m, jsonSerializer, response.Responses, this._settings });
+						generic.Invoke(null, new object[] { m, elasticSerializer.Serializer, response.Responses, this._settings });
 						continue;
 					}
 				}


### PR DESCRIPTION
removed:

```diff
- JsonSerializerSettingsModifier(Action<JsonSerializerSettings> modifier)		
-AddContractJsonConverters(params Func<Type, JsonConverter>[] contractSelectors)		
```

From `ConnectionSettings`. 

It now takes a `Func<TConnectionSettings, IElasticsearchSerializer> factory` to inject subclasses of `JsonNetSerializer` e.g

```charp
public class MyJsonNetSerializer : JsonNetSerializer
{
	public int X { get; set; } = 0;
	public MyJsonNetSerializer(IConnectionSettingsValues settings) : base(settings) { }

	protected override void ModifyJsonSerializerSettings(JsonSerializerSettings settings)
	{
		++X;
	}
}

[U] public void IsCalled()
{
	var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
	var settings = new ConnectionSettings(connectionPool, new InMemoryConnection(),s => new MyJsonNetSerializer(s));
	var client = new ElasticClient(settings);
	var serializer = ((IConnectionSettingsValues)settings).Serializer as MyJsonNetSerializer;
	serializer.X.Should().BeGreaterThan(0);
}
```
