### PR TITLE
DebugInformation property on responses and exceptions

### DIFF
--- a/src/Elasticsearch.Net/Exceptions/ElasticsearchClientException.cs
+++ b/src/Elasticsearch.Net/Exceptions/ElasticsearchClientException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Elasticsearch.Net
 {
@@ -30,7 +31,32 @@ namespace Elasticsearch.Net
 			Response = apiCall;
 			FailureReason = failure;
 			AuditTrail = apiCall?.AuditTrail;
-
 		}
+
+		public string DebugInformation
+		{
+			get
+			{
+				var sb = new StringBuilder();
+				sb.AppendLine($"# FailureReason: {FailureReason.GetStringValue()} when trying to {Request.Method.GetStringValue()} {Request.Uri}");
+				if (this.Response != null)
+					ResponseStatics.DebugInformationBuilder(this.Response, sb);
+				else
+				{
+					ResponseStatics.DebugAuditTrail(this.AuditTrail, sb);
+					ResponseStatics.DebugAuditTrailExceptions(this.AuditTrail, sb);
+				}
+				if (InnerException != null)
+				{
+					sb.AppendLine($"# Inner Exception: {InnerException.Message}");
+					sb.AppendLine(InnerException.ToString());
+				}
+				sb.AppendLine($"# Exception:");
+				sb.AppendLine(this.ToString());
+
+				return sb.ToString();
+			}
+		}
+
 	}
 }

--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -22,16 +22,16 @@ namespace Elasticsearch.Net
 
 			var response = r.ResponseBodyInBytes?.Utf8String() ?? ResponseStatics.ResponseAlreadyCaptured;
 			var request = r.RequestBodyInBytes?.Utf8String() ?? ResponseStatics.RequestAlreadyCaptured;
-			sb.AppendLine($"# Request :\r\n{request}");
-			sb.AppendLine($"# Response :\r\n{response}");
+			sb.AppendLine($"# Request:\r\n{request}");
+			sb.AppendLine($"# Response:\r\n{response}");
 
 			return sb.ToString();
 		}
 
 		public static void DebugAuditTrailExceptions(List<Audit> auditTrail, StringBuilder sb)
 		{
-			var auditExceptions = auditTrail.Where(a => a.Exception != null);
-			foreach (var a in auditExceptions.Select((audit, i) => new {audit, i}))
+			var auditExceptions = auditTrail.Select((audit, i) => new {audit, i}).Where(a => a.audit.Exception != null);
+			foreach (var a in auditExceptions)
 				sb.AppendLine($"# Audit exception in step {a.i} {a.audit.Event.GetStringValue()}:\r\n{a.audit.Exception}");
 		}
 

--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -3,14 +3,49 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 
 namespace Elasticsearch.Net
 {
-	internal static class ResponseStatics
+	public static class ResponseStatics
 	{
-		public static readonly string PrintFormat = "StatusCode: {1}, {0}\tMethod: {2}, {0}\tUrl: {3}, {0}\tRequest: {4}, {0}\tResponse: {5}";
-		public static readonly string ErrorFormat = "{0}\tExceptionMessage: {1}{0}\t StackTrace: {2}";
-		public static readonly string AlreadyCaptured = "<Response stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>";
+		private static readonly string ResponseAlreadyCaptured = "<Response stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>";
+		private static readonly string RequestAlreadyCaptured = "<Request stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>";
+		public static string DebugInformationBuilder(IApiCallDetails r, StringBuilder sb)
+		{
+			sb.AppendLine($"# Audit trail of this API call:");
+			var auditTrail = (r.AuditTrail ?? Enumerable.Empty<Audit>()).ToList();
+			DebugAuditTrail(auditTrail, sb);
+			if (r.ServerError != null) sb.AppendLine($"# ServerError: {r.ServerError}");
+			if (r.OriginalException != null) sb.AppendLine($"# OriginalException: {r.OriginalException}");
+			DebugAuditTrailExceptions(auditTrail, sb);
+
+			var response = r.ResponseBodyInBytes?.Utf8String() ?? ResponseStatics.ResponseAlreadyCaptured;
+			var request = r.RequestBodyInBytes?.Utf8String() ?? ResponseStatics.RequestAlreadyCaptured;
+			sb.AppendLine($"# Request :\r\n{request}");
+			sb.AppendLine($"# Response :\r\n{response}");
+
+			return sb.ToString();
+		}
+
+		public static void DebugAuditTrailExceptions(List<Audit> auditTrail, StringBuilder sb)
+		{
+			var auditExceptions = auditTrail.Where(a => a.Exception != null);
+			foreach (var a in auditExceptions.Select((audit, i) => new {audit, i}))
+				sb.AppendLine($"# Audit exception in step {a.i} {a.audit.Event.GetStringValue()}:\r\n{a.audit.Exception}");
+		}
+
+		public static void DebugAuditTrail(List<Audit> auditTrail, StringBuilder sb)
+		{
+			if (auditTrail == null) return;
+			foreach (var audit in auditTrail)
+			{
+				sb.Append($" - {audit.Event.GetStringValue()}:");
+				if (audit.Node?.Uri != null) sb.Append($" Node: {audit.Node.Uri}");
+				if (audit.Exception != null) sb.Append($" Exception: {audit.Exception.GetType().Name}");
+				sb.AppendLine($" Took: {(audit.Ended - audit.Started)}");
+			}
+		}
 	}
 
 	public class ElasticsearchResponse<T> : IApiCallDetails
@@ -59,25 +94,16 @@ namespace Elasticsearch.Net
 			this.HttpStatusCode = statusCode;
 		}
 
