### PR TITLE
await CreateAsync() when try to create a ServerError asynchronously

### DIFF
--- a/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
+++ b/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
@@ -11,20 +11,22 @@ namespace Elasticsearch.Net
 	{
 		private readonly byte[] _responseBody;
 		private readonly int _statusCode;
+		private readonly Exception _exception;
 
 		public InMemoryConnection()
 		{
 			_statusCode = 200;
 		}
 
-		public InMemoryConnection(byte[] responseBody, int statusCode = 200)
+		public InMemoryConnection(byte[] responseBody, int statusCode = 200, Exception exception = null)
 		{
 			_responseBody = responseBody;
 			_statusCode = statusCode;
+			_exception = exception;
 		}
 
-		public virtual Task<ElasticsearchResponse<TReturn>> RequestAsync<TReturn>(RequestData requestData) where TReturn : class =>
-			Task.FromResult(this.ReturnConnectionStatus<TReturn>(requestData));
+		public virtual async Task<ElasticsearchResponse<TReturn>> RequestAsync<TReturn>(RequestData requestData) where TReturn : class =>
+			await this.ReturnConnectionStatusAsync<TReturn>(requestData).ConfigureAwait(false);
 
 		public virtual ElasticsearchResponse<TReturn> Request<TReturn>(RequestData requestData) where TReturn : class =>
 			this.ReturnConnectionStatus<TReturn>(requestData);
@@ -49,9 +51,37 @@ namespace Elasticsearch.Net
 			var builder = new ResponseBuilder<TReturn>(requestData)
 			{
 				StatusCode = statusCode ?? this._statusCode,
-				Stream = (body != null) ? new MemoryStream(body) : null
+				Stream = (body != null) ? new MemoryStream(body) : null,
+				Exception = _exception
 			};
 			var cs = builder.ToResponse();
+			return cs;
+		}
+
+		protected async Task<ElasticsearchResponse<TReturn>> ReturnConnectionStatusAsync<TReturn>(RequestData requestData, byte[] responseBody = null, int? statusCode = null)
+			where TReturn : class
+		{
+			var body = responseBody ?? _responseBody;
+			var data = requestData.PostData;
+			if (data != null)
+			{
+				using (var stream = new MemoryStream())
+				{
+					if (requestData.HttpCompression)
+						using (var zipStream = new GZipStream(stream, CompressionMode.Compress))
+							await data.WriteAsync(zipStream, requestData.ConnectionSettings).ConfigureAwait(false);
+					else
+						await data.WriteAsync(stream, requestData.ConnectionSettings).ConfigureAwait(false);
+				}
+			}
+
+			var builder = new ResponseBuilder<TReturn>(requestData)
+			{
+				StatusCode = statusCode ?? this._statusCode,
+				Stream = (body != null) ? new MemoryStream(body) : null,
+				Exception = _exception
+			};
+			var cs = await builder.ToResponseAsync().ConfigureAwait(false);
 			return cs;
 		}
 

--- a/src/Elasticsearch.Net/Responses/ServerError.cs
+++ b/src/Elasticsearch.Net/Responses/ServerError.cs
@@ -14,7 +14,7 @@ namespace Elasticsearch.Net
 		public int Status { get; set; }
 
 		public static ServerError Create(Stream stream) => ElasticsearchDefaultSerializer.Instance.Deserialize<ServerError>(stream);
-		public static Task<ServerError> CreateAsync(Stream stream, CancellationToken token) => 
+		public static Task<ServerError> CreateAsync(Stream stream, CancellationToken token) =>
 			ElasticsearchDefaultSerializer.Instance.DeserializeAsync<ServerError>(stream, token);
 
 		/// <summary>
@@ -31,9 +31,9 @@ namespace Elasticsearch.Net
 		/// <summary>
 		/// Creating the server error might fail in cases where a proxy returns an http response which is not json at all
 		/// </summary>
-		public static Task<ServerError> TryCreateAsync(Stream stream, CancellationToken token)
+		public static async Task<ServerError> TryCreateAsync(Stream stream, CancellationToken token)
 		{
-			try { return CreateAsync(stream, token); }
+			try { return await CreateAsync(stream, token).ConfigureAwait(false); }
 			catch { // ignored
 			}
 			return null;
@@ -56,7 +56,7 @@ namespace Elasticsearch.Net
 			};
 		}
 
