### PR TITLE
Defer field naming conventions to Elasticsearch

### DIFF
--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ElasticLowLevelClient.cs" />
     <Compile Include="ElasticLowLevelClient.Generated.cs" />
     <Compile Include="Exceptions\ElasticsearchClientException.cs" />
+    <Compile Include="Exceptions\ResolveException.cs" />
     <Compile Include="Exceptions\UnexpectedElasticsearchClientException.cs" />
     <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Extensions\Extensions.cs" />

--- a/src/Elasticsearch.Net/Exceptions/ResolveException.cs
+++ b/src/Elasticsearch.Net/Exceptions/ResolveException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elasticsearch.Net
+{
+	public class ResolveException : Exception
+	{
+		public ResolveException(string message) : base(message) { }
+	}
+}

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -15,7 +15,7 @@ namespace Elasticsearch.Net
 		public IRequestPipelineFactory PipelineProvider { get; }
 
 		/// <summary>
-		/// Transport coordinates the client requests over the connection pool nodes and is in charge of falling over on different nodes 
+		/// Transport coordinates the client requests over the connection pool nodes and is in charge of falling over on different nodes
 		/// </summary>
 		/// <param name="configurationValues">The connectionsettings to use for this transport</param>
 		public Transport(TConnectionSettings configurationValues)
@@ -23,7 +23,7 @@ namespace Elasticsearch.Net
 		{ }
 
 		/// <summary>
-		/// Transport coordinates the client requests over the connection pool nodes and is in charge of falling over on different nodes 
+		/// Transport coordinates the client requests over the connection pool nodes and is in charge of falling over on different nodes
 		/// </summary>
 		/// <param name="configurationValues">The connectionsettings to use for this transport</param>
 		/// <param name="pipelineProvider">In charge of create a new pipeline, safe to pass null to use the default</param>
@@ -82,6 +82,11 @@ namespace Elasticsearch.Net
 					{
 						pipeline.MarkDead(node);
 						seenExceptions.Add(pipelineException);
+					}
+					catch (ResolveException resolveException)
+					{
+						resolveException.RethrowKeepingStackTrace();
+						return null; //dead code due to call to RethrowKeepingStackTrace()
 					}
 					catch (Exception killerException)
 					{
@@ -142,6 +147,11 @@ namespace Elasticsearch.Net
 					{
 						pipeline.MarkDead(node);
 						seenExceptions.Add(pipelineException);
+					}
+					catch (ResolveException resolveException)
+					{
+						resolveException.RethrowKeepingStackTrace();
+						return null; //dead code due to call to RethrowKeepingStackTrace()
 					}
 					catch (Exception killerException)
 					{

--- a/src/Nest/CommonAbstractions/Infer/Field/FieldResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/FieldResolver.cs
@@ -51,17 +51,14 @@ namespace Nest
 		{
 			if (property.IsConditionless()) return null;
 			if (!property.Name.IsNullOrEmpty())
-			{
-				if (property.Name.Contains("."))
-					throw new ArgumentException("Property names cannot contain dots.");
 				return property.Name;
-			}
-			string f;
-			if (this.Properties.TryGetValue(property, out f))
-				return f;
-			f = this.Resolve(property.Expression, property.Property, true);
-			this.Properties.TryAdd(property, f);
-			return f;
+
+			string propertyName;
+			if (this.Properties.TryGetValue(property, out propertyName))
+				return propertyName;
+			propertyName = this.Resolve(property.Expression, property.Property, true);
+			this.Properties.TryAdd(property, propertyName);
+			return propertyName;
 		}
 
 		private string Resolve(Expression expression, MemberInfo member, bool toLastToken = false)
@@ -74,7 +71,7 @@ namespace Nest
 					: null;
 
 			if (name == null)
-				throw new ArgumentException("Could not resolve a name from the given Expression or MemberInfo.");
+				throw new ResolveException("Name resolved to null for the given Expression or MemberInfo.");
 
 			return name;
 		}

--- a/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Elasticsearch.Net;
+using System;
 
 namespace Nest
 {
@@ -15,26 +16,37 @@ namespace Nest
 
 		public string Resolve(IndexName i)
 		{
-			if (i == null) return this.Resolve((Type)null);
-			return i.Name ?? this.Resolve(i.Type);
+			if (i == null || string.IsNullOrEmpty(i.Name))
+				return this.Resolve((Type)null);
+			ValidateIndexName(i.Name);
+			return i.Name;
 		}
 
 		public string Resolve(Type type)
 		{
+			var indexName = this._connectionSettings.DefaultIndex;
 			var defaultIndices = this._connectionSettings.DefaultIndices;
-
-			if (defaultIndices == null)
-				return this._connectionSettings.DefaultIndex;
-
-			if (type == null)
-				return this._connectionSettings.DefaultIndex;
-
-			string value;
-			if (defaultIndices.TryGetValue(type, out value) && !string.IsNullOrWhiteSpace(value))
-				return value;
-			return this._connectionSettings.DefaultIndex;
+			if (defaultIndices != null && type != null)
+			{
+				string value;
+				if (defaultIndices.TryGetValue(type, out value) && !string.IsNullOrEmpty(value))
+					indexName = value;
+			}
+			ValidateIndexName(indexName, type);
+			return indexName;
 		}
 
+		private void ValidateIndexName(string indexName, Type type = null)
+		{
+			if (string.IsNullOrWhiteSpace(indexName))
+				throw new ResolveException(
+					"Index name is null for the given type and no default index is set. "
+					+ "Map an index name using ConnectionSettings.MapDefaultTypeIndices() "
+					+ "or set a default index using ConnectionSettings.DefaultIndex()."
+				);
 
+			if (indexName.HasAny(c => char.IsUpper(c)))
+				throw new ResolveException($"Index names cannot contain uppercase characters: {indexName}.");
+		}
 	}
 }