-		public override string ToString()
+		public string DebugInformation
 		{
-			var r = this;
-			var e = r.OriginalException;
-			var response = this.ResponseBodyInBytes?.Utf8String() ?? ResponseStatics.AlreadyCaptured;
-
-			var requestJson = r.RequestBodyInBytes?.Utf8String();
-
-			var print = string.Format(ResponseStatics.PrintFormat,
-				Environment.NewLine,
-				r.HttpStatusCode.HasValue ? r.HttpStatusCode.Value.ToString(CultureInfo.InvariantCulture) : "-1",
-				r.HttpMethod,
-				r.Uri,
-				requestJson,
-				response
-			);
-			if (!this.Success && e != null)
-				print += string.Format(ResponseStatics.ErrorFormat,Environment.NewLine, e.Message, e.StackTrace);
-			return print;
+			get
+			{
+				var sb = new StringBuilder();
+				sb.AppendLine(this.ToString());
+				return ResponseStatics.DebugInformationBuilder(this, sb);
+			}
 		}
+
+		public override string ToString() =>  $"{(Success ? "S" : "Uns")}uccesful low level call on {HttpMethod.GetStringValue()}: {Uri.PathAndQuery}";
 	}
 }

--- a/src/Elasticsearch.Net/Responses/IApiCallDetails.cs
+++ b/src/Elasticsearch.Net/Responses/IApiCallDetails.cs
@@ -47,5 +47,7 @@ namespace Elasticsearch.Net
 		byte[] RequestBodyInBytes { get; }
 
 		List<Audit> AuditTrail { get; }
+
+		string DebugInformation { get; }
 	}
 }

--- a/src/Elasticsearch.Net/Responses/ServerError.cs
+++ b/src/Elasticsearch.Net/Responses/ServerError.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -53,6 +54,15 @@ namespace Elasticsearch.Net
 				Error = (Error)strategy.DeserializeObject(error, typeof(Error))
 			};
 		}
+
+		public override string ToString() 
+		{
+			var sb = new StringBuilder();
+			sb.Append($"ServerError: {Status}");
+			if (Error != null)
+				sb.Append(Error);
+			return sb.ToString();
+		}
 	}
 
 	public interface IRootCause
@@ -85,6 +95,8 @@ namespace Elasticsearch.Net
 			error.RootCause = os.Select(o => (RootCause)strategy.DeserializeObject(o, typeof(RootCause))).ToList();
 			return error;
 		}
+
+		public override string ToString() => $"Type: {this.Type} Reason: \"{this.Reason}\"";
 	}
 
 	public class RootCause : IRootCause
@@ -101,6 +113,8 @@ namespace Elasticsearch.Net
 			rootCause.FillValues(dict);
 			return rootCause;
 		}
+
+		public override string ToString() => $"Type: {this.Type} Reason: \"{this.Reason}\"";
 	}
 
 	internal static class RootCauseExtensions

