### PR TITLE
Set ComparisonValue when using Field Constructor

### DIFF
--- a/docs/asciidoc/client-concepts/high-level/inference/field-inference.asciidoc
+++ b/docs/asciidoc/client-concepts/high-level/inference/field-inference.asciidoc
@@ -14,28 +14,57 @@ These expressions are assigned to a type called `Field` and there are several wa
 
 === Constructor
 
-Using the constructor directly is possible but rather involved 
+Using the constructor directly is possible _but_ rather involved 
 
 [source,csharp]
 ----
 var fieldString = new Field { Name = "name" };
+var fieldProperty = new Field { Property = typeof(Project).GetProperty(nameof(Project.Name)) };
+Expression<Func<Project, object>> expression = p => p.Name;
+var fieldExpression = new Field { Expression = expression };
+Expect("name")
+    .WhenSerializing(fieldExpression)
+    .WhenSerializing(fieldString)
+    .WhenSerializing(fieldProperty);
 ----
 
-This is more cumbersome when using C# expressions since they cannot be instantiated easily
+When using the constructor and passing a value for `Name`, `Property` or `Expression`,`ComparisonValue` is also set on the `Field` instance; this is used when
+
+* determining `Field` equality
+
+* getting the hash code for a `Field` instance
 
 [source,csharp]
 ----
+var fieldStringWithBoostTwo = new Field { Name = "name^2" };
+
+var fieldStringWithBoostThree = new Field { Name = "name^3" };
+
 Expression<Func<Project, object>> expression = p => p.Name;
 
-var fieldExpression = Field.Create(expression);
-Expect("name")
-    .WhenSerializing(fieldExpression)
-    .WhenSerializing(fieldString);
+var fieldExpression = new Field { Expression = expression };
+
+var fieldProperty = new Field { Property = typeof(Project).GetProperty(nameof(Project.Name)) };
+
+fieldStringWithBoostTwo.GetHashCode().Should().NotBe(0);
+
+fieldStringWithBoostThree.GetHashCode().Should().NotBe(0);
+
+fieldExpression.GetHashCode().Should().NotBe(0);
+
+fieldProperty.GetHashCode().Should().NotBe(0);
+
+fieldStringWithBoostTwo.Should().Be(fieldStringWithBoostThree); <1>
 ----
+<1> <<field-name-with-boost,Fields can constructed with a name that contains a boost>>
+
+No more than one of `Name`, `Expression` or `Property` should be set (with a non-null value) when using the constructor
+to prevent ambiguity over which property should be used when resolving the path to a field that will be sent to Elasticsearch
 
 === Implicit Conversion
 
-Therefore you can also implicitly convert strings and expressions to a `Field` 
+As you can see from the previous examples, using the constructor is rather involved and cumbersome.
+Becuase of this, you can also implicitly convert strings and expressions to a `Field` 
 
 [source,csharp]
 ----
@@ -54,6 +83,34 @@ Expect("name")
     .WhenSerializing(fieldExpression)
     .WhenSerializing(fieldString);
 ----
+
+[[field-name-with-boost]]
+=== Field Names with Boost
+
+When specifying a `Field` name, the name can include a boost value; NEST will split the name and boost
+value and set the `Boost` property
+
+[source,csharp]
+----
+Field fieldString = "name^2";
+
+Field fieldStringConstructor = new Field { Name = "name^2" };
+
+Field fieldStringCreate = Field.Create("name^2", 3); <1>
+
+fieldString.Name.Should().Be("name");
+
+fieldStringConstructor.Name.Should().Be("name");
+
+fieldStringCreate.Name.Should().Be("name");
+
+fieldString.Boost.Should().Be(2);
+
+fieldStringConstructor.Boost.Should().Be(2);
+
+fieldStringCreate.Boost.Should().Be(2);
+----
+<1> NEST will take the boost from the name
 
 [[nest-infer]]
 === Using Nest.Infer
@@ -89,7 +146,7 @@ Expect("name")
     .WhenSerializing(fieldExpression);
 ----
 
-You can also specify boosts in the field using a string 
+You can specify boosts in the field using a string 
 
 [source,csharp]
 ----

