### PR TITLE
Minor refactoring

### DIFF
--- a/src/Elasticsearch.Net/Domain/RequestParameters/FluentRequestParameters.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/FluentRequestParameters.cs
@@ -4,72 +4,74 @@ using System.IO;
 
 namespace Elasticsearch.Net
 {
-	/// <summary>
-	/// Used by the raw client to compose querystring parameters in a matter that still exposes some xmldocs
-	/// You can always pass a simple NameValueCollection if you want.
-	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	public abstract class FluentRequestParameters<T> : IRequestParameters 
-		where T : FluentRequestParameters<T>
-	{
-		private IRequestParameters Self => this;
+    /// <summary>
+    /// Used by the raw client to compose querystring parameters in a matter that still exposes some xmldocs
+    /// You can always pass a simple NameValueCollection if you want.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public abstract class FluentRequestParameters<T> : IRequestParameters
+        where T : FluentRequestParameters<T>
+    {
+        private IRequestParameters Self => this;
 
-		public abstract HttpMethod DefaultHttpMethod { get; }
+        public abstract HttpMethod DefaultHttpMethod { get; }
 
-		IDictionary<string, object> IRequestParameters.QueryString { get; set; }
-		Func<IApiCallDetails, Stream, object> IRequestParameters.DeserializationOverride { get; set; }
-		IRequestConfiguration IRequestParameters.RequestConfiguration { get; set; }
+        #region Explicit implementation of IRequestParameters
 
-		protected FluentRequestParameters()
-		{
-			Self.QueryString = new Dictionary<string, object>();
-		}
+        IDictionary<string, object> IRequestParameters.QueryString { get; set; }
+        Func<IApiCallDetails, Stream, object> IRequestParameters.DeserializationOverride { get; set; }
+        IRequestConfiguration IRequestParameters.RequestConfiguration { get; set; }
 
-		void IRequestParameters.AddQueryStringValue(string name, object value)
-		{
-			if (value == null || name.IsNullOrEmpty()) return;
-			Self.QueryString[name] = value;
-		}
+        #endregion
 
-		public T AddQueryString(string name, object value)
-		{
-			Self.AddQueryStringValue(name, value);
-			return (T)this;
-		}
+        protected FluentRequestParameters()
+        {
+            Self.QueryString = new Dictionary<string, object>();
+        }
 
-		public T RemoveQueryString(string name)
-		{
-			Self.QueryString.Remove(name);
-			return (T)this;
-		}
+        void IRequestParameters.AddQueryStringValue(string name, object value)
+        {
+            if (value == null || name.IsNullOrEmpty()) return;
+            Self.QueryString[name] = value;
+        }
 
-		public T RequestConfiguration(Func<RequestConfigurationDescriptor, IRequestConfiguration> selector)
-		{
-			Self.RequestConfiguration = selector?.Invoke(new RequestConfigurationDescriptor()) ?? Self.RequestConfiguration;
-			return (T)this;
-		}
-		
-		public T DeserializationOverride(Func<IApiCallDetails, Stream, object> customResponseCreator)
-		{
-			Self.DeserializationOverride = customResponseCreator;
-			return (T)this;
-		}
+        public T AddQueryString(string name, object value)
+        {
+            Self.AddQueryStringValue(name, value);
+            return (T) this;
+        }
 
-		public bool ContainsKey(string name)
-		{
-			return Self.QueryString != null && Self.QueryString.ContainsKey(name);
-		}
+        public T RemoveQueryString(string name)
+        {
+            Self.QueryString.Remove(name);
+            return (T) this;
+        }
 
-		public TOut GetQueryStringValue<TOut>(string name)
-		{
-			if (!this.ContainsKey(name))
-				return default(TOut);
-			var value = Self.QueryString[name];
-			if (value == null)
-				return default(TOut);
-			return (TOut)value;
-		}
+        public T RequestConfiguration(Func<RequestConfigurationDescriptor, IRequestConfiguration> selector)
+        {
+            Self.RequestConfiguration = selector?.Invoke(new RequestConfigurationDescriptor()) ??
+                                        Self.RequestConfiguration;
+            return (T) this;
+        }
 
-	}
+        public T DeserializationOverride(Func<IApiCallDetails, Stream, object> customResponseCreator)
+        {
+            Self.DeserializationOverride = customResponseCreator;
+            return (T) this;
+        }
 
+        public bool ContainsKey(string name)
+        {
+            return Self.QueryString != null && Self.QueryString.ContainsKey(name);
+        }
+
+        public TOut GetQueryStringValue<TOut>(string name)
+        {
+            if (!this.ContainsKey(name))
+                return default(TOut);
+
+            var value = Self.QueryString[name];
+            return value == null ? default(TOut) : (TOut) value;
+        }
+    }
 }