--- a/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregation.cs
@@ -110,6 +110,14 @@ namespace Nest
 
 		public SignificantTermsAggregationDescriptor<T> Size(int size) => Assign(a => a.Size = size);
 
+		public SignificantTermsAggregationDescriptor<T> ExecutionHint(TermsAggregationExecutionHint? hint) => Assign(a => a.ExecutionHint = hint);
+
+		public SignificantTermsAggregationDescriptor<T> Include(Func<FluentDictionary<string, string>, FluentDictionary<string, string>> include) => 
+			Assign(a => a.Include = include?.Invoke(new FluentDictionary<string, string>()));
+
+		public SignificantTermsAggregationDescriptor<T> Exclude(Func<FluentDictionary<string, string>, FluentDictionary<string, string>> exclude) => 
+			Assign(a => a.Exclude = exclude?.Invoke(new FluentDictionary<string, string>()));
+
 		public SignificantTermsAggregationDescriptor<T> ShardSize(int shardSize) => Assign(a => a.ShardSize = shardSize);
 
 		public SignificantTermsAggregationDescriptor<T> MinimumDocumentCount(int minimumDocumentCount) =>

--- a/src/Nest/Cluster/NodesStats/NodesStatsRequest.cs
+++ b/src/Nest/Cluster/NodesStats/NodesStatsRequest.cs
@@ -3,6 +3,7 @@
 	public partial interface INodesStatsRequest { }
 
 	public partial class NodesStatsRequest { }
+
 	[DescriptorFor("NodesStats")]
 	public partial class NodesStatsDescriptor { }
 }

--- a/src/Nest/CommonAbstractions/Response/ApiCallDetailsOverride.cs
+++ b/src/Nest/CommonAbstractions/Response/ApiCallDetailsOverride.cs
@@ -23,6 +23,7 @@ namespace Nest
 		public byte[] ResponseBodyInBytes => this._original.ResponseBodyInBytes;
 		public byte[] RequestBodyInBytes => this._original.RequestBodyInBytes;
 		public List<Audit> AuditTrail => this._original.AuditTrail;
+		public string DebugInformation => this._original.DebugInformation;
 
 		public ApiCallDetailsOverride(IApiCallDetails original, bool isValid)
 		{

--- a/src/Nest/CommonAbstractions/Response/ResponseBase.cs
+++ b/src/Nest/CommonAbstractions/Response/ResponseBase.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
@@ -18,6 +21,9 @@ namespace Nest
 		[JsonIgnore]
 		Exception OriginalException { get; }
 
+		[JsonIgnore]
+		string DebugInformation { get; }
+
 	}
 
 	public abstract class ResponseBase : IResponse
@@ -27,9 +33,26 @@ namespace Nest
 		IApiCallDetails IBodyWithApiCallDetails.CallDetails { get; set; }
 
 		public virtual IApiCallDetails ApiCall => ((IBodyWithApiCallDetails)this).CallDetails;
-		
-		public virtual ServerError ServerError  => this.ApiCall?.ServerError;
 
-		public Exception OriginalException  => this.ApiCall?.OriginalException;
+		public virtual ServerError ServerError => this.ApiCall?.ServerError;
+
+		public Exception OriginalException => this.ApiCall?.OriginalException;
+
+		public string DebugInformation
+		{
+			get
+			{
+				var sb = new StringBuilder();
+				sb.Append($"{(!IsValid ? "Inv" : "V")}alid NEST response built from a ");
+				sb.AppendLine(ApiCall?.ToString().ToCamelCase() ?? "null ApiCall which is highly exceptional, please open a bug if you see this");
+				if (!this.IsValid) this.DebugIsValid(sb);
+				ResponseStatics.DebugInformationBuilder(ApiCall, sb);
+				return sb.ToString();
+			}
+		}
+		protected virtual void DebugIsValid(StringBuilder sb) { }
+
+		public override string ToString() =>  $"{(!IsValid ? "Inv" : "V")}alid NEST response built from a {this.ApiCall?.ToString().ToCamelCase()}";
+
 	}
 }

--- a/src/Nest/CommonOptions/Failures/BulkError.cs
+++ b/src/Nest/CommonOptions/Failures/BulkError.cs
@@ -17,5 +17,6 @@ namespace Nest
 		[JsonProperty("reason")]
 		public string Reason { get; internal set; }
 