--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -9,9 +9,43 @@ namespace Nest
 	[ContractJsonConverter(typeof(FieldJsonConverter))]
 	public class Field : IEquatable<Field>, IUrlParameter
 	{
-		public string Name { get; set; }
-		public Expression Expression { get; set; }
-		public PropertyInfo Property { get; set; }
+		private string _name;
+		private Expression _expression;
+		private PropertyInfo _property;
+
+		public string Name
+		{
+			get { return _name; }
+			set
+			{
+				double? b;
+				_name = ParseFieldName(value, out b);
+				if (b.HasValue) Boost = b;
+				SetComparisonValue(_name);
+			}
+		}
+
+		public Expression Expression
+		{
+			get { return _expression; }
+			set
+			{
+				_expression = value;
+				var comparisonValue = ComparisonValueFromExpression(value);
+				SetComparisonValue(comparisonValue);
+			}
+		}
+
+		public PropertyInfo Property
+		{
+			get { return _property; }
+			set
+			{
+				_property = value;
+				SetComparisonValue(value);
+			}
+		}
+
 		public double? Boost { get; set; }
 
 		private object ComparisonValue { get; set; }
@@ -25,9 +59,10 @@ namespace Nest
 		{
 			if (name.IsNullOrEmpty()) return null;
 
-			double? b;
-			Field field = ParseFieldName(name, out b);
-			field.Boost = b ?? boost;
+			Field field = name;
+			if (!field.Boost.HasValue)
+				field.Boost = boost;
+
 			return field;
 		}
 
@@ -41,6 +76,8 @@ namespace Nest
 		private static string ParseFieldName(string name, out double? boost)
 		{
 			boost = null;
+			if (name == null) return null;
+
 			var parts = name.Split(new [] { '^' }, StringSplitOptions.RemoveEmptyEntries);
 			if (parts.Length > 1)
 			{
@@ -50,42 +87,42 @@ namespace Nest
 			return name;
 		}
 
-		public static implicit operator Field(string name)
-		{
-			if (name.IsNullOrEmpty()) return null;
-
-			double? boost;
-			name = ParseFieldName(name, out boost);
-			return  new Field
-			{
-				Name = name,
-				ComparisonValue = name,
-				Boost = boost
-				
-			};
-		}
-
-		public static implicit operator Field(Expression expression)
+		private static object ComparisonValueFromExpression(Expression expression)
 		{
 			if (expression == null) return null;
 
 			var lambda = expression as LambdaExpression;
 			if (lambda == null)
-				return new Field { Expression = expression, ComparisonValue = expression.ToString() }; 
+				return expression.ToString();
 
 			var memberExpression = lambda.Body as MemberExpression;
 			if (memberExpression == null)
-				return new Field { Expression = expression, ComparisonValue = expression.ToString() }; 
-			
-			return new Field { Expression = expression, ComparisonValue = memberExpression}; 
+				return expression.ToString();
+
+			return memberExpression;
+		}
+
+		public static implicit operator Field(string name)
+		{
+			return name.IsNullOrEmpty() ? null : new Field
+			{
+				Name = name
+			};
+		}
+
+		public static implicit operator Field(Expression expression)
+		{
+			return expression == null ? null : new Field
+			{
+				Expression = expression
+			};
 		}
 
 		public static implicit operator Field(PropertyInfo property)
 		{
 			return property == null ? null : new Field
 			{
-				Property = property,
-				ComparisonValue = property
+				Property = property
 			};
 		}
 
@@ -108,6 +145,14 @@ namespace Nest
 				throw new Exception("Tried to pass field name on querysting but it could not be resolved because no nest settings are available");
 			var infer = new Inferrer(nestSettings);
 			return infer.Field(this);
+		}
+
+		private void SetComparisonValue(object value)
+		{
+			if (ComparisonValue != null && value != null)
+				throw new InvalidOperationException($"{nameof(ComparisonValue)} already has a value");
+
+			ComparisonValue = value;
 		}
 	}
 }


### PR DESCRIPTION
Throw an exception if more than one of Name, Property or Expression is set with a non-null value
Add documented tests for the changes
Regenerate docs

Fixes https://github.com/elastic/elasticsearch-net/issues/1964