-		public override string ToString() 
+		public override string ToString()
 		{
 			var sb = new StringBuilder();
 			sb.Append($"ServerError: {Status}");

--- a/src/Profiling_Net45/Profiling.csproj
+++ b/src/Profiling_Net45/Profiling.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props" Condition="Exists('..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -635,5 +634,6 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Import Project="..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props" Condition="Exists('..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props')" Label="Paket" />
   <Import Project="..\..\packages\JetBrains.Profiler.Kernel.Windows.Api\build\JetBrains.Profiler.Kernel.Windows.Api.Targets" Condition="Exists('..\..\packages\JetBrains.Profiler.Kernel.Windows.Api\build\JetBrains.Profiler.Kernel.Windows.Api.Targets')" Label="Paket" />
 </Project>

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -34,19 +34,19 @@ namespace Tests.Framework
 				.Ignore(p => p.PrivateValue)
 				.Rename(p => p.OnlineHandle, "nickname")
 			)
-			//We try and fetch the test name during integration tests when running fiddler to send the name 
+			//We try and fetch the test name during integration tests when running fiddler to send the name
 			//as the TestMethod header, this allows us to quickly identify which test sent which request
 			.GlobalHeaders(new NameValueCollection
 			{
 				{ "TestMethod", ExpensiveTestNameForIntegrationTests() }
 			});
 
-			
+
 		public static ConnectionSettings CreateSettings(
-			Func<ConnectionSettings, ConnectionSettings> modifySettings = null, 
-			int port = 9200, 
+			Func<ConnectionSettings, ConnectionSettings> modifySettings = null,
+			int port = 9200,
 			bool forceInMemory = false,
-			Func<Uri, IConnectionPool> createPool = null, 
+			Func<Uri, IConnectionPool> createPool = null,
 			Func<ConnectionSettings, IElasticsearchSerializer> serializerFactory = null
 			)
 		{
@@ -77,16 +77,29 @@ namespace Tests.Framework
 				: new InMemoryConnection();
 
 		public static IElasticClient GetFixedReturnClient(
-			object responseJson, int statusCode = 200, Func<ConnectionSettings, ConnectionSettings> modifySettings = null)
+			object response, 
+			int statusCode = 200, 
+			Func<ConnectionSettings, ConnectionSettings> modifySettings = null, 
+			string contentType = "application/json", 
+			Exception exception = null)
 		{
 			var serializer = new JsonNetSerializer(new ConnectionSettings());
 			byte[] fixedResult;
-			using (var ms = new MemoryStream())
+
+			if (contentType == "application/json")
 			{
-				serializer.Serialize(responseJson, ms);
-				fixedResult = ms.ToArray();
+				using (var ms = new MemoryStream())
+				{
+					serializer.Serialize(response, ms);
+					fixedResult = ms.ToArray();
+				}
 			}
-			var connection = new InMemoryConnection(fixedResult, statusCode);
+			else
+			{
+				fixedResult = Encoding.UTF8.GetBytes(response.ToString());
+			}
+
+			var connection = new InMemoryConnection(fixedResult, statusCode, exception);
 			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 			var defaultSettings = new ConnectionSettings(connectionPool, connection);
 			var settings = (modifySettings != null) ? modifySettings(defaultSettings) : defaultSettings;
@@ -130,8 +143,8 @@ namespace Tests.Framework
 
 			// If running the classic .NET solution, tests run from bin/{config} directory,
 			// but when running DNX solution, tests run from the test project root
-			var yamlConfigurationPath = directoryInfo.Name == "Tests" && 
-										directoryInfo.Parent != null && 
+			var yamlConfigurationPath = directoryInfo.Name == "Tests" &&
+										directoryInfo.Parent != null &&
 										directoryInfo.Parent.Name == "src"
 				? "tests.yaml"
 				: @"..\..\tests.yaml";

--- a/src/Tests/Reproduce/GithubIssue1901.cs
+++ b/src/Tests/Reproduce/GithubIssue1901.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Xunit;
+using FluentAssertions;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue1901
+	{
+		private class Example
+		{
+		}
+
+		private const string ProxyAuthResponse = @"<html>
+<head><title>401 Authorization Required</title></head>
+<body bgcolor=""white"">
+<center><h1>401 Authorization Required</h1></center>
+<hr><center>nginx/1.4.6 (Ubuntu)</center>
+</body>
+</html>
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->";
+
+		[U]
+		public async Task BadAuthResponseDoesNotThrowExceptionWhenAttemptingToDeserializeResponse()
+		{
+			var client = TestClient.GetFixedReturnClient(ProxyAuthResponse, 401, contentType: "text/html", exception: new Exception("problem with the request as a result of 401"));
+			var source = await client.LowLevel.GetSourceAsync<Example>("examples", "example", "1");
+			source.Success.Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: m
 # the elasticsearch version that should be started
 elasticsearch_version: 2.2.0
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running

--- a/src/Tests_Net45/Tests.csproj
+++ b/src/Tests_Net45/Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props" Condition="Exists('..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -790,4 +789,5 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Import Project="..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props" Condition="Exists('..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props')" Label="Paket" />
 </Project>


### PR DESCRIPTION
Fixes #1901

Add ability to set a non-json fixed response and additionally an Exception when creating a FixedReturnClient.

Introduced async version of `ReturnConnectionStatus` on `InMemoryConnection` in order to use the async request/response pipeline (which is where the original issue manifests)