+		public override string ToString() => $"Type: {Type} Reason: \"{Reason}\"";
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkResponse.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkResponse.cs
@@ -19,8 +19,9 @@ namespace Nest
 		public override bool IsValid => base.IsValid && !this.Errors && !this.ItemsWithErrors.HasAny();
 		protected override void DebugIsValid(StringBuilder sb)
 		{
+			sb.AppendLine($"# Invalid Bulk items:");
 			foreach(var i in Items.Select((item, i) => new { item, i}).Where(i=>!i.item.IsValid))
-				sb.AppendLine($"operation[{i.i}]: {i.item}");
+				sb.AppendLine($"  operation[{i.i}]: {i.item}");
 		}
 
 		[JsonProperty("took")]

--- a/src/Nest/Document/Multiple/Bulk/BulkResponse.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -16,6 +17,11 @@ namespace Nest
 	public class BulkResponse : ResponseBase, IBulkResponse
 	{
 		public override bool IsValid => base.IsValid && !this.Errors && !this.ItemsWithErrors.HasAny();
+		protected override void DebugIsValid(StringBuilder sb)
+		{
+			foreach(var i in Items.Select((item, i) => new { item, i}).Where(i=>!i.item.IsValid))
+				sb.AppendLine($"operation[{i.i}]: {i.item}");
+		}
 
 		[JsonProperty("took")]
 		public int Took { get; internal set; }

--- a/src/Nest/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
@@ -43,5 +43,7 @@ namespace Nest
 				}
 			}
 		}
+
+		public override string ToString() => $"{Operation} returned {Status} _index: {Index} _type: {Type} _id: {Id} _version: {Version} error: {Error}";
 	}
 }

--- a/src/Nest/Search/MultiSearch/MultiSearchResponse.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
@@ -15,6 +16,13 @@ namespace Nest
 		}
 
 		public override bool IsValid => base.IsValid && this.AllResponses.All(b => b.IsValid);
+
+		protected override void DebugIsValid(StringBuilder sb)
+		{
+			sb.AppendLine($"# Invalid searches (inspect individual response.DebugInformation for more detail):");
+			foreach(var i in AllResponses.Select((item, i) => new { item, i}).Where(i=>!i.item.IsValid))
+				sb.AppendLine($"  search[{i.i}]: {i.item}");
+		}
 
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter))]	
 		internal IDictionary<string, object> Responses { get; set; }

