### PR TITLE
Fix/mappings

### DIFF
--- a/src/Benchmarking/project.lock.json
+++ b/src/Benchmarking/project.lock.json
@@ -7811,7 +7811,7 @@
     "runtime.win7.System.Net.Requests/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HI99nCEekL4SNvkLmpqkOE0PuEF5B6xyDcnJesdjo06BrGYH3QCvqJt2VmzBVe6hDSo6FnGOlhMvLdCUpDXiXA==",
+      "sha512": "mqWBQUhXhzkiwb+zVUuKg+wswJUsnQtZkFtz6eISw8vWNXA9i2jkzYjU3pjjIVmtdopnhle9YaS4a/w4OuWGLw==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Net.Requests.4.0.11-beta-23516.nupkg",

--- a/src/Elasticsearch.Net/project.lock.json
+++ b/src/Elasticsearch.Net/project.lock.json
@@ -1739,7 +1739,7 @@
     "runtime.win7.System.Net.Requests/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HI99nCEekL4SNvkLmpqkOE0PuEF5B6xyDcnJesdjo06BrGYH3QCvqJt2VmzBVe6hDSo6FnGOlhMvLdCUpDXiXA==",
+      "sha512": "mqWBQUhXhzkiwb+zVUuKg+wswJUsnQtZkFtz6eISw8vWNXA9i2jkzYjU3pjjIVmtdopnhle9YaS4a/w4OuWGLw==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Net.Requests.4.0.11-beta-23516.nupkg",

