### PR TITLE
Added a null check to GeoLocation and updated ToString()

### DIFF
--- a/src/Nest/QueryDsl/Geo/GeoLocation.cs
+++ b/src/Nest/QueryDsl/Geo/GeoLocation.cs
@@ -82,7 +82,7 @@ namespace Nest
 
 		public override string ToString()
 		{
-            return _latitude.ToString("#0.0#####") + "," + _longitude.ToString("#0.0#####");
+            return _latitude.ToString("#0.0#######") + "," + _longitude.ToString("#0.0#######");
 		}
 
 		public bool Equals(GeoLocation other)

--- a/src/Nest/QueryDsl/Geo/GeoLocation.cs
+++ b/src/Nest/QueryDsl/Geo/GeoLocation.cs
@@ -82,7 +82,7 @@ namespace Nest
 
 		public override string ToString()
 		{
-			return string.Format(CultureInfo.InvariantCulture, "{0},{1}", _latitude, _longitude);
+            return _latitude.ToString("#0.0#####") + "," + _longitude.ToString("#0.0#####");
 		}
 
 		public bool Equals(GeoLocation other)
@@ -112,6 +112,9 @@ namespace Nest
 
 		public static implicit operator GeoLocation(string latLon)
 		{
+            if (string.IsNullOrEmpty(latLon))
+                throw new ArgumentNullException(nameof(latLon));
+
 			var parts = latLon.Split(',');
 			if (parts.Length != 2) throw new ArgumentException("Invalid format: string must be in the form of lat,lon");
 			double lat;


### PR DESCRIPTION
The ToString() must be in a specific format for lat long of which we know... 

Also there is only so much precision you can specify (http://www.geomidpoint.com/latlon.html)

You wouldn't want a number converted to 1.3e6 or 1.12345678901234545666666556 when 8 points of precision gets you to 1/16th of an inch