### PR TITLE
final passover the convenience methods, relates to #1612

### DIFF
--- a/src/Elasticsearch.Net/Elasticsearch.Net.xproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.xproj
@@ -14,6 +14,9 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
   <ProjectExtensions>
     <VisualStudio>

--- a/src/Nest/Nest.xproj
+++ b/src/Nest/Nest.xproj
@@ -11,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
 
@@ -72,13 +73,7 @@ namespace Nest
 		/// <summary>
 		/// A query that match on any (configurable) of the provided terms. This is a simpler syntax query for using a bool query with several term queries in the should clauses.
 		/// </summary>
-		public QueryContainer Terms<TValue>(Func<TermsQueryDescriptor<T, TValue>, ITermsQuery> selector) =>
-			this.Assign(selector, (query, container) => container.Terms = query);
-
-		/// <summary>
-		/// A query that match on any (configurable) of the provided terms. This is a simpler syntax query for using a bool query with several term queries in the should clauses.
-		/// </summary>
-		public QueryContainer Terms(Func<TermsQueryDescriptor<T, string>, ITermsQuery> selector) =>
+		public QueryContainer Terms(Func<TermsQueryDescriptor<T>, ITermsQuery> selector) =>
 			this.Assign(selector, (query, container) => container.Terms = query);
 
 		/// <summary>
@@ -363,47 +358,15 @@ namespace Nest
 		/// Matches documents that have fields that contain a term (not analyzed). 
 		/// The term query maps to Lucene TermQuery. 
 		/// </summary>
-		/// <typeparam name="TValue">The type of the field</typeparam>
-		public QueryContainer Term<TValue>(Expression<Func<T, TValue>> fieldDescriptor, TValue value, double? boost = null)
-		{
-			return this.Term(t =>
-			{
-				t.Field(fieldDescriptor).Value(value);
-				if (boost.HasValue)
-					t.Boost(boost.Value);
-				return t;
-			});
-		}
+		public QueryContainer Term(Expression<Func<T, object>> field, object value, double? boost = null, string name = null) =>
+			this.Term(t => t.Field(field).Value(value).Boost(boost).Name(name));
 
 		/// <summary>
 		/// Matches documents that have fields that contain a term (not analyzed). 
 		/// The term query maps to Lucene TermQuery. 
 		/// </summary>
-		public QueryContainer Term(Expression<Func<T, object>> fieldDescriptor, object value, double? boost = null)
-		{
-			return this.Term(t =>
-			{
-				t.Field(fieldDescriptor).Value(value);
-				if (boost.HasValue)
-					t.Boost(boost.Value);
-				return t;
-			});
-		}
-
-		/// <summary>
-		/// Matches documents that have fields that contain a term (not analyzed). 
-		/// The term query maps to Lucene TermQuery. 
-		/// </summary>
-		public QueryContainer Term(string field, object value, double? boost = null)
-		{
-			return this.Term(t =>
-			{
-				t.Field(field).Value(value);
-				if (boost.HasValue)
-					t.Boost(boost.Value);
-				return t;
-			});
-		}
+		public QueryContainer Term(string field, object value, double? boost = null, string name = null) => 
+			this.Term(t => t.Field(field).Value(value).Boost(boost).Name(name));
 
 		/// <summary>
 		/// Matches documents that have fields that contain a term (not analyzed). 
@@ -419,16 +382,8 @@ namespace Nest
 		/// over many terms. In order to prevent extremely slow wildcard queries, a wildcard term should 
 		/// not start with one of the wildcards * or ?. The wildcard query maps to Lucene WildcardQuery.
 		/// </summary>
-		public QueryContainer Wildcard(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null, RewriteMultiTerm? rewrite = null)
-		{
-			return this.Wildcard(t =>
-			{
-				t.Field(fieldDescriptor).Value(value);
-				if (boost.HasValue) t.Boost(boost.Value);
-				if (rewrite.HasValue) t.Rewrite(rewrite.Value);
-				return t;
-			});
-		}
+		public QueryContainer Wildcard(Expression<Func<T, object>> field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) => 
+			this.Wildcard(t => t.Field(field).Value(value).Rewrite(rewrite).Boost(boost).Name(name));
 
 		/// <summary>
 		/// Matches documents that have fields matching a wildcard expression (not analyzed). 
@@ -437,16 +392,8 @@ namespace Nest
 		/// In order to prevent extremely slow wildcard queries, a wildcard term should not start with 
 		/// one of the wildcards * or ?. The wildcard query maps to Lucene WildcardQuery.
 		/// </summary>