--- a/src/Nest/Mapping/Types/Specialized/Attachment/AttachmentProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/Attachment/AttachmentProperty.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -22,7 +22,7 @@ namespace Nest
 	{
 		public AttachmentProperty() : base("attachment") { }
 
-		private IDictionary Dictionary => this.Fields;
+		private IDictionary<PropertyName, IProperty> Dictionary => this.Fields ?? (this.Fields = new Properties());
 
 		public IStringProperty AuthorField
 		{
@@ -50,8 +50,8 @@ namespace Nest
 
 		public IStringProperty FileField
 		{
-			get { return Dictionary["file"] as IStringProperty; }
-			set { Dictionary["file"] = value; }
+			get { return Dictionary["content"] as IStringProperty; }
+			set { Dictionary["content"] = value; }
 		}
 
 		public IStringProperty KeywordsField
@@ -93,7 +93,7 @@ namespace Nest
 		INumberProperty IAttachmentProperty.ContentLengthField { get; set; }
 		IStringProperty IAttachmentProperty.LanguageField { get; set; }
 
-		private IDictionary Dictionary => Self.Fields;
+		private IDictionary<PropertyName, IProperty> Dictionary => Self.Fields ?? (Self.Fields = new Properties());
 
 		public AttachmentPropertyDescriptor() : base("attachment") { }
 
@@ -117,7 +117,7 @@ namespace Nest
 			SetMetadataField(selector, "name");
 
 		public AttachmentPropertyDescriptor<T> FileField(Func<StringPropertyDescriptor<T>, IStringProperty> selector) =>
-			SetMetadataField(selector, "file");
+			SetMetadataField(selector, "content");
 
 		public AttachmentPropertyDescriptor<T> AuthorField(Func<StringPropertyDescriptor<T>, IStringProperty> selector) =>
 			SetMetadataField(selector, "author");
@@ -128,10 +128,18 @@ namespace Nest
 		public AttachmentPropertyDescriptor<T> ContentTypeField(Func<StringPropertyDescriptor<T>, IStringProperty> selector) =>
 			SetMetadataField(selector, "content_type");
 
+		[Obsolete("Use ContentLengthField(Func<NumberPropertyDescriptor<T>, INumberProperty> selector)")]
 		public AttachmentPropertyDescriptor<T> ContentLengthField(Func<StringPropertyDescriptor<T>, IStringProperty> selector) =>
 			SetMetadataField(selector, "content_length");
 
+		public AttachmentPropertyDescriptor<T> ContentLengthField(Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetMetadataField(selector, "content_length");
+
+		[Obsolete("Use LanguageField(Func<StringPropertyDescriptor<T>, IStringProperty> selector)")]
 		public AttachmentPropertyDescriptor<T> LanguageField(Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetMetadataField(selector, "language");
+
+		public AttachmentPropertyDescriptor<T> LanguageField(Func<StringPropertyDescriptor<T>, IStringProperty> selector) =>
 			SetMetadataField(selector, "language");
 	}
 }

--- a/src/Nest/Mapping/Visitor/IMappingVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IMappingVisitor.cs
@@ -1,10 +1,13 @@
-﻿namespace Nest
+﻿using System;
+
+namespace Nest
 {
 	public interface IMappingVisitor
 	{
 		int Depth { get; set; }
 		void Visit(TypeMapping mapping);
 		void Visit(StringProperty mapping);
+		[Obsolete("Use Visit(NumberProperty mapping) for number mappings")]
 		void Visit(NumberType mapping);
 		void Visit(DateProperty mapping);
 		void Visit(BooleanProperty mapping);
@@ -16,5 +19,78 @@
 		void Visit(GeoShapeProperty mapping);
 		void Visit(AttachmentProperty mapping);
 		void Visit(NumberProperty mapping);
+		void Visit(CompletionProperty mapping);
+		void Visit(Murmur3HashProperty mapping);
+		void Visit(TokenCountProperty mapping);
+	}
+
+	public class NoopMappingVisitor : IMappingVisitor
+	{
+		public virtual int Depth { get; set; }
+
+		public virtual void Visit(TypeMapping mapping)
+		{
+		}
+
+		public virtual void Visit(StringProperty mapping)
+		{
+		}
+
+		[Obsolete("Use Visit(NumberProperty mapping) for number mappings")]
+		public virtual void Visit(NumberType mapping)
+		{
+		}
+
+		public virtual void Visit(DateProperty mapping)
+		{
+		}
+
+		public virtual void Visit(BooleanProperty mapping)
+		{
+		}
+
+		public virtual void Visit(BinaryProperty mapping)
+		{
+		}
+
+		public virtual void Visit(ObjectProperty mapping)
+		{
+		}
+
+		public virtual void Visit(NestedProperty mapping)
+		{
+		}
+
+		public virtual void Visit(IpProperty mapping)
+		{
+		}
+
+		public virtual void Visit(GeoPointProperty mapping)
+		{
+		}
+
+		public virtual void Visit(GeoShapeProperty mapping)
+		{
+		}
+
+		public virtual void Visit(AttachmentProperty mapping)
+		{
+		}
+
+		public virtual void Visit(NumberProperty mapping)
+		{
+		}
+
+		public virtual void Visit(CompletionProperty mapping)
+		{
+		}
+
+		public virtual void Visit(Murmur3HashProperty mapping)
+		{
+		}
+
+		public virtual void Visit(TokenCountProperty mapping)
+		{
+		}
 	}
 }

--- a/src/Nest/Mapping/Visitor/MappingWalker.cs
+++ b/src/Nest/Mapping/Visitor/MappingWalker.cs
@@ -90,24 +90,45 @@ namespace Nest
 						var i = field as IpProperty;
 						if (i == null) continue;
 						this._visitor.Visit(i);
+						this.Accept(i.Fields);
 						break;
 					case "geo_point":
 						var gp = field as GeoPointProperty;
 						if (gp == null) continue;
 						this._visitor.Visit(gp);
+						this.Accept(gp.Fields);
 						break;
 					case "geo_shape":
 						var gs = field as GeoShapeProperty;
 						if (gs == null) continue;
 						this._visitor.Visit(gs);
+						this.Accept(gs.Fields);
 						break;
 					case "attachment":
 						var a = field as AttachmentProperty;
 						if (a == null) continue;
 						this._visitor.Visit(a);
+						this.Accept(a.Fields);
+						break;
+					case "completion":
+						var c = field as CompletionProperty;
+						if (c == null) continue;
+						this._visitor.Visit(c);
+						this.Accept(c.Fields);
+						break;
+					case "murmur3":
+						var mm = field as Murmur3HashProperty;
+						if (mm == null) continue;
+						this._visitor.Visit(mm);
+						this.Accept(mm.Fields);
+						break;
+					case "token_count":
+						var tc = field as TokenCountProperty;
+						if (tc == null) continue;
+						this._visitor.Visit(tc);
+						this.Accept(tc.Fields);
 						break;
 				}
-
 			}
 		}
 	}

