### PR TITLE
Feature/build improvements

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -17,8 +17,6 @@ if errorlevel 1 (
   exit /b %errorlevel%
 )
 
-
-
 SET TARGET="build"
 SET VERSION=
 SET ESVERSIONS=
@@ -27,7 +25,10 @@ SET SKIPTESTS=0
 SET APIKEY=
 
 
-IF /I "%1"=="skiptests" (set SKIPTESTS="1")
+IF /I "%1"=="skiptests" (
+	set SKIPTESTS="1"
+	SHIFT
+)
 
 IF NOT [%1]==[] (set TARGET="%1")
 

--- a/build/scripts/Building.fsx
+++ b/build/scripts/Building.fsx
@@ -7,11 +7,11 @@ open Fake
 open Paths
 open Projects
 
-let gitLink pdbDir =
+let gitLink pdbDir projectName =
     let exe = Paths.Tool("gitlink/lib/net45/GitLink.exe")
     ExecProcess(fun p ->
       p.FileName <- exe
-      p.Arguments <- sprintf @". -u %s -d %s" Paths.Repository pdbDir
+      p.Arguments <- sprintf @". -u %s -d %s -include %s" Paths.Repository pdbDir projectName
     ) (TimeSpan.FromMinutes 5.0) |> ignore
 
 type Build() = 
@@ -28,8 +28,8 @@ type Build() =
         projects
         |> Seq.iter(fun project -> 
             let path = (Paths.Quote project)
-            Tooling.Dnu.Exec Tooling.DotNetRuntime.Desktop Build.BuildFailure project ["restore"; path]
-            Tooling.Dnu.Exec Tooling.DotNetRuntime.Desktop Build.BuildFailure project ["build"; path; "--configuration Release --quiet";]
+            Tooling.Dnu.Exec Tooling.DotNetRuntime.Desktop Build.BuildFailure project ["restore"; path; "--quiet"]
+            Tooling.Dnu.Exec Tooling.DotNetRuntime.Desktop Build.BuildFailure project ["build"; path; "--configuration Release --quiet"]
            )
 
     static member BuildFailure errors =
@@ -44,8 +44,8 @@ type Build() =
 
             //eventhough this says desktop it still builds all the tfm's it just hints wich installed dnx version to use
             let path = (Paths.Quote project)
-            Tooling.Dnu.Exec Tooling.DotNetRuntime.Desktop Build.BuildFailure project ["restore"; path]
-            Tooling.Dnu.Exec Tooling.DotNetRuntime.Desktop Build.BuildFailure project ["build"; path; "--configuration Release";]
+            Tooling.Dnu.Exec Tooling.DotNetRuntime.Desktop Build.BuildFailure project ["restore"; path; "--quiet"]
+            Tooling.Dnu.Exec Tooling.DotNetRuntime.Desktop Build.BuildFailure project ["build"; path; "--configuration Release --quiet"]
            )
 
         projects
@@ -57,8 +57,8 @@ type Build() =
                 match projectName with
                 | "Nest" 
                 | "Elasticsearch.Net" ->
-                    gitLink(Paths.Net45BinFolder projectName)
-                    gitLink(Paths.DotNet51BinFolder projectName)
+                    gitLink (Paths.Net45BinFolder projectName) projectName
+                    gitLink (Paths.DotNet51BinFolder projectName) projectName
                 | _  -> ()
             CopyDir outputFolder binFolder allFiles
         )

--- a/build/scripts/Paths.fsx
+++ b/build/scripts/Paths.fsx
@@ -119,34 +119,37 @@ module Tooling =
         member this.Path = Paths.Tool(path)
         member this.Exec arguments = exec this.Path arguments
 
-    let private dotTraceCommandLineTools = "JetBrains.dotTrace.CommandLineTools.10.0.20151114.191633"
-    let private buildToolsDirectory = Paths.Build("tools")
-    let private dotTraceDirectory = sprintf "%s/%s" buildToolsDirectory dotTraceCommandLineTools
-    
-    if (Directory.Exists(dotTraceDirectory) = false)
-    then
-        trace (sprintf "No JetBrains DotTrace tooling found in %s. Downloading now" buildToolsDirectory) 
-        let url = sprintf "https://d1opms6zj7jotq.cloudfront.net/resharper/%s.zip" dotTraceCommandLineTools      
-        let zipFile = sprintf "%s/%s.zip" buildToolsDirectory dotTraceCommandLineTools
-        use webClient = new WebClient()
-        webClient.DownloadFile(url, zipFile)
-        System.IO.Compression.ZipFile.ExtractToDirectory(zipFile, dotTraceDirectory)
-        File.Delete zipFile
-        trace "JetBrains DotTrace tooling downloaded"
-
-    let NugetFile = "build/tools/nuget/nuget.exe"
-    if (File.Exists(NugetFile) = false)
-    then
-        trace "Nuget not found %s. Downloading now"
-        let url = "http://nuget.org/nuget.exe" 
-        Directory.CreateDirectory("build/tools/nuget") |> ignore
-        use webClient = new WebClient()
-        webClient.DownloadFile(url, NugetFile)
-        trace "nuget downloaded"
+    let NugetFile = fun _ ->
+        let targetLocation = "build/tools/nuget/nuget.exe" 
+        if (not (File.Exists targetLocation))
+        then
+            trace "Nuget not found %s. Downloading now"
+            let url = "http://nuget.org/nuget.exe" 
+            Directory.CreateDirectory("build/tools/nuget") |> ignore
+            use webClient = new WebClient()
+            webClient.DownloadFile(url, targetLocation)
+            trace "nuget downloaded"
+        targetLocation
 
     type ProfilerTooling(path) =
