### PR TITLE
fix #1930 unwrap .Terms(new List<T>) to just T

### DIFF
--- a/src/Nest/QueryDsl/TermLevel/Terms/TermsQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/TermLevel/Terms/TermsQueryJsonConverter.cs
@@ -75,7 +75,7 @@ namespace Nest
 					case "minimum_should_match":
 						reader.Read();
 						var min = serializer.Deserialize<MinimumShouldMatch>(reader);
-						f.MinimumShouldMatch = min;	
+						f.MinimumShouldMatch = min;
 						break;
 					case "boost":
 						reader.Read();
@@ -131,7 +131,7 @@ namespace Nest
 			}
 			else if (reader.TokenType == JsonToken.StartArray)
 			{
-				var values = JArray.Load(reader).Values<string>();
+				var values = JArray.Load(reader).Values<object>();
 				termsQuery.Terms = values;
 			}
 		}

--- a/src/Tests/QueryDsl/QueryDslIntegrationTestsBase.cs
+++ b/src/Tests/QueryDsl/QueryDslIntegrationTestsBase.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.MockData;
+using Xunit;
+
+namespace Tests.QueryDsl
+{
+	[Collection(IntegrationContext.ReadOnly)]
+	public abstract class QueryDslIntegrationTestsBase : ApiIntegrationTestBase<ISearchResponse<Project>, ISearchRequest, SearchDescriptor<Project>, SearchRequest<Project>>
+	{
+		protected QueryDslIntegrationTestsBase(IIntegrationCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.Search<Project>(f),
+			fluentAsync: (client, f) => client.SearchAsync<Project>(f),
+			request: (client, r) => client.Search<Project>(r),
+			requestAsync: (client, r) => client.SearchAsync<Project>(r)
+		);
+
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+		protected override string UrlPath => "/project/project/_search";
+		protected override int ExpectStatusCode => 200;
+		protected override bool ExpectIsValid => true;
+
+		protected abstract object QueryJson { get; }
+
+		protected abstract QueryContainer QueryInitializer { get; }
+		protected abstract QueryContainer QueryFluent(QueryContainerDescriptor<Project> q);
+
+		protected override object ExpectJson => new { query = this.QueryJson };
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.Query(this.QueryFluent);
+
+		protected override SearchRequest<Project> Initializer =>
+			new SearchRequest<Project>
+			{
+				Query = this.QueryInitializer
+			};
+	}
+}

--- a/src/Tests/QueryDsl/TermLevel/Terms/TermsListQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Terms/TermsListQueryUsageTests.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.MockData;
+
+namespace Tests.QueryDsl.TermLevel.Terms
+{
+	public class TermsListQueryUsageTests : QueryDslUsageTestsBase
+	{
+		public TermsListQueryUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) {}
+
+		protected override object QueryJson => new
+		{
+			terms = new
+			{
+				_name = "named_query",
+				boost = 1.1,
+				description = new[] { "term1", "term2" },
+				disable_coord = true,
+				minimum_should_match = 2
+			}
+		};
+
+		protected override QueryContainer QueryInitializer => new TermsQuery
+		{
+			Name = "named_query",
+			Boost = 1.1,
+			Field = "description",
+			Terms = new List<string> { "term1", "term2" },
+			DisableCoord = true,
+			MinimumShouldMatch = 2
+		};
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.Terms(c => c
+				.Name("named_query")
+				.Boost(1.1)
+				.Field(p => p.Description)
+				.DisableCoord()
+				.MinimumShouldMatch(MinimumShouldMatch.Fixed(2))
+				.Terms(new List<string> { "term1", "term2" })
+			);
+	}
+
+	public class TermsListOfListIntegrationTests : QueryDslIntegrationTestsBase
+	{
+		public TermsListOfListIntegrationTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		private List<List<string>> _terms = new List<List<string>> { new List<string> { "term1", "term2" } };
+
+		protected override object QueryJson => new
+		{
+			terms = new
+			{
+				_name = "named_query",
+				boost = 1.1,
+				description = new[] { new [] { "term1", "term2" } },
+				disable_coord = true,
+			}
+		};
+
+		protected override QueryContainer QueryInitializer => new TermsQuery
+		{
+			Name = "named_query",
+			Boost = 1.1,
+			Field = "description",
+			Terms = _terms,
+			DisableCoord = true,
+		};
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.Terms(c => c
+				.Name("named_query")
+				.Boost(1.1)
+				.Field(p => p.Description)
+				.DisableCoord()
+				.Terms(_terms)
+			);
+
+	}
+
+	public class TermsListOfListStringAgainstNumericFieldIntegrationTests : QueryDslIntegrationTestsBase
+	{
+		public TermsListOfListStringAgainstNumericFieldIntegrationTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		private List<List<string>> _terms = new List<List<string>> { new List<string> { "term1", "term2" } };
+
+
+		protected override int ExpectStatusCode => 400;
+		protected override bool ExpectIsValid => false;
+
+		protected override object QueryJson => new
+		{
+			terms = new
+			{
+				_name = "named_query",
+				boost = 1.1,
+				numberOfCommits = new[] { new [] { "term1", "term2" } },
+				disable_coord = true,
+			}
+		};
+
+		protected override QueryContainer QueryInitializer => new TermsQuery
+		{
+			Name = "named_query",
+			Boost = 1.1,
+			Field = "numberOfCommits",
+			Terms = _terms,
+			DisableCoord = true,
+		};
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.Terms(c => c
+				.Name("named_query")
+				.Boost(1.1)
+				.Field(p => p.NumberOfCommits)
+				.DisableCoord()
+				.Terms(_terms)
+			);
+
+		[I] public Task AsserResponse() => AssertOnAllResponses(r =>
+		{
+			r.ServerError.Should().NotBeNull();
+			r.ServerError.Status.Should().Be(400);
+			r.ServerError.Error.Should().NotBeNull();
+			var rootCauses = r.ServerError.Error.RootCause;
+			rootCauses.Should().NotBeNullOrEmpty();
+			var rootCause = rootCauses.First();
+			rootCause.Type.Should().Be("number_format_exception");
+		});
+
+	}
+
+}