--- a/src/Elasticsearch.Net/Extensions/NameValueCollectionExtensions.cs
+++ b/src/Elasticsearch.Net/Extensions/NameValueCollectionExtensions.cs
@@ -5,41 +5,44 @@ using System.Linq;
 
 namespace Elasticsearch.Net
 {
-	internal static class NameValueCollectionExtensions
-	{
-		internal static void CopyKeyValues(this NameValueCollection source, NameValueCollection dest)
-		{
-			foreach (var key in source.AllKeys)
-			{
-				if (dest[key] != null) throw new Exception(string.Format("Attempted to add duplicate key '{0}'", key));
+    internal static class NameValueCollectionExtensions
+    {
+        internal static void CopyKeyValues(this NameValueCollection source, NameValueCollection dest)
+        {
+            foreach (var key in source.AllKeys)
+            {
+                if (dest[key] != null) throw new Exception($"Attempted to add duplicate key '{key}'");
 
-				dest.Add(key, source[key]);
-			}
-		}
-		internal static string ToQueryString(this NameValueCollection self, string prefix = "?")
-		{
-			if (self == null)
-				return null;
+                dest.Add(key, source[key]);
+            }
+        }
 
-			if (self.AllKeys.Length == 0) return string.Empty;
-			
-			return prefix + string.Join("&", self.AllKeys.Select(key => $"{Encode(key)}={Encode(self[key])}"));
-		}
+        internal static string ToQueryString(this NameValueCollection self, string prefix = "?")
+        {
+            if (self == null)
+                return null;
 
-		private static string Encode(string s) => s;
-		//private static string Encode(string s) => s == null ? null : Uri.EscapeDataString(s);
+            return self.AllKeys.Length == 0
+                ? string.Empty
+                : $"{prefix}{string.Join("&", self.AllKeys.Select(key => $"{Encode(key)}={Encode(self[key])}"))}";
+        }
 
-		internal static NameValueCollection ToNameValueCollection(this IDictionary<string, object> dict, IFormatProvider provider)
-		{
-			if (dict == null || dict.Count < 0)
-				return null;
-			
-			var nv = new NameValueCollection();
-			foreach (var kv in dict.Where(kv => !kv.Key.IsNullOrEmpty()))
-			{
-				nv.Add(kv.Key, string.Format(provider, "{0}", kv.Value));
-			}
-			return nv;
-		}
-	}
+        //TODO: It's not placeholder function ;)
+        private static string Encode(string s) => s;
+        //private static string Encode(string s) => s == null ? null : Uri.EscapeDataString(s);
+
+        internal static NameValueCollection ToNameValueCollection(this IDictionary<string, object> originalDictionary,
+            IFormatProvider provider)
+        {
+            if (originalDictionary == null || originalDictionary.Count < 0)
+                return null;
+
+            var nameValueCollection = new NameValueCollection();
+
+            foreach (var keyValuePair in originalDictionary.Where(kv => !kv.Key.IsNullOrEmpty()))
+                nameValueCollection.Add(keyValuePair.Key, string.Format(provider, "{0}", keyValuePair.Value));
+
+            return nameValueCollection;
+        }
+    }
 }

--- a/src/Elasticsearch.Net/Responses/DynamicResponse.cs
+++ b/src/Elasticsearch.Net/Responses/DynamicResponse.cs
@@ -36,9 +36,7 @@ namespace Elasticsearch.Net
 			var instance = new DynamicResponse();
 			
 			foreach (var key in values.Keys)
-			{
 				instance[key] = values[key];
-			}
 
 			return instance;
 		}
@@ -62,9 +60,7 @@ namespace Elasticsearch.Net
 		public override bool TryGetMember(GetMemberBinder binder, out object result)
 		{
 			if (!BackingDictionary.TryGetValue(binder.Name, out result))
-			{
 				result = new ElasticsearchDynamicValue(null);
-			}
 
 			return true;
 		}
