### PR TITLE
Update FiltersBucket.cs

### DIFF
--- a/src/Nest/Aggregations/Bucket/Filters/FiltersBucket.cs
+++ b/src/Nest/Aggregations/Bucket/Filters/FiltersBucket.cs
@@ -20,8 +20,8 @@ namespace Nest
 
 		public IList<SingleBucket> AnonymousBuckets() => this.Items?.OfType<SingleBucket>().ToList();
 
-		private AggregationsHelper Aggregations { get; set; }
+		public AggregationsHelper Aggregations { get; set; }
 
-		private IEnumerable<IAggregation> Items { get; set; }
+		public IEnumerable<IAggregation> Items { get; set; }
 	}
 }


### PR DESCRIPTION
Needed a way to access all the buckets in the result. The named bucket is great for single bucket access but in certain cases you may want to just loop all the buckets with the name and the bucket content in the output. See [here](https://github.com/elastic/elasticsearch-net/issues/1742) for example. 

Just made the Accessibility Level `Public` to allow this. 