--- a/src/Tests/QueryDsl/TermLevel/Terms/TermsQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Terms/TermsQueryUsageTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Nest;
 using Tests.Framework.Integration;
@@ -7,6 +8,8 @@ namespace Tests.QueryDsl.TermLevel.Terms
 {
 	public class TermsQueryUsageTests : QueryDslUsageTestsBase
 	{
+		protected virtual string[] ExpectedTerms => new [] { "term1", "term2" };
+
 		public TermsQueryUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) {}
 
 		protected override object QueryJson => new
@@ -15,7 +18,7 @@ namespace Tests.QueryDsl.TermLevel.Terms
 			{
 				_name = "named_query",
 				boost = 1.1,
-				description = new[] { "term1", "term2" },
+				description = ExpectedTerms,
 				disable_coord = true,
 				minimum_should_match = 2
 			}
@@ -26,7 +29,7 @@ namespace Tests.QueryDsl.TermLevel.Terms
 			Name = "named_query",
 			Boost = 1.1,
 			Field = "description",
-			Terms = new [] { "term1", "term2" },
+			Terms = ExpectedTerms,
 			DisableCoord = true,
 			MinimumShouldMatch = 2
 		};
@@ -49,4 +52,23 @@ namespace Tests.QueryDsl.TermLevel.Terms
 			q => q.Terms = new [] { "" }
 		};
 	}
+
+	public class SingleTermTermsQueryUsageTests : TermsQueryUsageTests
+	{
+		protected override string[] ExpectedTerms => new [] { "term1"  };
+
+		public SingleTermTermsQueryUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.Terms(c => c
+				.Name("named_query")
+				.Boost(1.1)
+				.Field(p => p.Description)
+				.DisableCoord()
+				.MinimumShouldMatch(MinimumShouldMatch.Fixed(2))
+				.Terms("term1")
+			);
+	}
+
+
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -542,6 +542,8 @@
     <Compile Include="Cat\CatRepositories\CatRepositoriesUrlTests.cs" />
     <Compile Include="Cat\CatSnapshots\CatSnapshotsApiTests.cs" />
     <Compile Include="Cat\CatSnapshots\CatSnapshotsUrlTests.cs" />
+    <Compile Include="QueryDsl\QueryDslIntegrationTestsBase.cs" />
+    <Compile Include="QueryDsl\TermLevel\Terms\TermsListQueryUsageTests.cs" />
     <Compile Include="Search\Request\ProfileUsageTests.cs" />
     <Compile Include="Indices\StatusManagement\ForceMerge\ForceMergeApiTests.cs" />
     <Compile Include="Indices\StatusManagement\ForceMerge\ForceMergeUrlTests.cs" />


### PR DESCRIPTION
When calling

```csharp
.Terms(new List<T>());
```

The user expects T[] to be written to elasticsearch but due to C#
resolution they end up calling

```csharp
.Terms<List<T>>(params List<T>)
```

 and we serialize to T[][] which is not a valid terms query.

The fluent Terms() method now tries to preempt these cases and unwraps
to T[] when a single IEnumerable is passed as T, special casing `string`
to be exluded from the unwrapping behavior so we do not unwrap string to
char[]


This PR also introduces `QueryDslIntegrationTestsBase`, all of our QueryDSL tests are unit tests but with this new base class we can start introducing more integration tests for the query dsl over time /cc @gmarz @russcam 