@@ -108,9 +104,7 @@ namespace Elasticsearch.Net
 
 				dynamic member;
 				if (!BackingDictionary.TryGetValue(name, out member))
-				{
 					member = new ElasticsearchDynamicValue(null);
-				}
 
 				return member;
 			}
@@ -129,15 +123,11 @@ namespace Elasticsearch.Net
 		/// <param name="other">An <see cref="DynamicResponse"/> instance to compare with this instance.</param>
 		public bool Equals(DynamicResponse other)
 		{
-			if (ReferenceEquals(null, other))
-			{
-				return false;
-			}
-
-			return ReferenceEquals(this, other) || Equals(other.BackingDictionary, this.BackingDictionary);
+		    return !ReferenceEquals(null, other) &&
+		           (ReferenceEquals(this, other) || Equals(other.BackingDictionary, this.BackingDictionary));
 		}
 
-		/// <summary>
+	    /// <summary>
 		/// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
 		/// </summary>
 		/// <param name="obj">The <see cref="System.Object"/> to compare with this instance.</param>
@@ -145,14 +135,10 @@ namespace Elasticsearch.Net
 		public override bool Equals(object obj)
 		{
 			if (ReferenceEquals(null, obj))
-			{
 				return false;
-			}
 
 			if (ReferenceEquals(this, obj))
-			{
 				return true;
-			}
 
 			return obj.GetType() == typeof(DynamicResponse) && this.Equals((DynamicResponse)obj);
 		}
@@ -216,11 +202,10 @@ namespace Elasticsearch.Net
 		/// <param name="value">When this method returns, the value associated with the specified key, if the key is found; otherwise, the default value for the type of the <paramref name="value"/> parameter. This parameter is passed uninitialized.</param>
 		public bool TryGetValue(string key, out dynamic value)
 		{
-			if (this.BackingDictionary.TryGetValue(key, out value)) return true;
-			return false;
+		    return this.BackingDictionary.TryGetValue(key, out value);
 		}
 
-		/// <summary>
+	    /// <summary>
 		/// Removes all items from the <see cref="DynamicResponse"/>.
 		/// </summary>
 		public void Clear() => this.BackingDictionary.Clear();
@@ -229,12 +214,9 @@ namespace Elasticsearch.Net
 		/// Gets the number of elements contained in the <see cref="DynamicResponse"/>.
 		/// </summary>
 		/// <returns>The number of elements contained in the <see cref="DynamicResponse"/>.</returns>
-		public int Count
-		{
-			get { return this.BackingDictionary.Count; }
-		}
+		public int Count => this.BackingDictionary.Count;
 
-		/// <summary>
+	    /// <summary>
 		/// Determines whether the <see cref="DynamicResponse"/> contains a specific value.
 		/// </summary>
 		/// <returns><see langword="true" /> if <paramref name="item"/> is found in the <see cref="DynamicResponse"/>; otherwise, <see langword="false" />.
@@ -242,8 +224,7 @@ namespace Elasticsearch.Net
 		/// <param name="item">The object to locate in the <see cref="DynamicResponse"/>.</param>
 		public bool Contains(KeyValuePair<string, dynamic> item)
 		{
-			var dynamicValueKeyValuePair =
-				GetDynamicKeyValuePair(item);
+			var dynamicValueKeyValuePair = GetDynamicKeyValuePair(item);
 
 			return this.BackingDictionary.Contains(dynamicValueKeyValuePair);
 		}
@@ -262,12 +243,9 @@ namespace Elasticsearch.Net
 		/// Gets a value indicating whether the <see cref="DynamicResponse"/> is read-only.
 		/// </summary>
 		/// <returns>Always returns <see langword="false" />.</returns>
-		public bool IsReadOnly
-		{
-			get { return false; }
-		}
+		public bool IsReadOnly => false;
 
-		/// <summary>
+	    /// <summary>
 		/// Removes the element with the specified key from the <see cref="DynamicResponse"/>.
 		/// </summary>
 		/// <returns><see langword="true" /> if the element is successfully removed; otherwise, <see langword="false" />.</returns>