-		public QueryContainer Wildcard(string field, string value, double? boost = null, RewriteMultiTerm? rewrite = null)
-		{
-			return this.Wildcard(t =>
-			{
-				t.Field(field).Value(value);
-				if (boost.HasValue) t.Boost(boost.Value);
-				if (rewrite.HasValue) t.Rewrite(rewrite.Value);
-				return t;
-			});
-		}
+		public QueryContainer Wildcard(string field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+			this.Wildcard(t => t.Field(field).Value(value).Rewrite(rewrite).Boost(boost).Name(name));
 
 		/// <summary>
 		/// Matches documents that have fields matching a wildcard expression (not analyzed). 
@@ -462,31 +409,15 @@ namespace Nest
 		/// Matches documents that have fields containing terms with a specified prefix (not analyzed). 
 		/// The prefix query maps to Lucene PrefixQuery. 
 		/// </summary>
-		public QueryContainer Prefix(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null, RewriteMultiTerm? rewrite = null)
-		{
-			return this.Prefix(t =>
-			{
-				t.Field(fieldDescriptor).Value(value);
-				if (boost.HasValue) t.Boost(boost.Value);
-				if (rewrite.HasValue) t.Rewrite(rewrite.Value);
-				return t;
-			});
-		}
+		public QueryContainer Prefix(Expression<Func<T, object>> field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) => 
+			this.Prefix(t => t.Field(field).Value(value).Boost(boost).Rewrite(rewrite).Name(name));
 
 		/// <summary>
 		/// Matches documents that have fields containing terms with a specified prefix (not analyzed). 
 		/// The prefix query maps to Lucene PrefixQuery. 
 		/// </summary>	
-		public QueryContainer Prefix(string field, string value, double? boost = null, RewriteMultiTerm? rewrite = null)
-		{
-			return this.Prefix(t =>
-			{
-				t.Field(field).Value(value);
-				if (boost.HasValue) t.Boost(boost.Value);
-				if (rewrite.HasValue) t.Rewrite(rewrite.Value);
-				return t;
-			});
-		}
+		public QueryContainer Prefix(string field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+			this.Prefix(t => t.Field(field).Value(value).Boost(boost).Rewrite(rewrite).Name(name));
 
 		/// <summary>
 		/// Matches documents that have fields containing terms with a specified prefix (not analyzed). 

--- a/src/Nest/QueryDsl/Abstractions/Query/QueryDescriptorBase.cs
+++ b/src/Nest/QueryDsl/Abstractions/Query/QueryDescriptorBase.cs
@@ -9,7 +9,7 @@
 		public TDescriptor Name(string name) => Assign(a => a.Name = name);
 
 		double? IQuery.Boost { get; set; }
-		public TDescriptor Boost(double boost) => Assign(a => a.Boost = boost);
+		public TDescriptor Boost(double? boost) => Assign(a => a.Boost = boost);
 
 		bool IQuery.Conditionless => this.Conditionless;
 		protected abstract bool Conditionless { get; }

--- a/src/Nest/QueryDsl/Query.cs
+++ b/src/Nest/QueryDsl/Query.cs
@@ -114,11 +114,14 @@ namespace Nest
         public static QueryContainer Nested(Func<NestedQueryDescriptor<T>, INestedQuery> selector) =>
             new QueryContainerDescriptor<T>().Nested(selector);
 
-        public static QueryContainer Prefix(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null) =>
-            new QueryContainerDescriptor<T>().Prefix(fieldDescriptor, value, boost);
+        public static QueryContainer Prefix(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+            new QueryContainerDescriptor<T>().Prefix(fieldDescriptor, value, boost, rewrite, name);
 
-        public static QueryContainer Prefix(string field, string value, double? boost = null) =>
-            new QueryContainerDescriptor<T>().Prefix(field, value, boost);
+        public static QueryContainer Prefix(string field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+            new QueryContainerDescriptor<T>().Prefix(field, value, boost, rewrite, name);
+
+        public static QueryContainer Prefix(Func<PrefixQueryDescriptor<T>, IPrefixQuery> selector) =>
+            new QueryContainerDescriptor<T>().Prefix(selector);
 
         public static QueryContainer QueryString(Func<QueryStringQueryDescriptor<T>, IQueryStringQuery> selector) =>
             new QueryContainerDescriptor<T>().QueryString(selector);
@@ -165,19 +168,19 @@ namespace Nest
         public static QueryContainer Template(Func<TemplateQueryDescriptor<T>, ITemplateQuery> selector) =>
             new QueryContainerDescriptor<T>().Template(selector);
 
-        public static QueryContainer Term<TValue>(Expression<Func<T, object>> fieldDescriptor, TValue value, double? boost = null) =>
-            new QueryContainerDescriptor<T>().Term(fieldDescriptor, value, boost);
+        public static QueryContainer Term(Expression<Func<T, object>> fieldDescriptor, object value, double? boost = null, string name = null) =>
+            new QueryContainerDescriptor<T>().Term(fieldDescriptor, value, boost, name);
 
-        public static QueryContainer Term<TValue>(string field, TValue value, double? boost = null) =>
-            new QueryContainerDescriptor<T>().Term(field, value, boost);
+        public static QueryContainer Term(string field, object value, double? boost = null, string name = null) =>
+            new QueryContainerDescriptor<T>().Term(field, value, boost, name);
+
+        public static QueryContainer Term(Func<TermQueryDescriptor<T>, ITermQuery> selector) =>
+            new QueryContainerDescriptor<T>().Term(selector);
 
         public static QueryContainer TermRange(Func<TermRangeQueryDescriptor<T>, ITermRangeQuery> selector) =>
             new QueryContainerDescriptor<T>().TermRange(selector);
 
-        public static QueryContainer Terms<TValue>(Func<TermsQueryDescriptor<T, TValue>, ITermsQuery> selector) =>
-            new QueryContainerDescriptor<T>().Terms(selector);
-
-        public static QueryContainer Terms(Func<TermsQueryDescriptor<T, object>, ITermsQuery> selector) =>
+        public static QueryContainer Terms(Func<TermsQueryDescriptor<T>, ITermsQuery> selector) =>
             new QueryContainerDescriptor<T>().Terms(selector);
 
         public static QueryContainer Type(Func<TypeQueryDescriptor, ITypeQuery> selector) =>
@@ -185,14 +188,15 @@ namespace Nest
 
         public static QueryContainer Type<TOther>() => Type(q => q.Value<TOther>());
 
-        public static QueryContainer Wildcard(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null) =>
-            new QueryContainerDescriptor<T>().Wildcard(fieldDescriptor, value, boost);
+        public static QueryContainer Wildcard(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+            new QueryContainerDescriptor<T>().Wildcard(fieldDescriptor, value, boost, rewrite, name);
+
+        public static QueryContainer Wildcard(string field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+            new QueryContainerDescriptor<T>().Wildcard(field, value, boost, rewrite, name);
 
         public static QueryContainer Wildcard(Func<WildcardQueryDescriptor<T>, IWildcardQuery> selector) =>
             new QueryContainerDescriptor<T>().Wildcard(selector);
 
-        public static QueryContainer Wildcard(string field, string value, double? boost = null) =>
-            new QueryContainerDescriptor<T>().Wildcard(field, value, boost);
 
 #pragma warning disable 618
         public static QueryContainer Filtered(Func<FilteredQueryDescriptor<T>, IFilteredQuery> selector) =>

--- a/src/Nest/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
@@ -26,7 +26,7 @@ namespace Nest
 	{
 		RewriteMultiTerm? IPrefixQuery.Rewrite { get; set; }
 
-		public PrefixQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
+		public PrefixQueryDescriptor<T> Rewrite(RewriteMultiTerm? rewrite) 
 		{
 			((IPrefixQuery)this).Rewrite = rewrite;
 			return this;

--- a/src/Nest/QueryDsl/TermLevel/Term/TermQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Term/TermQuery.cs
@@ -19,8 +19,7 @@ namespace Nest
 		internal static bool IsConditionless(ITermQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
 	}
 
-	public class TermQueryDescriptorBase<TDescriptor, T> 
-		: FieldNameQueryDescriptorBase<TermQueryDescriptorBase<TDescriptor, T>, ITermQuery, T>
+	public abstract class TermQueryDescriptorBase<TDescriptor, T> : FieldNameQueryDescriptorBase<TDescriptor, ITermQuery, T>
 		, ITermQuery
 		where TDescriptor : TermQueryDescriptorBase<TDescriptor, T>
 		where T : class

--- a/src/Nest/QueryDsl/TermLevel/Terms/TermsQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Terms/TermsQuery.cs
@@ -45,9 +45,8 @@ namespace Nest
 	/// This is a simpler syntax query for using a bool query with several term queries in the should clauses.
 	/// </summary>
 	/// <typeparam name="T">The type that represents the expected hit type</typeparam>
-	/// <typeparam name="TValue">The type of the field that we want to specfify terms for</typeparam>
-	public class TermsQueryDescriptor<T, TValue> 
-		: FieldNameQueryDescriptorBase<TermsQueryDescriptor<T, TValue>, ITermsQuery, T>
+	public class TermsQueryDescriptor<T> 
+		: FieldNameQueryDescriptorBase<TermsQueryDescriptor<T>, ITermsQuery, T>
 		, ITermsQuery where T : class
 	{
 		protected override bool Conditionless => TermsQuery.IsConditionless(this);
@@ -56,16 +55,16 @@ namespace Nest
 		IEnumerable<object> ITermsQuery.Terms { get; set; }
 		IFieldLookup ITermsQuery.TermsLookup { get; set; }
 
-		public TermsQueryDescriptor<T, TValue> TermsLookup<TOther>(Func<FieldLookupDescriptor<TOther>, IFieldLookup> selector)
+		public TermsQueryDescriptor<T> TermsLookup<TOther>(Func<FieldLookupDescriptor<TOther>, IFieldLookup> selector)
 			where TOther : class => Assign(a => a.TermsLookup = selector(new FieldLookupDescriptor<TOther>()));
 
-		public TermsQueryDescriptor<T, TValue> MinimumShouldMatch(MinimumShouldMatch minMatch) => Assign(a => a.MinimumShouldMatch = minMatch);
+		public TermsQueryDescriptor<T> MinimumShouldMatch(MinimumShouldMatch minMatch) => Assign(a => a.MinimumShouldMatch = minMatch);
 
-		public TermsQueryDescriptor<T, TValue> DisableCoord(bool? disable = true) => Assign(a => a.DisableCoord = disable);
+		public TermsQueryDescriptor<T> DisableCoord(bool? disable = true) => Assign(a => a.DisableCoord = disable);
 
-		public TermsQueryDescriptor<T, TValue> Terms(IEnumerable<TValue> terms) => Assign(a => a.Terms = terms.Cast<object>());
+		public TermsQueryDescriptor<T> Terms<TValue>(IEnumerable<TValue> terms) => Assign(a => a.Terms = terms.Cast<object>());
 
-		public TermsQueryDescriptor<T, TValue> Terms(params TValue[] terms) => Assign(a => a.Terms = terms.Cast<object>());
+		public TermsQueryDescriptor<T> Terms<TValue>(params TValue[] terms) => Assign(a => a.Terms = terms.Cast<object>());
 
 	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Terms/TermsQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/TermLevel/Terms/TermsQueryJsonConverter.cs
@@ -57,7 +57,7 @@ namespace Nest
 		}
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
-			var filter = new TermsQueryDescriptor<object, object>();
+			var filter = new TermsQueryDescriptor<object>();
 			ITermsQuery f = filter;
 			if (reader.TokenType != JsonToken.StartObject)
 				return null;

--- a/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
@@ -32,14 +32,13 @@ namespace Nest
 		internal override void WrapInContainer(IQueryContainer c) => c.Wildcard = this;
 	}
 
-	public class WildcardQueryDescriptor<T> : 
-		TermQueryDescriptorBase<WildcardQueryDescriptor<T>, T>, 
+	public class WildcardQueryDescriptor<T> : TermQueryDescriptorBase<WildcardQueryDescriptor<T>, T>, 
 		IWildcardQuery 
 		where T : class
 	{
 		RewriteMultiTerm? IWildcardQuery.Rewrite { get; set; }
 
-		public WildcardQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
+		public WildcardQueryDescriptor<T> Rewrite(RewriteMultiTerm? rewrite)
 		{
 			((IWildcardQuery)this).Rewrite = rewrite;
 			return this;


### PR DESCRIPTION
Did a final pass over the convenience query methods (shortcuts into the selector overload). 

Sadly the intellisense experience for `q=>q.Term(p,` does not improve if we rename the `.Term(selector)` overload so `Term()` still has three overloads.

Opted out of created convenience overloads for Tersm because it will introduce

```csharp
.Terms<K>(string, IEnumerable<K>)
.Terms<K>(Expression, IEnumerable<K>)
.Terms<K>(string, params K[])
.Terms<K>(Expression, params K[])
```

And then intellisense will  show `.Terms` and `.Terms<>` as two distinct options.

Fixed a small issue with TermQueryBase not being abstract and not curiously revealing the right descriptor for the return type.