--- a/src/Nest/Search/Percolator/MultiPercolate/MultiPercolateResponse.cs
+++ b/src/Nest/Search/Percolator/MultiPercolate/MultiPercolateResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
@@ -15,6 +16,13 @@ namespace Nest
 	public class MultiPercolateResponse : ResponseBase, IMultiPercolateResponse
 	{
 		public override bool IsValid => base.IsValid && this.Responses.All(r => r.IsValid);
+
+		protected override void DebugIsValid(StringBuilder sb)
+		{
+			sb.AppendLine($"# Invalid percolations (inspect individual response.DebugInformation for more detail):");
+			foreach(var i in AllResponses.Select((item, i) => new { item, i}).Where(i=>!i.item.IsValid))
+				sb.AppendLine($"  search[{i.i}]: {i.item}");
+		}
 
 		[JsonProperty("responses")]
 		internal IEnumerable<PercolateResponse> AllResponses { get; set; }

--- a/src/Tests/ClientConcepts/Exceptions/ExceptionTests.cs
+++ b/src/Tests/ClientConcepts/Exceptions/ExceptionTests.cs
@@ -10,10 +10,10 @@ namespace Tests.ClientConcepts.Exceptions
 {
 	public class ExceptionTests
 	{
-		//[I]
+		[I]
 		public void ServerTestWhenThrowExceptionsEnabled()
 		{
-			var settings = new ConnectionSettings(new Uri("http://ipv4.fiddler:9200"))
+			var settings = new ConnectionSettings(new Uri($"http://{TestClient.Host}:9200"))
 				.ThrowExceptions();
 			var client = new ElasticClient(settings);
 			var exception = Assert.Throws<ElasticsearchClientException>(() => client.GetMapping<Project>(s => s.Index("doesntexist")));
@@ -23,7 +23,7 @@ namespace Tests.ClientConcepts.Exceptions
 			exception.Response.ServerError.Status.Should().BeGreaterThan(0);
 		}
 
-		//[I]
+		[I]
 		public void ClientTestWhenThrowExceptionsEnabled()
 		{
 			var settings = new ConnectionSettings(new Uri("http://doesntexist:9200"))
@@ -34,10 +34,10 @@ namespace Tests.ClientConcepts.Exceptions
 			inner.Should().NotBeNull();
 		}
 
-		//[I]
+		[I]
 		public void ServerTestWhenThrowExceptionsDisabled()
 		{
-			var settings = new ConnectionSettings(new Uri("http://ipv4.fiddler:9200"));
+			var settings = new ConnectionSettings(new Uri($"http://{TestClient.Host}:9200"));
 			var client = new ElasticClient(settings);
 			var response = client.GetMapping<Project>(s => s.Index("doesntexist"));
 			response.CallDetails.OriginalException.Should().NotBeNull();
@@ -45,7 +45,7 @@ namespace Tests.ClientConcepts.Exceptions
 			response.CallDetails.ServerError.Status.Should().BeGreaterThan(0);
 		}
 
-		//[I]
+		[I]
 		public void ClientTestWhenThrowExceptionsDisabled()
 		{
 			var settings = new ConnectionSettings(new Uri("http://doesntexist:9200"));

--- a/src/Tests/Framework/ApiTestBase.cs
+++ b/src/Tests/Framework/ApiTestBase.cs
@@ -65,25 +65,25 @@ namespace Tests.Framework
 			{
 				this.BeforeAllCalls(client, UniqueValues);
 
-				var dict = new Dictionary<Integration.ClientMethod, IResponse>();
-				this.CallIsolatedValue = UniqueValues[Integration.ClientMethod.Fluent];
+				var dict = new Dictionary<ClientMethod, IResponse>();
+				this.CallIsolatedValue = UniqueValues[ClientMethod.Fluent];
 				OnBeforeCall(client);
-				dict.Add(Integration.ClientMethod.Fluent, fluent(client, this.Fluent));
+				dict.Add(ClientMethod.Fluent, fluent(client, this.Fluent));
 				OnAfterCall(client);
 
-				this.CallIsolatedValue = UniqueValues[Integration.ClientMethod.FluentAsync];
+				this.CallIsolatedValue = UniqueValues[ClientMethod.FluentAsync];
 				OnBeforeCall(client);
-				dict.Add(Integration.ClientMethod.FluentAsync, await fluentAsync(client, this.Fluent));
+				dict.Add(ClientMethod.FluentAsync, await fluentAsync(client, this.Fluent));
 				OnAfterCall(client);
 
-				this.CallIsolatedValue = UniqueValues[Integration.ClientMethod.Initializer];
+				this.CallIsolatedValue = UniqueValues[ClientMethod.Initializer];
 				OnBeforeCall(client);
-				dict.Add(Integration.ClientMethod.Initializer, request(client, this.Initializer));
+				dict.Add(ClientMethod.Initializer, request(client, this.Initializer));
 				OnAfterCall(client);
 
-				this.CallIsolatedValue = UniqueValues[Integration.ClientMethod.InitializerAsync];
+				this.CallIsolatedValue = UniqueValues[ClientMethod.InitializerAsync];
 				OnBeforeCall(client);
-				dict.Add(Integration.ClientMethod.InitializerAsync, await requestAsync(client, this.Initializer));
+				dict.Add(ClientMethod.InitializerAsync, await requestAsync(client, this.Initializer));
 				OnAfterCall(client);
 				return dict;
 			});

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -67,7 +67,9 @@ namespace Tests.Framework
 			new ElasticClient(CreateSettings(modifySettings, port, forceInMemory: false, createPool: createPool));
 
 		public static Uri CreateNode(int? port = null) =>
-			new UriBuilder("http", (RunningFiddler) ? "ipv4.fiddler" : "localhost", port.GetValueOrDefault(9200)).Uri;
+			new UriBuilder("http", Host, port.GetValueOrDefault(9200)).Uri;
+
+		public static string Host => (RunningFiddler) ? "ipv4.fiddler" : "localhost";
 
 		public static IConnection CreateConnection(ConnectionSettings settings = null, bool forceInMemory = false) =>
 			Configuration.RunIntegrationTests && !forceInMemory

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
+mode: u
 # the elasticsearch version that should be started
 elasticsearch_version: 2.0.1
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
This PR adds a `.DebugInformation` property on responses & exceptions which acts as the goto diagnosis tool both for devs using NEST and for us maintainers to ask for when we receive a bug report.

# Examples

### Valid response

```
Valid NEST response built from a succesful low level call on POST: /project/project/nest-92a78d48/_update?pretty=true&fields=name%2C_source
# Audit trail of this API call:
 - HealthyResponse: Node: http://ipv4.fiddler:9200/ Took: 00:00:00.0105188
# Request :
<Request stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>
# Response :
<Response stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>
```

### Invalid response from a healthy low level call:

Individual responses can explain why they marked the response as functionally invalid, e.g here the bulkresponse lists the failed responses

```
Invalid NEST response built from a succesful low level call on POST: /nest-311ded48/_bulk?pretty=true
operation[0]: update returned 404 _index: nest-311ded48 _type: project _id: Turcotte - Langworth _version: 0 error: Type: document_missing_exception Reason: "[project][Turcotte - Langworth]: document missing"
# Audit trail of this API call:
 - HealthyResponse: Node: http://ipv4.fiddler:9200/ Took: 00:00:00.9404774
# Request :
<Request stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>
# Response :
<Response stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>
```

### Response with exception caught:

```
Invalid NEST response built from a unsuccesful low level call on GET: /doesntexist/_mapping/project
# Audit trail of this API call:
 - BadResponse: Node: http://ipv4.fiddler:9200/ Took: 00:00:02.0921637
# ServerError: ServerError: 404Type: index_not_found_exception Reason: "no such index"
# OriginalException: System.Net.WebException: The remote server returned an error: (404) Not Found.
   at System.Net.HttpWebRequest.GetResponse()
   at Elasticsearch.Net.HttpConnection.Request[TReturn](RequestData requestData) in C:\Users\Mpdreamz\dev\elastic\coreclr\src\Elasticsearch.Net\Connection\HttpConnection.cs:line 138
# Request :
<Request stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>
# Response :
<Response stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>
```

### Exception

```
# FailureReason: BadResponse when trying to GET http://ipv4.fiddler:9200/doesntexist/_mapping/project
# Audit trail of this API call:
 - BadResponse: Node: http://ipv4.fiddler:9200/ Took: 00:00:02.0759486
# ServerError: ServerError: 404Type: index_not_found_exception Reason: "no such index"
# OriginalException: System.Net.WebException: The remote server returned an error: (404) Not Found.
   at System.Net.HttpWebRequest.GetResponse()
   at Elasticsearch.Net.HttpConnection.Request[TReturn](RequestData requestData) in C:\Users\Mpdreamz\dev\elastic\coreclr\src\Elasticsearch.Net\Connection\HttpConnection.cs:line 138
# Request :
<Request stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>
# Response :
<Response stream not captured or already read to completion by serializer. Set DisableDirectStreaming() on ConnectionSettings to force it to be set on the response.>
# Inner Exception: The remote server returned an error: (404) Not Found.
System.Net.WebException: The remote server returned an error: (404) Not Found.
   at System.Net.HttpWebRequest.GetResponse()
   at Elasticsearch.Net.HttpConnection.Request[TReturn](RequestData requestData) in C:\Users\Mpdreamz\dev\elastic\coreclr\src\Elasticsearch.Net\Connection\HttpConnection.cs:line 138
# Exception:
<stracktrace_trimmed>
````

### Interesting audit trail exception:

This one is from our virtual clustering tests that throws hard `Exception`'s

```
# FailureReason: Unexpected when trying to POST http://localhost:9201/_search
 - PingFailure: Node: http://localhost:9200/ Exception: Exception Took: 00:00:00
 - PingSuccess: Node: http://localhost:9201/ Took: 00:00:00
 - BadResponse: Node: http://localhost:9201/ Exception: Exception Took: 00:00:00
# Audit exception in step 0 PingFailure:
System.Exception: ping exception
<snip>
# Audit exception in step 1 BadResponse:
System.Exception: boom!
   at Tests.Framework.VirtualClusterConnection.<>c__13`2.<Fail>b__13_0(Exception e) in <snip>
# Inner Exception: boom!
System.Exception: boom!
   at Tests.Framework.VirtualClusterConnection.<>c__13`2.<Fail>b__13_0(Exception e) in <snip>
```
