### PR TITLE
Support specifying one or many types as part of Reindexing

### DIFF
--- a/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
@@ -54,7 +54,7 @@ namespace Nest
 			var searchResult = this._client.Search<T>(
 				s => s
 					.Index(fromIndex)
-					.Type(Types.All)
+					.Type(this._reindexRequest.Type)
 					.From(0)
 					.Size(size)
 					.Query(q=>this._reindexRequest.Query)

--- a/src/Nest/Document/Multiple/Reindex/ReindexRequest.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexRequest.cs
@@ -6,6 +6,7 @@ namespace Nest
 	{
 		IndexName To { get; set; }
 		IndexName From { get; set; }
+		Types Type { get; set; }
 		Time Scroll { get; set; }
 		int? Size { get; set; }
 		
@@ -15,19 +16,22 @@ namespace Nest
 
 		IPutMappingRequest PutMappingRequest { get; set; } 
 	}
+
 	public class ReindexRequest : IReindexRequest
 	{
 		public IndexName To { get; set; }
 		public IndexName From { get; set; }
+		public Types Type { get; set; }
 		public Time Scroll { get; set; }
 		public int? Size { get; set; }
 		public QueryContainer Query { get; set; }
 		public ICreateIndexRequest CreateIndexRequest { get; set; }
 		public IPutMappingRequest PutMappingRequest { get; set; } 
-		public ReindexRequest(IndexName from, IndexName to)
+		public ReindexRequest(IndexName from, IndexName to, Types type)
 		{
 			this.To = to;
 			this.From = from;
+			this.Type = type;
 		}
 	}
 
@@ -35,6 +39,7 @@ namespace Nest
 	{
 		IndexName IReindexRequest.To { get; set; }
 		IndexName IReindexRequest.From { get; set; }
+		Types IReindexRequest.Type { get; set; }
 		Time IReindexRequest.Scroll { get; set; }
 		int? IReindexRequest.Size { get; set; }
 		QueryContainer IReindexRequest.Query { get; set; }
@@ -43,7 +48,9 @@ namespace Nest
 		
 		public ReindexDescriptor(IndexName from, IndexName to)
 		{
-			Assign(a => a.From = from).Assign(a => a.To = to);
+			Assign(a => a.From = from)
+			.Assign(a => a.To = to)
+			.Assign(a => a.Type = typeof(T));
 		}
 
 		/// <summary>
@@ -74,6 +81,16 @@ namespace Nest
 		/// A query to optionally limit the documents to use for the reindex operation.  
 		/// </summary>
 		public ReindexDescriptor<T> Query(QueryContainer query) => Assign(a => a.Query = query);
+
+		/// <summary>
+		/// Specify the document types to reindex. By default, will be <typeparamref name="T"/>  
+		/// </summary>
+		public ReindexDescriptor<T> Type(Types type) => Assign(a => a.Type = type);
+
+		/// <summary>
+		/// Reindex all document types.
+		/// </summary>
+		public ReindexDescriptor<T> AllTypes() => this.Type(Types.AllTypes); 
 
 		/// <summary>
 		/// CreateIndex selector, will be passed the a descriptor initialized with the settings from

--- a/src/Nest/Document/Multiple/Reindex/ReindexResponse.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexResponse.cs
@@ -39,13 +39,8 @@ namespace Nest
 
 		public int Scroll { get; internal set; }
 
-		public bool IsValid
-		{
-			get
-			{
-				return (this.BulkResponse != null && this.BulkResponse.IsValid
-					&& this.SearchResponse != null && this.SearchResponse.IsValid);
-			}
-		}
+		public bool IsValid => 
+			this.BulkResponse != null && this.BulkResponse.IsValid
+			&& this.SearchResponse != null && this.SearchResponse.IsValid;
 	}
 }


### PR DESCRIPTION
Current implementation takes a generic ReindexDescriptor<T> but specifies all types when performing the scan and scroll for retrieving documents to reindex. The type of T should be used as the type of documents to target in the reindex operation, with methods exposed to allow the consumer to specify other other types / all types.
See https://github.com/elastic/elasticsearch-net/issues/1433