--- a/src/Tests/ClientConcepts/HighLevel/Inferrence/IndexNameInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inferrence/IndexNameInference.doc.cs
@@ -1,0 +1,88 @@
+﻿using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Framework;
+using Tests.Framework.MockData;
+using Xunit;
+
+namespace Tests.ClientConcepts.HighLevel.Inferrence
+{
+	public class IndexNameInference
+	{
+		[U]
+		public void DefaultIndexIsInferred()
+		{
+			var settings = new ConnectionSettings()
+				.DefaultIndex("defaultindex");
+			var resolver = new IndexNameResolver(settings);
+			var index = resolver.Resolve<Project>();
+			index.Should().Be("defaultindex");
+		}
+
+		[U]
+		public void ExplicitMappingIsInferred()
+		{
+			var settings = new ConnectionSettings()
+				.MapDefaultTypeIndices(m => m
+					.Add(typeof(Project), "projects")
+				);
+			var resolver = new IndexNameResolver(settings);
+			var index = resolver.Resolve<Project>();
+			index.Should().Be("projects");
+		}
+
+		[U]
+		public void ExplicitMappingTakesPrecedence()
+		{
+			var settings = new ConnectionSettings()
+				.DefaultIndex("defaultindex")
+				.MapDefaultTypeIndices(m => m
+					.Add(typeof(Project), "projects")
+				);
+			var resolver = new IndexNameResolver(settings);
+			var index = resolver.Resolve<Project>();
+			index.Should().Be("projects");
+		}
+
+		[U]
+		public void UppercaseCharacterThrowsResolveException()
+		{
+			var settings = new ConnectionSettings()
+				.DefaultIndex("Default")
+				.MapDefaultTypeIndices(m => m
+					.Add(typeof(Project), "myProjects")
+				);
+
+			var resolver = new IndexNameResolver(settings);
+
+			var e = Assert.Throws<ResolveException>(() => resolver.Resolve<Project>());
+			e.Message.Should().Be($"Index names cannot contain uppercase characters: myProjects.");
+			e = Assert.Throws<ResolveException>(() => resolver.Resolve<Tag>());
+			e.Message.Should().Be($"Index names cannot contain uppercase characters: Default.");
+			e = Assert.Throws<ResolveException>(() => resolver.Resolve("Foo"));
+			e.Message.Should().Be($"Index names cannot contain uppercase characters: Foo.");
+		}
+
+		[U]
+		public void NoIndexThrowsResolveException()
+		{
+			var settings = new ConnectionSettings();
+			var resolver = new IndexNameResolver(settings);
+			var e = Assert.Throws<ResolveException>(() => resolver.Resolve<Project>());
+			e.Message.Should().Contain("Index name is null");
+		}
+
+		[U]
+		public void ResolveExceptionBubblesOut()
+		{
+			var client = TestClient.GetInMemoryClient(s => new ConnectionSettings());
+			var e = Assert.Throws<ResolveException>(() => client.Search<Project>());
+
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inferrence/PropertyInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inferrence/PropertyInference.doc.cs
@@ -2,24 +2,69 @@
 using System.Linq.Expressions;
 using Nest;
 using Tests.Framework;
+using Tests.Framework.Integration;
 using Tests.Framework.MockData;
 using static Tests.Framework.RoundTripper;
 using Xunit;
+using FluentAssertions;
 
 namespace Tests.ClientConcepts.HighLevel.Inferrence.PropertyNames
 {
-
-	public class PropertyNames
+	/** == Property Names */
+	[Collection(IntegrationContext.Indexing)]
+	public class PropertyNames : SimpleIntegration
 	{
+		private IElasticClient _client;
+
+		public PropertyNames(IndexingCluster cluster) : base(cluster)
+		{
+			_client = cluster.Node.Client();
+		}
+
+		/** Property names resolve to the last token */
 		[U] public void PropertyNamesAreResolvedToLastToken()
 		{
 			Expression<Func<Project, object>> expression = p => p.Name.Suffix("raw");
 			Expect("raw").WhenSerializing<PropertyName>(expression);
 		}
 
-		[U] public void StringsContainingDotsIsAnException()
+		/** :multi-field: {ref_current}/_multi_fields.html
+		 *Property names cannot contain a `.` (dot), because of the potential for ambiguity with
+		 *a field that is mapped as a {multi-field}[`multi_field`].
+		 *
+		 *NEST allows the call to go to Elasticsearch, deferring the naming conventions to the server side and,
+		 * in the case of dots in field names, returns a `400 Bad Response` with a server error indicating the reason.
+		 */
+		[I] public void PropertyNamesContainingDotsCausesElasticsearchServerError()
 		{
-			Assert.Throws<ArgumentException>(() => Expect("exception!").WhenSerializing<PropertyName>("name.raw"));
+			var createIndexResponse = _client.CreateIndex("random-" + Guid.NewGuid().ToString().ToLowerInvariant(), c => c
+				.Mappings(m => m
+					.Map("type-with-dot", mm => mm
+						.Properties(p => p
+							.String(s => s
+								.Name("name-with.dot")
+							)
+						)
+					)
+				)
+			);
+
+			/** The response is not valid */
+			createIndexResponse.IsValid.Should().BeFalse();
+
+			/** `DebugInformation` provides an audit trail of information to help diagnose the issue */
+			createIndexResponse.DebugInformation.Should().NotBeNullOrEmpty();
+
+			/** `ServerError` contains information from the response from Elasticsearch */
+			createIndexResponse.ServerError.Should().NotBeNull();
+			createIndexResponse.ServerError.Status.Should().Be(400);
+			createIndexResponse.ServerError.Error.Should().NotBeNull();
+			createIndexResponse.ServerError.Error.RootCause.Should().NotBeNullOrEmpty();
+
+			var rootCause = createIndexResponse.ServerError.Error.RootCause[0];
+
+			rootCause.Reason.Should().Be("Field name [name-with.dot] cannot contain '.'");
+			rootCause.Type.Should().Be("mapper_parsing_exception");
 		}
 	}
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -542,6 +542,7 @@
     <Compile Include="Cat\CatRepositories\CatRepositoriesUrlTests.cs" />
     <Compile Include="Cat\CatSnapshots\CatSnapshotsApiTests.cs" />
     <Compile Include="Cat\CatSnapshots\CatSnapshotsUrlTests.cs" />
+    <Compile Include="ClientConcepts\HighLevel\Inferrence\IndexNameInference.doc.cs" />
     <Compile Include="Search\Request\ProfileUsageTests.cs" />
     <Compile Include="Indices\StatusManagement\ForceMerge\ForceMergeApiTests.cs" />
     <Compile Include="Indices\StatusManagement\ForceMerge\ForceMergeUrlTests.cs" />

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: u
 # the elasticsearch version that should be started
 elasticsearch_version: 2.2.0
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
Don't throw an ArgumentException if a field name contains a dot (.), instead let Elasticsearch decide.
Fixes #1889