@@ -285,8 +263,7 @@ namespace Elasticsearch.Net
 		/// <param name="item">The object to remove from the <see cref="DynamicResponse"/>.</param>
 		public bool Remove(KeyValuePair<string, dynamic> item)
 		{
-			var dynamicValueKeyValuePair =
-				GetDynamicKeyValuePair(item);
+			var dynamicValueKeyValuePair = GetDynamicKeyValuePair(item);
 
 			return this.BackingDictionary.Remove(dynamicValueKeyValuePair);
 		}
@@ -295,19 +272,15 @@ namespace Elasticsearch.Net
 		/// Gets an <see cref="T:System.Collections.Generic.ICollection`1"/> containing the values in the <see cref="DynamicResponse"/>.
 		/// </summary>
 		/// <returns>An <see cref="T:System.Collections.Generic.ICollection`1"/> containing the values in the <see cref="DynamicResponse"/>.</returns>
-		public ICollection<dynamic> Values
+		public ICollection<dynamic> Values => this.BackingDictionary.Values;
+
+	    private static KeyValuePair<string, dynamic> GetDynamicKeyValuePair(KeyValuePair<string, dynamic> item)
 		{
-			get { return this.BackingDictionary.Values; }
+			return new KeyValuePair<string, dynamic>(item.Key, new ElasticsearchDynamicValue(item.Value));
 		}
 
-		private static KeyValuePair<string, dynamic> GetDynamicKeyValuePair(KeyValuePair<string, dynamic> item)
-		{
-			var dynamicValueKeyValuePair =
-				new KeyValuePair<string, dynamic>(item.Key, new ElasticsearchDynamicValue(item.Value));
-			return dynamicValueKeyValuePair;
-		}
-
-		private static string GetNeutralKey(string key)
+        //TODO:For what purpose do you use this function?
+        private static string GetNeutralKey(string key)
 		{
 			return key;
 		}

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Threading;
 using System;
 
 namespace Elasticsearch.Net
@@ -14,15 +13,7 @@ namespace Elasticsearch.Net
 		public IMemoryStreamFactory MemoryStreamFactory { get; }
 		public IRequestPipelineFactory PipelineProvider { get; }
 
-		/// <summary>
-		/// Transport coordinates the client requests over the connection pool nodes and is in charge of falling over on different nodes 
-		/// </summary>
-		/// <param name="configurationValues">The connectionsettings to use for this transport</param>
-		public Transport(TConnectionSettings configurationValues)
-			: this(configurationValues, null, null, null)
-		{ }
-
-		/// <summary>
+	    /// <summary>
 		/// Transport coordinates the client requests over the connection pool nodes and is in charge of falling over on different nodes 
 		/// </summary>
 		/// <param name="configurationValues">The connectionsettings to use for this transport</param>
@@ -31,10 +22,9 @@ namespace Elasticsearch.Net
 		/// <param name="memoryStreamFactory">The memory stream provider to use, safe to pass null to use the default</param>
 		public Transport(
 			TConnectionSettings configurationValues,
-			IRequestPipelineFactory pipelineProvider,
-			IDateTimeProvider dateTimeProvider,
-			IMemoryStreamFactory memoryStreamFactory
-			)
+			IRequestPipelineFactory pipelineProvider = null,
+			IDateTimeProvider dateTimeProvider = null,
+			IMemoryStreamFactory memoryStreamFactory = null)
 		{
 			configurationValues.ThrowIfNull(nameof(configurationValues));
 			configurationValues.ConnectionPool.ThrowIfNull(nameof(configurationValues.ConnectionPool));


### PR DESCRIPTION
I suggest some code readability and simplification improvements.

Such as:
One constructor with optional parameters 

`public Transport(TConnectionSettings configurationValues,`
`IRequestPipelineFactory pipelineProvider = null,`
`IDateTimeProvider dateTimeProvider = null,`
`IMemoryStreamFactory memoryStreamFactory = null)`

instead of two:
`public Transport(TConnectionSettings configurationValues)`
`: this(configurationValues, null, null, null){ }`
and 
`public Transport(TConnectionSettings configurationValues,`
`IRequestPipelineFactory pipelineProvider,`
`IDateTimeProvider dateTimeProvider,`
`IMemoryStreamFactory memoryStreamFactory)`

And some other minor refactoring (for example - mark private members as readonly, etc.)