--- a/src/Nest/project.lock.json
+++ b/src/Nest/project.lock.json
@@ -2059,7 +2059,7 @@
     "runtime.win7.System.Net.Requests/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HI99nCEekL4SNvkLmpqkOE0PuEF5B6xyDcnJesdjo06BrGYH3QCvqJt2VmzBVe6hDSo6FnGOlhMvLdCUpDXiXA==",
+      "sha512": "mqWBQUhXhzkiwb+zVUuKg+wswJUsnQtZkFtz6eISw8vWNXA9i2jkzYjU3pjjIVmtdopnhle9YaS4a/w4OuWGLw==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Net.Requests.4.0.11-beta-23516.nupkg",

--- a/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using Elasticsearch.Net;
+using FluentAssertions;
 using Nest;
 using Tests.Framework;
 using Tests.Framework.Integration;
@@ -33,5 +35,130 @@ namespace Tests.Indices.MappingManagement.GetMapping
 		{
 			IgnoreUnavailable = true
 		};
+
+		protected override void ExpectResponse(IGetMappingResponse response)
+		{
+			response.IsValid.Should().BeTrue();
+
+			var visitor = new TestVisitor();
+			response.Accept(visitor);
+
+			visitor.CountsShouldContainKeyAndCountBe("type", 2);
+			visitor.CountsShouldContainKeyAndCountBe("object", 3);
+			visitor.CountsShouldContainKeyAndCountBe("date", 5);
+			visitor.CountsShouldContainKeyAndCountBe("string", 18);
+			visitor.CountsShouldContainKeyAndCountBe("ip", 2);
+			visitor.CountsShouldContainKeyAndCountBe("number", 3);
+			visitor.CountsShouldContainKeyAndCountBe("geo_point", 3);
+			visitor.CountsShouldContainKeyAndCountBe("completion", 3);
+			visitor.CountsShouldContainKeyAndCountBe("nested", 2);
+		}
+	}
+
+	internal class TestVisitor : IMappingVisitor
+	{
+		public TestVisitor()
+		{
+			Counts = new Dictionary<string, int>();
+		}
+
+		public int Depth { get; set; }
+
+		public Dictionary<string, int> Counts { get; }
+
+		private void Increment(string key)
+		{
+			if (!Counts.ContainsKey(key))
+			{
+				Counts.Add(key, 1);
+			}
+			Counts[key] += 1;
+		}
+
+		public void CountsShouldContainKeyAndCountBe(string key, int count)
+		{
+			this.Counts.ContainsKey(key).Should().BeTrue();
+			this.Counts[key].Should().Be(count);
+		}
+
+		public void Visit(DateProperty mapping)
+		{
+			Increment("date");
+		}
+
+		public void Visit(BinaryProperty mapping)
+		{
+			Increment("binary");
+		}
+
+		public void Visit(NestedProperty mapping)
+		{
+			Increment("nested");
+		}
+
+		public void Visit(GeoPointProperty mapping)
+		{
+			Increment("geo_point");
+		}
+
+		public void Visit(AttachmentProperty mapping)
+		{
+			Increment("attachment");
+		}
+
+		public void Visit(CompletionProperty mapping)
+		{
+			Increment("completion");
+		}
+
+		public void Visit(TokenCountProperty mapping)
+		{
+			Increment("token_count");
+		}
+
+		public void Visit(Murmur3HashProperty mapping)
+		{
+			Increment("murmur3");
+		}
+
+		public void Visit(NumberProperty mapping)
+		{
+			Increment("number");
+		}
+
+		public void Visit(GeoShapeProperty mapping)
+		{
+			Increment("geo_shape");
+		}
+
+		public void Visit(IpProperty mapping)
+		{
+			Increment("ip");
+		}
+
+		public void Visit(ObjectProperty mapping)
+		{
+			Increment("object");
+		}
+
+		public void Visit(BooleanProperty mapping)
+		{
+			Increment("boolean");
+		}
+
+		public void Visit(NumberType mapping)
+		{
+			throw new InvalidOperationException("NumberType should never be called");
+		}
+
+		public void Visit(StringProperty mapping)
+		{
+			Increment("string");
+		}
+
+		public void Visit(TypeMapping mapping)
+		{
+			Increment("type");
+		}
 	}
 }