+        let dotTraceCommandLineTools = "JetBrains.dotTrace.CommandLineTools.10.0.20151114.191633"
+        let buildToolsDirectory = Paths.Build("tools")
+        let dotTraceDirectory = sprintf "%s/%s" buildToolsDirectory dotTraceCommandLineTools
+        member this.Bootstrap = fun _ ->
+            if (not (Directory.Exists dotTraceDirectory)) then
+                trace (sprintf "No JetBrains DotTrace tooling found in %s. Downloading now" buildToolsDirectory) 
+                let url = sprintf "https://d1opms6zj7jotq.cloudfront.net/resharper/%s.zip" dotTraceCommandLineTools      
+                let zipFile = sprintf "%s/%s.zip" buildToolsDirectory dotTraceCommandLineTools
+                use webClient = new WebClient()
+                webClient.DownloadFile(url, zipFile)
+                System.IO.Compression.ZipFile.ExtractToDirectory(zipFile, dotTraceDirectory)
+                File.Delete zipFile
+                trace "JetBrains DotTrace tooling downloaded"
+            
         member this.Path = sprintf "%s/%s" dotTraceDirectory path
-        member this.Exec arguments = exec this.Path arguments
+        member this.Exec arguments = 
+            this.Bootstrap()
+            exec this.Path arguments
 
     let GitLink = new NugetTooling("GitLink", "gitlink/lib/net45/gitlink.exe")
     let Node = new NugetTooling("node.js", "Node.js/node.exe")
@@ -154,7 +157,7 @@ module Tooling =
     let Npm = new NugetTooling("npm", npmCli)
     let XUnit = new NugetTooling("xunit.runner.console", "xunit.runner.console/tools/xunit.console.exe")
     let DotTraceProfiler = new ProfilerTooling("ConsoleProfiler.exe")
-    let DotTraceReporter = new ProfilerTooling("Reporter.exe")           
+    let DotTraceReporter = new ProfilerTooling("Reporter.exe")
     let DotTraceSnapshotStats = new ProfilerTooling("SnapshotStat.exe")
 
     //only used to boostrap fake itself

--- a/build/scripts/Releasing.fsx
+++ b/build/scripts/Releasing.fsx
@@ -100,7 +100,7 @@ type Release() =
             ZipHelper.Unzip unzippedDir package
                         
             // rename NEST package id
-            if (projectName.Equals("Nest", StringComparison.InvariantCultureIgnoreCase) = true)
+            if (projectName.Equals("Nest", StringComparison.InvariantCultureIgnoreCase))
             then
                 let nuspec = sprintf "%s/Nest.nuspec" unzippedDir
                 FileHelper.RegexReplaceInFileWithEncoding 
@@ -138,7 +138,7 @@ type Release() =
     static member PublishCanaryBuild accessKey = 
         !! "build/output/_packages/*-ci*.nupkg"
         |> Seq.iter(fun f -> 
-            let success = Tooling.execProcess Tooling.NugetFile ["push"; f; accessKey; "-source"; "https://www.myget.org/F/elasticsearch-net/api/v2/package"] 
+            let success = Tooling.execProcess (Tooling.NugetFile()) ["push"; f; accessKey; "-source"; "https://www.myget.org/F/elasticsearch-net/api/v2/package"] 
             match success with
             | 0 -> traceFAKE "publish to myget succeeded" |> ignore
             | _ -> failwith "publish to myget failed" |> ignore

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -27,12 +27,12 @@ nuget Rx-Main
 nuget Rx-PlatformServices
 
 group build
-    
-	source https://www.nuget.org/api/v2
 
-	nuget FAKE
+    source https://www.nuget.org/api/v2
+
+    nuget FAKE
     nuget FSharp.Data
-    nuget GitLink
+    nuget GitLink prerelease
     nuget node.js
-	nuget npm
+    nuget npm
     nuget xunit.runner.console

--- a/paket.lock
+++ b/paket.lock
@@ -353,10 +353,10 @@ GROUP build
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
-    FAKE (4.14.5)
+    FAKE (4.19.0)
     FSharp.Data (2.2.5)
       Zlib.Portable (>= 1.10.0) - framework: portable-net40+sl50+wp80+win80
-    gitlink (2.2.0)
+    gitlink (2.3.0-unstable0022)
     Node.js (5.3.0)
     NoGit (0.1.0)
       Node.js (>= 0.12.0)


### PR DESCRIPTION
* `build.bat skiptests` now works again
* download of jetbrains profiler tooling and nuget is lazy (only some targets need them)
* depend on prelease version of GitLink that allows us to selectively include the projects to sourcelink, will remove errors on build outputs without pdb's