### PR TITLE
fix #1947 favor throw; over e.RethrowKeepingStackTrace()

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -392,8 +392,7 @@ namespace Elasticsearch.Net
 					(response as ElasticsearchResponse<Stream>)?.Body?.Dispose();
 					audit.Event = AuditEvent.BadResponse;
 					audit.Exception = e;
-					e.RethrowKeepingStackTrace();
-					return null; //dead code due to call to RethrowKeepingStackTrace()
+					throw;
 				}
 			}
 		}
@@ -419,8 +418,7 @@ namespace Elasticsearch.Net
 					(response as ElasticsearchResponse<Stream>)?.Body?.Dispose();
 					audit.Event = AuditEvent.BadResponse;
 					audit.Exception = e;
-					e.RethrowKeepingStackTrace();
-					return null; //dead code due to call to RethrowKeepingStackTrace()
+					throw;
 				}
 			}
 		}

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -83,10 +83,9 @@ namespace Elasticsearch.Net
 						pipeline.MarkDead(node);
 						seenExceptions.Add(pipelineException);
 					}
-					catch (ResolveException resolveException)
+					catch (ResolveException)
 					{
-						resolveException.RethrowKeepingStackTrace();
-						return null; //dead code due to call to RethrowKeepingStackTrace()
+						throw;
 					}
 					catch (Exception killerException)
 					{
@@ -148,10 +147,9 @@ namespace Elasticsearch.Net
 						pipeline.MarkDead(node);
 						seenExceptions.Add(pipelineException);
 					}
-					catch (ResolveException resolveException)
+					catch (ResolveException)
 					{
-						resolveException.RethrowKeepingStackTrace();
-						return null; //dead code due to call to RethrowKeepingStackTrace()
+						throw;
 					}
 					catch (Exception killerException)
 					{
@@ -186,7 +184,7 @@ namespace Elasticsearch.Net
 			catch (PipelineException e) when (e.Recoverable)
 			{
 				pipeline.SniffOnConnectionFailure();
-				e.RethrowKeepingStackTrace();
+				throw;
 			}
 		}
 
@@ -199,7 +197,7 @@ namespace Elasticsearch.Net
 			catch (PipelineException e) when (e.Recoverable)
 			{
 				await pipeline.SniffOnConnectionFailureAsync().ConfigureAwait(false);
-				e.RethrowKeepingStackTrace();
+				throw;
 			}
 		}
 

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: u
 # the elasticsearch version that should be started
 elasticsearch_version: 2.2.0
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
The latter is only good for rethrowing inner exceptions, which no longer
serves a purpose in the refactored 2.x world`

ty for raising this @TioLuiso