--- a/src/Tests/Mapping/Types/Specialized/Attachment/AttachmentMappingTests.cs
+++ b/src/Tests/Mapping/Types/Specialized/Attachment/AttachmentMappingTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Nest;
+using Xunit;
+
+namespace Tests.Mapping.Types.Specialized.Attachment
+{
+	public class AttachmentTest
+	{
+		public string File { get; set; }
+
+		public string Author { get; set; }
+
+		public long ContentLength { get; set; }
+
+		public string ContentType { get; set; }
+
+		public DateTime Date { get; set; }
+
+		public string Keywords { get; set; }
+
+		public string Language { get; set; }
+
+		public string Name { get; set; }
+
+		public string Title { get; set; }
+	}
+
+	public class AttachmentMappingTests : TypeMappingTestBase<AttachmentTest>
+	{
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				file = new
+				{
+					type = "attachment",
+					fields = new
+					{
+						author = new
+						{
+							type = "string"
+						},
+						content = new
+						{
+							type = "string"
+						},
+						content_length = new
+						{
+							type = "double"
+						},
+						content_type = new
+						{
+							type = "string"
+						},
+						date = new
+						{
+							type = "date"
+						},
+						keywords = new
+						{
+							type = "string"
+						},
+						language = new
+						{
+							type = "string",
+							doc_values = true,
+							index = "not_analyzed"
+						},
+						name = new
+						{
+							type = "string"
+						},
+						title = new
+						{
+							type = "string"
+						}
+					}
+				}
+			}
+		};
+
+		protected override void AttributeBasedSerializes()
+		{
+			// TODO: Implement
+		}
+
+		protected override Func<PropertiesDescriptor<AttachmentTest>, IPromise<IProperties>> FluentProperties => p => p
+			.Attachment(a => a
+				//.Fields(s => s)
+				.Name(n => n.File)
+				.AuthorField(d => d
+					.Name(n => n.Author)
+				)
+				.FileField(d => d
+					.Name(n => n.File)
+				)
+				.ContentLengthField((NumberPropertyDescriptor<AttachmentTest> d) => d
+					.Name(n => n.ContentLength)
+				)
+				.ContentTypeField(d => d
+					.Name(n => n.ContentType)
+				)
+				.DateField(d => d
+					.Name(n => n.Date)
+				)
+				.KeywordsField(d => d
+					.Name(n => n.Keywords)
+				)
+				.LanguageField((StringPropertyDescriptor<AttachmentTest> d) => d
+					.Name(n => n.Language)
+					.DocValues()
+					.NotAnalyzed()
+				)
+				.NameField(d => d
+					.Name(n => n.Name)
+				)
+				.TitleField(d => d
+					.Name(n => n.Title)
+				)
+			);
+	}
+}
+

--- a/src/Tests/project.lock.json
+++ b/src/Tests/project.lock.json
@@ -6406,7 +6406,7 @@
     "runtime.win7.System.Net.Requests/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HI99nCEekL4SNvkLmpqkOE0PuEF5B6xyDcnJesdjo06BrGYH3QCvqJt2VmzBVe6hDSo6FnGOlhMvLdCUpDXiXA==",
+      "sha512": "mqWBQUhXhzkiwb+zVUuKg+wswJUsnQtZkFtz6eISw8vWNXA9i2jkzYjU3pjjIVmtdopnhle9YaS4a/w4OuWGLw==",
       "files": [
         "ref/dotnet/_._",
         "runtime.win7.System.Net.Requests.4.0.11-beta-23516.nupkg",


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch-net/issues/1826
Ensure `Fields` is initialized before adding attachment metadata fields.
Add overloaded fluent method signatures that use the correct property types for language and content_length.

Add Visit methods for all supported `IProperty` types
Add `NoopMappingVisitor` to make it easier to write a custom `IMappingVisitor` implementation