### PR TITLE
Elasticsearch 2.3 new API's feature parity

### DIFF
--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.snapshots.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/cat.snapshots.json
@@ -8,7 +8,7 @@
       "parts": {
         "repository": {
           "type" : "list",
-          "required" : true,
+          "required": true,
           "description": "Name of repository from which to fetch the snapshot information"
         }
       },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.analyze.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.analyze.json
@@ -44,13 +44,13 @@
           "type" : "string",
           "description" : "The name of the tokenizer to use for the analysis"
         },
-        "detail": {
+        "explain": {
           "type" : "boolean",
           "description" : "With `true`, outputs more advanced details. (default: false)"
         },
         "attributes": {
           "type" : "list",
-          "description" : "A comma-separated list of token attributes to output, this parameter works only with `detail=true`"
+          "description" : "A comma-separated list of token attributes to output, this parameter works only with `explain=true`"
         },
         "format": {
           "type": "enum",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.optimize.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/indices.optimize.json
@@ -1,6 +1,6 @@
 {
   "indices.optimize": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_optimize",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/reindex.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/reindex.json
@@ -1,0 +1,36 @@
+{
+  "reindex": {
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html",
+    "methods": ["POST"],
+    "url": {
+      "path": "/_reindex",
+      "paths": ["/_reindex"],
+      "parts": {},
+      "params": {
+        "refresh": {
+          "type" : "boolean",
+          "description" : "Should the effected indexes be refreshed?"
+        },
+        "timeout": {
+          "type" : "time",
+          "default": "1m",
+          "description" : "Time each individual bulk request should wait for shards that are unavailable."
+        },
+        "consistency": {
+          "type" : "enum",
+          "options" : ["one", "quorum", "all"],
+          "description" : "Explicit write consistency setting for the operation"
+        },
+        "wait_for_completion": {
+           "type" : "boolean",
+           "default": false,
+           "description" : "Should the request should block until the reindex is complete."
+        }
+      }
+    },
+    "body": {
+      "description": "The search definition using the Query DSL and the prototype for the index request.",
+      "required": true
+    }
+  }
+}

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/root.html
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/root.html
@@ -8,7 +8,7 @@
     <meta charset='utf-8'>
 
     <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-94b6f3ff54dcc728ea8e0bb66a51433d9ac8f238ae6fff13829d767fcd15c261.css" media="all" rel="stylesheet" />
-    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-d8ae058d31b9f4426c2f16e381380775b7fe703d6471e7fb94572ce36b1b5b04.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-cd7db7531e028fe278b7d6d4277ddf3130074ee6a807246434f9213550de9490.css" media="all" rel="stylesheet" />
     
     
     
@@ -54,7 +54,7 @@
 <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
     <meta name="google-analytics" content="UA-3769691-2">
 
-<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="D47BE622:5F9C:24AAB54A:56FCF628" name="octolytics-dimension-request_id" />
+<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="D47BE622:6F7F:121EDA0:56FD14A9" name="octolytics-dimension-request_id" />
 <meta content="/&lt;user-name&gt;/&lt;repo-name&gt;/files/disambiguate" data-pjax-transient="true" name="analytics-location" />
 
 
@@ -67,14 +67,14 @@
     <meta name="user-login" content="">
 
         <meta name="expected-hostname" content="github.com">
-      <meta name="js-proxy-site-detection-payload" content="MTA3ZDRmMDM3MTdmOTRiNzJjNTdmOTQ2YTBiYmVmYzFkOTdkOGE0MWYxZTAzNjE0MzdhOThlNzg0NTM4ODI3OXx7InJlbW90ZV9hZGRyZXNzIjoiMjEyLjEyMy4yMzAuMzQiLCJyZXF1ZXN0X2lkIjoiRDQ3QkU2MjI6NUY5QzoyNEFBQjU0QTo1NkZDRjYyOCIsInRpbWVzdGFtcCI6MTQ1OTQxODY2NX0=">
+      <meta name="js-proxy-site-detection-payload" content="NGZjNTNhMjBkYWUyYmIxN2UxMTVmZjllZGNhOGNkZGRiNzM3M2ZmZGUzMGRhNDhkMTU3N2ZiMzBhMjA0ZDFkMHx7InJlbW90ZV9hZGRyZXNzIjoiMjEyLjEyMy4yMzAuMzQiLCJyZXF1ZXN0X2lkIjoiRDQ3QkU2MjI6NkY3RjoxMjFFREEwOjU2RkQxNEE5IiwidGltZXN0YW1wIjoxNDU5NDI2NDczfQ==">
 
       <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#4078c0">
       <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
 
-    <meta content="3a1b283dfb4ccfd90a2e083bc3fa145c0766cf1f" name="form-nonce" />
+    <meta content="f00a3c25ed5b2a80dca109d6adb448c86a3b060f" name="form-nonce" />
 
-    <meta http-equiv="x-pjax-version" content="34630b4b47171c7473c56c198c5465bf">
+    <meta http-equiv="x-pjax-version" content="5fd91682a3a8d23f918a84ca96e915f3">
     
 
       
@@ -241,7 +241,7 @@
       <a href="/elastic/elasticsearch/issues" class="js-selected-navigation-item reponav-item" data-hotkey="g i" data-selected-links="repo_issues repo_labels repo_milestones /elastic/elasticsearch/issues" itemprop="url">
         <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7S10.14 13.7 7 13.7 1.3 11.14 1.3 8s2.56-5.7 5.7-5.7m0-1.3C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7S10.86 1 7 1z m1 3H6v5h2V4z m0 6H6v2h2V10z"></path></svg>
         <span itemprop="name">Issues</span>
-        <span class="counter">959</span>
+        <span class="counter">958</span>
         <meta itemprop="position" content="2">
 </a>    </span>
 
@@ -1852,34 +1852,22 @@
       </a>
     </span>
 
-      This branch is 1414 commits ahead, 5702 commits behind master.
+      This branch is 1415 commits ahead, 5702 commits behind master.
   </div>
 
-
-  <div class="commit-tease js-details-container">
-    <span class="right">
-      Latest commit
-      <a class="commit-tease-sha" href="/elastic/elasticsearch/commit/5c2d216a2cda067204dd1e8d1147c69a2c923ce2" data-pjax>
-        5c2d216
-      </a>
-      <span itemprop="dateModified"><time datetime="2016-03-29T11:15:36Z" is="relative-time">Mar 29, 2016</time></span>
-    </span>
-
-
-    <span class="commit-author-section">
-      <img alt="@clintongormley" class="avatar" height="20" src="https://avatars1.githubusercontent.com/u/56599?v=3&amp;s=40" width="20" />
-      <a href="/clintongormley" class="user-mention" rel="contributor">clintongormley</a>
-    </span>
-
-        <a href="/elastic/elasticsearch/commit/5c2d216a2cda067204dd1e8d1147c69a2c923ce2" class="message" data-pjax="true" title="Renamed REST tests to use update_by_query instead of update-by-query">Renamed REST tests to use update_by_query instead of update-by-query</a>
-    </span>
-
+<include-fragment class="commit-tease commit-loader" src="/elastic/elasticsearch/tree-commit/6d1f651bafb36c1ff79cf1db2d7b7512c99a01dc/rest-api-spec/src/main/resources/rest-api-spec/api">
+  <div class="blank">
+    <img alt="" class="loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32-EAF2F5.gif" width="16" />
+    Fetching latest commitâ€¦
   </div>
+  <div class="loader-error">
+    Cannot retrieve the latest commit at this time.
+  </div>
+</include-fragment>
 
+<include-fragment class="file-wrap" src="/elastic/elasticsearch/file-list/2.3/rest-api-spec/src/main/resources/rest-api-spec/api">
 
-<div class="file-wrap">
-
-  <a href="/elastic/elasticsearch/tree/e559ecaaf8d9836404d4b2c53a222ad7c560d239/rest-api-spec/src/main/resources/rest-api-spec/api" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
+  <a href="/elastic/elasticsearch/tree/6d1f651bafb36c1ff79cf1db2d7b7512c99a01dc/rest-api-spec/src/main/resources/rest-api-spec/api" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
 
   <table class="files js-navigation-container js-active-navigation-container" data-pjax>
       <tr class="up-tree js-navigation-item">
@@ -1906,11 +1894,10 @@
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/ccbea2e5d2a892ff5df788c75b0a45acff0830c1" class="message" data-pjax="true" title="Fix parsing of the `fields` parameter of bulk requests.">Fix parsing of the `fields` parameter of bulk requests.</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-07-08T17:55:24Z" is="time-ago">Jul 8, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -1923,13 +1910,10 @@
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -1942,13 +1926,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -1961,13 +1942,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -1980,13 +1958,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -1999,13 +1974,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2018,15 +1990,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2039,13 +2006,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2058,13 +2022,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2077,13 +2038,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2096,13 +2054,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2115,13 +2070,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2134,13 +2086,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2153,13 +2102,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2172,14 +2118,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/50a92fb5d9da4a3d1a3c319a17391619b9dabdb8" class="message" data-pjax="true" title="Add cat API for repositories and snapshots
-
-Closes #14247
-Closes #13919">Add cat API for repositories and snapshots</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-26T18:22:41Z" is="time-ago">Oct 26, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2192,13 +2134,10 @@ Closes #13919">Add cat API for repositories and snapshots</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2211,13 +2150,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2230,13 +2166,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/8371be8d5fe5df7fb9c0516c474d77b9feddd888" class="message" data-pjax="true" title="In cat.snapshots, repository is required
-
-Closes #17216">In cat.snapshots, repository is required</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2016-03-25T13:24:29Z" is="time-ago">Mar 25, 2016</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2249,13 +2182,10 @@ Closes #17216">In cat.snapshots, repository is required</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
-
-Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2268,15 +2198,10 @@ Closes #13156">[CAT] Default verbose to false</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2289,15 +2214,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2310,13 +2230,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/72868a8c5e71292e1ba62e349cb07e0eb96d2813" class="message" data-pjax="true" title="{index} can be one or many indices and should be typed to list.
-
-{index} can be one or many indices and should be typed to list.">{index} can be one or many indices and should be typed to list.</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:51:52Z" is="time-ago">Oct 6, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2329,15 +2246,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2350,15 +2262,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2371,15 +2278,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2392,15 +2294,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2413,13 +2310,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/3d51e2f2135d151de061265fb1f641d63a215cd3" class="message" data-pjax="true" title="Expose nodes operation timeout in REST API
-
-Currently it&#39;s not possible to specify a timeout for nodes operations (such as node info, node stats, cluster stats and hot threads) via REST-based APIs.">Expose nodes operation timeout in REST API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-07T22:08:47Z" is="time-ago">Oct 7, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2432,15 +2326,10 @@ Currently it&#39;s not possible to specify a timeout for nodes operations (such 
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2453,15 +2342,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2474,15 +2358,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2495,15 +2374,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2516,13 +2390,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/4fca4ac49c53cfec9e3ba91d6dd02ac9ea597433" class="message" data-pjax="true" title="id route value is required
-
-id route value is required">id route value is required</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:51:59Z" is="time-ago">Oct 6, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2535,15 +2406,10 @@ id route value is required">id route value is required</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2556,15 +2422,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2577,35 +2438,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/ef9d70b9b39d1447b43d7d4177f371febbefe617" class="message" data-pjax="true" title="field stats: added index constraints
-
-Field stats index constraints allows to omit all field stats for indices that don&#39;t match with the constraint. An index
-constraint can exclude indices&#39; field stats based on the `min_value` and `max_value` statistic. This option is only
-useful if the `level` option is set to `indices`.
-
-For example index constraints can be useful to find out the min and max value of a particular property of your data in
-a time based scenario. The following request only returns field stats for the `answer_count` property for indices
-holding questions created in the year 2014:
-
-curl -XPOST &#39;http://localhost:9200/_field_stats?level=indices&#39; -d &#39;{
-   &quot;fields&quot; : [&quot;answer_count&quot;] &lt;1&gt;
-   &quot;index_constraints&quot; : { &lt;2&gt;
-      &quot;creation_date&quot; : { &lt;3&gt;
-         &quot;min_value&quot; : { &lt;4&gt;
-            &quot;gte&quot; : &quot;2014-01-01T00:00:00.000Z&quot;,
-         },
-         &quot;max_value&quot; : {
-            &quot;lt&quot; : &quot;2015-01-01T00:00:00.000Z&quot;
-         }
-      }
-   }
-}&#39;
-
-Closes #11187">field stats: added index constraints</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-07-01T06:47:03Z" is="time-ago">Jul 1, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2618,15 +2454,10 @@ Closes #11187">field stats: added index constraints</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2639,15 +2470,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2660,15 +2486,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2681,15 +2502,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2702,15 +2518,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2723,20 +2534,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/a632db2e220d8bc241d2dafbe50d48f8f7055265" class="message" data-pjax="true" title="Analysis : Allow string explain param in JSON
-
-Move some test methods from AnalylzeActionIT to RestAnalyzeActionTest
-Allow string explain param if it can parse
-Fix wrong param name in rest-api-spec
-Fix typo
-Remove unused import
-
-Backport of #16977
-Related to #16925">Analysis : Allow string explain param in JSON</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2016-03-08T14:29:28Z" is="time-ago">Mar 8, 2016</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2749,29 +2550,10 @@ Related to #16925">Analysis : Allow string explain param in JSON</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/38f5cc236ac6d06556d25eab81f7b05854b326ca" class="message" data-pjax="true" title="Rename caches.
-
-In order to be more consistent with what they do, the query cache has been
-renamed to request cache and the filter cache has been renamed to query
-cache.
-
-A known issue is that package/logger names do no longer match settings names,
-please speak up if you think this is an issue.
-
-Here are the settings for which I kept backward compatibility. Note that they
-are a bit different from what was discussed on #11569 but putting `cache` before
-the name of what is cached has the benefit of making these settings consistent
-with the fielddata cache whose size is configured by
-`indices.fielddata.cache.size`:
- * index.cache.query.enable -&gt; index.requests.cache.enable
- * indices.cache.query.size -&gt; indices.requests.cache.size
- * indices.cache.filter.size -&gt; indices.queries.cache.size
-
-Close #11569">Rename caches.</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-29T08:15:27Z" is="time-ago">Jun 29, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2784,13 +2566,10 @@ Close #11569">Rename caches.</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/53c1a80505af59bca68ff3147ec2e1f7e88ddae6" class="message" data-pjax="true" title=" indices.close takes a list of indices
-
- not single index"> indices.close takes a list of indices</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:52:24Z" is="time-ago">Oct 6, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2803,13 +2582,10 @@ Close #11569">Rename caches.</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/a254b2da2919ba5e82f19bc890eb7e32c39cb037" class="message" data-pjax="true" title="REST spec: Added update_all_types to indices.put_mapping and indices.create
-
-Closes #12840">REST spec: Added update_all_types to indices.put_mapping and indices.â€¦</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-26T13:33:23Z" is="time-ago">Aug 26, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2822,15 +2598,10 @@ Closes #12840">REST spec: Added update_all_types to indices.put_mapping and indi
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2843,15 +2614,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2864,15 +2630,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2885,15 +2646,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2906,15 +2662,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2927,15 +2678,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2948,15 +2694,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2969,15 +2710,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -2990,15 +2726,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3011,11 +2742,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/aa7914eb492ac477047a1a36e9ff746fbfdcff12" class="message" data-pjax="true" title="synced flush incorrectly documented url parameters as path parameters">synced flush incorrectly documented url parameters as path parameters</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-09-10T10:06:44Z" is="time-ago">Sep 10, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3028,15 +2758,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/c07fbd8bdabcdb8c6ea186b2b9f998dbaeb79f34" class="message" data-pjax="true" title="Add Force Merge API, deprecate Optimize API
-
-This adds an API for force merging lucene segments. The `/_optimize` API is now
-deprecated and replaced by the `/_forcemerge` API, which has all the same flags
-and action, just a different name.">Add Force Merge API, deprecate Optimize API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-21T04:30:41Z" is="time-ago">Oct 20, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3049,13 +2774,10 @@ and action, just a different name.">Add Force Merge API, deprecate Optimize API<
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/fc54ee2e68d7496f6e9ac6ba60825487eff83fc2" class="message" data-pjax="true" title="Add options for indices.get feature
-
-As described here https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html?q=get%20index#_filtering_index_information">Add options for indices.get feature</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T18:32:46Z" is="time-ago">Oct 6, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3068,15 +2790,10 @@ As described here https://www.elastic.co/guide/en/elasticsearch/reference/curren
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3089,15 +2806,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3110,11 +2822,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/6ae9c9cb26d473ca5c4bbc9629e0f02f29f9e637" class="message" data-pjax="true" title="Get field mapping documented fields as field">Get field mapping documented fields as field</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:52:33Z" is="time-ago">Oct 6, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3127,15 +2838,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3148,15 +2854,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3169,13 +2870,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/e86a928c06e69e4a523a9d34012234d683159507" class="message" data-pjax="true" title="indices get template accepts a list of names
-
-not just string">indices get template accepts a list of names</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:52:07Z" is="time-ago">Oct 6, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3188,15 +2886,10 @@ not just string">indices get template accepts a list of names</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3209,15 +2902,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3230,13 +2918,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/01f24aecf9292b06d0027e9b2a3b570156a2aeee" class="message" data-pjax="true" title="indices.open takes a list of indices
-
-not single index">indices.open takes a list of indices</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:52:15Z" is="time-ago">Oct 6, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3249,15 +2934,10 @@ not single index">indices.open takes a list of indices</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3270,15 +2950,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3291,13 +2966,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/a254b2da2919ba5e82f19bc890eb7e32c39cb037" class="message" data-pjax="true" title="REST spec: Added update_all_types to indices.put_mapping and indices.create
-
-Closes #12840">REST spec: Added update_all_types to indices.put_mapping and indices.â€¦</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-26T13:33:23Z" is="time-ago">Aug 26, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3310,15 +2982,10 @@ Closes #12840">REST spec: Added update_all_types to indices.put_mapping and indi
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3331,15 +2998,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3352,11 +3014,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/33e04083a79e3a2990c3bf53166a5c7ea793db78" class="message" data-pjax="true" title="Corrected some typos in the REST spec">Corrected some typos in the REST spec</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-27T09:28:27Z" is="time-ago">Aug 27, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3369,15 +3030,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3390,15 +3046,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3411,13 +3062,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/3ef614dce85ca1d117effead331b54dadb783b38" class="message" data-pjax="true" title="REST spec: Added the verbose flag to indices.segments
-
-Relates to #9111">REST spec: Added the verbose flag to indices.segments</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-11-30T06:41:33Z" is="time-ago">Nov 30, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3430,13 +3078,10 @@ Relates to #9111">REST spec: Added the verbose flag to indices.segments</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/56d7cb8bd80b70ef50d69865775db537cad86da5" class="message" data-pjax="true" title="Update indices.shard_stores.json
-
-Correct documentation url">Update indices.shard_stores.json</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-08-25T20:21:04Z" is="time-ago">Aug 25, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3449,15 +3094,10 @@ Correct documentation url">Update indices.shard_stores.json</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/5512eb39e9015726fcaae7fb4cda18079e54bf97" class="message" data-pjax="true" title="Merge pull request #15051 from apatrida/patch-1
-
-body attribute was at wrong nesting level">Merge pull request</a> <a href="https://github.com/elastic/elasticsearch/pull/15051" class="issue-link js-issue-link" data-url="https://github.com/elastic/elasticsearch/issues/15051" data-id="119083916" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#15051</a> <a href="/elastic/elasticsearch/commit/5512eb39e9015726fcaae7fb4cda18079e54bf97" class="message" data-pjax="true" title="Merge pull request #15051 from apatrida/patch-1
-
-body attribute was at wrong nesting level">from apatrida/patch-1</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-11-28T10:32:13Z" is="time-ago">Nov 28, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3470,15 +3110,10 @@ body attribute was at wrong nesting level">from apatrida/patch-1</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3491,15 +3126,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3512,15 +3142,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3533,15 +3158,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3554,15 +3174,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3575,15 +3190,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3596,15 +3206,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3617,15 +3222,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3638,13 +3238,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/3d51e2f2135d151de061265fb1f641d63a215cd3" class="message" data-pjax="true" title="Expose nodes operation timeout in REST API
-
-Currently it&#39;s not possible to specify a timeout for nodes operations (such as node info, node stats, cluster stats and hot threads) via REST-based APIs.">Expose nodes operation timeout in REST API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-07T22:08:47Z" is="time-ago">Oct 7, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3657,13 +3254,10 @@ Currently it&#39;s not possible to specify a timeout for nodes operations (such 
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/3d51e2f2135d151de061265fb1f641d63a215cd3" class="message" data-pjax="true" title="Expose nodes operation timeout in REST API
-
-Currently it&#39;s not possible to specify a timeout for nodes operations (such as node info, node stats, cluster stats and hot threads) via REST-based APIs.">Expose nodes operation timeout in REST API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-07T22:08:47Z" is="time-ago">Oct 7, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3676,13 +3270,10 @@ Currently it&#39;s not possible to specify a timeout for nodes operations (such 
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/3d51e2f2135d151de061265fb1f641d63a215cd3" class="message" data-pjax="true" title="Expose nodes operation timeout in REST API
-
-Currently it&#39;s not possible to specify a timeout for nodes operations (such as node info, node stats, cluster stats and hot threads) via REST-based APIs.">Expose nodes operation timeout in REST API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-10-07T22:08:47Z" is="time-ago">Oct 7, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3695,15 +3286,10 @@ Currently it&#39;s not possible to specify a timeout for nodes operations (such 
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3716,15 +3302,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3737,15 +3318,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3758,15 +3334,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3779,11 +3350,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/986861d305ff1086b585b7e019cccd54e10084f2" class="message" data-pjax="true" title="REST: The body is required in the reindex API">REST: The body is required in the reindex API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2016-03-28T11:14:48Z" is="time-ago">Mar 28, 2016</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3796,11 +3366,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/a847dd267c5b358596119903df27ee9fd0e4b67c" class="message" data-pjax="true" title="[TEST] Fix location of render_search_template.json">[TEST] Fix location of render_search_template.json</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-30T16:45:43Z" is="time-ago">Jun 30, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3813,15 +3382,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3834,29 +3398,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/38f5cc236ac6d06556d25eab81f7b05854b326ca" class="message" data-pjax="true" title="Rename caches.
-
-In order to be more consistent with what they do, the query cache has been
-renamed to request cache and the filter cache has been renamed to query
-cache.
-
-A known issue is that package/logger names do no longer match settings names,
-please speak up if you think this is an issue.
-
-Here are the settings for which I kept backward compatibility. Note that they
-are a bit different from what was discussed on #11569 but putting `cache` before
-the name of what is cached has the benefit of making these settings consistent
-with the fielddata cache whose size is configured by
-`indices.fielddata.cache.size`:
- * index.cache.query.enable -&gt; index.requests.cache.enable
- * indices.cache.query.size -&gt; indices.requests.cache.size
- * indices.cache.filter.size -&gt; indices.queries.cache.size
-
-Close #11569">Rename caches.</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-29T08:15:27Z" is="time-ago">Jun 29, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3869,15 +3414,10 @@ Close #11569">Rename caches.</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3890,11 +3430,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/1d950a8c258f59f729d48dff19e7b3a5fbca6db2" class="message" data-pjax="true" title="part types are not string but list on the _search_shards endpoint">part types are not string but list on the _search_shards endpoint</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-09-10T10:06:37Z" is="time-ago">Sep 10, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3907,15 +3446,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3928,11 +3462,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/e2d76aaa20e0ccab4452b263a5718b23e46d9c75" class="message" data-pjax="true" title="remove _create from POST to match PUT path">remove _create from POST to match PUT path</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-29T19:55:52Z" is="time-ago">Jun 29, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3945,15 +3478,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3966,15 +3494,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -3987,15 +3510,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4008,15 +3526,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4029,15 +3542,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4050,15 +3558,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4071,15 +3574,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4092,15 +3590,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4113,15 +3606,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4134,13 +3622,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/700b64f89cffef76c9189f0e32b40fc45d405fd5" class="message" data-pjax="true" title="Combine node name and task id into single string task id
-
-This commit changes the URL for task operations from `/_tasks/{nodeId}/{taskId}` to `/_tasks/{taskId}`, where `{taskId}` has a form of nodeid:id">Combine node name and task id into single string task id</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2016-03-04T15:04:31Z" is="time-ago">Mar 4, 2016</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4153,28 +3638,10 @@ This commit changes the URL for task operations from `/_tasks/{nodeId}/{taskId}`
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/5b6779ed54b2c628e1fbb4c18518d96b8f6cec4e" class="message" data-pjax="true" title="Teach list tasks api to wait for tasks to finish
-
-Backport of 6d0efae7139401f497e6cd4ab329fba82dd922bf.
-
-_wait_for_completion defaults to false. If set to true then the API will
-wait for all the tasks that it finds to stop running before returning. You
-can use the timeout parameter to prevent it from waiting forever. If you
-don&#39;t set a timeout parameter it&#39;ll default to 30 seconds.
-
-Does not backport the portion of 6d0efae7139401f497e6cd4ab329fba82dd922bf
-that logs a message if any tasks overrun the current REST test. This would
-be useful but the rest test runner is missing some important bits that are
-in master that&#39;d let me backport that safely and it isn&#39;t worth the risk.
-
-Switches the request to getter/setter style methods as we&#39;re going that
-way in the Elasticsearch code base. Reindex is all getter/setter style.
-
-Closes #16906">Teach list tasks api to wait for tasks to finish</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2016-03-14T18:30:14Z" is="time-ago">Mar 14, 2016</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4187,15 +3654,10 @@ Closes #16906">Teach list tasks api to wait for tasks to finish</a>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
-
-The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
-
-The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4208,11 +3670,10 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/54af556618e9265a486a79dd0a968795796ed3d9" class="message" data-pjax="true" title="Remove detect_noop from REST spec">Remove detect_noop from REST spec</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2016-02-02T20:45:18Z" is="time-ago">Feb 2, 2016</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
@@ -4225,17 +3686,16 @@ The main stimulus for this change is that for those using Eclipse the current bu
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
-                  <a href="/elastic/elasticsearch/commit/5c2d216a2cda067204dd1e8d1147c69a2c923ce2" class="message" data-pjax="true" title="Renamed REST tests to use update_by_query instead of update-by-query">Renamed REST tests to use update_by_query instead of update-by-query</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"><time datetime="2016-03-29T11:15:45Z" is="time-ago">Mar 29, 2016</time></span>
+            <span class="css-truncate css-truncate-target"></span>
           </td>
         </tr>
     </tbody>
   </table>
 
-</div>
+</include-fragment>
 
 
 
@@ -4268,7 +3728,7 @@ The main stimulus for this change is that for those using Eclipse the current bu
       <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" title="GitHub " version="1.1" viewBox="0 0 16 16" width="24"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
 </a>
     <ul class="site-footer-links">
-      <li>&copy; 2016 <span title="0.10875s from github-fe149-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+      <li>&copy; 2016 <span title="0.07890s from github-fe119-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
         <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
         <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
         <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/root.html
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/root.html
@@ -7,22 +7,22 @@
   <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
     <meta charset='utf-8'>
 
-    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-2cbc4060c4ac5481bfbedea9bb8fc752a93db97fca12f72ed99555906f567387.css" media="all" rel="stylesheet" />
-    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-96ad60c299ea29f60354f3cd04103143fde49fa6c81f6c8573b8535c594ee9b0.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-94b6f3ff54dcc728ea8e0bb66a51433d9ac8f238ae6fff13829d767fcd15c261.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-d8ae058d31b9f4426c2f16e381380775b7fe703d6471e7fb94572ce36b1b5b04.css" media="all" rel="stylesheet" />
     
     
     
-    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-cba73ccd3ee30bf3b90aaf16f1aad8d8f91886bd3bc7fa5b42abf46dd3c46210.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-1bd23793fa6ea7331120b0c618363c3c479f68b6aa10e8e58097327cc3640a36.css" media="all" rel="stylesheet" />
 
-    <link as="script" href="https://assets-cdn.github.com/assets/frameworks-d7233eaabb7531aaf275fa71e7bca3c43cb11eae12c8359622bd13d725320aee.js" rel="preload" />
-    <link as="script" href="https://assets-cdn.github.com/assets/github-be09baa865e75e7094b35490a7eaf276a214c9e78489fd8a161a61b10da8fca8.js" rel="preload" />
+    <link as="script" href="https://assets-cdn.github.com/assets/frameworks-b27673619ec3b4382e890963468a5c0f6d32cb8f61aefc2c4492d7f15c441aec.js" rel="preload" />
+    <link as="script" href="https://assets-cdn.github.com/assets/github-4fdb66600a7fca3b074a0f95ff36ac791e8d20a880e7b904624960b0ce852565.js" rel="preload" />
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="Content-Language" content="en">
     <meta name="viewport" content="width=1020">
     
     
-    <title>elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/api at 2.2 Â· elastic/elasticsearch Â· GitHub</title>
+    <title>elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/api at 2.3 Â· elastic/elasticsearch Â· GitHub</title>
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
     <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
@@ -54,7 +54,7 @@
 <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
     <meta name="google-analytics" content="UA-3769691-2">
 
-<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="6423A20A:5F9E:A17E429:56F01AAE" name="octolytics-dimension-request_id" />
+<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="D47BE622:5F9C:24AAB54A:56FCF628" name="octolytics-dimension-request_id" />
 <meta content="/&lt;user-name&gt;/&lt;repo-name&gt;/files/disambiguate" data-pjax-transient="true" name="analytics-location" />
 
 
@@ -67,14 +67,14 @@
     <meta name="user-login" content="">
 
         <meta name="expected-hostname" content="github.com">
-      <meta name="js-proxy-site-detection-payload" content="YTI0NzMwOTk5MzMzMzc5NGZmYTJhYmYxYmVmYzY2MTk1NDc4ODBmOWYzNTk0NzQ4Yjg5Y2VhODMyMzMwODhiZHx7InJlbW90ZV9hZGRyZXNzIjoiMTAwLjM1LjE2Mi4xMCIsInJlcXVlc3RfaWQiOiI2NDIzQTIwQTo1RjlFOkExN0U0Mjk6NTZGMDFBQUUifQ==">
+      <meta name="js-proxy-site-detection-payload" content="MTA3ZDRmMDM3MTdmOTRiNzJjNTdmOTQ2YTBiYmVmYzFkOTdkOGE0MWYxZTAzNjE0MzdhOThlNzg0NTM4ODI3OXx7InJlbW90ZV9hZGRyZXNzIjoiMjEyLjEyMy4yMzAuMzQiLCJyZXF1ZXN0X2lkIjoiRDQ3QkU2MjI6NUY5QzoyNEFBQjU0QTo1NkZDRjYyOCIsInRpbWVzdGFtcCI6MTQ1OTQxODY2NX0=">
 
       <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#4078c0">
       <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
 
-    <meta content="ce4ee2328a61bf6bebe529295d615ca65bba3571" name="form-nonce" />
+    <meta content="3a1b283dfb4ccfd90a2e083bc3fa145c0766cf1f" name="form-nonce" />
 
-    <meta http-equiv="x-pjax-version" content="0d093e2d1eab9d4032686ae1025986f5">
+    <meta http-equiv="x-pjax-version" content="34630b4b47171c7473c56c198c5465bf">
     
 
       
@@ -82,14 +82,15 @@
   <meta name="go-import" content="github.com/elastic/elasticsearch git https://github.com/elastic/elasticsearch.git">
 
   <meta content="6764390" name="octolytics-dimension-user_id" /><meta content="elastic" name="octolytics-dimension-user_login" /><meta content="507775" name="octolytics-dimension-repository_id" /><meta content="elastic/elasticsearch" name="octolytics-dimension-repository_nwo" /><meta content="true" name="octolytics-dimension-repository_public" /><meta content="false" name="octolytics-dimension-repository_is_fork" /><meta content="507775" name="octolytics-dimension-repository_network_root_id" /><meta content="elastic/elasticsearch" name="octolytics-dimension-repository_network_root_nwo" />
-  <link href="https://github.com/elastic/elasticsearch/commits/2.2.atom" rel="alternate" title="Recent Commits to elasticsearch:2.2" type="application/atom+xml">
+  <link href="https://github.com/elastic/elasticsearch/commits/2.3.atom" rel="alternate" title="Recent Commits to elasticsearch:2.3" type="application/atom+xml">
 
 
-      <link rel="canonical" href="https://github.com/elastic/elasticsearch/tree/2.2/rest-api-spec/src/main/resources/rest-api-spec/api" data-pjax-transient>
+      <link rel="canonical" href="https://github.com/elastic/elasticsearch/tree/2.3/rest-api-spec/src/main/resources/rest-api-spec/api" data-pjax-transient>
   </head>
 
 
-  <body class="logged_out   env-production  vis-public">
+  <body class="logged-out   env-production  vis-public">
+    <div id="js-pjax-loader-bar" class="pjax-loader-bar"></div>
     <a href="#start-of-content" tabindex="1" class="accessibility-aid js-skip-to-content">Skip to content</a>
 
     
@@ -98,14 +99,14 @@
 
 
 
-        <header class="site-header js-details-container" role="banner">
+          <header class="site-header js-details-container" role="banner">
   <div class="container-responsive">
     <a class="header-logo-invertocat" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
-      <svg aria-hidden="true" class="octicon octicon-mark-github" height="32" role="img" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
+      <svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
     </a>
 
     <button class="btn-link right site-header-toggle js-details-target" type="button" aria-label="Toggle navigation">
-      <svg aria-hidden="true" class="octicon octicon-three-bars" height="24" role="img" version="1.1" viewBox="0 0 12 16" width="18"><path d="M11.41 9H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1z m0-4H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1zM0.59 11h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1z"></path></svg>
+      <svg aria-hidden="true" class="octicon octicon-three-bars" height="24" version="1.1" viewBox="0 0 12 16" width="18"><path d="M11.41 9H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1z m0-4H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1zM0.59 11h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1z"></path></svg>
     </button>
 
     <div class="site-header-menu">
@@ -122,13 +123,31 @@
 
       <div class="site-header-actions">
             <a class="btn btn-primary site-header-actions-btn" href="/join?source=header-repo" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign up</a>
-          <a class="btn site-header-actions-btn mr-2" href="/login?return_to=%2Felastic%2Felasticsearch%2Ftree%2F2.2%2Frest-api-spec%2Fsrc%2Fmain%2Fresources%2Frest-api-spec%2Fapi" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
+          <a class="btn site-header-actions-btn mr-2" href="/login?return_to=%2Felastic%2Felasticsearch%2Ftree%2F2.3%2Frest-api-spec%2Fsrc%2Fmain%2Fresources%2Frest-api-spec%2Fapi" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
       </div>
 
         <nav class="site-header-nav site-header-nav-secondary">
           <a class="nav-item" href="/pricing">Pricing</a>
           <a class="nav-item" href="/blog">Blog</a>
           <a class="nav-item" href="https://help.github.com">Support</a>
+          <a class="nav-item header-search-link" href="https://github.com/search">Search GitHub</a>
+              <div class="header-search scoped-search site-scoped-search js-site-search" role="search">
+  <!-- </textarea> --><!-- '"` --><form accept-charset="UTF-8" action="/elastic/elasticsearch/search" class="js-site-search-form" data-scoped-search-url="/elastic/elasticsearch/search" data-unscoped-search-url="/search" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
+    <label class="form-control header-search-wrapper js-chromeless-input-container">
+      <div class="header-search-scope">This repository</div>
+      <input type="text"
+        class="form-control header-search-input js-site-search-focus js-site-search-field is-clearable"
+        data-hotkey="s"
+        name="q"
+        placeholder="Search"
+        aria-label="Search this repository"
+        data-unscoped-placeholder="Search GitHub"
+        data-scoped-placeholder="Search"
+        tabindex="1"
+        autocapitalize="off">
+    </label>
+</form></div>
+
         </nav>
     </div>
   </div>
@@ -144,7 +163,7 @@
 
     <div role="main" class="main-content">
         <div itemscope itemtype="http://schema.org/SoftwareSourceCode">
-    <div id="js-repo-pjax-container" class="context-loader-container js-repo-nav-next" data-pjax-container>
+    <div id="js-repo-pjax-container" data-pjax-container>
       
 <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav">
   <div class="container repohead-details-container">
@@ -157,11 +176,11 @@
       <a href="/login?return_to=%2Felastic%2Felasticsearch"
     class="btn btn-sm btn-with-count tooltipped tooltipped-n"
     aria-label="You must be signed in to watch a repository" rel="nofollow">
-    <svg aria-hidden="true" class="octicon octicon-eye" height="16" role="img" version="1.1" viewBox="0 0 16 16" width="16"><path d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6c4.94 0 7.94-6 7.94-6S13 2 8.06 2z m-0.06 10c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4z m2-4c0 1.11-0.89 2-2 2s-2-0.89-2-2 0.89-2 2-2 2 0.89 2 2z"></path></svg>
+    <svg aria-hidden="true" class="octicon octicon-eye" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6c4.94 0 7.94-6 7.94-6S13 2 8.06 2z m-0.06 10c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4z m2-4c0 1.11-0.89 2-2 2s-2-0.89-2-2 0.89-2 2-2 2 0.89 2 2z"></path></svg>
     Watch
   </a>
   <a class="social-count" href="/elastic/elasticsearch/watchers">
-    1,605
+    1,604
   </a>
 
   </li>
@@ -170,12 +189,12 @@
       <a href="/login?return_to=%2Felastic%2Felasticsearch"
     class="btn btn-sm btn-with-count tooltipped tooltipped-n"
     aria-label="You must be signed in to star a repository" rel="nofollow">
-    <svg aria-hidden="true" class="octicon octicon-star" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M14 6l-4.9-0.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14l4.33-2.33 4.33 2.33L10.4 9.26 14 6z"></path></svg>
+    <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M14 6l-4.9-0.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14l4.33-2.33 4.33 2.33L10.4 9.26 14 6z"></path></svg>
     Star
   </a>
 
     <a class="social-count js-social-count" href="/elastic/elasticsearch/stargazers">
-      16,167
+      15,775
     </a>
 
   </li>
@@ -184,67 +203,63 @@
       <a href="/login?return_to=%2Felastic%2Felasticsearch"
         class="btn btn-sm btn-with-count tooltipped tooltipped-n"
         aria-label="You must be signed in to fork a repository" rel="nofollow">
-        <svg aria-hidden="true" class="octicon octicon-repo-forked" height="16" role="img" version="1.1" viewBox="0 0 10 16" width="10"><path d="M8 1c-1.11 0-2 0.89-2 2 0 0.73 0.41 1.38 1 1.72v1.28L5 8 3 6v-1.28c0.59-0.34 1-0.98 1-1.72 0-1.11-0.89-2-2-2S0 1.89 0 3c0 0.73 0.41 1.38 1 1.72v1.78l3 3v1.78c-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72V9.5l3-3V4.72c0.59-0.34 1-0.98 1-1.72 0-1.11-0.89-2-2-2zM2 4.2c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z m3 10c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z m3-10c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z"></path></svg>
+        <svg aria-hidden="true" class="octicon octicon-repo-forked" height="16" version="1.1" viewBox="0 0 10 16" width="10"><path d="M8 1c-1.11 0-2 0.89-2 2 0 0.73 0.41 1.38 1 1.72v1.28L5 8 3 6v-1.28c0.59-0.34 1-0.98 1-1.72 0-1.11-0.89-2-2-2S0 1.89 0 3c0 0.73 0.41 1.38 1 1.72v1.78l3 3v1.78c-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72V9.5l3-3V4.72c0.59-0.34 1-0.98 1-1.72 0-1.11-0.89-2-2-2zM2 4.2c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z m3 10c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z m3-10c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z"></path></svg>
         Fork
       </a>
 
     <a href="/elastic/elasticsearch/network" class="social-count">
-      5,206
+      5,273
     </a>
   </li>
 </ul>
 
     <h1 class="entry-title public ">
-  <svg aria-hidden="true" class="octicon octicon-repo" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M4 9h-1v-1h1v1z m0-3h-1v1h1v-1z m0-2h-1v1h1v-1z m0-2h-1v1h1v-1z m8-1v12c0 0.55-0.45 1-1 1H6v2l-1.5-1.5-1.5 1.5V14H1c-0.55 0-1-0.45-1-1V1C0 0.45 0.45 0 1 0h10c0.55 0 1 0.45 1 1z m-1 10H1v2h2v-1h3v1h5V11z m0-10H2v9h9V1z"></path></svg>
+  <svg aria-hidden="true" class="octicon octicon-repo" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M4 9h-1v-1h1v1z m0-3h-1v1h1v-1z m0-2h-1v1h1v-1z m0-2h-1v1h1v-1z m8-1v12c0 0.55-0.45 1-1 1H6v2l-1.5-1.5-1.5 1.5V14H1c-0.55 0-1-0.45-1-1V1C0 0.45 0.45 0 1 0h10c0.55 0 1 0.45 1 1z m-1 10H1v2h2v-1h3v1h5V11z m0-10H2v9h9V1z"></path></svg>
   <span class="author" itemprop="author"><a href="/elastic" class="url fn" rel="author">elastic</a></span><!--
 --><span class="path-divider">/</span><!--
 --><strong itemprop="name"><a href="/elastic/elasticsearch" data-pjax="#js-repo-pjax-container">elasticsearch</a></strong>
-
-  <span class="page-context-loader">
-    <img alt="" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
-  </span>
 
 </h1>
 
   </div>
   <div class="container">
     
-<nav class="reponav js-repo-nav js-sidenav-container-pjax js-octicon-loaders"
+<nav class="reponav js-repo-nav js-sidenav-container-pjax"
      itemscope
      itemtype="http://schema.org/BreadcrumbList"
      role="navigation"
      data-pjax="#js-repo-pjax-container">
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a href="/elastic/elasticsearch/tree/2.2" aria-selected="true" class="js-selected-navigation-item selected reponav-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /elastic/elasticsearch/tree/2.2" itemprop="url">
-      <svg aria-hidden="true" class="octicon octicon-code" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M9.5 3l-1.5 1.5 3.5 3.5L8 11.5l1.5 1.5 4.5-5L9.5 3zM4.5 3L0 8l4.5 5 1.5-1.5L2.5 8l3.5-3.5L4.5 3z"></path></svg>
+    <a href="/elastic/elasticsearch/tree/2.3" aria-selected="true" class="js-selected-navigation-item selected reponav-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /elastic/elasticsearch/tree/2.3" itemprop="url">
+      <svg aria-hidden="true" class="octicon octicon-code" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M9.5 3l-1.5 1.5 3.5 3.5L8 11.5l1.5 1.5 4.5-5L9.5 3zM4.5 3L0 8l4.5 5 1.5-1.5L2.5 8l3.5-3.5L4.5 3z"></path></svg>
       <span itemprop="name">Code</span>
       <meta itemprop="position" content="1">
 </a>  </span>
 
     <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
       <a href="/elastic/elasticsearch/issues" class="js-selected-navigation-item reponav-item" data-hotkey="g i" data-selected-links="repo_issues repo_labels repo_milestones /elastic/elasticsearch/issues" itemprop="url">
-        <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7S10.14 13.7 7 13.7 1.3 11.14 1.3 8s2.56-5.7 5.7-5.7m0-1.3C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7S10.86 1 7 1z m1 3H6v5h2V4z m0 6H6v2h2V10z"></path></svg>
+        <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7S10.14 13.7 7 13.7 1.3 11.14 1.3 8s2.56-5.7 5.7-5.7m0-1.3C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7S10.86 1 7 1z m1 3H6v5h2V4z m0 6H6v2h2V10z"></path></svg>
         <span itemprop="name">Issues</span>
-        <span class="counter">941</span>
+        <span class="counter">959</span>
         <meta itemprop="position" content="2">
 </a>    </span>
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
     <a href="/elastic/elasticsearch/pulls" class="js-selected-navigation-item reponav-item" data-hotkey="g p" data-selected-links="repo_pulls /elastic/elasticsearch/pulls" itemprop="url">
-      <svg aria-hidden="true" class="octicon octicon-git-pull-request" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M11 11.28c0-1.73 0-6.28 0-6.28-0.03-0.78-0.34-1.47-0.94-2.06s-1.28-0.91-2.06-0.94c0 0-1.02 0-1 0V0L4 3l3 3V4h1c0.27 0.02 0.48 0.11 0.69 0.31s0.3 0.42 0.31 0.69v6.28c-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72z m-1 2.92c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2zM4 3c0-1.11-0.89-2-2-2S0 1.89 0 3c0 0.73 0.41 1.38 1 1.72 0 1.55 0 5.56 0 6.56-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72V4.72c0.59-0.34 1-0.98 1-1.72z m-0.8 10c0 0.66-0.55 1.2-1.2 1.2s-1.2-0.55-1.2-1.2 0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2z m-1.2-8.8c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z"></path></svg>
+      <svg aria-hidden="true" class="octicon octicon-git-pull-request" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M11 11.28c0-1.73 0-6.28 0-6.28-0.03-0.78-0.34-1.47-0.94-2.06s-1.28-0.91-2.06-0.94c0 0-1.02 0-1 0V0L4 3l3 3V4h1c0.27 0.02 0.48 0.11 0.69 0.31s0.3 0.42 0.31 0.69v6.28c-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72z m-1 2.92c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2zM4 3c0-1.11-0.89-2-2-2S0 1.89 0 3c0 0.73 0.41 1.38 1 1.72 0 1.55 0 5.56 0 6.56-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72V4.72c0.59-0.34 1-0.98 1-1.72z m-0.8 10c0 0.66-0.55 1.2-1.2 1.2s-1.2-0.55-1.2-1.2 0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2z m-1.2-8.8c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z"></path></svg>
       <span itemprop="name">Pull requests</span>
-      <span class="counter">120</span>
+      <span class="counter">117</span>
       <meta itemprop="position" content="3">
 </a>  </span>
 
 
   <a href="/elastic/elasticsearch/pulse" class="js-selected-navigation-item reponav-item" data-selected-links="pulse /elastic/elasticsearch/pulse">
-    <svg aria-hidden="true" class="octicon octicon-pulse" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M11.5 8L8.8 5.4 6.6 8.5 5.5 1.6 2.38 8H0V10h3.6L4.5 8.2l0.9 5.4L9 8.5l1.6 1.5H14V8H11.5z"></path></svg>
+    <svg aria-hidden="true" class="octicon octicon-pulse" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M11.5 8L8.8 5.4 6.6 8.5 5.5 1.6 2.38 8H0V10h3.6L4.5 8.2l0.9 5.4L9 8.5l1.6 1.5H14V8H11.5z"></path></svg>
     Pulse
 </a>
   <a href="/elastic/elasticsearch/graphs" class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors /elastic/elasticsearch/graphs">
-    <svg aria-hidden="true" class="octicon octicon-graph" height="16" role="img" version="1.1" viewBox="0 0 16 16" width="16"><path d="M16 14v1H0V0h1v14h15z m-11-1H3V8h2v5z m4 0H7V3h2v10z m4 0H11V6h2v7z"></path></svg>
+    <svg aria-hidden="true" class="octicon octicon-graph" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M16 14v1H0V0h1v14h15z m-11-1H3V8h2v5z m4 0H7V3h2v10z m4 0H11V6h2v7z"></path></svg>
     Graphs
 </a>
 
@@ -261,10 +276,10 @@
   
 <div class="select-menu js-menu-container js-select-menu left">
   <button class="btn btn-sm select-menu-button js-menu-target css-truncate" data-hotkey="w"
-    title="2.2"
+    title="2.3"
     type="button" aria-label="Switch branches or tags" tabindex="0" aria-haspopup="true">
     <i>Branch:</i>
-    <span class="js-select-button css-truncate-target">2.2</span>
+    <span class="js-select-button css-truncate-target">2.3</span>
   </button>
 
   <div class="select-menu-modal-holder js-menu-content js-navigation-container" data-pjax aria-hidden="true">
@@ -301,7 +316,7 @@
                data-name="0.12"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.12">
                 0.12
               </span>
@@ -311,7 +326,7 @@
                data-name="0.13"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.13">
                 0.13
               </span>
@@ -321,7 +336,7 @@
                data-name="0.14"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.14">
                 0.14
               </span>
@@ -331,7 +346,7 @@
                data-name="0.15"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.15">
                 0.15
               </span>
@@ -341,7 +356,7 @@
                data-name="0.16"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.16">
                 0.16
               </span>
@@ -351,7 +366,7 @@
                data-name="0.17"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.17">
                 0.17
               </span>
@@ -361,7 +376,7 @@
                data-name="0.18"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.18">
                 0.18
               </span>
@@ -371,7 +386,7 @@
                data-name="0.19"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.19">
                 0.19
               </span>
@@ -381,7 +396,7 @@
                data-name="0.20"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.20">
                 0.20
               </span>
@@ -391,7 +406,7 @@
                data-name="0.90"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="0.90">
                 0.90
               </span>
@@ -401,7 +416,7 @@
                data-name="1.0"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="1.0">
                 1.0
               </span>
@@ -411,7 +426,7 @@
                data-name="1.1"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="1.1">
                 1.1
               </span>
@@ -421,7 +436,7 @@
                data-name="1.2"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="1.2">
                 1.2
               </span>
@@ -431,7 +446,7 @@
                data-name="1.3"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="1.3">
                 1.3
               </span>
@@ -441,7 +456,7 @@
                data-name="1.4"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="1.4">
                 1.4
               </span>
@@ -451,7 +466,7 @@
                data-name="1.5"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="1.5">
                 1.5
               </span>
@@ -461,7 +476,7 @@
                data-name="1.6"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="1.6">
                 1.6
               </span>
@@ -471,7 +486,7 @@
                data-name="1.7"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="1.7">
                 1.7
               </span>
@@ -481,7 +496,7 @@
                data-name="2.x"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="2.x">
                 2.x
               </span>
@@ -491,7 +506,7 @@
                data-name="2.0"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="2.0">
                 2.0
               </span>
@@ -501,27 +516,27 @@
                data-name="2.1"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="2.1">
                 2.1
               </span>
             </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open selected"
+            <a class="select-menu-item js-navigation-item js-navigation-open "
                href="/elastic/elasticsearch/tree/2.2/rest-api-spec/src/main/resources/rest-api-spec/api"
                data-name="2.2"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="2.2">
                 2.2
               </span>
             </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
+            <a class="select-menu-item js-navigation-item js-navigation-open selected"
                href="/elastic/elasticsearch/tree/2.3/rest-api-spec/src/main/resources/rest-api-spec/api"
                data-name="2.3"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="2.3">
                 2.3
               </span>
@@ -531,7 +546,7 @@
                data-name="GlenRSmith-patch-1"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="GlenRSmith-patch-1">
                 GlenRSmith-patch-1
               </span>
@@ -541,7 +556,7 @@
                data-name="bleskes-patch-1"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="bleskes-patch-1">
                 bleskes-patch-1
               </span>
@@ -551,7 +566,7 @@
                data-name="burn_maven_with_fire"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="burn_maven_with_fire">
                 burn_maven_with_fire
               </span>
@@ -561,7 +576,7 @@
                data-name="cli-parsing"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="cli-parsing">
                 cli-parsing
               </span>
@@ -571,7 +586,7 @@
                data-name="completion_suggester_v2"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="completion_suggester_v2">
                 completion_suggester_v2
               </span>
@@ -581,9 +596,19 @@
                data-name="cors-handling"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="cors-handling">
                 cors-handling
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+               href="/elastic/elasticsearch/tree/docs/remove-rest-api-utils-reference/rest-api-spec/src/main/resources/rest-api-spec/api"
+               data-name="docs/remove-rest-api-utils-reference"
+               data-skip-pjax="true"
+               rel="nofollow">
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="docs/remove-rest-api-utils-reference">
+                docs/remove-rest-api-utils-reference
               </span>
             </a>
             <a class="select-menu-item js-navigation-item js-navigation-open "
@@ -591,7 +616,7 @@
                data-name="elasticon1"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="elasticon1">
                 elasticon1
               </span>
@@ -601,7 +626,7 @@
                data-name="enhancement/dependencies-netty4-upgrade"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="enhancement/dependencies-netty4-upgrade">
                 enhancement/dependencies-netty4-upgrade
               </span>
@@ -611,7 +636,7 @@
                data-name="feature-suggest-refactoring"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="feature-suggest-refactoring">
                 feature-suggest-refactoring
               </span>
@@ -621,7 +646,7 @@
                data-name="feature/bench"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="feature/bench">
                 feature/bench
               </span>
@@ -631,7 +656,7 @@
                data-name="feature/benchmark"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="feature/benchmark">
                 feature/benchmark
               </span>
@@ -641,7 +666,7 @@
                data-name="feature/completion_suggester_v2"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="feature/completion_suggester_v2">
                 feature/completion_suggester_v2
               </span>
@@ -651,7 +676,7 @@
                data-name="feature/reindex"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="feature/reindex">
                 feature/reindex
               </span>
@@ -661,7 +686,7 @@
                data-name="feature/seq_no"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="feature/seq_no">
                 feature/seq_no
               </span>
@@ -671,19 +696,9 @@
                data-name="lucene6"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="lucene6">
                 lucene6
-              </span>
-            </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
-               href="/elastic/elasticsearch/tree/mase/rest-api-spec/src/main/resources/rest-api-spec/api"
-               data-name="mase"
-               data-skip-pjax="true"
-               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
-              <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="mase">
-                mase
               </span>
             </a>
             <a class="select-menu-item js-navigation-item js-navigation-open "
@@ -691,9 +706,19 @@
                data-name="master"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="master">
                 master
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+               href="/elastic/elasticsearch/tree/minor-doc-fix-ptg-1/rest-api-spec/src/main/resources/rest-api-spec/api"
+               data-name="minor-doc-fix-ptg-1"
+               data-skip-pjax="true"
+               rel="nofollow">
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="minor-doc-fix-ptg-1">
+                minor-doc-fix-ptg-1
               </span>
             </a>
             <a class="select-menu-item js-navigation-item js-navigation-open "
@@ -701,7 +726,7 @@
                data-name="pmusa-patch-rm-source-disable"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="pmusa-patch-rm-source-disable">
                 pmusa-patch-rm-source-disable
               </span>
@@ -711,7 +736,7 @@
                data-name="query_profiler"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="query_profiler">
                 query_profiler
               </span>
@@ -721,7 +746,7 @@
                data-name="remove_leniency_in_commitpoint_checks"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="remove_leniency_in_commitpoint_checks">
                 remove_leniency_in_commitpoint_checks
               </span>
@@ -731,7 +756,7 @@
                data-name="revert-16930-remove_wait_for_lock"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="revert-16930-remove_wait_for_lock">
                 revert-16930-remove_wait_for_lock
               </span>
@@ -741,7 +766,7 @@
                data-name="revert-17182-issues/17090"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="revert-17182-issues/17090">
                 revert-17182-issues/17090
               </span>
@@ -751,7 +776,7 @@
                data-name="robin13-patch-1"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="robin13-patch-1">
                 robin13-patch-1
               </span>
@@ -761,9 +786,19 @@
                data-name="robin13-patch-2"
                data-skip-pjax="true"
                rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="robin13-patch-2">
                 robin13-patch-2
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+               href="/elastic/elasticsearch/tree/tsouza-patch-1/rest-api-spec/src/main/resources/rest-api-spec/api"
+               data-name="tsouza-patch-1"
+               data-skip-pjax="true"
+               rel="nofollow">
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text" title="tsouza-patch-1">
+                tsouza-patch-1
               </span>
             </a>
         </div>
@@ -776,11 +811,31 @@
 
 
             <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/elastic/elasticsearch/tree/v2.3.0/rest-api-spec/src/main/resources/rest-api-spec/api"
+              data-name="v2.3.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v2.3.0">
+                v2.3.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/elastic/elasticsearch/tree/v2.2.2/rest-api-spec/src/main/resources/rest-api-spec/api"
+              data-name="v2.2.2"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v2.2.2">
+                v2.2.2
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
               href="/elastic/elasticsearch/tree/v2.2.1/rest-api-spec/src/main/resources/rest-api-spec/api"
               data-name="v2.2.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.2.1">
                 v2.2.1
               </span>
@@ -790,7 +845,7 @@
               data-name="v2.2.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.2.0">
                 v2.2.0
               </span>
@@ -800,7 +855,7 @@
               data-name="v2.1.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.1.2">
                 v2.1.2
               </span>
@@ -810,7 +865,7 @@
               data-name="v2.1.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.1.1">
                 v2.1.1
               </span>
@@ -820,7 +875,7 @@
               data-name="v2.1.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.1.0">
                 v2.1.0
               </span>
@@ -830,7 +885,7 @@
               data-name="v2.0.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.0.2">
                 v2.0.2
               </span>
@@ -840,7 +895,7 @@
               data-name="v2.0.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.0.1">
                 v2.0.1
               </span>
@@ -850,7 +905,7 @@
               data-name="v2.0.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.0.0">
                 v2.0.0
               </span>
@@ -860,7 +915,7 @@
               data-name="v2.0.0-rc1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.0.0-rc1">
                 v2.0.0-rc1
               </span>
@@ -870,7 +925,7 @@
               data-name="v2.0.0-beta2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.0.0-beta2">
                 v2.0.0-beta2
               </span>
@@ -880,7 +935,7 @@
               data-name="v2.0.0-beta1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v2.0.0-beta1">
                 v2.0.0-beta1
               </span>
@@ -890,7 +945,7 @@
               data-name="v1.7.5"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.7.5">
                 v1.7.5
               </span>
@@ -900,7 +955,7 @@
               data-name="v1.7.4"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.7.4">
                 v1.7.4
               </span>
@@ -910,7 +965,7 @@
               data-name="v1.7.3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.7.3">
                 v1.7.3
               </span>
@@ -920,7 +975,7 @@
               data-name="v1.7.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.7.2">
                 v1.7.2
               </span>
@@ -930,7 +985,7 @@
               data-name="v1.7.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.7.1">
                 v1.7.1
               </span>
@@ -940,7 +995,7 @@
               data-name="v1.7.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.7.0">
                 v1.7.0
               </span>
@@ -950,7 +1005,7 @@
               data-name="v1.6.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.6.2">
                 v1.6.2
               </span>
@@ -960,7 +1015,7 @@
               data-name="v1.6.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.6.1">
                 v1.6.1
               </span>
@@ -970,7 +1025,7 @@
               data-name="v1.6.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.6.0">
                 v1.6.0
               </span>
@@ -980,7 +1035,7 @@
               data-name="v1.5.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.5.2">
                 v1.5.2
               </span>
@@ -990,7 +1045,7 @@
               data-name="v1.5.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.5.1">
                 v1.5.1
               </span>
@@ -1000,7 +1055,7 @@
               data-name="v1.5.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.5.0">
                 v1.5.0
               </span>
@@ -1010,7 +1065,7 @@
               data-name="v1.4.5"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.4.5">
                 v1.4.5
               </span>
@@ -1020,7 +1075,7 @@
               data-name="v1.4.4"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.4.4">
                 v1.4.4
               </span>
@@ -1030,7 +1085,7 @@
               data-name="v1.4.3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.4.3">
                 v1.4.3
               </span>
@@ -1040,7 +1095,7 @@
               data-name="v1.4.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.4.2">
                 v1.4.2
               </span>
@@ -1050,7 +1105,7 @@
               data-name="v1.4.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.4.1">
                 v1.4.1
               </span>
@@ -1060,7 +1115,7 @@
               data-name="v1.4.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.4.0">
                 v1.4.0
               </span>
@@ -1070,7 +1125,7 @@
               data-name="v1.4.0.Beta1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.4.0.Beta1">
                 v1.4.0.Beta1
               </span>
@@ -1080,7 +1135,7 @@
               data-name="v1.3.9"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.9">
                 v1.3.9
               </span>
@@ -1090,7 +1145,7 @@
               data-name="v1.3.8"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.8">
                 v1.3.8
               </span>
@@ -1100,7 +1155,7 @@
               data-name="v1.3.7"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.7">
                 v1.3.7
               </span>
@@ -1110,7 +1165,7 @@
               data-name="v1.3.6"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.6">
                 v1.3.6
               </span>
@@ -1120,7 +1175,7 @@
               data-name="v1.3.5"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.5">
                 v1.3.5
               </span>
@@ -1130,7 +1185,7 @@
               data-name="v1.3.4"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.4">
                 v1.3.4
               </span>
@@ -1140,7 +1195,7 @@
               data-name="v1.3.3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.3">
                 v1.3.3
               </span>
@@ -1150,7 +1205,7 @@
               data-name="v1.3.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.2">
                 v1.3.2
               </span>
@@ -1160,7 +1215,7 @@
               data-name="v1.3.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.1">
                 v1.3.1
               </span>
@@ -1170,7 +1225,7 @@
               data-name="v1.3.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.3.0">
                 v1.3.0
               </span>
@@ -1180,7 +1235,7 @@
               data-name="v1.2.4"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.2.4">
                 v1.2.4
               </span>
@@ -1190,7 +1245,7 @@
               data-name="v1.2.3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.2.3">
                 v1.2.3
               </span>
@@ -1200,7 +1255,7 @@
               data-name="v1.2.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.2.2">
                 v1.2.2
               </span>
@@ -1210,7 +1265,7 @@
               data-name="v1.2.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.2.1">
                 v1.2.1
               </span>
@@ -1220,7 +1275,7 @@
               data-name="v1.2.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.2.0">
                 v1.2.0
               </span>
@@ -1230,7 +1285,7 @@
               data-name="v1.1.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.1.2">
                 v1.1.2
               </span>
@@ -1240,7 +1295,7 @@
               data-name="v1.1.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.1.1">
                 v1.1.1
               </span>
@@ -1250,7 +1305,7 @@
               data-name="v1.1.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.1.0">
                 v1.1.0
               </span>
@@ -1260,7 +1315,7 @@
               data-name="v1.0.3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.0.3">
                 v1.0.3
               </span>
@@ -1270,7 +1325,7 @@
               data-name="v1.0.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.0.2">
                 v1.0.2
               </span>
@@ -1280,7 +1335,7 @@
               data-name="v1.0.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.0.1">
                 v1.0.1
               </span>
@@ -1290,7 +1345,7 @@
               data-name="v1.0.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.0.0">
                 v1.0.0
               </span>
@@ -1300,7 +1355,7 @@
               data-name="v1.0.0.RC2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.0.0.RC2">
                 v1.0.0.RC2
               </span>
@@ -1310,7 +1365,7 @@
               data-name="v1.0.0.RC1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.0.0.RC1">
                 v1.0.0.RC1
               </span>
@@ -1320,7 +1375,7 @@
               data-name="v1.0.0.Beta2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.0.0.Beta2">
                 v1.0.0.Beta2
               </span>
@@ -1330,7 +1385,7 @@
               data-name="v1.0.0.Beta1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v1.0.0.Beta1">
                 v1.0.0.Beta1
               </span>
@@ -1340,7 +1395,7 @@
               data-name="v0.90.13"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.13">
                 v0.90.13
               </span>
@@ -1350,7 +1405,7 @@
               data-name="v0.90.12"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.12">
                 v0.90.12
               </span>
@@ -1360,7 +1415,7 @@
               data-name="v0.90.11"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.11">
                 v0.90.11
               </span>
@@ -1370,7 +1425,7 @@
               data-name="v0.90.10"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.10">
                 v0.90.10
               </span>
@@ -1380,7 +1435,7 @@
               data-name="v0.90.9"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.9">
                 v0.90.9
               </span>
@@ -1390,7 +1445,7 @@
               data-name="v0.90.8"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.8">
                 v0.90.8
               </span>
@@ -1400,7 +1455,7 @@
               data-name="v0.90.7"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.7">
                 v0.90.7
               </span>
@@ -1410,7 +1465,7 @@
               data-name="v0.90.6"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.6">
                 v0.90.6
               </span>
@@ -1420,7 +1475,7 @@
               data-name="v0.90.5"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.5">
                 v0.90.5
               </span>
@@ -1430,7 +1485,7 @@
               data-name="v0.90.4"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.4">
                 v0.90.4
               </span>
@@ -1440,7 +1495,7 @@
               data-name="v0.90.3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.3">
                 v0.90.3
               </span>
@@ -1450,7 +1505,7 @@
               data-name="v0.90.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.2">
                 v0.90.2
               </span>
@@ -1460,7 +1515,7 @@
               data-name="v0.90.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.1">
                 v0.90.1
               </span>
@@ -1470,7 +1525,7 @@
               data-name="v0.90.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.0">
                 v0.90.0
               </span>
@@ -1480,7 +1535,7 @@
               data-name="v0.90.0.RC2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.0.RC2">
                 v0.90.0.RC2
               </span>
@@ -1490,7 +1545,7 @@
               data-name="v0.90.0.RC1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.0.RC1">
                 v0.90.0.RC1
               </span>
@@ -1500,7 +1555,7 @@
               data-name="v0.90.0.Beta1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.90.0.Beta1">
                 v0.90.0.Beta1
               </span>
@@ -1510,7 +1565,7 @@
               data-name="v0.20.6"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.20.6">
                 v0.20.6
               </span>
@@ -1520,7 +1575,7 @@
               data-name="v0.20.5"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.20.5">
                 v0.20.5
               </span>
@@ -1530,7 +1585,7 @@
               data-name="v0.20.4"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.20.4">
                 v0.20.4
               </span>
@@ -1540,7 +1595,7 @@
               data-name="v0.20.3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.20.3">
                 v0.20.3
               </span>
@@ -1550,7 +1605,7 @@
               data-name="v0.20.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.20.2">
                 v0.20.2
               </span>
@@ -1560,7 +1615,7 @@
               data-name="v0.20.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.20.1">
                 v0.20.1
               </span>
@@ -1570,7 +1625,7 @@
               data-name="v0.20.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.20.0">
                 v0.20.0
               </span>
@@ -1580,7 +1635,7 @@
               data-name="v0.20.0.RC1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.20.0.RC1">
                 v0.20.0.RC1
               </span>
@@ -1590,7 +1645,7 @@
               data-name="v0.19.12"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.12">
                 v0.19.12
               </span>
@@ -1600,7 +1655,7 @@
               data-name="v0.19.11"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.11">
                 v0.19.11
               </span>
@@ -1610,7 +1665,7 @@
               data-name="v0.19.10"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.10">
                 v0.19.10
               </span>
@@ -1620,7 +1675,7 @@
               data-name="v0.19.9"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.9">
                 v0.19.9
               </span>
@@ -1630,7 +1685,7 @@
               data-name="v0.19.8"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.8">
                 v0.19.8
               </span>
@@ -1640,7 +1695,7 @@
               data-name="v0.19.7"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.7">
                 v0.19.7
               </span>
@@ -1650,7 +1705,7 @@
               data-name="v0.19.6"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.6">
                 v0.19.6
               </span>
@@ -1660,7 +1715,7 @@
               data-name="v0.19.5"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.5">
                 v0.19.5
               </span>
@@ -1670,7 +1725,7 @@
               data-name="v0.19.4"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.4">
                 v0.19.4
               </span>
@@ -1680,7 +1735,7 @@
               data-name="v0.19.3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.3">
                 v0.19.3
               </span>
@@ -1690,7 +1745,7 @@
               data-name="v0.19.2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.2">
                 v0.19.2
               </span>
@@ -1700,7 +1755,7 @@
               data-name="v0.19.1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.1">
                 v0.19.1
               </span>
@@ -1710,7 +1765,7 @@
               data-name="v0.19.0"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.0">
                 v0.19.0
               </span>
@@ -1720,7 +1775,7 @@
               data-name="v0.19.0.RC3"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.0.RC3">
                 v0.19.0.RC3
               </span>
@@ -1730,7 +1785,7 @@
               data-name="v0.19.0.RC2"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.0.RC2">
                 v0.19.0.RC2
               </span>
@@ -1740,7 +1795,7 @@
               data-name="v0.19.0.RC1"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.19.0.RC1">
                 v0.19.0.RC1
               </span>
@@ -1750,29 +1805,9 @@
               data-name="v0.18.7"
               data-skip-pjax="true"
               rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
+              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
               <span class="select-menu-item-text css-truncate-target" title="v0.18.7">
                 v0.18.7
-              </span>
-            </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
-              href="/elastic/elasticsearch/tree/v0.18.6/rest-api-spec/src/main/resources/rest-api-spec/api"
-              data-name="v0.18.6"
-              data-skip-pjax="true"
-              rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
-              <span class="select-menu-item-text css-truncate-target" title="v0.18.6">
-                v0.18.6
-              </span>
-            </a>
-            <a class="select-menu-item js-navigation-item js-navigation-open "
-              href="/elastic/elasticsearch/tree/v0.18.5/rest-api-spec/src/main/resources/rest-api-spec/api"
-              data-name="v0.18.5"
-              data-skip-pjax="true"
-              rel="nofollow">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M12 5L4 13 0 9l1.5-1.5 2.5 2.5 6.5-6.5 1.5 1.5z"></path></svg>
-              <span class="select-menu-item-text css-truncate-target" title="v0.18.5">
-                v0.18.5
               </span>
             </a>
         </div>
@@ -1792,52 +1827,64 @@
 
 
 
-    <a href="/elastic/elasticsearch/find/2.2" data-pjax data-hotkey="t" class="js-pjax-capture-input btn btn-sm empty-icon">
+    <a href="/elastic/elasticsearch/find/2.3" data-pjax data-hotkey="t" class="js-pjax-capture-input btn btn-sm empty-icon">
       Find file
     </a>
-    <a href="/elastic/elasticsearch/commits/2.2/rest-api-spec/src/main/resources/rest-api-spec/api" class="btn btn-sm empty-icon tooltipped tooltipped-nw" aria-label="Browse commits for this branch">
+    <a href="/elastic/elasticsearch/commits/2.3/rest-api-spec/src/main/resources/rest-api-spec/api" class="btn btn-sm empty-icon tooltipped tooltipped-nw" aria-label="Browse commits for this branch">
       History
     </a>
   </div>
 
 
-  <div class="breadcrumb"><span class="repo-root js-repo-root"><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.2"><span>elasticsearch</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.2/rest-api-spec"><span>rest-api-spec</span></a></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.2/rest-api-spec/src"><span>src</span></a></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.2/rest-api-spec/src/main"><span>main</span></a></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.2/rest-api-spec/src/main/resources"><span>resources</span></a></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.2/rest-api-spec/src/main/resources/rest-api-spec"><span>rest-api-spec</span></a></span><span class="separator">/</span><strong class="final-path">api</strong><span class="separator">/</span></div>
+  <div class="breadcrumb"><span class="repo-root js-repo-root"><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.3"><span>elasticsearch</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.3/rest-api-spec"><span>rest-api-spec</span></a></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.3/rest-api-spec/src"><span>src</span></a></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.3/rest-api-spec/src/main"><span>main</span></a></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.3/rest-api-spec/src/main/resources"><span>resources</span></a></span><span class="separator">/</span><span class="js-path-segment"><a href="/elastic/elasticsearch/tree/2.3/rest-api-spec/src/main/resources/rest-api-spec"><span>rest-api-spec</span></a></span><span class="separator">/</span><strong class="final-path">api</strong><span class="separator">/</span></div>
 </div>
 
 
   <div class="branch-infobar">
     <span class="right">
-        <a class="muted-link" href="/elastic/elasticsearch/pull/new/2.2">
-          <svg aria-hidden="true" class="octicon octicon-git-pull-request" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M11 11.28c0-1.73 0-6.28 0-6.28-0.03-0.78-0.34-1.47-0.94-2.06s-1.28-0.91-2.06-0.94c0 0-1.02 0-1 0V0L4 3l3 3V4h1c0.27 0.02 0.48 0.11 0.69 0.31s0.3 0.42 0.31 0.69v6.28c-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72z m-1 2.92c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2zM4 3c0-1.11-0.89-2-2-2S0 1.89 0 3c0 0.73 0.41 1.38 1 1.72 0 1.55 0 5.56 0 6.56-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72V4.72c0.59-0.34 1-0.98 1-1.72z m-0.8 10c0 0.66-0.55 1.2-1.2 1.2s-1.2-0.55-1.2-1.2 0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2z m-1.2-8.8c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z"></path></svg>
+        <a class="muted-link" href="/elastic/elasticsearch/pull/new/2.3">
+          <svg aria-hidden="true" class="octicon octicon-git-pull-request" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M11 11.28c0-1.73 0-6.28 0-6.28-0.03-0.78-0.34-1.47-0.94-2.06s-1.28-0.91-2.06-0.94c0 0-1.02 0-1 0V0L4 3l3 3V4h1c0.27 0.02 0.48 0.11 0.69 0.31s0.3 0.42 0.31 0.69v6.28c-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72z m-1 2.92c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2zM4 3c0-1.11-0.89-2-2-2S0 1.89 0 3c0 0.73 0.41 1.38 1 1.72 0 1.55 0 5.56 0 6.56-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72V4.72c0.59-0.34 1-0.98 1-1.72z m-0.8 10c0 0.66-0.55 1.2-1.2 1.2s-1.2-0.55-1.2-1.2 0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2z m-1.2-8.8c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z"></path></svg>
           Pull request
         </a>
-      <a class="muted-link" href="/elastic/elasticsearch/compare/2.2">
-        <svg aria-hidden="true" class="octicon octicon-diff" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6 7h2v1H6v2h-1V8H3v-1h2V5h1v2zM3 13h5v-1H3v1z m4.5-11l3.5 3.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V3c0-0.55 0.45-1 1-1h6.5z m2.5 4L7 3H1v12h9V6zM8.5 0S3 0 3 0v1h5l4 4v8h1V4.5L8.5 0z"></path></svg>
+      <a class="muted-link" href="/elastic/elasticsearch/compare/2.3">
+        <svg aria-hidden="true" class="octicon octicon-diff" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6 7h2v1H6v2h-1V8H3v-1h2V5h1v2zM3 13h5v-1H3v1z m4.5-11l3.5 3.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V3c0-0.55 0.45-1 1-1h6.5z m2.5 4L7 3H1v12h9V6zM8.5 0S3 0 3 0v1h5l4 4v8h1V4.5L8.5 0z"></path></svg>
         Compare
       </a>
     </span>
 
-      This branch is 1217 commits ahead, 5367 commits behind master.
+      This branch is 1414 commits ahead, 5702 commits behind master.
   </div>
 
-<include-fragment class="commit-tease commit-loader" src="/elastic/elasticsearch/tree-commit/4b150d86316f013a576081a9b26df6a4f0c3b230/rest-api-spec/src/main/resources/rest-api-spec/api">
-  <div class="blank">
-    <img alt="" class="loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32-EAF2F5.gif" width="16" />
-    Fetching latest commitâ€¦
-  </div>
-  <div class="loader-error">
-    Cannot retrieve the latest commit at this time.
-  </div>
-</include-fragment>
 
-<include-fragment class="file-wrap" src="/elastic/elasticsearch/file-list/2.2/rest-api-spec/src/main/resources/rest-api-spec/api">
+  <div class="commit-tease js-details-container">
+    <span class="right">
+      Latest commit
+      <a class="commit-tease-sha" href="/elastic/elasticsearch/commit/5c2d216a2cda067204dd1e8d1147c69a2c923ce2" data-pjax>
+        5c2d216
+      </a>
+      <span itemprop="dateModified"><time datetime="2016-03-29T11:15:36Z" is="relative-time">Mar 29, 2016</time></span>
+    </span>
 
-  <a href="/elastic/elasticsearch/tree/4b150d86316f013a576081a9b26df6a4f0c3b230/rest-api-spec/src/main/resources/rest-api-spec/api" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
+
+    <span class="commit-author-section">
+      <img alt="@clintongormley" class="avatar" height="20" src="https://avatars1.githubusercontent.com/u/56599?v=3&amp;s=40" width="20" />
+      <a href="/clintongormley" class="user-mention" rel="contributor">clintongormley</a>
+    </span>
+
+        <a href="/elastic/elasticsearch/commit/5c2d216a2cda067204dd1e8d1147c69a2c923ce2" class="message" data-pjax="true" title="Renamed REST tests to use update_by_query instead of update-by-query">Renamed REST tests to use update_by_query instead of update-by-query</a>
+    </span>
+
+  </div>
+
+
+<div class="file-wrap">
+
+  <a href="/elastic/elasticsearch/tree/e559ecaaf8d9836404d4b2c53a222ad7c560d239/rest-api-spec/src/main/resources/rest-api-spec/api" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
 
   <table class="files js-navigation-container js-active-navigation-container" data-pjax>
       <tr class="up-tree js-navigation-item">
         <td></td>
-        <td><a href="/elastic/elasticsearch/tree/2.2/rest-api-spec/src/main/resources/rest-api-spec" class="js-navigation-open" rel="nofollow" title="Go to parent directory">..</a></td>
+        <td><a href="/elastic/elasticsearch/tree/2.3/rest-api-spec/src/main/resources/rest-api-spec" class="js-navigation-open" rel="nofollow" title="Go to parent directory">..</a></td>
         <td></td>
         <td></td>
       </tr>
@@ -1845,1758 +1892,2350 @@
 
     <tbody>
       <tr class="warning include-fragment-error">
-        <td class="icon"><svg aria-hidden="true" class="octicon octicon-alert" height="16" role="img" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg></td>
+        <td class="icon"><svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg></td>
         <td class="content" colspan="3">Failed to load latest commit information.</td>
       </tr>
 
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json" class="js-directory-link js-navigation-open" id="6c4fbc1bd36df5d9905ce1df9cf222c0-577a03fd7706a435ac3281228995b6b00251e4ac" title="bulk.json">bulk.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json" class="js-navigation-open" id="6c4fbc1bd36df5d9905ce1df9cf222c0-577a03fd7706a435ac3281228995b6b00251e4ac" title="bulk.json">bulk.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/ccbea2e5d2a892ff5df788c75b0a45acff0830c1" class="message" data-pjax="true" title="Fix parsing of the `fields` parameter of bulk requests.">Fix parsing of the `fields` parameter of bulk requests.</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-07-08T17:55:24Z" is="time-ago">Jul 8, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json" class="js-directory-link js-navigation-open" id="22e2d431e2e1793e41b5f065dceaa89e-07c72a2ac98033268147f098f8db7d3cc317e49a" title="cat.aliases.json">cat.aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json" class="js-navigation-open" id="22e2d431e2e1793e41b5f065dceaa89e-07c72a2ac98033268147f098f8db7d3cc317e49a" title="cat.aliases.json">cat.aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json" class="js-directory-link js-navigation-open" id="4579bbcb4332bcaa7d0fb18c63b2fdd1-9de5a729faa1bd5779f9be4ca562f142567a0fd7" title="cat.allocation.json">cat.allocation.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json" class="js-navigation-open" id="4579bbcb4332bcaa7d0fb18c63b2fdd1-9de5a729faa1bd5779f9be4ca562f142567a0fd7" title="cat.allocation.json">cat.allocation.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json" class="js-directory-link js-navigation-open" id="aa6d9382bc0b00917e17cb6dec212d42-2661af347d0ebcf32e748dd73f638fb01be8333e" title="cat.count.json">cat.count.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json" class="js-navigation-open" id="aa6d9382bc0b00917e17cb6dec212d42-2661af347d0ebcf32e748dd73f638fb01be8333e" title="cat.count.json">cat.count.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json" class="js-directory-link js-navigation-open" id="ac8f77984707b6255de6dc1447665b53-a380b558e89b42f34d8e55be4438dbacfbf12f42" title="cat.fielddata.json">cat.fielddata.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json" class="js-navigation-open" id="ac8f77984707b6255de6dc1447665b53-a380b558e89b42f34d8e55be4438dbacfbf12f42" title="cat.fielddata.json">cat.fielddata.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json" class="js-directory-link js-navigation-open" id="2339db869d5a3d7653d999028dbf5dbb-bd0cfcedd53ddbc2d4dfb208460506552ef482f8" title="cat.health.json">cat.health.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json" class="js-navigation-open" id="2339db869d5a3d7653d999028dbf5dbb-bd0cfcedd53ddbc2d4dfb208460506552ef482f8" title="cat.health.json">cat.health.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json" class="js-directory-link js-navigation-open" id="2c1bf912a288d9a69ad3aa77a0ad1c3a-f21e6485d586d68a0450eb012db83760b437c3e2" title="cat.help.json">cat.help.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json" class="js-navigation-open" id="2c1bf912a288d9a69ad3aa77a0ad1c3a-f21e6485d586d68a0450eb012db83760b437c3e2" title="cat.help.json">cat.help.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json" class="js-directory-link js-navigation-open" id="51f4fa0dcdc855c076d42cd209daefbf-b5c487b9521f5c4e002a4a3f492f96928c42c980" title="cat.indices.json">cat.indices.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json" class="js-navigation-open" id="51f4fa0dcdc855c076d42cd209daefbf-b5c487b9521f5c4e002a4a3f492f96928c42c980" title="cat.indices.json">cat.indices.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json" class="js-directory-link js-navigation-open" id="777752fc1e100524ad85bffc292b262b-d3e35330e1d7c9d312c4b54ae0c0b3fa57de0a16" title="cat.master.json">cat.master.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json" class="js-navigation-open" id="777752fc1e100524ad85bffc292b262b-d3e35330e1d7c9d312c4b54ae0c0b3fa57de0a16" title="cat.master.json">cat.master.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json" class="js-directory-link js-navigation-open" id="1db897e5b423bc3115781de6209b27a9-cdbe75ac936dddfa0d961c0adac7556b6adf2f4e" title="cat.nodeattrs.json">cat.nodeattrs.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json" class="js-navigation-open" id="1db897e5b423bc3115781de6209b27a9-cdbe75ac936dddfa0d961c0adac7556b6adf2f4e" title="cat.nodeattrs.json">cat.nodeattrs.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json" class="js-directory-link js-navigation-open" id="c673b074876c5b81edb6826075e32d92-1d8bcda3c01e867ba9a65c5dcb7678bdd9c124f1" title="cat.nodes.json">cat.nodes.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json" class="js-navigation-open" id="c673b074876c5b81edb6826075e32d92-1d8bcda3c01e867ba9a65c5dcb7678bdd9c124f1" title="cat.nodes.json">cat.nodes.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json" class="js-directory-link js-navigation-open" id="a51d665aca06cbf8fca196ef68c5490e-88afa9b0c40934d409c2a1932413fe07fddefc5c" title="cat.pending_tasks.json">cat.pending_tasks.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json" class="js-navigation-open" id="a51d665aca06cbf8fca196ef68c5490e-88afa9b0c40934d409c2a1932413fe07fddefc5c" title="cat.pending_tasks.json">cat.pending_tasks.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json" class="js-directory-link js-navigation-open" id="babca80f1103a775be37ca111c02126b-55ee66a27926774a1cd4345bdc523dcc7f5bfa3e" title="cat.plugins.json">cat.plugins.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json" class="js-navigation-open" id="babca80f1103a775be37ca111c02126b-55ee66a27926774a1cd4345bdc523dcc7f5bfa3e" title="cat.plugins.json">cat.plugins.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json" class="js-directory-link js-navigation-open" id="b2755b9dbefea2a2111d7d436f45eeb2-c235406221ab52d45a64e872187a27b1610c2663" title="cat.recovery.json">cat.recovery.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json" class="js-navigation-open" id="b2755b9dbefea2a2111d7d436f45eeb2-c235406221ab52d45a64e872187a27b1610c2663" title="cat.recovery.json">cat.recovery.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json" class="js-directory-link js-navigation-open" id="bbaebf30b084249a09dcfbe86697eb39-2dcbac5cac90552ece7b2192aef678a2d7430c48" title="cat.repositories.json">cat.repositories.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json" class="js-navigation-open" id="bbaebf30b084249a09dcfbe86697eb39-2dcbac5cac90552ece7b2192aef678a2d7430c48" title="cat.repositories.json">cat.repositories.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/50a92fb5d9da4a3d1a3c319a17391619b9dabdb8" class="message" data-pjax="true" title="Add cat API for repositories and snapshots
+
+Closes #14247
+Closes #13919">Add cat API for repositories and snapshots</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-26T18:22:41Z" is="time-ago">Oct 26, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json" class="js-directory-link js-navigation-open" id="f83e55e75343f860635f6a521d60cf41-ebb989b4cf658c8f1f695b3d5b2961b8e063b3ea" title="cat.segments.json">cat.segments.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json" class="js-navigation-open" id="f83e55e75343f860635f6a521d60cf41-ebb989b4cf658c8f1f695b3d5b2961b8e063b3ea" title="cat.segments.json">cat.segments.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json" class="js-directory-link js-navigation-open" id="864b15ab41822be341f433cdcd6b294a-6d941f17d101ee30a69fd511493b67e2af305ed3" title="cat.shards.json">cat.shards.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json" class="js-navigation-open" id="864b15ab41822be341f433cdcd6b294a-6d941f17d101ee30a69fd511493b67e2af305ed3" title="cat.shards.json">cat.shards.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json" class="js-directory-link js-navigation-open" id="4469f919a303ce0321831650cfd4c781-4fd5520ecb1a39bdce870baba1f92948e2da7056" title="cat.snapshots.json">cat.snapshots.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json" class="js-navigation-open" id="4469f919a303ce0321831650cfd4c781-4f1db6974f70f982388100c2274232517479fdb5" title="cat.snapshots.json">cat.snapshots.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/8371be8d5fe5df7fb9c0516c474d77b9feddd888" class="message" data-pjax="true" title="In cat.snapshots, repository is required
+
+Closes #17216">In cat.snapshots, repository is required</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2016-03-25T13:24:29Z" is="time-ago">Mar 25, 2016</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json" class="js-directory-link js-navigation-open" id="0f45c62bc5b57fcaf01a0ee8e2be1a1f-cb8e5e13632a24a2800a5e379088d215281d84f6" title="cat.thread_pool.json">cat.thread_pool.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json" class="js-navigation-open" id="0f45c62bc5b57fcaf01a0ee8e2be1a1f-cb8e5e13632a24a2800a5e379088d215281d84f6" title="cat.thread_pool.json">cat.thread_pool.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c180defb10db8181506c9dafa731675b8d32804b" class="message" data-pjax="true" title="[CAT] Default verbose to false
+
+Closes #13156">[CAT] Default verbose to false</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-28T15:15:44Z" is="time-ago">Aug 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json" class="js-directory-link js-navigation-open" id="fb88c998e68dce2106c94c0bc6cc3dac-6b82d1dc4742a120d2b625791a566a7bba8a1fba" title="clear_scroll.json">clear_scroll.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json" class="js-navigation-open" id="fb88c998e68dce2106c94c0bc6cc3dac-6b82d1dc4742a120d2b625791a566a7bba8a1fba" title="clear_scroll.json">clear_scroll.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json" class="js-directory-link js-navigation-open" id="381ace7cc8ee62a6a019ff3d4fa5918b-7f13d47fc06a4a99aa01d4e3215299dc502ea9c8" title="cluster.get_settings.json">cluster.get_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json" class="js-navigation-open" id="381ace7cc8ee62a6a019ff3d4fa5918b-7f13d47fc06a4a99aa01d4e3215299dc502ea9c8" title="cluster.get_settings.json">cluster.get_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json" class="js-directory-link js-navigation-open" id="c2c52db081b723be399bb732f65aca84-b622d01e60c7bee6a1e16e3d011aa38a80ff0116" title="cluster.health.json">cluster.health.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json" class="js-navigation-open" id="c2c52db081b723be399bb732f65aca84-b622d01e60c7bee6a1e16e3d011aa38a80ff0116" title="cluster.health.json">cluster.health.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/72868a8c5e71292e1ba62e349cb07e0eb96d2813" class="message" data-pjax="true" title="{index} can be one or many indices and should be typed to list.
+
+{index} can be one or many indices and should be typed to list.">{index} can be one or many indices and should be typed to list.</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:51:52Z" is="time-ago">Oct 6, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json" class="js-directory-link js-navigation-open" id="8a69fbf26be58ddfb4da9890e9ab2c28-fb5e1609ff39d2f1617a9f0f5d5c8bcfa3884e55" title="cluster.pending_tasks.json">cluster.pending_tasks.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json" class="js-navigation-open" id="8a69fbf26be58ddfb4da9890e9ab2c28-fb5e1609ff39d2f1617a9f0f5d5c8bcfa3884e55" title="cluster.pending_tasks.json">cluster.pending_tasks.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json" class="js-directory-link js-navigation-open" id="e87166468da155e9d9c15de6e56a9f9e-393d1350dd3e2487f116bf46397a5ceb69e45511" title="cluster.put_settings.json">cluster.put_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json" class="js-navigation-open" id="e87166468da155e9d9c15de6e56a9f9e-393d1350dd3e2487f116bf46397a5ceb69e45511" title="cluster.put_settings.json">cluster.put_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json" class="js-directory-link js-navigation-open" id="a2b21ed6ff197a1803c961126ab8960c-2ae42c089d31896fbc629c4f151c9d9efbdbac09" title="cluster.reroute.json">cluster.reroute.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json" class="js-navigation-open" id="a2b21ed6ff197a1803c961126ab8960c-2ae42c089d31896fbc629c4f151c9d9efbdbac09" title="cluster.reroute.json">cluster.reroute.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json" class="js-directory-link js-navigation-open" id="6acc013937ed94065ffab45cc3d7ec36-0f4bf6f21ad4a9d4127b3ff6c263abfe874754b3" title="cluster.state.json">cluster.state.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json" class="js-navigation-open" id="6acc013937ed94065ffab45cc3d7ec36-0f4bf6f21ad4a9d4127b3ff6c263abfe874754b3" title="cluster.state.json">cluster.state.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json" class="js-directory-link js-navigation-open" id="ddd8cd720c91c6531768ce3ede81e8d3-2bccb20f36e3537848532eaa614dbe0151045096" title="cluster.stats.json">cluster.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json" class="js-navigation-open" id="ddd8cd720c91c6531768ce3ede81e8d3-2bccb20f36e3537848532eaa614dbe0151045096" title="cluster.stats.json">cluster.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/3d51e2f2135d151de061265fb1f641d63a215cd3" class="message" data-pjax="true" title="Expose nodes operation timeout in REST API
+
+Currently it&#39;s not possible to specify a timeout for nodes operations (such as node info, node stats, cluster stats and hot threads) via REST-based APIs.">Expose nodes operation timeout in REST API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-07T22:08:47Z" is="time-ago">Oct 7, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/count.json" class="js-directory-link js-navigation-open" id="3baa357d5adf340622c003b0856dd25f-9048f982712b02cc7f13bfbcd0d301666f343de8" title="count.json">count.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/count.json" class="js-navigation-open" id="3baa357d5adf340622c003b0856dd25f-9048f982712b02cc7f13bfbcd0d301666f343de8" title="count.json">count.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/count_percolate.json" class="js-directory-link js-navigation-open" id="2d9528db75f1df48e5cc5080a4dbdb3e-584f33685d30b4e238b7750c32f99ff042bca871" title="count_percolate.json">count_percolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/count_percolate.json" class="js-navigation-open" id="2d9528db75f1df48e5cc5080a4dbdb3e-584f33685d30b4e238b7750c32f99ff042bca871" title="count_percolate.json">count_percolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json" class="js-directory-link js-navigation-open" id="32e7b62c510daf7d16345f4d4bb54d69-be09c0179d4be0268622702d2f10b6f885448fa7" title="delete.json">delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json" class="js-navigation-open" id="32e7b62c510daf7d16345f4d4bb54d69-be09c0179d4be0268622702d2f10b6f885448fa7" title="delete.json">delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json" class="js-directory-link js-navigation-open" id="0f1829713245eba3e6695da9d37342c1-d3f7771fc852cc31c5eb4d108cf5b2bdc1514f4a" title="delete_script.json">delete_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json" class="js-navigation-open" id="0f1829713245eba3e6695da9d37342c1-d3f7771fc852cc31c5eb4d108cf5b2bdc1514f4a" title="delete_script.json">delete_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/delete_template.json" class="js-directory-link js-navigation-open" id="64be6114ddd1e414654ed6b052a067ba-1dbc40ae168efe8e188bb549993622078b821d0e" title="delete_template.json">delete_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/delete_template.json" class="js-navigation-open" id="64be6114ddd1e414654ed6b052a067ba-1dbc40ae168efe8e188bb549993622078b821d0e" title="delete_template.json">delete_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/4fca4ac49c53cfec9e3ba91d6dd02ac9ea597433" class="message" data-pjax="true" title="id route value is required
+
+id route value is required">id route value is required</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:51:59Z" is="time-ago">Oct 6, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json" class="js-directory-link js-navigation-open" id="3d89dbbbdf2cfe3ecaccea759487838f-2e64a2da7cdec0f23805a69e021c5b776c1fbcb3" title="exists.json">exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json" class="js-navigation-open" id="3d89dbbbdf2cfe3ecaccea759487838f-2e64a2da7cdec0f23805a69e021c5b776c1fbcb3" title="exists.json">exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json" class="js-directory-link js-navigation-open" id="f1262f2a3266d79bc85a4907d455c177-30b5deff1d3d173a59476af7eefd659b61016dfc" title="explain.json">explain.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json" class="js-navigation-open" id="f1262f2a3266d79bc85a4907d455c177-30b5deff1d3d173a59476af7eefd659b61016dfc" title="explain.json">explain.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/field_stats.json" class="js-directory-link js-navigation-open" id="6f118aa7a31508b462aae4b9be7f3e9d-c7e95dd683ee9e78c281b83a60886e47f6cc31ed" title="field_stats.json">field_stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/field_stats.json" class="js-navigation-open" id="6f118aa7a31508b462aae4b9be7f3e9d-c7e95dd683ee9e78c281b83a60886e47f6cc31ed" title="field_stats.json">field_stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/ef9d70b9b39d1447b43d7d4177f371febbefe617" class="message" data-pjax="true" title="field stats: added index constraints
+
+Field stats index constraints allows to omit all field stats for indices that don&#39;t match with the constraint. An index
+constraint can exclude indices&#39; field stats based on the `min_value` and `max_value` statistic. This option is only
+useful if the `level` option is set to `indices`.
+
+For example index constraints can be useful to find out the min and max value of a particular property of your data in
+a time based scenario. The following request only returns field stats for the `answer_count` property for indices
+holding questions created in the year 2014:
+
+curl -XPOST &#39;http://localhost:9200/_field_stats?level=indices&#39; -d &#39;{
+   &quot;fields&quot; : [&quot;answer_count&quot;] &lt;1&gt;
+   &quot;index_constraints&quot; : { &lt;2&gt;
+      &quot;creation_date&quot; : { &lt;3&gt;
+         &quot;min_value&quot; : { &lt;4&gt;
+            &quot;gte&quot; : &quot;2014-01-01T00:00:00.000Z&quot;,
+         },
+         &quot;max_value&quot; : {
+            &quot;lt&quot; : &quot;2015-01-01T00:00:00.000Z&quot;
+         }
+      }
+   }
+}&#39;
+
+Closes #11187">field stats: added index constraints</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-07-01T06:47:03Z" is="time-ago">Jul 1, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/get.json" class="js-directory-link js-navigation-open" id="08e364c89f4f291dd93f7be65f3c1629-e0e5170f9c3ac44374505fb40ea5637147ba10c1" title="get.json">get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/get.json" class="js-navigation-open" id="08e364c89f4f291dd93f7be65f3c1629-e0e5170f9c3ac44374505fb40ea5637147ba10c1" title="get.json">get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json" class="js-directory-link js-navigation-open" id="ec949f8f96d44ae7d86392e6939249fc-d6cae320caa142e1ad0ec7a318c97e5482180f47" title="get_script.json">get_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json" class="js-navigation-open" id="ec949f8f96d44ae7d86392e6939249fc-d6cae320caa142e1ad0ec7a318c97e5482180f47" title="get_script.json">get_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json" class="js-directory-link js-navigation-open" id="06c3cb0e17ebff492b057f22db913580-36065a13f6e99500b4654478d45f5587a03f86c6" title="get_source.json">get_source.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json" class="js-navigation-open" id="06c3cb0e17ebff492b057f22db913580-36065a13f6e99500b4654478d45f5587a03f86c6" title="get_source.json">get_source.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/get_template.json" class="js-directory-link js-navigation-open" id="ab816619a3803791da2da066912f78f0-8052b1d63fb3ffa9c520aaabccc9b1b624af96f1" title="get_template.json">get_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/get_template.json" class="js-navigation-open" id="ab816619a3803791da2da066912f78f0-8052b1d63fb3ffa9c520aaabccc9b1b624af96f1" title="get_template.json">get_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/index.json" class="js-directory-link js-navigation-open" id="9e743aa713dcae5405f290e3db88178b-1b8f7140dcdc550a6bed64dcbb6b47c3726565db" title="index.json">index.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/index.json" class="js-navigation-open" id="9e743aa713dcae5405f290e3db88178b-1b8f7140dcdc550a6bed64dcbb6b47c3726565db" title="index.json">index.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json" class="js-directory-link js-navigation-open" id="ea53ca0f9f948fb3fa7fb805c578af11-9fe9bfe3cadcffd9f0d3fe4c6c9a761cee1329f8" title="indices.analyze.json">indices.analyze.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json" class="js-navigation-open" id="ea53ca0f9f948fb3fa7fb805c578af11-c3dc0a18b453ad219bb29d6dfb71395386431186" title="indices.analyze.json">indices.analyze.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/a632db2e220d8bc241d2dafbe50d48f8f7055265" class="message" data-pjax="true" title="Analysis : Allow string explain param in JSON
+
+Move some test methods from AnalylzeActionIT to RestAnalyzeActionTest
+Allow string explain param if it can parse
+Fix wrong param name in rest-api-spec
+Fix typo
+Remove unused import
+
+Backport of #16977
+Related to #16925">Analysis : Allow string explain param in JSON</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2016-03-08T14:29:28Z" is="time-ago">Mar 8, 2016</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json" class="js-directory-link js-navigation-open" id="2c9d7dd90e792d3063a65d93493a8d3e-31a50c4a8c4204e59c0ae2e44813080c840d7315" title="indices.clear_cache.json">indices.clear_cache.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json" class="js-navigation-open" id="2c9d7dd90e792d3063a65d93493a8d3e-31a50c4a8c4204e59c0ae2e44813080c840d7315" title="indices.clear_cache.json">indices.clear_cache.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/38f5cc236ac6d06556d25eab81f7b05854b326ca" class="message" data-pjax="true" title="Rename caches.
+
+In order to be more consistent with what they do, the query cache has been
+renamed to request cache and the filter cache has been renamed to query
+cache.
+
+A known issue is that package/logger names do no longer match settings names,
+please speak up if you think this is an issue.
+
+Here are the settings for which I kept backward compatibility. Note that they
+are a bit different from what was discussed on #11569 but putting `cache` before
+the name of what is cached has the benefit of making these settings consistent
+with the fielddata cache whose size is configured by
+`indices.fielddata.cache.size`:
+ * index.cache.query.enable -&gt; index.requests.cache.enable
+ * indices.cache.query.size -&gt; indices.requests.cache.size
+ * indices.cache.filter.size -&gt; indices.queries.cache.size
+
+Close #11569">Rename caches.</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-29T08:15:27Z" is="time-ago">Jun 29, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json" class="js-directory-link js-navigation-open" id="d613995d3cc3e47e00e6584ccfb82a35-4eaa93030ee7b68d59511bf0252cde6ddb38826e" title="indices.close.json">indices.close.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json" class="js-navigation-open" id="d613995d3cc3e47e00e6584ccfb82a35-4eaa93030ee7b68d59511bf0252cde6ddb38826e" title="indices.close.json">indices.close.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/53c1a80505af59bca68ff3147ec2e1f7e88ddae6" class="message" data-pjax="true" title=" indices.close takes a list of indices
+
+ not single index"> indices.close takes a list of indices</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:52:24Z" is="time-ago">Oct 6, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json" class="js-directory-link js-navigation-open" id="63f95a3c21061e2fb572cef0eb2eab90-bdac6d9a9ab891d292fb22b29109afe2d3e69190" title="indices.create.json">indices.create.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json" class="js-navigation-open" id="63f95a3c21061e2fb572cef0eb2eab90-bdac6d9a9ab891d292fb22b29109afe2d3e69190" title="indices.create.json">indices.create.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/a254b2da2919ba5e82f19bc890eb7e32c39cb037" class="message" data-pjax="true" title="REST spec: Added update_all_types to indices.put_mapping and indices.create
+
+Closes #12840">REST spec: Added update_all_types to indices.put_mapping and indices.â€¦</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-26T13:33:23Z" is="time-ago">Aug 26, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json" class="js-directory-link js-navigation-open" id="a48e4dc86992215871f3270ad541bc6d-829e7a2ded1ee59c949f58ad2d10eb37021cb88b" title="indices.delete.json">indices.delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json" class="js-navigation-open" id="a48e4dc86992215871f3270ad541bc6d-829e7a2ded1ee59c949f58ad2d10eb37021cb88b" title="indices.delete.json">indices.delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json" class="js-directory-link js-navigation-open" id="9a24979aa4a99ba087361de8997ba9d8-30a32fbfef871208db9a93dc9e627acfc3c61360" title="indices.delete_alias.json">indices.delete_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json" class="js-navigation-open" id="9a24979aa4a99ba087361de8997ba9d8-30a32fbfef871208db9a93dc9e627acfc3c61360" title="indices.delete_alias.json">indices.delete_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json" class="js-directory-link js-navigation-open" id="7e86ed5d6fec40fca7550c69311db515-b311c9bbda82ac8a2da1fcf980827125c73fcd62" title="indices.delete_template.json">indices.delete_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json" class="js-navigation-open" id="7e86ed5d6fec40fca7550c69311db515-b311c9bbda82ac8a2da1fcf980827125c73fcd62" title="indices.delete_template.json">indices.delete_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_warmer.json" class="js-directory-link js-navigation-open" id="0cb555d38237effd9567bb06c47530c3-7284da6291a47bdd8640a65d31500c66ff726a54" title="indices.delete_warmer.json">indices.delete_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_warmer.json" class="js-navigation-open" id="0cb555d38237effd9567bb06c47530c3-7284da6291a47bdd8640a65d31500c66ff726a54" title="indices.delete_warmer.json">indices.delete_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json" class="js-directory-link js-navigation-open" id="8adc33572e46831f609304d8616b1b1d-ebfd5cc3a7335ce6ff76dc22266892dbf3a17757" title="indices.exists.json">indices.exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json" class="js-navigation-open" id="8adc33572e46831f609304d8616b1b1d-ebfd5cc3a7335ce6ff76dc22266892dbf3a17757" title="indices.exists.json">indices.exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json" class="js-directory-link js-navigation-open" id="a8d7a4ce4b4a60cb658f043d5488dd39-8862481c18fbcc94c1db53ccd322718ecfdac166" title="indices.exists_alias.json">indices.exists_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json" class="js-navigation-open" id="a8d7a4ce4b4a60cb658f043d5488dd39-8862481c18fbcc94c1db53ccd322718ecfdac166" title="indices.exists_alias.json">indices.exists_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json" class="js-directory-link js-navigation-open" id="3431ee0eca88f8bae40fe200f78f2d99-18684bc940856bd6c6f98c6708c1445370c1ddb0" title="indices.exists_template.json">indices.exists_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json" class="js-navigation-open" id="3431ee0eca88f8bae40fe200f78f2d99-18684bc940856bd6c6f98c6708c1445370c1ddb0" title="indices.exists_template.json">indices.exists_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json" class="js-directory-link js-navigation-open" id="e3050c1e9f7f37ca82a87ed38a0bb95f-37d9d979fa5847a326b6a6600be2f5fbcc2f6941" title="indices.exists_type.json">indices.exists_type.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json" class="js-navigation-open" id="e3050c1e9f7f37ca82a87ed38a0bb95f-37d9d979fa5847a326b6a6600be2f5fbcc2f6941" title="indices.exists_type.json">indices.exists_type.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json" class="js-directory-link js-navigation-open" id="9c0d06f79fd7551fb765652a4296136e-d47619c73a163d77f01aba14e3904448ec593a14" title="indices.flush.json">indices.flush.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json" class="js-navigation-open" id="9c0d06f79fd7551fb765652a4296136e-d47619c73a163d77f01aba14e3904448ec593a14" title="indices.flush.json">indices.flush.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush_synced.json" class="js-directory-link js-navigation-open" id="1c80af8fdeffd1c1809f79ec7f2bcef5-08488eae8648b5245f7c46af71a4738ea3df5e70" title="indices.flush_synced.json">indices.flush_synced.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush_synced.json" class="js-navigation-open" id="1c80af8fdeffd1c1809f79ec7f2bcef5-08488eae8648b5245f7c46af71a4738ea3df5e70" title="indices.flush_synced.json">indices.flush_synced.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/aa7914eb492ac477047a1a36e9ff746fbfdcff12" class="message" data-pjax="true" title="synced flush incorrectly documented url parameters as path parameters">synced flush incorrectly documented url parameters as path parameters</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-09-10T10:06:44Z" is="time-ago">Sep 10, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json" class="js-directory-link js-navigation-open" id="8ed0e5c235f9cfc480bab92241aefd82-0e6c6ab23f94a262050c2b5d9bf759039e6eede9" title="indices.forcemerge.json">indices.forcemerge.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json" class="js-navigation-open" id="8ed0e5c235f9cfc480bab92241aefd82-0e6c6ab23f94a262050c2b5d9bf759039e6eede9" title="indices.forcemerge.json">indices.forcemerge.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/c07fbd8bdabcdb8c6ea186b2b9f998dbaeb79f34" class="message" data-pjax="true" title="Add Force Merge API, deprecate Optimize API
+
+This adds an API for force merging lucene segments. The `/_optimize` API is now
+deprecated and replaced by the `/_forcemerge` API, which has all the same flags
+and action, just a different name.">Add Force Merge API, deprecate Optimize API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-21T04:30:41Z" is="time-ago">Oct 20, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json" class="js-directory-link js-navigation-open" id="c7dfb0129e6d01bcdaa59a6d9bef56b1-5c426f962a7ad5597c9707af7a365c7ae475dc31" title="indices.get.json">indices.get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json" class="js-navigation-open" id="c7dfb0129e6d01bcdaa59a6d9bef56b1-5c426f962a7ad5597c9707af7a365c7ae475dc31" title="indices.get.json">indices.get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/fc54ee2e68d7496f6e9ac6ba60825487eff83fc2" class="message" data-pjax="true" title="Add options for indices.get feature
+
+As described here https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html?q=get%20index#_filtering_index_information">Add options for indices.get feature</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T18:32:46Z" is="time-ago">Oct 6, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json" class="js-directory-link js-navigation-open" id="b359991822afa51a4920347b06236830-228e0199af0bd9ab8c4f2c30a541d5146a120cdc" title="indices.get_alias.json">indices.get_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json" class="js-navigation-open" id="b359991822afa51a4920347b06236830-228e0199af0bd9ab8c4f2c30a541d5146a120cdc" title="indices.get_alias.json">indices.get_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_aliases.json" class="js-directory-link js-navigation-open" id="a4b0f80dfc2206cac0dae0dd5c2edf63-428c56db57a9aae0ef2a0d1067f48fd04900371b" title="indices.get_aliases.json">indices.get_aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_aliases.json" class="js-navigation-open" id="a4b0f80dfc2206cac0dae0dd5c2edf63-428c56db57a9aae0ef2a0d1067f48fd04900371b" title="indices.get_aliases.json">indices.get_aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json" class="js-directory-link js-navigation-open" id="7a95e8e39115ae0693c0e9ebac94aae4-3d5a629eff08ea75c5fb10fcac8d8000e780f460" title="indices.get_field_mapping.json">indices.get_field_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json" class="js-navigation-open" id="7a95e8e39115ae0693c0e9ebac94aae4-3d5a629eff08ea75c5fb10fcac8d8000e780f460" title="indices.get_field_mapping.json">indices.get_field_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/6ae9c9cb26d473ca5c4bbc9629e0f02f29f9e637" class="message" data-pjax="true" title="Get field mapping documented fields as field">Get field mapping documented fields as field</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:52:33Z" is="time-ago">Oct 6, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json" class="js-directory-link js-navigation-open" id="043a6a009b58931d43b9f4fcf495e584-c3c0622844bb156dbc07ba984545d42191984b34" title="indices.get_mapping.json">indices.get_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json" class="js-navigation-open" id="043a6a009b58931d43b9f4fcf495e584-c3c0622844bb156dbc07ba984545d42191984b34" title="indices.get_mapping.json">indices.get_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json" class="js-directory-link js-navigation-open" id="573611d97c9a674af4eb1fd67f06ba87-1e35c272fa0368634f3f448ba98b10f5fba6824b" title="indices.get_settings.json">indices.get_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json" class="js-navigation-open" id="573611d97c9a674af4eb1fd67f06ba87-1e35c272fa0368634f3f448ba98b10f5fba6824b" title="indices.get_settings.json">indices.get_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json" class="js-directory-link js-navigation-open" id="6a31359bb097d3ebbe0a9ee6758c86ea-e3a97ee5c012a6513658c988cf34fdf61748984f" title="indices.get_template.json">indices.get_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json" class="js-navigation-open" id="6a31359bb097d3ebbe0a9ee6758c86ea-e3a97ee5c012a6513658c988cf34fdf61748984f" title="indices.get_template.json">indices.get_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/e86a928c06e69e4a523a9d34012234d683159507" class="message" data-pjax="true" title="indices get template accepts a list of names
+
+not just string">indices get template accepts a list of names</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:52:07Z" is="time-ago">Oct 6, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json" class="js-directory-link js-navigation-open" id="8a2688acbdae5eff0da90082f894d6ff-63d9bbf418bab2863bdf23f0506298995fc491a9" title="indices.get_upgrade.json">indices.get_upgrade.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json" class="js-navigation-open" id="8a2688acbdae5eff0da90082f894d6ff-63d9bbf418bab2863bdf23f0506298995fc491a9" title="indices.get_upgrade.json">indices.get_upgrade.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_warmer.json" class="js-directory-link js-navigation-open" id="696ba757658b41eb345ac40688505bf3-fbd7abbc34cdf1c08595386779d7dd23dfbb850f" title="indices.get_warmer.json">indices.get_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_warmer.json" class="js-navigation-open" id="696ba757658b41eb345ac40688505bf3-fbd7abbc34cdf1c08595386779d7dd23dfbb850f" title="indices.get_warmer.json">indices.get_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json" class="js-directory-link js-navigation-open" id="373e5d7e5484cc081c4980032ab53333-879ce5a2b9d9a12b07b17a11ba9d1d916d22f3bf" title="indices.open.json">indices.open.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json" class="js-navigation-open" id="373e5d7e5484cc081c4980032ab53333-879ce5a2b9d9a12b07b17a11ba9d1d916d22f3bf" title="indices.open.json">indices.open.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/01f24aecf9292b06d0027e9b2a3b570156a2aeee" class="message" data-pjax="true" title="indices.open takes a list of indices
+
+not single index">indices.open takes a list of indices</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-06T09:52:15Z" is="time-ago">Oct 6, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.optimize.json" class="js-directory-link js-navigation-open" id="8efebf88db11882bb5adedfc25de4847-72aa77fcbc92e29cb5992053f2ee5606e71d82c6" title="indices.optimize.json">indices.optimize.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.optimize.json" class="js-navigation-open" id="8efebf88db11882bb5adedfc25de4847-c5e63bfe60de6349a5c50c949c6277ab97c58644" title="indices.optimize.json">indices.optimize.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json" class="js-directory-link js-navigation-open" id="7c4d55dd18903fbe6a08229325f31825-da53d5ac441e169657c33519833fee12db41b5a4" title="indices.put_alias.json">indices.put_alias.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json" class="js-navigation-open" id="7c4d55dd18903fbe6a08229325f31825-da53d5ac441e169657c33519833fee12db41b5a4" title="indices.put_alias.json">indices.put_alias.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json" class="js-directory-link js-navigation-open" id="250bd21a9bccfcf55d2e743ea58da37e-5fce0bcefc89abe20230aeddc9ddf3f5506af431" title="indices.put_mapping.json">indices.put_mapping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json" class="js-navigation-open" id="250bd21a9bccfcf55d2e743ea58da37e-5fce0bcefc89abe20230aeddc9ddf3f5506af431" title="indices.put_mapping.json">indices.put_mapping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/a254b2da2919ba5e82f19bc890eb7e32c39cb037" class="message" data-pjax="true" title="REST spec: Added update_all_types to indices.put_mapping and indices.create
+
+Closes #12840">REST spec: Added update_all_types to indices.put_mapping and indices.â€¦</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-26T13:33:23Z" is="time-ago">Aug 26, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json" class="js-directory-link js-navigation-open" id="d6b150b68eeb6f484cdae6fec82c913f-587fe0278132013964f570029109706ddbd7dca6" title="indices.put_settings.json">indices.put_settings.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json" class="js-navigation-open" id="d6b150b68eeb6f484cdae6fec82c913f-587fe0278132013964f570029109706ddbd7dca6" title="indices.put_settings.json">indices.put_settings.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json" class="js-directory-link js-navigation-open" id="481ea697fa69449ad04daf3c10691415-5bcb2f8a243468f190850fbb4258c70418256765" title="indices.put_template.json">indices.put_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json" class="js-navigation-open" id="481ea697fa69449ad04daf3c10691415-5bcb2f8a243468f190850fbb4258c70418256765" title="indices.put_template.json">indices.put_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_warmer.json" class="js-directory-link js-navigation-open" id="7144ddc1e315d2eb87f6d7fa415b3027-9039367d15f8049520ca804abca4b4cc884dfcfe" title="indices.put_warmer.json">indices.put_warmer.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_warmer.json" class="js-navigation-open" id="7144ddc1e315d2eb87f6d7fa415b3027-9039367d15f8049520ca804abca4b4cc884dfcfe" title="indices.put_warmer.json">indices.put_warmer.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/33e04083a79e3a2990c3bf53166a5c7ea793db78" class="message" data-pjax="true" title="Corrected some typos in the REST spec">Corrected some typos in the REST spec</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-27T09:28:27Z" is="time-ago">Aug 27, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json" class="js-directory-link js-navigation-open" id="7a1cc9a6701c8cfa3c52bbaffa9f22b8-2b94f1ad3d6920f905242ed843bcb6102a51afed" title="indices.recovery.json">indices.recovery.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json" class="js-navigation-open" id="7a1cc9a6701c8cfa3c52bbaffa9f22b8-2b94f1ad3d6920f905242ed843bcb6102a51afed" title="indices.recovery.json">indices.recovery.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json" class="js-directory-link js-navigation-open" id="3717be850ac7c14c749c955fb79f61d7-703fa73f8d3880d331d449f45d49b093ecda55e7" title="indices.refresh.json">indices.refresh.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json" class="js-navigation-open" id="3717be850ac7c14c749c955fb79f61d7-703fa73f8d3880d331d449f45d49b093ecda55e7" title="indices.refresh.json">indices.refresh.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json" class="js-directory-link js-navigation-open" id="56a2f2774152e652738ca9703cf447dc-cc51bdab2c3a36815dfba282170d7c8cfcaf43a1" title="indices.segments.json">indices.segments.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json" class="js-navigation-open" id="56a2f2774152e652738ca9703cf447dc-cc51bdab2c3a36815dfba282170d7c8cfcaf43a1" title="indices.segments.json">indices.segments.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/3ef614dce85ca1d117effead331b54dadb783b38" class="message" data-pjax="true" title="REST spec: Added the verbose flag to indices.segments
+
+Relates to #9111">REST spec: Added the verbose flag to indices.segments</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-11-30T06:41:33Z" is="time-ago">Nov 30, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json" class="js-directory-link js-navigation-open" id="ec6f9508e9a4bc767d082c48ac6f3467-f3d644d5e344f907cc7cd599879053f3cb2ba6e2" title="indices.shard_stores.json">indices.shard_stores.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json" class="js-navigation-open" id="ec6f9508e9a4bc767d082c48ac6f3467-f3d644d5e344f907cc7cd599879053f3cb2ba6e2" title="indices.shard_stores.json">indices.shard_stores.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/56d7cb8bd80b70ef50d69865775db537cad86da5" class="message" data-pjax="true" title="Update indices.shard_stores.json
+
+Correct documentation url">Update indices.shard_stores.json</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-08-25T20:21:04Z" is="time-ago">Aug 25, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json" class="js-directory-link js-navigation-open" id="cb782133ac617be36b33b196df8059b5-7099f3e2fd2c311d1653f36661d3de7b9bf501a0" title="indices.stats.json">indices.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json" class="js-navigation-open" id="cb782133ac617be36b33b196df8059b5-7099f3e2fd2c311d1653f36661d3de7b9bf501a0" title="indices.stats.json">indices.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/5512eb39e9015726fcaae7fb4cda18079e54bf97" class="message" data-pjax="true" title="Merge pull request #15051 from apatrida/patch-1
+
+body attribute was at wrong nesting level">Merge pull request</a> <a href="https://github.com/elastic/elasticsearch/pull/15051" class="issue-link js-issue-link" data-url="https://github.com/elastic/elasticsearch/issues/15051" data-id="119083916" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#15051</a> <a href="/elastic/elasticsearch/commit/5512eb39e9015726fcaae7fb4cda18079e54bf97" class="message" data-pjax="true" title="Merge pull request #15051 from apatrida/patch-1
+
+body attribute was at wrong nesting level">from apatrida/patch-1</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-11-28T10:32:13Z" is="time-ago">Nov 28, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json" class="js-directory-link js-navigation-open" id="655e7332a9c5cd438b45d4ff1cb30b85-30c369e410a25d58f3d75376d6a48c0b1062f1f6" title="indices.update_aliases.json">indices.update_aliases.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json" class="js-navigation-open" id="655e7332a9c5cd438b45d4ff1cb30b85-30c369e410a25d58f3d75376d6a48c0b1062f1f6" title="indices.update_aliases.json">indices.update_aliases.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json" class="js-directory-link js-navigation-open" id="49572445346c6fe5f226279051b88082-0e5e4ffd244c6fb8242ee0534528a1a3dae55724" title="indices.upgrade.json">indices.upgrade.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json" class="js-navigation-open" id="49572445346c6fe5f226279051b88082-0e5e4ffd244c6fb8242ee0534528a1a3dae55724" title="indices.upgrade.json">indices.upgrade.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json" class="js-directory-link js-navigation-open" id="abeaaf04f453c9902ecb8d3315d3d43d-98af689833a063fdd457f0c7104eace57a051339" title="indices.validate_query.json">indices.validate_query.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json" class="js-navigation-open" id="abeaaf04f453c9902ecb8d3315d3d43d-98af689833a063fdd457f0c7104eace57a051339" title="indices.validate_query.json">indices.validate_query.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/info.json" class="js-directory-link js-navigation-open" id="379da8ee275d0393f12cdff8542d368d-63754eb7f7c3ccae5da2b584be5ba2a90c71fa4a" title="info.json">info.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/info.json" class="js-navigation-open" id="379da8ee275d0393f12cdff8542d368d-63754eb7f7c3ccae5da2b584be5ba2a90c71fa4a" title="info.json">info.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json" class="js-directory-link js-navigation-open" id="7db3deffe9680ffd2cdb16a331aea2fa-1639f3619b39d432e4fe10719a20002988d10572" title="mget.json">mget.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json" class="js-navigation-open" id="7db3deffe9680ffd2cdb16a331aea2fa-1639f3619b39d432e4fe10719a20002988d10572" title="mget.json">mget.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/mpercolate.json" class="js-directory-link js-navigation-open" id="9410cd2b17f09ec3ccfa9fbc452c0e98-7cbf4f61e434d83c638a56b11cbc187dcf37620e" title="mpercolate.json">mpercolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/mpercolate.json" class="js-navigation-open" id="9410cd2b17f09ec3ccfa9fbc452c0e98-7cbf4f61e434d83c638a56b11cbc187dcf37620e" title="mpercolate.json">mpercolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json" class="js-directory-link js-navigation-open" id="41473f6391667dbfeb8f12856e6dbf9b-3d8297e496d6eac5033e0da50b72ca8bd08dbf9a" title="msearch.json">msearch.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json" class="js-navigation-open" id="41473f6391667dbfeb8f12856e6dbf9b-3d8297e496d6eac5033e0da50b72ca8bd08dbf9a" title="msearch.json">msearch.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json" class="js-directory-link js-navigation-open" id="717daf7be8083a78bf284fe4a9a25223-58978b7d190fab89cab8e314ec0fd4e8e0c81976" title="mtermvectors.json">mtermvectors.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json" class="js-navigation-open" id="717daf7be8083a78bf284fe4a9a25223-58978b7d190fab89cab8e314ec0fd4e8e0c81976" title="mtermvectors.json">mtermvectors.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json" class="js-directory-link js-navigation-open" id="0ef0e709908091e3498307d32d74fa69-854cde1a9e731293d38ac873eca636637c0121ac" title="nodes.hot_threads.json">nodes.hot_threads.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json" class="js-navigation-open" id="0ef0e709908091e3498307d32d74fa69-854cde1a9e731293d38ac873eca636637c0121ac" title="nodes.hot_threads.json">nodes.hot_threads.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/3d51e2f2135d151de061265fb1f641d63a215cd3" class="message" data-pjax="true" title="Expose nodes operation timeout in REST API
+
+Currently it&#39;s not possible to specify a timeout for nodes operations (such as node info, node stats, cluster stats and hot threads) via REST-based APIs.">Expose nodes operation timeout in REST API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-07T22:08:47Z" is="time-ago">Oct 7, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json" class="js-directory-link js-navigation-open" id="827644931be55e9818fb73ba26553cba-43be35a5a864efd3f3b23ab115ac7888433d9848" title="nodes.info.json">nodes.info.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json" class="js-navigation-open" id="827644931be55e9818fb73ba26553cba-43be35a5a864efd3f3b23ab115ac7888433d9848" title="nodes.info.json">nodes.info.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/3d51e2f2135d151de061265fb1f641d63a215cd3" class="message" data-pjax="true" title="Expose nodes operation timeout in REST API
+
+Currently it&#39;s not possible to specify a timeout for nodes operations (such as node info, node stats, cluster stats and hot threads) via REST-based APIs.">Expose nodes operation timeout in REST API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-07T22:08:47Z" is="time-ago">Oct 7, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json" class="js-directory-link js-navigation-open" id="1402dc0afe821bc096932f4af7774b7b-874294102c78edf6e9bc71f5360d618bb05b6c29" title="nodes.stats.json">nodes.stats.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json" class="js-navigation-open" id="1402dc0afe821bc096932f4af7774b7b-874294102c78edf6e9bc71f5360d618bb05b6c29" title="nodes.stats.json">nodes.stats.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/3d51e2f2135d151de061265fb1f641d63a215cd3" class="message" data-pjax="true" title="Expose nodes operation timeout in REST API
+
+Currently it&#39;s not possible to specify a timeout for nodes operations (such as node info, node stats, cluster stats and hot threads) via REST-based APIs.">Expose nodes operation timeout in REST API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-10-07T22:08:47Z" is="time-ago">Oct 7, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/percolate.json" class="js-directory-link js-navigation-open" id="4b2043d3c446183feab58857c7d22954-e58655dea5a27a8f933f854ed5ec1d9ab6838070" title="percolate.json">percolate.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/percolate.json" class="js-navigation-open" id="4b2043d3c446183feab58857c7d22954-e58655dea5a27a8f933f854ed5ec1d9ab6838070" title="percolate.json">percolate.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json" class="js-directory-link js-navigation-open" id="2c0ccb85c134546fc2419cd212d7c7a1-41310bb30d4942e3edb97d489c5613685227ca33" title="ping.json">ping.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json" class="js-navigation-open" id="2c0ccb85c134546fc2419cd212d7c7a1-41310bb30d4942e3edb97d489c5613685227ca33" title="ping.json">ping.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json" class="js-directory-link js-navigation-open" id="3e5e341e9944ac912cd75b44d94ffb18-1a0d6ac5f74a3a6016759884301a1e0252b45f73" title="put_script.json">put_script.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json" class="js-navigation-open" id="3e5e341e9944ac912cd75b44d94ffb18-1a0d6ac5f74a3a6016759884301a1e0252b45f73" title="put_script.json">put_script.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/put_template.json" class="js-directory-link js-navigation-open" id="eb9589368281828322f480b4696c4a51-845a368493e97af0b5a1a818454c0da795d8eb03" title="put_template.json">put_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/put_template.json" class="js-navigation-open" id="eb9589368281828322f480b4696c4a51-845a368493e97af0b5a1a818454c0da795d8eb03" title="put_template.json">put_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json" class="js-directory-link js-navigation-open" id="cb9bf5f91f02219dae3acf287c8b1a1c-8f27c12b819daa5478035c84ba911b31e4d08d4d" title="render_search_template.json">render_search_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json" class="js-navigation-open" id="2247f212c49382eddd2483fc9e395e26-59cd3ef7d38705d1803709e42f9738f7c68e0663" title="reindex.json">reindex.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/986861d305ff1086b585b7e019cccd54e10084f2" class="message" data-pjax="true" title="REST: The body is required in the reindex API">REST: The body is required in the reindex API</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2016-03-28T11:14:48Z" is="time-ago">Mar 28, 2016</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json" class="js-directory-link js-navigation-open" id="b68a77ffff64b26fa9efb03e5f4fec69-885b746d095331a61ce505112e59cdce10deb104" title="scroll.json">scroll.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json" class="js-navigation-open" id="cb9bf5f91f02219dae3acf287c8b1a1c-8f27c12b819daa5478035c84ba911b31e4d08d4d" title="render_search_template.json">render_search_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/a847dd267c5b358596119903df27ee9fd0e4b67c" class="message" data-pjax="true" title="[TEST] Fix location of render_search_template.json">[TEST] Fix location of render_search_template.json</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-30T16:45:43Z" is="time-ago">Jun 30, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/search.json" class="js-directory-link js-navigation-open" id="36e64ee591eb44c77488faec76357456-f0ca4d80bafcf2957f7c13352b8de67f0f2b467f" title="search.json">search.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json" class="js-navigation-open" id="b68a77ffff64b26fa9efb03e5f4fec69-885b746d095331a61ce505112e59cdce10deb104" title="scroll.json">scroll.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/search_exists.json" class="js-directory-link js-navigation-open" id="05525aaadd0ea9bb5405273c1ccbeb9c-f0e5e4489bd02266e3dc03ba99f1a230769e2625" title="search_exists.json">search_exists.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/search.json" class="js-navigation-open" id="36e64ee591eb44c77488faec76357456-f0ca4d80bafcf2957f7c13352b8de67f0f2b467f" title="search.json">search.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/38f5cc236ac6d06556d25eab81f7b05854b326ca" class="message" data-pjax="true" title="Rename caches.
+
+In order to be more consistent with what they do, the query cache has been
+renamed to request cache and the filter cache has been renamed to query
+cache.
+
+A known issue is that package/logger names do no longer match settings names,
+please speak up if you think this is an issue.
+
+Here are the settings for which I kept backward compatibility. Note that they
+are a bit different from what was discussed on #11569 but putting `cache` before
+the name of what is cached has the benefit of making these settings consistent
+with the fielddata cache whose size is configured by
+`indices.fielddata.cache.size`:
+ * index.cache.query.enable -&gt; index.requests.cache.enable
+ * indices.cache.query.size -&gt; indices.requests.cache.size
+ * indices.cache.filter.size -&gt; indices.queries.cache.size
+
+Close #11569">Rename caches.</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-29T08:15:27Z" is="time-ago">Jun 29, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json" class="js-directory-link js-navigation-open" id="087e36570eccc7017ef612e4d4fcab82-e03ed8fef2fec518918b13521a3dcef1155f9e8f" title="search_shards.json">search_shards.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/search_exists.json" class="js-navigation-open" id="05525aaadd0ea9bb5405273c1ccbeb9c-a8970467d1c11870059a945a2a161271b42102e6" title="search_exists.json">search_exists.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json" class="js-directory-link js-navigation-open" id="271a84623de72292ff6257d567a959a8-a1122f19a1e80fc5506dd23edff72ab3dc00393f" title="search_template.json">search_template.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json" class="js-navigation-open" id="087e36570eccc7017ef612e4d4fcab82-e03ed8fef2fec518918b13521a3dcef1155f9e8f" title="search_shards.json">search_shards.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/1d950a8c258f59f729d48dff19e7b3a5fbca6db2" class="message" data-pjax="true" title="part types are not string but list on the _search_shards endpoint">part types are not string but list on the _search_shards endpoint</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-09-10T10:06:37Z" is="time-ago">Sep 10, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json" class="js-directory-link js-navigation-open" id="3142f56582a6a4f221f2ca9613092485-29ae2206c8568d6574b0a0fc53c79b2b98084a96" title="snapshot.create.json">snapshot.create.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json" class="js-navigation-open" id="271a84623de72292ff6257d567a959a8-a1122f19a1e80fc5506dd23edff72ab3dc00393f" title="search_template.json">search_template.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json" class="js-directory-link js-navigation-open" id="3c7efb7259ad685fcc61441956417466-7a73f6abc3c286e533368d51ff1c3aa16c9833af" title="snapshot.create_repository.json">snapshot.create_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json" class="js-navigation-open" id="3142f56582a6a4f221f2ca9613092485-29ae2206c8568d6574b0a0fc53c79b2b98084a96" title="snapshot.create.json">snapshot.create.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/e2d76aaa20e0ccab4452b263a5718b23e46d9c75" class="message" data-pjax="true" title="remove _create from POST to match PUT path">remove _create from POST to match PUT path</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-29T19:55:52Z" is="time-ago">Jun 29, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json" class="js-directory-link js-navigation-open" id="057c6616838d5438ead24db42bab5b2e-6668289f442a6f57afa14b0fe73a4aaf6c7f9241" title="snapshot.delete.json">snapshot.delete.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json" class="js-navigation-open" id="3c7efb7259ad685fcc61441956417466-7a73f6abc3c286e533368d51ff1c3aa16c9833af" title="snapshot.create_repository.json">snapshot.create_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json" class="js-directory-link js-navigation-open" id="9af95f6a49693f226af744dec7d88ed3-4f0c43b8f03177ab4c897339f0a5f4e3a5dd8f4f" title="snapshot.delete_repository.json">snapshot.delete_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json" class="js-navigation-open" id="057c6616838d5438ead24db42bab5b2e-6668289f442a6f57afa14b0fe73a4aaf6c7f9241" title="snapshot.delete.json">snapshot.delete.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json" class="js-directory-link js-navigation-open" id="651bdc0b78c2633f9a5da0947a67d317-65a8deace7ac4ffdc13a09168e99df312a330a9c" title="snapshot.get.json">snapshot.get.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json" class="js-navigation-open" id="9af95f6a49693f226af744dec7d88ed3-4f0c43b8f03177ab4c897339f0a5f4e3a5dd8f4f" title="snapshot.delete_repository.json">snapshot.delete_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json" class="js-directory-link js-navigation-open" id="2dd6796f7524ee470c4ba617cb6be760-bf6a660146173eec38f991b7b65913cf9190993f" title="snapshot.get_repository.json">snapshot.get_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json" class="js-navigation-open" id="651bdc0b78c2633f9a5da0947a67d317-65a8deace7ac4ffdc13a09168e99df312a330a9c" title="snapshot.get.json">snapshot.get.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json" class="js-directory-link js-navigation-open" id="b2377ab03bc2e7f239f6f9d2b1689802-bdd265799ce4bedc76525907996bbe46191d23ff" title="snapshot.restore.json">snapshot.restore.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json" class="js-navigation-open" id="2dd6796f7524ee470c4ba617cb6be760-bf6a660146173eec38f991b7b65913cf9190993f" title="snapshot.get_repository.json">snapshot.get_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json" class="js-directory-link js-navigation-open" id="e790b0dada2bf67f54709c5f222b8ef1-ebc9180cb527c8e3dc1a6cc78e327b8e8e82d2f9" title="snapshot.status.json">snapshot.status.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json" class="js-navigation-open" id="b2377ab03bc2e7f239f6f9d2b1689802-bdd265799ce4bedc76525907996bbe46191d23ff" title="snapshot.restore.json">snapshot.restore.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json" class="js-directory-link js-navigation-open" id="4b88bdf4b93ee8150855454ee6b250f4-0d9a97c10877b5494b9eb5074f2a0953ac7a9e70" title="snapshot.verify_repository.json">snapshot.verify_repository.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json" class="js-navigation-open" id="e790b0dada2bf67f54709c5f222b8ef1-ebc9180cb527c8e3dc1a6cc78e327b8e8e82d2f9" title="snapshot.status.json">snapshot.status.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/suggest.json" class="js-directory-link js-navigation-open" id="ede60bf6805d74020a897b7189fd2c28-ca0ae8b4f3c8a201249b3c75019305ab9da0c330" title="suggest.json">suggest.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json" class="js-navigation-open" id="4b88bdf4b93ee8150855454ee6b250f4-0d9a97c10877b5494b9eb5074f2a0953ac7a9e70" title="snapshot.verify_repository.json">snapshot.verify_repository.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json" class="js-directory-link js-navigation-open" id="9c95f706bf29eccab82d573979265810-147d7971c9c9300d2eab20fd8ea7c4ee93d255f0" title="termvectors.json">termvectors.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/suggest.json" class="js-navigation-open" id="ede60bf6805d74020a897b7189fd2c28-ca0ae8b4f3c8a201249b3c75019305ab9da0c330" title="suggest.json">suggest.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
           </td>
         </tr>
         <tr class="js-navigation-item">
           <td class="icon">
-            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
             <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
           </td>
           <td class="content">
-            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.2/rest-api-spec/src/main/resources/rest-api-spec/api/update.json" class="js-directory-link js-navigation-open" id="2103efac9db966ed8688bc9b541c1638-20fc3524283e5ef4d83790a75c03469f12291b04" title="update.json">update.json</a></span>
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json" class="js-navigation-open" id="97fecb58388bc9ded81c71e2449aa0a2-14ac986280036ac33b955919335738d1c57b5af4" title="tasks.cancel.json">tasks.cancel.json</a></span>
           </td>
           <td class="message">
             <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/700b64f89cffef76c9189f0e32b40fc45d405fd5" class="message" data-pjax="true" title="Combine node name and task id into single string task id
+
+This commit changes the URL for task operations from `/_tasks/{nodeId}/{taskId}` to `/_tasks/{taskId}`, where `{taskId}` has a form of nodeid:id">Combine node name and task id into single string task id</a>
             </span>
           </td>
           <td class="age">
-            <span class="css-truncate css-truncate-target"></span>
+            <span class="css-truncate css-truncate-target"><time datetime="2016-03-04T15:04:31Z" is="time-ago">Mar 4, 2016</time></span>
+          </td>
+        </tr>
+        <tr class="js-navigation-item">
+          <td class="icon">
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
+          </td>
+          <td class="content">
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json" class="js-navigation-open" id="3c886f3e2a8d77a0a541367c54e39d55-5cdeed1b14248ac06f529e83793b05f2cd3c47bf" title="tasks.list.json">tasks.list.json</a></span>
+          </td>
+          <td class="message">
+            <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/5b6779ed54b2c628e1fbb4c18518d96b8f6cec4e" class="message" data-pjax="true" title="Teach list tasks api to wait for tasks to finish
+
+Backport of 6d0efae7139401f497e6cd4ab329fba82dd922bf.
+
+_wait_for_completion defaults to false. If set to true then the API will
+wait for all the tasks that it finds to stop running before returning. You
+can use the timeout parameter to prevent it from waiting forever. If you
+don&#39;t set a timeout parameter it&#39;ll default to 30 seconds.
+
+Does not backport the portion of 6d0efae7139401f497e6cd4ab329fba82dd922bf
+that logs a message if any tasks overrun the current REST test. This would
+be useful but the rest test runner is missing some important bits that are
+in master that&#39;d let me backport that safely and it isn&#39;t worth the risk.
+
+Switches the request to getter/setter style methods as we&#39;re going that
+way in the Elasticsearch code base. Reindex is all getter/setter style.
+
+Closes #16906">Teach list tasks api to wait for tasks to finish</a>
+            </span>
+          </td>
+          <td class="age">
+            <span class="css-truncate css-truncate-target"><time datetime="2016-03-14T18:30:14Z" is="time-ago">Mar 14, 2016</time></span>
+          </td>
+        </tr>
+        <tr class="js-navigation-item">
+          <td class="icon">
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
+          </td>
+          <td class="content">
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json" class="js-navigation-open" id="9c95f706bf29eccab82d573979265810-147d7971c9c9300d2eab20fd8ea7c4ee93d255f0" title="termvectors.json">termvectors.json</a></span>
+          </td>
+          <td class="message">
+            <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/772d0cc6e78fcb4633ba510fa7e8f28b6fd21dce" class="message" data-pjax="true" title="Build: Make rest-spec-api a project so eclipse build works
+
+The change makes rest-spec-api a project in the same way as we build dev-tools. it packages the tests and api in a bundle using the maven-remote-resources-plugin and uses the same plugin in the plugins and core pom to unpack the rest-api-spec into the target directory and references the rest tests there in the test resources.
+
+The main stimulus for this change is that for those using Eclipse the current build does not work. After running `mvn eclipse:eclipse` the Eclipse IDE errors because the rest-api-spec is outside of the project scope, meaning that every time the command is run (required whenever any dependencies change), the class path of all the projects has to be manually fixed.">Build: Make rest-spec-api a project so eclipse build works</a>
+            </span>
+          </td>
+          <td class="age">
+            <span class="css-truncate css-truncate-target"><time datetime="2015-06-22T10:41:44Z" is="time-ago">Jun 22, 2015</time></span>
+          </td>
+        </tr>
+        <tr class="js-navigation-item">
+          <td class="icon">
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
+          </td>
+          <td class="content">
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/update.json" class="js-navigation-open" id="2103efac9db966ed8688bc9b541c1638-20fc3524283e5ef4d83790a75c03469f12291b04" title="update.json">update.json</a></span>
+          </td>
+          <td class="message">
+            <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/54af556618e9265a486a79dd0a968795796ed3d9" class="message" data-pjax="true" title="Remove detect_noop from REST spec">Remove detect_noop from REST spec</a>
+            </span>
+          </td>
+          <td class="age">
+            <span class="css-truncate css-truncate-target"><time datetime="2016-02-02T20:45:18Z" is="time-ago">Feb 2, 2016</time></span>
+          </td>
+        </tr>
+        <tr class="js-navigation-item">
+          <td class="icon">
+            <svg aria-hidden="true" class="octicon octicon-file-text" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M6 5H2v-1h4v1zM2 8h7v-1H2v1z m0 2h7v-1H2v1z m0 2h7v-1H2v1z m10-7.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v12h10V5z"></path></svg>
+            <img alt="" class="spinner" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
+          </td>
+          <td class="content">
+            <span class="css-truncate css-truncate-target"><a href="/elastic/elasticsearch/blob/2.3/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json" class="js-navigation-open" id="981891e5b7ef8732b758b429194f35cf-c41e6a8831d1fcb809151aa035b62162255ebc8f" title="update_by_query.json">update_by_query.json</a></span>
+          </td>
+          <td class="message">
+            <span class="css-truncate css-truncate-target">
+                  <a href="/elastic/elasticsearch/commit/5c2d216a2cda067204dd1e8d1147c69a2c923ce2" class="message" data-pjax="true" title="Renamed REST tests to use update_by_query instead of update-by-query">Renamed REST tests to use update_by_query instead of update-by-query</a>
+            </span>
+          </td>
+          <td class="age">
+            <span class="css-truncate css-truncate-target"><time datetime="2016-03-29T11:15:45Z" is="time-ago">Mar 29, 2016</time></span>
           </td>
         </tr>
     </tbody>
   </table>
 
-</include-fragment>
+</div>
 
 
 
@@ -3626,10 +4265,10 @@
     </ul>
 
     <a href="https://github.com" aria-label="Homepage" class="site-footer-mark">
-      <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" role="img" title="GitHub " version="1.1" viewBox="0 0 16 16" width="24"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
+      <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" title="GitHub " version="1.1" viewBox="0 0 16 16" width="24"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
 </a>
     <ul class="site-footer-links">
-      <li>&copy; 2016 <span title="0.09780s from github-fe138-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+      <li>&copy; 2016 <span title="0.10875s from github-fe149-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
         <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
         <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
         <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
@@ -3643,26 +4282,25 @@
 
     
     
-    
 
     <div id="ajax-error-message" class="ajax-error-message flash flash-error">
-      <svg aria-hidden="true" class="octicon octicon-alert" height="16" role="img" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg>
+      <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg>
       <button type="button" class="flash-close js-flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
-        <svg aria-hidden="true" class="octicon octicon-x" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75-1.48-1.48 3.75-3.75L0.77 4.25l1.48-1.48 3.75 3.75 3.75-3.75 1.48 1.48-3.75 3.75z"></path></svg>
+        <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75-1.48-1.48 3.75-3.75L0.77 4.25l1.48-1.48 3.75 3.75 3.75-3.75 1.48 1.48-3.75 3.75z"></path></svg>
       </button>
       Something went wrong with that request. Please try again.
     </div>
 
 
       <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/compat-7db58f8b7b91111107fac755dd8b178fe7db0f209ced51fc339c446ad3f8da2b.js"></script>
-      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-d7233eaabb7531aaf275fa71e7bca3c43cb11eae12c8359622bd13d725320aee.js"></script>
-      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-be09baa865e75e7094b35490a7eaf276a214c9e78489fd8a161a61b10da8fca8.js"></script>
+      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-b27673619ec3b4382e890963468a5c0f6d32cb8f61aefc2c4492d7f15c441aec.js"></script>
+      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-4fdb66600a7fca3b074a0f95ff36ac791e8d20a880e7b904624960b0ce852565.js"></script>
       
       
       
       
     <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner hidden">
-      <svg aria-hidden="true" class="octicon octicon-alert" height="16" role="img" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg>
+      <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg>
       <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
       <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
     </div>
@@ -3671,7 +4309,7 @@
     <div class="facebox-content" role="dialog" aria-labelledby="facebox-header" aria-describedby="facebox-description">
     </div>
     <button type="button" class="facebox-close js-facebox-close" aria-label="Close modal">
-      <svg aria-hidden="true" class="octicon octicon-x" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75-1.48-1.48 3.75-3.75L0.77 4.25l1.48-1.48 3.75 3.75 3.75-3.75 1.48 1.48-3.75 3.75z"></path></svg>
+      <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75-1.48-1.48 3.75-3.75L0.77 4.25l1.48-1.48 3.75 3.75 3.75-3.75 1.48 1.48-3.75 3.75z"></path></svg>
     </button>
   </div>
 </div>

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search_exists.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/search_exists.json
@@ -1,6 +1,6 @@
 {
   "search_exists": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html",
     "methods": ["POST", "GET"],
     "url": {
       "path": "/_search/exists",

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/tasks.cancel.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/tasks.cancel.json
@@ -1,0 +1,35 @@
+{
+  "tasks.cancel": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html",
+    "methods": ["POST"],
+    "url": {
+      "path": "/_tasks",
+      "paths": ["/_tasks/_cancel", "/_tasks/{task_id}/_cancel"],
+      "parts": {
+        "task_id": {
+          "type": "number",
+          "description": "Cancel the task with specified id"
+        }
+      },
+      "params": {
+        "node_id": {
+          "type": "list",
+          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
+        },
+        "actions": {
+          "type": "list",
+          "description": "A comma-separated list of actions that should be cancelled. Leave empty to cancel all."
+        },
+        "parent_node": {
+          "type": "string",
+          "description": "Cancel tasks with specified parent node."
+        },
+        "parent_task": {
+          "type" : "number",
+          "description" : "Cancel tasks with specified parent task id. Set to -1 to cancel all."
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/tasks.cancel.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/tasks.cancel.json
@@ -7,7 +7,7 @@
       "paths": ["/_tasks/_cancel", "/_tasks/{task_id}/_cancel"],
       "parts": {
         "task_id": {
-          "type": "number",
+          "type": "string",
           "description": "Cancel the task with specified id"
         }
       },
@@ -25,7 +25,7 @@
           "description": "Cancel tasks with specified parent node."
         },
         "parent_task": {
-          "type" : "number",
+          "type" : "string",
           "description" : "Cancel tasks with specified parent task id. Set to -1 to cancel all."
         }
       }

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/tasks.list.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/tasks.list.json
@@ -1,0 +1,43 @@
+{
+  "tasks.list": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html",
+    "methods": ["GET"],
+    "url": {
+      "path": "/_tasks",
+      "paths": ["/_tasks", "/_tasks/{task_id}"],
+      "parts": {
+        "task_id": {
+          "type": "number",
+          "description": "Return the task with specified id"
+        }
+      },
+      "params": {
+        "node_id": {
+          "type": "list",
+          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
+        },
+        "actions": {
+          "type": "list",
+          "description": "A comma-separated list of actions that should be returned. Leave empty to return all."
+        },
+        "detailed": {
+          "type": "boolean",
+          "description": "Return detailed task information (default: false)"
+        },
+        "parent_node": {
+          "type": "string",
+          "description": "Return tasks with specified parent node."
+        },
+        "parent_task": {
+          "type" : "number",
+          "description" : "Return tasks with specified parent task id. Set to -1 to return all."
+        },
+        "wait_for_completion": {
+          "type": "boolean",
+          "description": "Wait for the matching tasks to complete (default: false)"
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/tasks.list.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/tasks.list.json
@@ -7,7 +7,7 @@
       "paths": ["/_tasks", "/_tasks/{task_id}"],
       "parts": {
         "task_id": {
-          "type": "number",
+          "type": "string",
           "description": "Return the task with specified id"
         }
       },
@@ -29,7 +29,7 @@
           "description": "Return tasks with specified parent node."
         },
         "parent_task": {
-          "type" : "number",
+          "type" : "string",
           "description" : "Return tasks with specified parent task id. Set to -1 to return all."
         },
         "wait_for_completion": {

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/update_by_query.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/update_by_query.json
@@ -8,6 +8,7 @@
       "comment": "most things below this are just copied from search.json",
       "parts": {
         "index": {
+         "required" : true,
          "type" : "list",
          "description" : "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"
         },

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/update_by_query.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiEndpoints/update_by_query.json
@@ -1,0 +1,204 @@
+{
+  "update_by_query": {
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html",
+    "methods": ["POST"],
+    "url": {
+      "path": "/{index}/_update_by_query",
+      "paths": ["/{index}/_update_by_query", "/{index}/{type}/_update_by_query"],
+      "comment": "most things below this are just copied from search.json",
+      "parts": {
+        "index": {
+         "type" : "list",
+         "description" : "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"
+        },
+        "type": {
+          "type" : "list",
+          "description" : "A comma-separated list of document types to search; leave empty to perform the operation on all types"
+        }
+      },
+      "params": {
+        "analyzer": {
+          "type" : "string",
+          "description" : "The analyzer to use for the query string"
+        },
+        "analyze_wildcard": {
+          "type" : "boolean",
+          "description" : "Specify whether wildcard and prefix queries should be analyzed (default: false)"
+        },
+        "default_operator": {
+          "type" : "enum",
+          "options" : ["AND","OR"],
+          "default" : "OR",
+          "description" : "The default operator for query string query (AND or OR)"
+        },
+        "df": {
+          "type" : "string",
+          "description" : "The field to use as default where no field prefix is given in the query string"
+        },
+        "explain": {
+          "type" : "boolean",
+          "description" : "Specify whether to return detailed information about score computation as part of a hit"
+        },
+        "fields": {
+          "type" : "list",
+          "description" : "A comma-separated list of fields to return as part of a hit"
+        },
+        "fielddata_fields": {
+          "type" : "list",
+          "description" : "A comma-separated list of fields to return as the field data representation of a field for each hit"
+        },
+        "from": {
+          "type" : "number",
+          "description" : "Starting offset (default: 0)"
+        },
+        "ignore_unavailable": {
+            "type" : "boolean",
+            "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+        },
+        "allow_no_indices": {
+            "type" : "boolean",
+            "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        },
+        "conflicts": {
+            "note": "This is not copied from search",
+            "type" : "enum",
+            "options": ["abort", "proceed"],
+            "default": "abort",
+            "description" : "What to do when the reindex hits version conflicts?"
+        },
+        "expand_wildcards": {
+            "type" : "enum",
+            "options" : ["open","closed","none","all"],
+            "default" : "open",
+            "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "lenient": {
+          "type" : "boolean",
+          "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
+        },
+        "lowercase_expanded_terms": {
+          "type" : "boolean",
+          "description" : "Specify whether query terms should be lowercased"
+        },
+        "preference": {
+          "type" : "string",
+          "description" : "Specify the node or shard the operation should be performed on (default: random)"
+        },
+        "q": {
+          "type" : "string",
+          "description" : "Query in the Lucene query string syntax"
+        },
+        "routing": {
+          "type" : "list",
+          "description" : "A comma-separated list of specific routing values"
+        },
+        "scroll": {
+          "type" : "duration",
+          "description" : "Specify how long a consistent view of the index should be maintained for scrolled search"
+        },
+        "search_type": {
+          "type" : "enum",
+          "options" : ["query_then_fetch", "dfs_query_then_fetch"],
+          "description" : "Search operation type"
+        },
+        "search_timeout": {
+          "type" : "time",
+          "description" : "Explicit timeout for each search request. Defaults to no timeout."
+        },
+        "size": {
+          "type" : "number",
+          "description" : "Number of hits to return (default: 10)"
+        },
+        "sort": {
+          "type" : "list",
+          "description" : "A comma-separated list of <field>:<direction> pairs"
+        },
+        "_source": {
+          "type" : "list",
+          "description" : "True or false to return the _source field or not, or a list of fields to return"
+        },
+        "_source_exclude": {
+          "type" : "list",
+          "description" : "A list of fields to exclude from the returned _source field"
+        },
+        "_source_include": {
+          "type" : "list",
+          "description" : "A list of fields to extract and return from the _source field"
+        },
+        "terminate_after": {
+          "type" : "number",
+          "description" : "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
+        },
+        "stats": {
+          "type" : "list",
+          "description" : "Specific 'tag' of the request for logging and statistical purposes"
+        },
+        "suggest_field": {
+          "type" : "string",
+          "description" : "Specify which field to use for suggestions"
+        },
+        "suggest_mode": {
+          "type" : "enum",
+          "options" : ["missing", "popular", "always"],
+          "default" : "missing",
+          "description" : "Specify suggest mode"
+        },
+        "suggest_size": {
+          "type" : "number",
+          "description" : "How many suggestions to return in response"
+        },
+        "suggest_text": {
+          "type" : "text",
+          "description" : "The source text for which the suggestions should be returned"
+        },
+        "timeout": {
+          "type" : "time",
+          "description" : "Explicit operation timeout"
+        },
+        "track_scores": {
+          "type" : "boolean",
+          "description": "Whether to calculate and return scores even if they are not used for sorting"
+        },
+        "version": {
+          "type" : "boolean",
+          "description" : "Specify whether to return document version as part of a hit"
+        },
+        "version_type": {
+          "type" : "boolean",
+          "description" : "Should the document increment the version number (internal) on hit or not (reindex)"
+        },
+        "request_cache": {
+          "type" : "boolean",
+          "description" : "Specify if request cache should be used for this request or not, defaults to index level setting"
+        },
+        "refresh": {
+          "type" : "boolean",
+          "description" : "Should the effected indexes be refreshed?"
+        },
+        "timeout": {
+          "type" : "time",
+          "default": "1m",
+          "description" : "Time each individual bulk request should wait for shards that are unavailable."
+        },
+        "consistency": {
+          "type" : "enum",
+          "options" : ["one", "quorum", "all"],
+          "description" : "Explicit write consistency setting for the operation"
+        },
+        "scroll_size": {
+          "type": "integer",
+          "defaut_value": 100,
+          "description": "Size on the scroll request powering the update_by_query"
+        },
+        "wait_for_completion": {
+           "type" : "boolean",
+           "default": false,
+           "description" : "Should the request should block until the reindex is complete."
+        }
+      }
+    },
+    "body": {
+      "description": "The search definition using the Query DSL"
+    }
+  }
+}

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiGenerator.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/ApiGenerator.cs
@@ -24,7 +24,7 @@ namespace CodeGeneration.LowLevelClient
 		private static string ViewFolder;
 		private static string ApiEndpointsFolder;
 		private static readonly RazorMachine RazorHelper;
-		private static readonly string Version = "2.2";
+		private static readonly string Version = "2.3";
 		private static readonly List<string> ApiListings = new List<string>
 		{
 			"https://github.com/elastic/elasticsearch/tree/{version}/rest-api-spec/src/main/resources/rest-api-spec/api"

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/CodeGeneration.LowLevelClient.csproj
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/CodeGeneration.LowLevelClient.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Overrides\Descriptors\PutIndexTemplateDescriptorOverrides.cs" />
     <Compile Include="Overrides\Descriptors\ScrollDescriptorOverrides.cs" />
     <Compile Include="Overrides\Descriptors\SearchDescriptorOverrides.cs" />
+    <Compile Include="Overrides\Descriptors\ReindexOnServerDescriptorOverrides.cs" />
     <Compile Include="Overrides\Descriptors\UpdateDescriptorOverrides.cs" />
     <Compile Include="Overrides\Global\GlobalQueryParameters.cs" />
     <Compile Include="Program.cs" />

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Domain/ApiQueryParameters.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Domain/ApiQueryParameters.cs
@@ -19,9 +19,10 @@ namespace CodeGeneration.LowLevelClient.Domain
 					return "bool";
 				case "list":
 					return "params string[]";
+				case "integer":
 				case "number":
-					return new [] {"boost", "percen", "score"}.Any(s=>paramName.ToLowerInvariant().Contains(s)) 
-						? "double" 
+					return new [] {"boost", "percen", "score"}.Any(s=>paramName.ToLowerInvariant().Contains(s))
+						? "double"
 						: "long";
 				case "duration":
 				case "time":
@@ -36,7 +37,7 @@ namespace CodeGeneration.LowLevelClient.Domain
 					return this.Type;
 			}
 		}
-		
+
 		public string HighLevelType(string paramName)
 		{
 			var csharpType = this.CsharpType(paramName);

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Domain/ApiUrlPart.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Domain/ApiUrlPart.cs
@@ -21,7 +21,7 @@ namespace CodeGeneration.LowLevelClient.Domain
 					case "id": return this.Type == "string" ? "Id" : "Ids";
 					case "node_id": return this.Type == "string" ? "NodeId" : "NodeIds";
 					case "scroll_id": return this.Type == "string" ? "ScrollId" : "ScrollIds";
-					case "field": 
+					case "field":
 					case "fields": return this.Type == "string" ? "Field" : "Fields";
 					case "index_metric": return "IndexMetrics";
 					case "metric": return "Metrics";
@@ -30,6 +30,7 @@ namespace CodeGeneration.LowLevelClient.Domain
 					case "snapshot":
 					case "lang":
 					case "name": return this.Type == "string" ? "Name" : "Names";
+					case "task_id": return "TaskId";
 					default: return this.Type + "_";
 				}
 			}

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Domain/CsharpMethod.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Domain/CsharpMethod.cs
@@ -120,7 +120,7 @@ namespace CodeGeneration.LowLevelClient.Domain
 				{
 					var generic = this.RequestTypeGeneric.Replace("<", "").Replace(">", "");
 					generated = $"public {m}({par}) : this({cp.First().Key}, typeof({generic})){{}}";
-                }
+				}
 
 				var c = new Constructor { Generated = generated, Description = doc };
 				ctors.Add(c);

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/ReindexOnServerDescriptorOverrides.cs
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/Overrides/Descriptors/ReindexOnServerDescriptorOverrides.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace CodeGeneration.LowLevelClient.Overrides.Descriptors
+{
+	// ReSharper disable once UnusedMember.Global
+	public class ReindexOnServerDescriptorOverrides : IDescriptorOverrides
+	{
+		public IEnumerable<string> SkipQueryStringParams => new []
+		{
+			"source"
+		};
+
+		public IDictionary<string, string> RenameQueryStringParams => null;
+	}
+
+}

--- a/src/Elasticsearch.Net/Domain/Enums.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/Enums.Generated.cs
@@ -156,6 +156,15 @@ namespace Elasticsearch.Net
 	}
 	
 	
+	public enum Conflicts 
+	{
+		[EnumMember(Value = "abort")]
+		Abort,
+		[EnumMember(Value = "proceed")]
+		Proceed
+	}
+	
+	
 	[Flags]public enum ClusterStateMetric 
 	{
 		[EnumMember(Value = "blocks")]
@@ -459,6 +468,16 @@ namespace Elasticsearch.Net
 					case SuggestMode.Missing: return "missing";
 					case SuggestMode.Popular: return "popular";
 					case SuggestMode.Always: return "always";
+				}
+			
+			}
+			
+			if (e is Conflicts)
+			{ 
+				switch((Conflicts)e)
+				{
+					case Conflicts.Abort: return "abort";
+					case Conflicts.Proceed: return "proceed";
 				}
 			
 			}

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -3545,32 +3545,28 @@ namespace Elasticsearch.Net
 	///https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html
 	///</pre>
 	///</summary>
-	public class ReindexRequestParameters : FluentRequestParameters<ReindexRequestParameters> 
+	public class ReindexOnServerRequestParameters : FluentRequestParameters<ReindexOnServerRequestParameters> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 		
 		///<summary>Should the effected indexes be refreshed?</summary>
-		public ReindexRequestParameters Refresh(bool refresh) => this.AddQueryString("refresh", refresh);
+		public ReindexOnServerRequestParameters Refresh(bool refresh) => this.AddQueryString("refresh", refresh);
 		
 		
 		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
-		public ReindexRequestParameters Timeout(TimeSpan timeout) => this.AddQueryString("timeout", timeout.ToTimeUnit());
+		public ReindexOnServerRequestParameters Timeout(TimeSpan timeout) => this.AddQueryString("timeout", timeout.ToTimeUnit());
 		
 		
 		///<summary>Explicit write consistency setting for the operation</summary>
-		public ReindexRequestParameters Consistency(Consistency consistency) => this.AddQueryString("consistency", consistency);
+		public ReindexOnServerRequestParameters Consistency(Consistency consistency) => this.AddQueryString("consistency", consistency);
 		
 		
 		///<summary>Should the request should block until the reindex is complete.</summary>
-		public ReindexRequestParameters WaitForCompletion(bool wait_for_completion) => this.AddQueryString("wait_for_completion", wait_for_completion);
-		
-		
-		///<summary>The URL-encoded request definition</summary>
-		public ReindexRequestParameters Source(string source) => this.AddQueryString("source", source);
+		public ReindexOnServerRequestParameters WaitForCompletion(bool wait_for_completion) => this.AddQueryString("wait_for_completion", wait_for_completion);
 		
 		
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
-		public ReindexRequestParameters FilterPath(string filter_path) => this.AddQueryString("filter_path", filter_path);
+		public ReindexOnServerRequestParameters FilterPath(string filter_path) => this.AddQueryString("filter_path", filter_path);
 		
 	}
 	
@@ -4144,7 +4140,7 @@ namespace Elasticsearch.Net
 		
 		
 		///<summary>Cancel tasks with specified parent task id. Set to -1 to cancel all.</summary>
-		public TasksCancelRequestParameters ParentTask(long parent_task) => this.AddQueryString("parent_task", parent_task);
+		public TasksCancelRequestParameters ParentTask(string parent_task) => this.AddQueryString("parent_task", parent_task);
 		
 		
 		///<summary>The URL-encoded request definition</summary>
@@ -4182,7 +4178,7 @@ namespace Elasticsearch.Net
 		
 		
 		///<summary>Return tasks with specified parent task id. Set to -1 to return all.</summary>
-		public TasksListRequestParameters ParentTask(long parent_task) => this.AddQueryString("parent_task", parent_task);
+		public TasksListRequestParameters ParentTask(string parent_task) => this.AddQueryString("parent_task", parent_task);
 		
 		
 		///<summary>Wait for the matching tasks to complete (default: false)</summary>
@@ -4504,7 +4500,7 @@ namespace Elasticsearch.Net
 		
 		
 		///<summary>Size on the scroll request powering the update_by_query</summary>
-		public UpdateByQueryRequestParameters ScrollSize(integer scroll_size) => this.AddQueryString("scroll_size", scroll_size);
+		public UpdateByQueryRequestParameters ScrollSize(long scroll_size) => this.AddQueryString("scroll_size", scroll_size);
 		
 		
 		///<summary>Should the request should block until the reindex is complete.</summary>

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -1700,10 +1700,10 @@ namespace Elasticsearch.Net
 		
 		
 		///<summary>With `true`, outputs more advanced details. (default: false)</summary>
-		public AnalyzeRequestParameters Detail(bool detail) => this.AddQueryString("detail", detail);
+		public AnalyzeRequestParameters Explain(bool explain) => this.AddQueryString("explain", explain);
 		
 		
-		///<summary>A comma-separated list of token attributes to output, this parameter works only with `detail=true`</summary>
+		///<summary>A comma-separated list of token attributes to output, this parameter works only with `explain=true`</summary>
 		public AnalyzeRequestParameters Attributes(params string[] attributes) => this.AddQueryString("attributes", attributes);
 		
 		
@@ -2542,7 +2542,7 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for IndicesOptimizeForAll
 	///<pre>
-	///https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html
 	///</pre>
 	///</summary>
 	public class OptimizeRequestParameters : FluentRequestParameters<OptimizeRequestParameters> 
@@ -3540,6 +3540,40 @@ namespace Elasticsearch.Net
 		
 	}
 	
+	///<summary>Request parameters descriptor for Reindex
+	///<pre>
+	///https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html
+	///</pre>
+	///</summary>
+	public class ReindexRequestParameters : FluentRequestParameters<ReindexRequestParameters> 
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
+		
+		///<summary>Should the effected indexes be refreshed?</summary>
+		public ReindexRequestParameters Refresh(bool refresh) => this.AddQueryString("refresh", refresh);
+		
+		
+		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
+		public ReindexRequestParameters Timeout(TimeSpan timeout) => this.AddQueryString("timeout", timeout.ToTimeUnit());
+		
+		
+		///<summary>Explicit write consistency setting for the operation</summary>
+		public ReindexRequestParameters Consistency(Consistency consistency) => this.AddQueryString("consistency", consistency);
+		
+		
+		///<summary>Should the request should block until the reindex is complete.</summary>
+		public ReindexRequestParameters WaitForCompletion(bool wait_for_completion) => this.AddQueryString("wait_for_completion", wait_for_completion);
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public ReindexRequestParameters Source(string source) => this.AddQueryString("source", source);
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ReindexRequestParameters FilterPath(string filter_path) => this.AddQueryString("filter_path", filter_path);
+		
+	}
+	
 	///<summary>Request parameters descriptor for RenderSearchTemplate
 	///<pre>
 	///http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
@@ -3668,7 +3702,7 @@ namespace Elasticsearch.Net
 	
 	///<summary>Request parameters descriptor for SearchExists
 	///<pre>
-	///https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
 	///</pre>
 	///</summary>
 	public class SearchExistsRequestParameters : FluentRequestParameters<SearchExistsRequestParameters> 
@@ -4088,6 +4122,82 @@ namespace Elasticsearch.Net
 		
 	}
 	
+	///<summary>Request parameters descriptor for TasksCancel
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html
+	///</pre>
+	///</summary>
+	public class TasksCancelRequestParameters : FluentRequestParameters<TasksCancelRequestParameters> 
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
+		
+		///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
+		public TasksCancelRequestParameters NodeId(params string[] node_id) => this.AddQueryString("node_id", node_id);
+		
+		
+		///<summary>A comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
+		public TasksCancelRequestParameters Actions(params string[] actions) => this.AddQueryString("actions", actions);
+		
+		
+		///<summary>Cancel tasks with specified parent node.</summary>
+		public TasksCancelRequestParameters ParentNode(string parent_node) => this.AddQueryString("parent_node", parent_node);
+		
+		
+		///<summary>Cancel tasks with specified parent task id. Set to -1 to cancel all.</summary>
+		public TasksCancelRequestParameters ParentTask(long parent_task) => this.AddQueryString("parent_task", parent_task);
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public TasksCancelRequestParameters Source(string source) => this.AddQueryString("source", source);
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TasksCancelRequestParameters FilterPath(string filter_path) => this.AddQueryString("filter_path", filter_path);
+		
+	}
+	
+	///<summary>Request parameters descriptor for TasksList
+	///<pre>
+	///http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html
+	///</pre>
+	///</summary>
+	public class TasksListRequestParameters : FluentRequestParameters<TasksListRequestParameters> 
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
+		
+		///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
+		public TasksListRequestParameters NodeId(params string[] node_id) => this.AddQueryString("node_id", node_id);
+		
+		
+		///<summary>A comma-separated list of actions that should be returned. Leave empty to return all.</summary>
+		public TasksListRequestParameters Actions(params string[] actions) => this.AddQueryString("actions", actions);
+		
+		
+		///<summary>Return detailed task information (default: false)</summary>
+		public TasksListRequestParameters Detailed(bool detailed) => this.AddQueryString("detailed", detailed);
+		
+		
+		///<summary>Return tasks with specified parent node.</summary>
+		public TasksListRequestParameters ParentNode(string parent_node) => this.AddQueryString("parent_node", parent_node);
+		
+		
+		///<summary>Return tasks with specified parent task id. Set to -1 to return all.</summary>
+		public TasksListRequestParameters ParentTask(long parent_task) => this.AddQueryString("parent_task", parent_task);
+		
+		
+		///<summary>Wait for the matching tasks to complete (default: false)</summary>
+		public TasksListRequestParameters WaitForCompletion(bool wait_for_completion) => this.AddQueryString("wait_for_completion", wait_for_completion);
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public TasksListRequestParameters Source(string source) => this.AddQueryString("source", source);
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TasksListRequestParameters FilterPath(string filter_path) => this.AddQueryString("filter_path", filter_path);
+		
+	}
+	
 	///<summary>Request parameters descriptor for Termvectors
 	///<pre>
 	///http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html
@@ -4229,6 +4339,184 @@ namespace Elasticsearch.Net
 		
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
 		public UpdateRequestParameters FilterPath(string filter_path) => this.AddQueryString("filter_path", filter_path);
+		
+	}
+	
+	///<summary>Request parameters descriptor for UpdateByQuery
+	///<pre>
+	///https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html
+	///</pre>
+	///</summary>
+	public class UpdateByQueryRequestParameters : FluentRequestParameters<UpdateByQueryRequestParameters> 
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
+		
+		///<summary>The analyzer to use for the query string</summary>
+		public UpdateByQueryRequestParameters Analyzer(string analyzer) => this.AddQueryString("analyzer", analyzer);
+		
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public UpdateByQueryRequestParameters AnalyzeWildcard(bool analyze_wildcard) => this.AddQueryString("analyze_wildcard", analyze_wildcard);
+		
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public UpdateByQueryRequestParameters DefaultOperator(DefaultOperator default_operator) => this.AddQueryString("default_operator", default_operator);
+		
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public UpdateByQueryRequestParameters Df(string df) => this.AddQueryString("df", df);
+		
+		
+		///<summary>Specify whether to return detailed information about score computation as part of a hit</summary>
+		public UpdateByQueryRequestParameters Explain(bool explain) => this.AddQueryString("explain", explain);
+		
+		
+		///<summary>A comma-separated list of fields to return as part of a hit</summary>
+		public UpdateByQueryRequestParameters Fields(params string[] fields) => this.AddQueryString("fields", fields);
+		
+		
+		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
+		public UpdateByQueryRequestParameters FielddataFields(params string[] fielddata_fields) => this.AddQueryString("fielddata_fields", fielddata_fields);
+		
+		
+		///<summary>Starting offset (default: 0)</summary>
+		public UpdateByQueryRequestParameters From(long from) => this.AddQueryString("from", from);
+		
+		
+		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
+		public UpdateByQueryRequestParameters IgnoreUnavailable(bool ignore_unavailable) => this.AddQueryString("ignore_unavailable", ignore_unavailable);
+		
+		
+		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
+		public UpdateByQueryRequestParameters AllowNoIndices(bool allow_no_indices) => this.AddQueryString("allow_no_indices", allow_no_indices);
+		
+		
+		///<summary>What to do when the reindex hits version conflicts?</summary>
+		public UpdateByQueryRequestParameters Conflicts(Conflicts conflicts) => this.AddQueryString("conflicts", conflicts);
+		
+		
+		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+		public UpdateByQueryRequestParameters ExpandWildcards(ExpandWildcards expand_wildcards) => this.AddQueryString("expand_wildcards", expand_wildcards);
+		
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public UpdateByQueryRequestParameters Lenient(bool lenient) => this.AddQueryString("lenient", lenient);
+		
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public UpdateByQueryRequestParameters LowercaseExpandedTerms(bool lowercase_expanded_terms) => this.AddQueryString("lowercase_expanded_terms", lowercase_expanded_terms);
+		
+		
+		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
+		public UpdateByQueryRequestParameters Preference(string preference) => this.AddQueryString("preference", preference);
+		
+		
+		///<summary>Query in the Lucene query string syntax</summary>
+		public UpdateByQueryRequestParameters QueryOnQueryString(string query_on_query_string) => this.AddQueryString("q", query_on_query_string);
+		
+		
+		///<summary>A comma-separated list of specific routing values</summary>
+		public UpdateByQueryRequestParameters Routing(params string[] routing) => this.AddQueryString("routing", routing);
+		
+		
+		///<summary>Specify how long a consistent view of the index should be maintained for scrolled search</summary>
+		public UpdateByQueryRequestParameters Scroll(TimeSpan scroll) => this.AddQueryString("scroll", scroll.ToTimeUnit());
+		
+		
+		///<summary>Search operation type</summary>
+		public UpdateByQueryRequestParameters SearchType(SearchType search_type) => this.AddQueryString("search_type", search_type);
+		
+		
+		///<summary>Explicit timeout for each search request. Defaults to no timeout.</summary>
+		public UpdateByQueryRequestParameters SearchTimeout(TimeSpan search_timeout) => this.AddQueryString("search_timeout", search_timeout.ToTimeUnit());
+		
+		
+		///<summary>Number of hits to return (default: 10)</summary>
+		public UpdateByQueryRequestParameters Size(long size) => this.AddQueryString("size", size);
+		
+		
+		///<summary>A comma-separated list of &lt;field&gt;:&lt;direction&gt; pairs</summary>
+		public UpdateByQueryRequestParameters Sort(params string[] sort) => this.AddQueryString("sort", sort);
+		
+		
+		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
+		public UpdateByQueryRequestParameters SourceEnabled(params string[] source_enabled) => this.AddQueryString("_source", source_enabled);
+		
+		
+		///<summary>A list of fields to exclude from the returned _source field</summary>
+		public UpdateByQueryRequestParameters SourceExclude(params string[] source_exclude) => this.AddQueryString("_source_exclude", source_exclude);
+		
+		
+		///<summary>A list of fields to extract and return from the _source field</summary>
+		public UpdateByQueryRequestParameters SourceInclude(params string[] source_include) => this.AddQueryString("_source_include", source_include);
+		
+		
+		///<summary>The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.</summary>
+		public UpdateByQueryRequestParameters TerminateAfter(long terminate_after) => this.AddQueryString("terminate_after", terminate_after);
+		
+		
+		///<summary>Specific &#39;tag&#39; of the request for logging and statistical purposes</summary>
+		public UpdateByQueryRequestParameters Stats(params string[] stats) => this.AddQueryString("stats", stats);
+		
+		
+		///<summary>Specify which field to use for suggestions</summary>
+		public UpdateByQueryRequestParameters SuggestField(string suggest_field) => this.AddQueryString("suggest_field", suggest_field);
+		
+		
+		///<summary>Specify suggest mode</summary>
+		public UpdateByQueryRequestParameters SuggestMode(SuggestMode suggest_mode) => this.AddQueryString("suggest_mode", suggest_mode);
+		
+		
+		///<summary>How many suggestions to return in response</summary>
+		public UpdateByQueryRequestParameters SuggestSize(long suggest_size) => this.AddQueryString("suggest_size", suggest_size);
+		
+		
+		///<summary>The source text for which the suggestions should be returned</summary>
+		public UpdateByQueryRequestParameters SuggestText(string suggest_text) => this.AddQueryString("suggest_text", suggest_text);
+		
+		
+		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
+		public UpdateByQueryRequestParameters Timeout(TimeSpan timeout) => this.AddQueryString("timeout", timeout.ToTimeUnit());
+		
+		
+		///<summary>Whether to calculate and return scores even if they are not used for sorting</summary>
+		public UpdateByQueryRequestParameters TrackScores(bool track_scores) => this.AddQueryString("track_scores", track_scores);
+		
+		
+		///<summary>Specify whether to return document version as part of a hit</summary>
+		public UpdateByQueryRequestParameters Version(bool version) => this.AddQueryString("version", version);
+		
+		
+		///<summary>Should the document increment the version number (internal) on hit or not (reindex)</summary>
+		public UpdateByQueryRequestParameters VersionType(bool version_type) => this.AddQueryString("version_type", version_type);
+		
+		
+		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
+		public UpdateByQueryRequestParameters RequestCache(bool request_cache) => this.AddQueryString("request_cache", request_cache);
+		
+		
+		///<summary>Should the effected indexes be refreshed?</summary>
+		public UpdateByQueryRequestParameters Refresh(bool refresh) => this.AddQueryString("refresh", refresh);
+		
+		
+		///<summary>Explicit write consistency setting for the operation</summary>
+		public UpdateByQueryRequestParameters Consistency(Consistency consistency) => this.AddQueryString("consistency", consistency);
+		
+		
+		///<summary>Size on the scroll request powering the update_by_query</summary>
+		public UpdateByQueryRequestParameters ScrollSize(integer scroll_size) => this.AddQueryString("scroll_size", scroll_size);
+		
+		
+		///<summary>Should the request should block until the reindex is complete.</summary>
+		public UpdateByQueryRequestParameters WaitForCompletion(bool wait_for_completion) => this.AddQueryString("wait_for_completion", wait_for_completion);
+		
+		
+		///<summary>The URL-encoded request definition</summary>
+		public UpdateByQueryRequestParameters Source(string source) => this.AddQueryString("source", source);
+		
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpdateByQueryRequestParameters FilterPath(string filter_path) => this.AddQueryString("filter_path", filter_path);
 		
 	}
 }

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
@@ -6558,7 +6558,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Reindex<T>(PostData<object> body, Func<ReindexRequestParameters, ReindexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Reindex<T>(PostData<object> body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_reindex"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_reindex 
@@ -6572,7 +6572,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData<object> body, Func<ReindexRequestParameters, ReindexRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData<object> body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null)
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_reindex"), body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_render/template 
@@ -7990,7 +7990,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="task_id">Cancel the task with specified id</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> TasksCancel<T>(number task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> TasksCancel<T>(string task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_tasks/{task_id.NotNull("task_id")}/_cancel"), null, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_tasks/{task_id}/_cancel 
@@ -8004,7 +8004,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="task_id">Cancel the task with specified id</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> TasksCancelAsync<T>(number task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<T>> TasksCancelAsync<T>(string task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null)
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_tasks/{task_id.NotNull("task_id")}/_cancel"), null, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_tasks 
@@ -8044,7 +8044,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="task_id">Return the task with specified id</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> TasksList<T>(number task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> TasksList<T>(string task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(GET, Url($"_tasks/{task_id.NotNull("task_id")}"), null, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_tasks/{task_id} 
@@ -8058,7 +8058,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="task_id">Return the task with specified id</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> TasksListAsync<T>(number task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null)
+		public Task<ElasticsearchResponse<T>> TasksListAsync<T>(string task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null)
 			where T : class => this.DoRequestAsync<T>(GET, Url($"_tasks/{task_id.NotNull("task_id")}"), null, _params(requestParameters));
 		
 		///<summary>Represents a GET on /{index}/{type}/_termvectors 

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
@@ -3970,7 +3970,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 	    ///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public ElasticsearchResponse<T> IndicesOptimizeForAll<T>(Func<OptimizeRequestParameters, OptimizeRequestParameters> requestParameters = null)
@@ -3983,7 +3983,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 	    ///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public Task<ElasticsearchResponse<T>> IndicesOptimizeForAllAsync<T>(Func<OptimizeRequestParameters, OptimizeRequestParameters> requestParameters = null)
@@ -3996,7 +3996,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -4010,7 +4010,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -4024,7 +4024,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 	    ///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public ElasticsearchResponse<T> IndicesOptimizeGetForAll<T>(Func<OptimizeRequestParameters, OptimizeRequestParameters> requestParameters = null)
@@ -4037,7 +4037,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 	    ///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public Task<ElasticsearchResponse<T>> IndicesOptimizeGetForAllAsync<T>(Func<OptimizeRequestParameters, OptimizeRequestParameters> requestParameters = null)
@@ -4050,7 +4050,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -4064,7 +4064,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -6547,6 +6547,34 @@ namespace Elasticsearch.Net
 		public Task<ElasticsearchResponse<T>> PutTemplatePostAsync<T>(string id, PostData<object> body, Func<PutSearchTemplateRequestParameters, PutSearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_search/template/{id.NotNull("id")}"), body, _params(requestParameters));
 		
+		///<summary>Represents a POST on /_reindex 
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+	    ///</summary>
+		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public ElasticsearchResponse<T> Reindex<T>(PostData<object> body, Func<ReindexRequestParameters, ReindexRequestParameters> requestParameters = null)
+			where T : class => this.DoRequest<T>(POST, Url($"_reindex"), body, _params(requestParameters));
+		
+		///<summary>Represents a POST on /_reindex 
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+	    ///</summary>
+		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData<object> body, Func<ReindexRequestParameters, ReindexRequestParameters> requestParameters = null)
+			where T : class => this.DoRequestAsync<T>(POST, Url($"_reindex"), body, _params(requestParameters));
+		
 		///<summary>Represents a GET on /_render/template 
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
 		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
@@ -6894,7 +6922,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -6908,7 +6936,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -6922,7 +6950,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -6937,7 +6965,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -6952,7 +6980,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6968,7 +6996,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6984,7 +7012,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public ElasticsearchResponse<T> SearchExistsGet<T>(Func<SearchExistsRequestParameters, SearchExistsRequestParameters> requestParameters = null)
@@ -6997,7 +7025,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public Task<ElasticsearchResponse<T>> SearchExistsGetAsync<T>(Func<SearchExistsRequestParameters, SearchExistsRequestParameters> requestParameters = null)
@@ -7010,7 +7038,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -7024,7 +7052,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -7038,7 +7066,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -7053,7 +7081,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
-	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 	    ///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -7925,6 +7953,114 @@ namespace Elasticsearch.Net
 		public Task<ElasticsearchResponse<T>> SuggestGetAsync<T>(string index, Func<SuggestRequestParameters, SuggestRequestParameters> requestParameters = null)
 			where T : class => this.DoRequestAsync<T>(GET, Url($"{index.NotNull("index")}/_suggest"), null, _params(requestParameters));
 		
+		///<summary>Represents a POST on /_tasks/_cancel 
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html </para>	
+	    ///</summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public ElasticsearchResponse<T> TasksCancel<T>(Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null)
+			where T : class => this.DoRequest<T>(POST, Url($"_tasks/_cancel"), null, _params(requestParameters));
+		
+		///<summary>Represents a POST on /_tasks/_cancel 
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html </para>	
+	    ///</summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<ElasticsearchResponse<T>> TasksCancelAsync<T>(Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null)
+			where T : class => this.DoRequestAsync<T>(POST, Url($"_tasks/_cancel"), null, _params(requestParameters));
+		
+		///<summary>Represents a POST on /_tasks/{task_id}/_cancel 
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html </para>	
+	    ///</summary>
+		///<param name="task_id">Cancel the task with specified id</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public ElasticsearchResponse<T> TasksCancel<T>(number task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null)
+			where T : class => this.DoRequest<T>(POST, Url($"_tasks/{task_id.NotNull("task_id")}/_cancel"), null, _params(requestParameters));
+		
+		///<summary>Represents a POST on /_tasks/{task_id}/_cancel 
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html </para>	
+	    ///</summary>
+		///<param name="task_id">Cancel the task with specified id</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<ElasticsearchResponse<T>> TasksCancelAsync<T>(number task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null)
+			where T : class => this.DoRequestAsync<T>(POST, Url($"_tasks/{task_id.NotNull("task_id")}/_cancel"), null, _params(requestParameters));
+		
+		///<summary>Represents a GET on /_tasks 
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html </para>	
+	    ///</summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public ElasticsearchResponse<T> TasksList<T>(Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null)
+			where T : class => this.DoRequest<T>(GET, Url($"_tasks"), null, _params(requestParameters));
+		
+		///<summary>Represents a GET on /_tasks 
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html </para>	
+	    ///</summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<ElasticsearchResponse<T>> TasksListAsync<T>(Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null)
+			where T : class => this.DoRequestAsync<T>(GET, Url($"_tasks"), null, _params(requestParameters));
+		
+		///<summary>Represents a GET on /_tasks/{task_id} 
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html </para>	
+	    ///</summary>
+		///<param name="task_id">Return the task with specified id</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public ElasticsearchResponse<T> TasksList<T>(number task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null)
+			where T : class => this.DoRequest<T>(GET, Url($"_tasks/{task_id.NotNull("task_id")}"), null, _params(requestParameters));
+		
+		///<summary>Represents a GET on /_tasks/{task_id} 
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html </para>	
+	    ///</summary>
+		///<param name="task_id">Return the task with specified id</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<ElasticsearchResponse<T>> TasksListAsync<T>(number task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null)
+			where T : class => this.DoRequestAsync<T>(GET, Url($"_tasks/{task_id.NotNull("task_id")}"), null, _params(requestParameters));
+		
 		///<summary>Represents a GET on /{index}/{type}/_termvectors 
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
 		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
@@ -8086,6 +8222,68 @@ namespace Elasticsearch.Net
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public Task<ElasticsearchResponse<T>> UpdateAsync<T>(string index, string type, string id, PostData<object> body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_update"), body, _params(requestParameters));
+		
+		///<summary>Represents a POST on /{index}/_update_by_query 
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="body">The search definition using the Query DSL</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public ElasticsearchResponse<T> UpdateByQuery<T>(string index, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null)
+			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_update_by_query"), body, _params(requestParameters));
+		
+		///<summary>Represents a POST on /{index}/_update_by_query 
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="body">The search definition using the Query DSL</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null)
+			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_update_by_query"), body, _params(requestParameters));
+		
+		///<summary>Represents a POST on /{index}/{type}/_update_by_query 
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
+		///<param name="body">The search definition using the Query DSL</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public ElasticsearchResponse<T> UpdateByQuery<T>(string index, string type, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null)
+			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_update_by_query"), body, _params(requestParameters));
+		
+		///<summary>Represents a POST on /{index}/{type}/_update_by_query 
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para> 
+	    ///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+	    ///</summary>
+		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
+		///<param name="body">The search definition using the Query DSL</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, string type, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null)
+			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_update_by_query"), body, _params(requestParameters));
 		
 	
 	  }

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
@@ -6109,7 +6109,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Reindex<T>(PostData<object> body, Func<ReindexRequestParameters, ReindexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Reindex<T>(PostData<object> body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_reindex
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6122,7 +6122,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData<object> body, Func<ReindexRequestParameters, ReindexRequestParameters> requestParameters = null) where T : class;
+		Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData<object> body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a GET on /_render/template
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7441,7 +7441,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="task_id">Cancel the task with specified id</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> TasksCancel<T>(number task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> TasksCancel<T>(string task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_tasks/{task_id}/_cancel
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7454,7 +7454,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="task_id">Cancel the task with specified id</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> TasksCancelAsync<T>(number task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null) where T : class;
+		Task<ElasticsearchResponse<T>> TasksCancelAsync<T>(string task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a GET on /_tasks
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7491,7 +7491,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="task_id">Return the task with specified id</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> TasksList<T>(number task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> TasksList<T>(string task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a GET on /_tasks/{task_id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7504,7 +7504,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="task_id">Return the task with specified id</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> TasksListAsync<T>(number task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null) where T : class;
+		Task<ElasticsearchResponse<T>> TasksListAsync<T>(string task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a GET on /{index}/{type}/_termvectors
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
@@ -3699,7 +3699,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 		///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		ElasticsearchResponse<T> IndicesOptimizeForAll<T>(Func<OptimizeRequestParameters, OptimizeRequestParameters> requestParameters = null) where T : class;
@@ -3711,7 +3711,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 		///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<ElasticsearchResponse<T>> IndicesOptimizeForAllAsync<T>(Func<OptimizeRequestParameters, OptimizeRequestParameters> requestParameters = null) where T : class;
@@ -3723,7 +3723,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -3736,7 +3736,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -3749,7 +3749,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 		///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		ElasticsearchResponse<T> IndicesOptimizeGetForAll<T>(Func<OptimizeRequestParameters, OptimizeRequestParameters> requestParameters = null) where T : class;
@@ -3761,7 +3761,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 		///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<ElasticsearchResponse<T>> IndicesOptimizeGetForAllAsync<T>(Func<OptimizeRequestParameters, OptimizeRequestParameters> requestParameters = null) where T : class;
@@ -3773,7 +3773,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -3786,7 +3786,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -6098,6 +6098,32 @@ namespace Elasticsearch.Net
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<ElasticsearchResponse<T>> PutTemplatePostAsync<T>(string id, PostData<object> body, Func<PutSearchTemplateRequestParameters, PutSearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
+		///<summary>Represents a POST on /_reindex
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+		///</summary>
+		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		ElasticsearchResponse<T> Reindex<T>(PostData<object> body, Func<ReindexRequestParameters, ReindexRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a POST on /_reindex
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+		///</summary>
+		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData<object> body, Func<ReindexRequestParameters, ReindexRequestParameters> requestParameters = null) where T : class;
+		
 		///<summary>Represents a GET on /_render/template
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
 		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
@@ -6421,7 +6447,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -6434,7 +6460,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -6447,7 +6473,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -6461,7 +6487,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
@@ -6475,7 +6501,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6490,7 +6516,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6505,7 +6531,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		ElasticsearchResponse<T> SearchExistsGet<T>(Func<SearchExistsRequestParameters, SearchExistsRequestParameters> requestParameters = null) where T : class;
@@ -6517,7 +6543,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<ElasticsearchResponse<T>> SearchExistsGetAsync<T>(Func<SearchExistsRequestParameters, SearchExistsRequestParameters> requestParameters = null) where T : class;
@@ -6529,7 +6555,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -6542,7 +6568,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -6555,7 +6581,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -6569,7 +6595,7 @@ namespace Elasticsearch.Net
 		///<para> - Stream, no deserialization, response stream is your responsibility </para>
 		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
 		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
-		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html </para>	
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html </para>	
 		///</summary>
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="type">A comma-separated list of types to restrict the results</param>
@@ -7380,6 +7406,106 @@ namespace Elasticsearch.Net
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<ElasticsearchResponse<T>> SuggestGetAsync<T>(string index, Func<SuggestRequestParameters, SuggestRequestParameters> requestParameters = null) where T : class;
 		
+		///<summary>Represents a POST on /_tasks/_cancel
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html </para>	
+		///</summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		ElasticsearchResponse<T> TasksCancel<T>(Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a POST on /_tasks/_cancel
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html </para>	
+		///</summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<ElasticsearchResponse<T>> TasksCancelAsync<T>(Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a POST on /_tasks/{task_id}/_cancel
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html </para>	
+		///</summary>
+		///<param name="task_id">Cancel the task with specified id</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		ElasticsearchResponse<T> TasksCancel<T>(number task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a POST on /_tasks/{task_id}/_cancel
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html </para>	
+		///</summary>
+		///<param name="task_id">Cancel the task with specified id</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<ElasticsearchResponse<T>> TasksCancelAsync<T>(number task_id, Func<TasksCancelRequestParameters, TasksCancelRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a GET on /_tasks
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html </para>	
+		///</summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		ElasticsearchResponse<T> TasksList<T>(Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a GET on /_tasks
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html </para>	
+		///</summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<ElasticsearchResponse<T>> TasksListAsync<T>(Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a GET on /_tasks/{task_id}
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html </para>	
+		///</summary>
+		///<param name="task_id">Return the task with specified id</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		ElasticsearchResponse<T> TasksList<T>(number task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a GET on /_tasks/{task_id}
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html </para>	
+		///</summary>
+		///<param name="task_id">Return the task with specified id</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<ElasticsearchResponse<T>> TasksListAsync<T>(number task_id, Func<TasksListRequestParameters, TasksListRequestParameters> requestParameters = null) where T : class;
+		
 		///<summary>Represents a GET on /{index}/{type}/_termvectors
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
 		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
@@ -7531,6 +7657,64 @@ namespace Elasticsearch.Net
 		///<param name="body">The request definition using either `script` or partial `doc`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<ElasticsearchResponse<T>> UpdateAsync<T>(string index, string type, string id, PostData<object> body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a POST on /{index}/_update_by_query
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="body">The search definition using the Query DSL</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		ElasticsearchResponse<T> UpdateByQuery<T>(string index, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a POST on /{index}/_update_by_query
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="body">The search definition using the Query DSL</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a POST on /{index}/{type}/_update_by_query
+		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
+		///<param name="body">The search definition using the Query DSL</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		ElasticsearchResponse<T> UpdateByQuery<T>(string index, string type, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null) where T : class;
+		
+		///<summary>Represents a POST on /{index}/{type}/_update_by_query
+		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
+		///<para> - T, an object you own that the elasticsearch response will be deserialized to </para>
+		///<para> - byte[], no deserialization, but the response stream will be closed </para>
+		///<para> - Stream, no deserialization, response stream is your responsibility </para>
+		///<para> - VoidResponse, no deserialization, response stream never read and closed </para>
+		///<para> - DynamicDictionary, a dynamic aware dictionary that can be safely traversed to any depth </para>
+		///<para>See also: https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html </para>	
+		///</summary>
+		///<param name="index">A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</param>
+		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
+		///<param name="body">The search definition using the Query DSL</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, string type, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null) where T : class;
 		
 	}
 }

--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -75,7 +75,7 @@ namespace Elasticsearch.Net
 		public bool SuccessOrKnownError =>
 			this.Success || (HttpStatusCode >= 400 && HttpStatusCode < 599
 				&& HttpStatusCode != 503 //service unavailable needs to be retried
-				&& HttpStatusCode != 502 //bad gateway needs to be retried 
+				&& HttpStatusCode != 502 //bad gateway needs to be retried
 			);
 
 		public Exception OriginalException { get; protected internal set; }
@@ -90,7 +90,8 @@ namespace Elasticsearch.Net
 
 		public ElasticsearchResponse(int statusCode, IEnumerable<int> allowedStatusCodes)
 		{
-			this.Success = statusCode >= 200 && statusCode < 300 || allowedStatusCodes.Contains(statusCode);
+			var statusCodes = allowedStatusCodes as int[] ?? allowedStatusCodes.ToArray();
+			this.Success = statusCode >= 200 && statusCode < 300 || statusCodes.Contains(statusCode) || statusCodes.Contains(-1);
 			this.HttpStatusCode = statusCode;
 		}
 

--- a/src/Elasticsearch.Net/Serialization/UrlFormatProvider.cs
+++ b/src/Elasticsearch.Net/Serialization/UrlFormatProvider.cs
@@ -46,12 +46,12 @@ namespace Elasticsearch.Net
 
 			return AttemptTheRightToString(valueType);
 		}
-		
+
 		public string AttemptTheRightToString(object value)
 		{
 			var explicitImplementation = this.QueryStringValueType(value as IUrlParameter);
 			if (explicitImplementation != null) return explicitImplementation;
-			
+
 
 			return value.ToString();
 		}

--- a/src/Nest/Cat/CatNodeAttributes/CatNodeAttributesRequest.cs
+++ b/src/Nest/Cat/CatNodeAttributes/CatNodeAttributesRequest.cs
@@ -12,7 +12,8 @@ namespace Nest
 	[Obsolete("Scheduled to be removed in 5.0.  Use CatNodeAttributesDescriptor instead.")]
 	public partial class CatNodeattrsDescriptor { }
 
-
+	// TODO add the following as attribute when we remove the obsolete version
+	//DescriptorFor "CatNodeattrs"
 	public interface ICatNodeAttributesRequest : ICatNodeattrsRequest { }
 	public class CatNodeAttributesRequest : CatNodeattrsRequest, ICatNodeAttributesRequest { }
 	public class CatNodeAttributesDescriptor : CatNodeattrsDescriptor, ICatNodeAttributesRequest { }

--- a/src/Nest/Cluster/TaskManagement/TasksCancel/ElasticClient-TasksCancel.cs
+++ b/src/Nest/Cluster/TaskManagement/TasksCancel/ElasticClient-TasksCancel.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <summary>
+		/// Does a request to the root of an elasticsearch node
+		/// </summary>
+		/// <param name="selector">A descriptor to further describe the root operation</param>
+		ITasksCancelResponse TasksCancel(Func<TasksCancelDescriptor, ITasksCancelRequest> selector = null);
+
+		/// <inheritdoc/>
+		ITasksCancelResponse TasksCancel(ITasksCancelRequest request);
+
+		/// <inheritdoc/>
+		Task<ITasksCancelResponse> TasksCancelAsync(Func<TasksCancelDescriptor, ITasksCancelRequest> selector = null);
+
+		/// <inheritdoc/>
+		Task<ITasksCancelResponse> TasksCancelAsync(ITasksCancelRequest request);
+	}
+
+	public partial class ElasticClient
+	{
+		/// <inheritdoc/>
+		public ITasksCancelResponse TasksCancel(Func<TasksCancelDescriptor, ITasksCancelRequest> selector = null) =>
+			this.TasksCancel(selector.InvokeOrDefault(new TasksCancelDescriptor()));
+
+		/// <inheritdoc/>
+		public ITasksCancelResponse TasksCancel(ITasksCancelRequest request) =>
+			this.Dispatcher.Dispatch<ITasksCancelRequest, TasksCancelRequestParameters, TasksCancelResponse>(
+				request,
+				(p, d) => this.LowLevelDispatch.TasksCancelDispatch<TasksCancelResponse>(p)
+			);
+
+		/// <inheritdoc/>
+		public Task<ITasksCancelResponse> TasksCancelAsync(Func<TasksCancelDescriptor, ITasksCancelRequest> selector = null) =>
+			this.TasksCancelAsync(selector.InvokeOrDefault(new TasksCancelDescriptor()));
+
+		/// <inheritdoc/>
+		public Task<ITasksCancelResponse> TasksCancelAsync(ITasksCancelRequest request) =>
+			this.Dispatcher.DispatchAsync<ITasksCancelRequest, TasksCancelRequestParameters, TasksCancelResponse, ITasksCancelResponse>(
+				request,
+				(p, d) => this.LowLevelDispatch.TasksCancelDispatchAsync<TasksCancelResponse>(p)
+			);
+	}
+}

--- a/src/Nest/Cluster/TaskManagement/TasksCancel/TasksCancelRequest.cs
+++ b/src/Nest/Cluster/TaskManagement/TasksCancel/TasksCancelRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Nest
+{
+	public partial interface ITasksCancelRequest { }
+
+	public partial class TasksCancelRequest { }
+
+	public partial class TasksCancelDescriptor { }
+}

--- a/src/Nest/Cluster/TaskManagement/TasksCancel/TasksCancelResponse.cs
+++ b/src/Nest/Cluster/TaskManagement/TasksCancel/TasksCancelResponse.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+using System.Linq;
+
+namespace Nest
+{
+	[JsonObject(MemberSerialization.OptIn)]
+	public interface ITasksCancelResponse: IResponse
+	{
+		[JsonProperty("nodes")]
+		IDictionary<string, TaskExecutingNode> Nodes { get; }
+
+		[JsonProperty("node_failures")]
+		IEnumerable<Throwable> NodeFailures { get; }
+	}
+
+	public class TasksCancelResponse : ResponseBase, ITasksCancelResponse
+	{
+		public override bool IsValid => base.IsValid && !this.NodeFailures.HasAny();
+
+		public IDictionary<string, TaskExecutingNode> Nodes { get; internal set; }
+		public IEnumerable<Throwable> NodeFailures { get; internal set; }
+	}
+}

--- a/src/Nest/Cluster/TaskManagement/TasksList/ElasticClient-TasksList.cs
+++ b/src/Nest/Cluster/TaskManagement/TasksList/ElasticClient-TasksList.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <summary>
+		/// Does a request to the root of an elasticsearch node
+		/// </summary>
+		/// <param name="selector">A descriptor to further describe the root operation</param>
+		ITasksListResponse TasksList(Func<TasksListDescriptor, ITasksListRequest> selector = null);
+
+		/// <inheritdoc/>
+		ITasksListResponse TasksList(ITasksListRequest request);
+
+		/// <inheritdoc/>
+		Task<ITasksListResponse> TasksListAsync(Func<TasksListDescriptor, ITasksListRequest> selector = null);
+
+		/// <inheritdoc/>
+		Task<ITasksListResponse> TasksListAsync(ITasksListRequest request);
+	}
+
+	public partial class ElasticClient
+	{
+		/// <inheritdoc/>
+		public ITasksListResponse TasksList(Func<TasksListDescriptor, ITasksListRequest> selector = null) =>
+			this.TasksList(selector.InvokeOrDefault(new TasksListDescriptor()));
+
+		/// <inheritdoc/>
+		public ITasksListResponse TasksList(ITasksListRequest request) =>
+			this.Dispatcher.Dispatch<ITasksListRequest, TasksListRequestParameters, TasksListResponse>(
+				request,
+				(p, d) => this.LowLevelDispatch.TasksListDispatch<TasksListResponse>(p)
+			);
+
+		/// <inheritdoc/>
+		public Task<ITasksListResponse> TasksListAsync(Func<TasksListDescriptor, ITasksListRequest> selector = null) =>
+			this.TasksListAsync(selector.InvokeOrDefault(new TasksListDescriptor()));
+
+		/// <inheritdoc/>
+		public Task<ITasksListResponse> TasksListAsync(ITasksListRequest request) =>
+			this.Dispatcher.DispatchAsync<ITasksListRequest, TasksListRequestParameters, TasksListResponse, ITasksListResponse>(
+				request,
+				(p, d) => this.LowLevelDispatch.TasksListDispatchAsync<TasksListResponse>(p)
+			);
+	}
+}

--- a/src/Nest/Cluster/TaskManagement/TasksList/TasksListRequest.cs
+++ b/src/Nest/Cluster/TaskManagement/TasksList/TasksListRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Nest
+{
+	public partial interface ITasksListRequest { }
+
+	public partial class TasksListRequest { }
+
+	public partial class TasksListDescriptor { }
+}

--- a/src/Nest/Cluster/TaskManagement/TasksList/TasksListResponse.cs
+++ b/src/Nest/Cluster/TaskManagement/TasksList/TasksListResponse.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+using System.Linq;
+
+namespace Nest
+{
+	[JsonObject(MemberSerialization.OptIn)]
+	public interface ITasksListResponse: IResponse
+	{
+		[JsonProperty("nodes")]
+		IDictionary<string, TaskExecutingNode> Nodes { get; }
+
+		[JsonProperty("node_failures")]
+		IEnumerable<Throwable> NodeFailures { get; }
+
+	}
+
+	public class TasksListResponse : ResponseBase, ITasksListResponse
+	{
+		public override bool IsValid => base.IsValid && !this.NodeFailures.HasAny();
+
+		public IDictionary<string, TaskExecutingNode> Nodes { get; internal set; }
+		public IEnumerable<Throwable> NodeFailures { get; internal set; }
+	}
+
+
+	public class TaskExecutingNode
+	{
+		[JsonProperty("name")]
+		public string Name { get; internal set; }
+
+		[JsonProperty("transport_address")]
+		public string TransportAddress { get; internal set; }
+
+		[JsonProperty("host")]
+		public string Host { get; internal set; }
+
+		[JsonProperty("ip")]
+		public string Ip { get; internal set; }
+
+		[JsonProperty("tasks")]
+		public IDictionary<TaskId, TaskState> Tasks { get; internal set; }
+	}
+
+	public class TaskState
+	{
+		[JsonProperty("node")]
+		public string Node { get; internal set; }
+
+		[JsonProperty("id")]
+		public long Id { get; internal set; }
+
+		[JsonProperty("type")]
+		public string Type { get; internal set; }
+
+		[JsonProperty("action")]
+		public string Action { get; internal set; }
+
+		[JsonProperty("start_time_in_millis")]
+		public long StartTimeInMilliseconds { get; internal set; }
+
+		[JsonProperty("running_time_in_nanos")]
+		public long RunningTimeInNanoSeconds { get; internal set; }
+
+		[JsonProperty("parent_task_id")]
+		public TaskId ParentTaskId { get; internal set; }
+
+	}
+}

--- a/src/Nest/CommonAbstractions/CoordinatedRequestObserverBase.cs
+++ b/src/Nest/CommonAbstractions/CoordinatedRequestObserverBase.cs
@@ -8,7 +8,7 @@ namespace Nest
 		private readonly Action<Exception> _onError;
 		private readonly Action _completed;
 
-	    protected CoordinatedRequestObserverBase(Action<T> onNext = null, Action<Exception> onError = null, Action completed = null)
+		protected CoordinatedRequestObserverBase(Action<T> onNext = null, Action<Exception> onError = null, Action completed = null)
 		{
 			_onNext = onNext;
 			_onError = onError;
@@ -17,17 +17,17 @@ namespace Nest
 
 		public void OnNext(T value)
 		{
-		    this._onNext?.Invoke(value);
+			this._onNext?.Invoke(value);
 		}
 
-	    public void OnError(Exception error)
-	    {
-	        this._onError?.Invoke(error);
-	    }
+		public void OnError(Exception error)
+		{
+			this._onError?.Invoke(error);
+		}
 
-	    public void OnCompleted()
-	    {
-	        this._completed?.Invoke();
-	    }
+		public void OnCompleted()
+		{
+			this._completed?.Invoke();
+		}
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/TaskId/TaskId.cs
+++ b/src/Nest/CommonAbstractions/Infer/TaskId/TaskId.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Globalization;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public class TaskId : IUrlParameter, IEquatable<TaskId>
+	{
+
+		public string NodeId { get; }
+		public long TaskNumber { get; }
+		public string FullyQualifiedId => $"{NodeId}:{TaskNumber.ToString(CultureInfo.InvariantCulture)}";
+
+		/// <summary>
+		/// A task id exists in the form <node_id>:<task_id>
+		/// </summary>
+		/// <param name="taskId"></param>
+		public TaskId(string taskId)
+		{
+			if (string.IsNullOrWhiteSpace(taskId))
+				throw new ArgumentException("TaskId can not be an empty string", nameof(taskId));
+
+			var tokens = taskId.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+			if (tokens.Length != 2)
+				throw new ArgumentException($"TaskId:{taskId} not in expected format of <node_id>:<task_id>", nameof(taskId));
+
+			this.NodeId = tokens[0];
+			long t;
+			if (!long.TryParse(tokens[1], NumberStyles.Any, CultureInfo.InvariantCulture, out t) || t < -1 || t == 0)
+				throw new ArgumentException($"TaskId task component:{tokens[1]} could not be parsed to long or is out of range", nameof(taskId));
+			this.TaskNumber = t;
+		}
+
+		public override string ToString() => FullyQualifiedId;
+
+		public string GetString(IConnectionConfigurationValues settings) => FullyQualifiedId;
+
+		public static implicit operator TaskId(string taskId) => new TaskId(taskId);
+
+		public bool Equals(TaskId other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+			return string.Equals(NodeId, other.NodeId) && TaskNumber == other.TaskNumber;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((TaskId) obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return (NodeId.GetHashCode()*397) ^ TaskNumber.GetHashCode();
+			}
+		}
+
+		public static bool operator ==(TaskId left, TaskId right) => Equals(left, right);
+
+		public static bool operator !=(TaskId left, TaskId right) => !Equals(left, right);
+	}
+}

--- a/src/Nest/CommonAbstractions/Request/RouteValues.cs
+++ b/src/Nest/CommonAbstractions/Request/RouteValues.cs
@@ -24,6 +24,7 @@ namespace Nest
 		public string Metric => GetResolved("metric");
 		public string IndexMetric => GetResolved("index_metric");
 		public string Lang => GetResolved("lang");
+		public string TaskId => GetResolved("task_id");
 
 		private string GetResolved(string route)
 		{
@@ -68,6 +69,6 @@ namespace Nest
 		{
 			this._resolved.Remove(route);
 			this._routeValues.Remove(route);
-		}	
+		}
 	}
 }

--- a/src/Nest/CommonOptions/Failures/Throwable.cs
+++ b/src/Nest/CommonOptions/Failures/Throwable.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	[JsonObject]
+	public class Throwable
+	{
+		[JsonProperty("type")]
+		public string Type { get; internal set; }
+
+		[JsonProperty("reason")]
+		public string Reason { get; internal set; }
+
+		[JsonProperty("caused_by")]
+		public Throwable CausedBy { get; internal set; }
+	}
+}

--- a/src/Nest/Document/Multiple/BulkIndexByScrollFailure.cs
+++ b/src/Nest/Document/Multiple/BulkIndexByScrollFailure.cs
@@ -1,0 +1,39 @@
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	// ReindexOnServer and UpdateByQuery aggregate failures under a single failures property
+	// So the shape is a bit odd
+	// https://github.com/elastic/elasticsearch/issues/17539
+	// We could come up with abstractions and normalization here but we should fix this at the root for 5.0
+
+	[JsonObject]
+	public class BulkIndexByScrollFailure
+	{
+		[JsonProperty("index")]
+		public string Index { get; internal set; }
+
+		[JsonProperty("type")]
+		public string Type { get; internal set; }
+
+		[JsonProperty("id")]
+		public string Id { get; internal set; }
+
+		[JsonProperty("node")]
+		public string Node { get; internal set; }
+
+		[JsonProperty("shard")]
+		public int Shard { get; internal set; }
+
+		[JsonProperty("status")]
+		public int Status { get; internal set; }
+
+		[JsonProperty("cause")]
+		public Throwable Cause { get; internal set; }
+
+		[JsonProperty("reason")]
+		public Throwable Reason { get; internal set; }
+
+
+	}
+}

--- a/src/Nest/Document/Multiple/Reindex/ElasticClient-Reindex.cs
+++ b/src/Nest/Document/Multiple/Reindex/ElasticClient-Reindex.cs
@@ -4,44 +4,44 @@ namespace Nest
 {
 	public partial interface IElasticClient
 	{
-        /// <summary>
-        /// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
-        /// </summary>
-        /// <param name="from">the index that documents will be reindexed from</param>
-        /// <param name="to">the index that documents will be reindexed to</param>
-        /// <param name="selector">the descriptor to describe the reindex operation</param>
-        /// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
-        IObservable<IReindexResponse<T>> Reindex<T>(IndexName from, IndexName to, Func<ReindexDescriptor<T>, IReindexRequest> selector = null)
+		/// <summary>
+		/// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
+		/// </summary>
+		/// <param name="from">the index that documents will be reindexed from</param>
+		/// <param name="to">the index that documents will be reindexed to</param>
+		/// <param name="selector">the descriptor to describe the reindex operation</param>
+		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		IObservable<IReindexResponse<T>> Reindex<T>(IndexName from, IndexName to, Func<ReindexDescriptor<T>, IReindexRequest> selector = null)
 			where T : class;
 
-        /// <summary>
-        /// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
-        /// </summary>
-        /// <param name="request">a request object to describe the reindex operation</param>
-        /// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
-        IObservable<IReindexResponse<T>> Reindex<T>(IReindexRequest request) where T : class;
+		/// <summary>
+		/// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
+		/// </summary>
+		/// <param name="request">a request object to describe the reindex operation</param>
+		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		IObservable<IReindexResponse<T>> Reindex<T>(IReindexRequest request) where T : class;
 	}
 
 	public partial class ElasticClient
 	{
-        /// <summary>
-        /// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
-        /// </summary>
-        /// <param name="from">the index that documents will be reindexed from</param>
-        /// <param name="to">the index that documents will be reindexed to</param>
-        /// <param name="selector">the descriptor to describe the reindex operation</param>
-        /// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
-        public IObservable<IReindexResponse<T>> Reindex<T>(IndexName from, IndexName to, Func<ReindexDescriptor<T>, IReindexRequest> selector = null)
-			where T : class => 
+		/// <summary>
+		/// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
+		/// </summary>
+		/// <param name="from">the index that documents will be reindexed from</param>
+		/// <param name="to">the index that documents will be reindexed to</param>
+		/// <param name="selector">the descriptor to describe the reindex operation</param>
+		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		public IObservable<IReindexResponse<T>> Reindex<T>(IndexName from, IndexName to, Func<ReindexDescriptor<T>, IReindexRequest> selector = null)
+			where T : class =>
 			this.Reindex<T>(selector.InvokeOrDefault(new ReindexDescriptor<T>(from, to)));
 
-        /// <summary>
-        /// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
-        /// </summary>
-        /// <param name="request">a request object to describe the reindex operation</param>
-        /// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
-        public IObservable<IReindexResponse<T>> Reindex<T>(IReindexRequest request)
-			where T : class => 
+		/// <summary>
+		/// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
+		/// </summary>
+		/// <param name="request">a request object to describe the reindex operation</param>
+		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		public IObservable<IReindexResponse<T>> Reindex<T>(IReindexRequest request)
+			where T : class =>
 			new ReindexObservable<T>(this, ConnectionSettings, request);
 	}
 }

--- a/src/Nest/Document/Multiple/ReindexOnServer/ElasticClient-ReindexOnServer.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ElasticClient-ReindexOnServer.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using System.IO;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <inheritdoc/>
+		IReindexOnServerResponse ReindexOnServer(Func<ReindexOnServerDescriptor, IReindexOnServerRequest> selector);
+
+		/// <inheritdoc/>
+		IReindexOnServerResponse ReindexOnServer(IReindexOnServerRequest request);
+
+		/// <inheritdoc/>
+		Task<IReindexOnServerResponse> ReindexOnServerAsync(Func<ReindexOnServerDescriptor, IReindexOnServerRequest> selector);
+
+		/// <inheritdoc/>
+		Task<IReindexOnServerResponse> ReindexOnServerAsync(IReindexOnServerRequest request);
+
+	}
+
+	public partial class ElasticClient
+	{
+		/// <inheritdoc/>
+		public IReindexOnServerResponse ReindexOnServer(Func<ReindexOnServerDescriptor, IReindexOnServerRequest> selector) =>
+			this.ReindexOnServer(selector.InvokeOrDefault(new ReindexOnServerDescriptor()));
+
+		/// <inheritdoc/>
+		public IReindexOnServerResponse ReindexOnServer(IReindexOnServerRequest request) =>
+			this.Dispatcher.Dispatch<IReindexOnServerRequest, ReindexOnServerRequestParameters, ReindexOnServerResponse>(
+				request,
+				this.LowLevelDispatch.ReindexDispatch<ReindexOnServerResponse>
+			);
+
+		/// <inheritdoc/>
+		public Task<IReindexOnServerResponse> ReindexOnServerAsync(Func<ReindexOnServerDescriptor, IReindexOnServerRequest> selector) =>
+			this.ReindexOnServerAsync(selector.InvokeOrDefault(new ReindexOnServerDescriptor()));
+
+		/// <inheritdoc/>
+		public Task<IReindexOnServerResponse> ReindexOnServerAsync(IReindexOnServerRequest request) =>
+			this.Dispatcher.DispatchAsync<IReindexOnServerRequest, ReindexOnServerRequestParameters, ReindexOnServerResponse, IReindexOnServerResponse>(
+				request,
+				this.LowLevelDispatch.ReindexDispatchAsync<ReindexOnServerResponse>
+			);
+	}
+}

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexDestination.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexDestination.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Elasticsearch.Net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Nest
+{
+	public interface IReindexDestination
+	{
+		[JsonProperty("index")]
+		IndexName Index { get; set; }
+
+		[JsonProperty("type")]
+		TypeName Type { get; set; }
+
+		[JsonProperty("routing")]
+		ReindexRouting Routing { get; set; }
+
+		[JsonProperty("op_type")]
+		[JsonConverter(typeof(StringEnumConverter))]
+		OpType? OpType { get; set; }
+
+		[JsonProperty("version_type")]
+		[JsonConverter(typeof(StringEnumConverter))]
+		VersionType? VersionType { get; set; }
+	}
+
+	public class ReindexDestination : IReindexDestination
+	{
+		public IndexName Index { get; set; }
+
+		public TypeName Type { get; set; }
+
+
+		public ReindexRouting Routing { get; set; }
+
+		public OpType? OpType { get; set; }
+
+		public VersionType? VersionType { get; set; }
+	}
+
+	public class ReindexDestinationDescriptor : DescriptorBase<ReindexDestinationDescriptor, IReindexDestination>, IReindexDestination
+	{
+		IndexName IReindexDestination.Index { get; set; }
+		TypeName IReindexDestination.Type { get; set; }
+		ReindexRouting IReindexDestination.Routing { get; set; }
+		OpType? IReindexDestination.OpType { get; set; }
+		VersionType? IReindexDestination.VersionType { get; set; }
+
+		public ReindexDestinationDescriptor Routing(ReindexRouting routing) => Assign(a => a.Routing = routing);
+
+		public ReindexDestinationDescriptor OpType(OpType opType) => Assign(a => a.OpType = opType);
+
+		public ReindexDestinationDescriptor VersionType(VersionType versionType) => Assign(a => a.VersionType = versionType);
+
+		public ReindexDestinationDescriptor Index(IndexName index) => Assign(a => a.Index = index);
+
+		public ReindexDestinationDescriptor Type(TypeName type) => Assign(a => a.Type = type);
+
+	}
+}

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerRequest.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerRequest.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.CodeDom;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	public partial interface IReindexOnServerRequest
+	{
+		[JsonProperty("source")]
+		IReindexSource Source { get; set; }
+
+		[JsonProperty("dest")]
+		IReindexDestination Destination { get; set; }
+
+		[JsonProperty("script")]
+		IScript Script { get; set; }
+
+		[JsonProperty("size")]
+		long? Size { get; set; }
+	}
+
+	public partial class ReindexOnServerRequest
+	{
+		public IReindexSource Source { get; set; }
+		public IReindexDestination Destination { get; set; }
+		public IScript Script { get; set; }
+		public long? Size { get; set; }
+	}
+
+	[DescriptorFor("Reindex")]
+	public partial class ReindexOnServerDescriptor
+	{
+		IReindexSource IReindexOnServerRequest.Source { get; set; }
+		IReindexDestination IReindexOnServerRequest.Destination { get; set; }
+		IScript IReindexOnServerRequest.Script { get; set; }
+		long? IReindexOnServerRequest.Size { get; set; }
+
+		public ReindexOnServerDescriptor Source(Func<ReindexSourceDescriptor, IReindexSource> selector = null) =>
+			Assign(a => a.Source = selector.InvokeOrDefault(new ReindexSourceDescriptor()));
+
+		public ReindexOnServerDescriptor Destination(Func<ReindexDestinationDescriptor, IReindexDestination> selector) =>
+			Assign(a => a.Destination = selector?.Invoke(new ReindexDestinationDescriptor()));
+
+		public ReindexOnServerDescriptor Script(string script) => Assign(a => a.Script = (InlineScript)script);
+
+		public ReindexOnServerDescriptor Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
+			Assign(a => a.Script = scriptSelector?.Invoke(new ScriptDescriptor()));
+
+		public ReindexOnServerDescriptor Size(long? size) => Assign(a => a.Size = size);
+	}
+}

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerResponse.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerResponse.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+using System.Linq;
+
+namespace Nest
+{
+	public interface IReindexOnServerResponse : IResponse
+	{
+		//https://github.com/elastic/elasticsearch/commit/11f90bffda50f0acc8dc1409f3f33005e1249234
+		// 2.3 released this writing the time value's to string e.g 123.4ms instead of long as all the others took responses
+		[JsonProperty("took")]
+		Time Took { get; }
+
+		/// <summary>
+		/// Only has a value if WaitForCompletion is set to false on the request
+		/// </summary>
+		[JsonProperty("task")]
+		TaskId Task { get; }
+
+		[JsonProperty("timed_out")]
+		bool TimedOut { get; }
+
+		[JsonProperty("total")]
+		long Total { get; }
+
+		[JsonProperty("created")]
+		long Created { get; }
+
+		[JsonProperty("updated")]
+		long Updated { get; }
+
+		[JsonProperty("batches")]
+		long Batches { get; }
+
+		[JsonProperty("version_conflicts")]
+		long VersionConflicts { get; }
+
+		[JsonProperty("noops")]
+		long Noops { get; }
+
+		[JsonProperty("retries")]
+		long Retries { get; }
+
+		[JsonProperty("failures")]
+		IEnumerable<BulkIndexByScrollFailure> Failures { get; }
+	}
+
+	[JsonObject(MemberSerialization.OptIn)]
+	public class ReindexOnServerResponse : ResponseBase, IReindexOnServerResponse
+	{
+
+		public override bool IsValid => !this.Failures.HasAny();
+
+		public Time Took { get; internal set; }
+
+		/// <summary>
+		/// Only has a value if WaitForCompletion is set to false on the request
+		/// </summary>
+		public TaskId Task { get; internal set; }
+
+		public bool TimedOut { get; internal set; }
+
+		public long Total { get; internal set; }
+
+		public long Created { get; internal set; }
+
+		public long Updated { get; internal set; }
+
+		public long Batches { get; internal set; }
+
+		public long VersionConflicts { get; internal set; }
+
+		public long Noops { get; internal set; }
+
+		public long Retries { get; internal set; }
+
+		public IEnumerable<BulkIndexByScrollFailure> Failures { get; internal set; }
+	}
+}

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexRouting.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexRouting.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ServiceModel.Security;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	[JsonConverter(typeof(ReindexRoutingJsonConverter))]
+	public class ReindexRouting
+	{
+		private readonly string _newRoutingValue;
+		public static ReindexRouting Keep = new ReindexRouting("keep", true);
+		public static ReindexRouting Discard = new ReindexRouting("discard", true);
+
+		/// <summary>
+		/// Use ReindexRouting.Keep or ReindexRouting.Discard if you want to sent "keep" or "discard", this
+		/// constructor always sends <param name="newRoutingValue" /> prefixed with '='
+		/// </summary>
+		/// <param name="newRoutingValue"></param>
+		public ReindexRouting(string newRoutingValue) : this(newRoutingValue, false) { }
+
+		private ReindexRouting(string newRoutingValue, bool noPrefix)
+		{
+			var routing = newRoutingValue.TrimStart('=');
+			var prefix = noPrefix ? "" : "=";
+			_newRoutingValue = $"{prefix}{routing}";
+		}
+
+		public static implicit operator ReindexRouting(string routing) => new ReindexRouting(routing);
+
+		public override string ToString() => _newRoutingValue;
+	}
+
+	public class ReindexRoutingJsonConverter : JsonConverter
+	{
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var v = value as ReindexRouting;
+			if (v == null) writer.WriteNull();
+			else writer.WriteValue(v.ToString());
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var s = reader.ReadAsString();
+			switch(s)
+			{
+				case "keep": return ReindexRouting.Keep;
+				case "discard": return ReindexRouting.Discard;
+				default: return new ReindexRouting(s);
+			}
+		}
+
+		public override bool CanConvert(Type objectType) => true;
+	}
+}

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexSource.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexSource.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	public interface IReindexSource
+	{
+		[JsonProperty("query")]
+		QueryContainer Query { get; set; }
+
+		[JsonProperty("sort")]
+		IList<ISort> Sort { get; set; }
+
+		[JsonProperty("index")]
+		Indices Index { get; set; }
+
+		[JsonProperty("type")]
+		Types Type { get; set; }
+	}
+
+	public class ReindexSource : IReindexSource
+	{
+		public QueryContainer Query { get; set; }
+
+		public IList<ISort> Sort { get; set; }
+
+		public Indices Index { get; set; }
+
+		public Types Type { get; set; }
+	}
+
+	public class ReindexSourceDescriptor : DescriptorBase<ReindexSourceDescriptor, IReindexSource>, IReindexSource
+	{
+		QueryContainer IReindexSource.Query { get; set; }
+		IList<ISort> IReindexSource.Sort { get; set; }
+		Indices IReindexSource.Index { get; set; }
+		Types IReindexSource.Type { get; set; }
+
+		public ReindexSourceDescriptor Query<T>(Func<QueryContainerDescriptor<T>, QueryContainer> querySelector) where T : class =>
+			Assign(a => a.Query = querySelector?.InvokeQuery(new QueryContainerDescriptor<T>()));
+
+		public ReindexSourceDescriptor Sort<T>(Func<SortDescriptor<T>, IPromise<IList<ISort>>> selector) where T : class =>
+			Assign(a => a.Sort = selector?.Invoke(new SortDescriptor<T>())?.Value);
+
+		public ReindexSourceDescriptor Index(Indices indices) => Assign(a => a.Index = indices);
+
+		public ReindexSourceDescriptor Type(Types types) => Assign(a => a.Type = types);
+
+	}
+}

--- a/src/Nest/Document/Multiple/UpdateByQuery/ElasticClient-UpdateByQuery.cs
+++ b/src/Nest/Document/Multiple/UpdateByQuery/ElasticClient-UpdateByQuery.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <summary>
+		/// The delete by query API allows to delete documents from one or more indices and one or more types based on a query.
+		/// <para> </para><a href="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
+		/// </summary>
+		/// <typeparam name="T">The type used to infer the default index and typename as well as describe the strongly
+		///  typed parts of the query</typeparam>
+		/// <param name="selector">An optional descriptor to further describe the delete by query operation</param>
+		IUpdateByQueryResponse UpdateByQuery<T>(Indices indices, Types types, Func<UpdateByQueryDescriptor<T>, IUpdateByQueryRequest> selector)
+			where T : class;
+
+		/// <inheritdoc/>
+		IUpdateByQueryResponse UpdateByQuery(IUpdateByQueryRequest request);
+
+		/// <inheritdoc/>
+		Task<IUpdateByQueryResponse> UpdateByQueryAsync<T>(Indices indices, Types types, Func<UpdateByQueryDescriptor<T>, IUpdateByQueryRequest> selector)
+			where T : class;
+
+		/// <inheritdoc/>
+		Task<IUpdateByQueryResponse> UpdateByQueryAsync(IUpdateByQueryRequest request);
+
+	}
+
+	public partial class ElasticClient
+	{
+		/// <inheritdoc/>
+		public IUpdateByQueryResponse UpdateByQuery<T>(Indices indices, Types types, Func<UpdateByQueryDescriptor<T>, IUpdateByQueryRequest> selector) where T : class =>
+			this.UpdateByQuery(selector?.Invoke(new UpdateByQueryDescriptor<T>(indices).Type(types)));
+
+		/// <inheritdoc/>
+		public IUpdateByQueryResponse UpdateByQuery(IUpdateByQueryRequest request) =>
+			this.Dispatcher.Dispatch<IUpdateByQueryRequest, UpdateByQueryRequestParameters, UpdateByQueryResponse>(
+				request,
+				(p,d) => {
+					p.RequestParameters.RequestConfiguration(f => f.AllowedStatusCodes(-1));
+					return this.LowLevelDispatch.UpdateByQueryDispatch<UpdateByQueryResponse>(p, d);
+				}
+			);
+
+		/// <inheritdoc/>
+		public Task<IUpdateByQueryResponse> UpdateByQueryAsync<T>(Indices indices, Types types, Func<UpdateByQueryDescriptor<T>, IUpdateByQueryRequest> selector) where T : class =>
+			this.UpdateByQueryAsync(selector?.Invoke(new UpdateByQueryDescriptor<T>(indices).Type(types)));
+
+		/// <inheritdoc/>
+		public Task<IUpdateByQueryResponse> UpdateByQueryAsync(IUpdateByQueryRequest request) =>
+			this.Dispatcher.DispatchAsync<IUpdateByQueryRequest, UpdateByQueryRequestParameters, UpdateByQueryResponse, IUpdateByQueryResponse>(
+				request,
+				(p,d) => {
+					p.RequestParameters.RequestConfiguration(f => f.AllowedStatusCodes(-1));
+					return this.LowLevelDispatch.UpdateByQueryDispatchAsync<UpdateByQueryResponse>(p, d);
+				}
+			);
+	}
+}

--- a/src/Nest/Document/Multiple/UpdateByQuery/UpdateByQueryRequest.cs
+++ b/src/Nest/Document/Multiple/UpdateByQuery/UpdateByQueryRequest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	public partial interface IUpdateByQueryRequest
+	{
+		[JsonProperty("query")]
+		QueryContainer Query { get; set; }
+
+		[JsonProperty("script")]
+		IScript Script { get; set; }
+	}
+
+	public interface IUpdateByQueryRequest<T> : IUpdateByQueryRequest where T : class { }
+
+	public partial class UpdateByQueryRequest
+	{
+		public QueryContainer Query { get; set; }
+		public IScript Script { get; set; }
+
+	}
+
+	public partial class UpdateByQueryRequest<T> : IUpdateByQueryRequest<T>
+		where T : class
+	{
+		public QueryContainer Query { get; set; }
+		public IScript Script { get; set; }
+	}
+
+	public partial class UpdateByQueryDescriptor<T> : IUpdateByQueryRequest<T>
+		where T : class
+	{
+		QueryContainer IUpdateByQueryRequest.Query { get; set; }
+		IScript IUpdateByQueryRequest.Script { get; set; }
+
+		public UpdateByQueryDescriptor<T> MatchAll() => Assign(a => a.Query = new QueryContainerDescriptor<T>().MatchAll());
+
+		public UpdateByQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> querySelector) =>
+			Assign(a => a.Query = querySelector?.InvokeQuery(new QueryContainerDescriptor<T>()));
+
+		public UpdateByQueryDescriptor<T> Script(string script) => Assign(a => a.Script = (InlineScript)script);
+
+		public UpdateByQueryDescriptor<T> Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
+			Assign(a => a.Script = scriptSelector?.Invoke(new ScriptDescriptor()));
+
+	}
+}

--- a/src/Nest/Document/Multiple/UpdateByQuery/UpdateByQueryResponse.cs
+++ b/src/Nest/Document/Multiple/UpdateByQuery/UpdateByQueryResponse.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	public interface IUpdateByQueryResponse : IResponse
+	{
+		[JsonProperty("took")]
+		long Took { get; }
+
+		/// <summary>
+		/// Only has a value if WaitForCompletion is set to false on the request
+		/// </summary>
+		[JsonProperty("task")]
+		TaskId Task { get; }
+
+		[JsonProperty("timed_out")]
+		bool TimedOut { get; }
+
+		[JsonProperty("total")]
+		long Total { get; }
+
+		[JsonProperty("updated")]
+		long Updated { get; }
+
+		[JsonProperty("batches")]
+		long Batches { get; }
+
+		[JsonProperty("version_conflicts")]
+		long VersionConflicts { get; }
+
+		[JsonProperty("noops")]
+		long Noops { get; }
+
+		[JsonProperty("retries")]
+		long Retries { get; }
+
+		[JsonProperty("failures")]
+		IEnumerable<BulkIndexByScrollFailure> Failures { get; }
+	}
+
+	public class UpdateByQueryResponse : ResponseBase, IUpdateByQueryResponse
+	{
+		public override bool IsValid => this.ApiCall?.HttpStatusCode == 200 || !this.Failures.HasAny();
+
+		public long Took { get; internal set; }
+
+		/// <summary>
+		/// Only has a value if WaitForCompletion is set to false on the request
+		/// </summary>
+		public TaskId Task { get; internal set; }
+
+		public bool TimedOut { get; internal set; }
+
+		public long Total { get; internal set; }
+
+		public long Updated { get; internal set; }
+
+		public long Batches { get; internal set; }
+
+		public long VersionConflicts { get; internal set; }
+
+		public long Noops { get; internal set; }
+
+		public long Retries { get; internal set; }
+
+		public IEnumerable<BulkIndexByScrollFailure> Failures { get; internal set; }
+	}
+}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -158,7 +158,7 @@
     <Compile Include="Aggregations\Pipeline\MovingAverage\MovingAverageAggregation.cs" />
     <Compile Include="Aggregations\Pipeline\MovingAverage\MovingAverageAggregationJsonConverter.cs" />
     <Compile Include="Aggregations\Pipeline\PipelineAggregationBase.cs" />
-    <Compile Include="Aggregations\Pipeline\SerialDifferencing\SerialDifferencingAggregation.cs" />    
+    <Compile Include="Aggregations\Pipeline\SerialDifferencing\SerialDifferencingAggregation.cs" />
     <Compile Include="Aggregations\Pipeline\SumBucket\SumBucketAggregation.cs" />
     <Compile Include="Aggregations\Visitor\AggregationVisitor.cs" />
     <Compile Include="Aggregations\Visitor\AggregationVisitorScope.cs" />
@@ -360,6 +360,12 @@
     <Compile Include="Cluster\RootNodeInfo\ElasticClient-RootNodeInfo.cs" />
     <Compile Include="Cluster\RootNodeInfo\RootNodeInfoRequest.cs" />
     <Compile Include="Cluster\RootNodeInfo\RootVersionInfoResponse.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksCancel\ElasticClient-TasksCancel.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksCancel\TasksCancelRequest.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksCancel\TasksCancelResponse.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksList\ElasticClient-TasksList.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksList\TasksListRequest.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksList\TasksListResponse.cs" />
     <Compile Include="CommonAbstractions\ConnectionSettings\ClrTypeMapping.cs" />
     <Compile Include="CommonAbstractions\ConnectionSettings\ConnectionSettingsBase.cs" />
     <Compile Include="CommonAbstractions\ConnectionSettings\IConnectionSettingsValues.cs" />
@@ -413,6 +419,7 @@
     <Compile Include="CommonAbstractions\Infer\PropertyName\PropertyName.cs" />
     <Compile Include="CommonAbstractions\Infer\PropertyName\PropertyNameExtensions.cs" />
     <Compile Include="CommonAbstractions\Infer\PropertyName\PropertyNameJsonConverter.cs" />
+    <Compile Include="CommonAbstractions\Infer\TaskId\TaskId.cs" />
     <Compile Include="CommonAbstractions\Infer\TypeName\TypeName.cs" />
     <Compile Include="CommonAbstractions\Infer\TypeName\TypeNameExtensions.cs" />
     <Compile Include="CommonAbstractions\Infer\TypeName\TypeNameJsonConverter.cs" />
@@ -457,7 +464,9 @@
     <Compile Include="CommonOptions\DateMath\DateMathExpression.cs" />
     <Compile Include="CommonOptions\DateMath\DateMathOperation.cs" />
     <Compile Include="CommonOptions\Failures\BulkError.cs" />
+    <Compile Include="Document\Multiple\BulkIndexByScrollFailure.cs" />
     <Compile Include="CommonOptions\Failures\ShardFailure.cs" />
+    <Compile Include="CommonOptions\Failures\Throwable.cs" />
     <Compile Include="CommonOptions\Fuzziness\Fuzziness.cs" />
     <Compile Include="CommonOptions\Fuzziness\FuzzinessJsonConverter.cs" />
     <Compile Include="CommonOptions\Fuzziness\IFuzziness.cs" />
@@ -520,6 +529,12 @@
     <Compile Include="Document\Multiple\Bulk\ElasticClient-Bulk.cs" />
     <Compile Include="Document\Multiple\Bulk\ElasticClient-DeleteMany.cs" />
     <Compile Include="Document\Multiple\Bulk\ElasticClient-IndexMany.cs" />
+    <Compile Include="Document\Multiple\ReindexOnServer\ReindexDestination.cs" />
+    <Compile Include="Document\Multiple\ReindexOnServer\ReindexRouting.cs" />
+    <Compile Include="Document\Multiple\ReindexOnServer\ReindexSource.cs" />
+    <Compile Include="Document\Multiple\UpdateByQuery\UpdateByQueryRequest.cs" />
+    <Compile Include="Document\Multiple\UpdateByQuery\UpdateByQueryResponse.cs" />
+    <Compile Include="Document\Multiple\UpdateByQuery\ElasticClient-UpdateByQuery.cs" />
     <Compile Include="Document\Multiple\DeleteByQuery\DeleteByQueryRequest.cs" />
     <Compile Include="Document\Multiple\DeleteByQuery\DeleteByQueryResponse.cs" />
     <Compile Include="Document\Multiple\DeleteByQuery\ElasticClient-DeleteByQuery.cs" />
@@ -537,6 +552,9 @@
     <Compile Include="Document\Multiple\MultiTermVectors\MultiTermVectorOperation.cs" />
     <Compile Include="Document\Multiple\MultiTermVectors\MultiTermVectorsRequest.cs" />
     <Compile Include="Document\Multiple\MultiTermVectors\MultiTermVectorsResponse.cs" />
+    <Compile Include="Document\Multiple\ReindexOnServer\ElasticClient-ReindexOnServer.cs" />
+    <Compile Include="Document\Multiple\ReindexOnServer\ReindexOnServerResponse.cs" />
+    <Compile Include="Document\Multiple\ReindexOnServer\ReindexOnServerRequest.cs" />
     <Compile Include="Document\Multiple\Reindex\ElasticClient-Reindex.cs" />
     <Compile Include="Document\Multiple\Reindex\ReindexObservable.cs" />
     <Compile Include="Document\Multiple\Reindex\ReindexObserver.cs" />
@@ -1198,6 +1216,7 @@
   <ItemGroup>
     <None Include="paket.references" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Nest/_Generated/_Descriptors.generated.cs
+++ b/src/Nest/_Generated/_Descriptors.generated.cs
@@ -3823,26 +3823,23 @@ namespace Nest
 	}
 	
 	///<summary>descriptor for Reindex <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
-	public partial class ReindexDescriptor<T>  : RequestDescriptorBase<ReindexDescriptor<T>,ReindexRequestParameters, IReindexRequest>, IReindexRequest
+	public partial class ReindexOnServerDescriptor  : RequestDescriptorBase<ReindexOnServerDescriptor,ReindexOnServerRequestParameters, IReindexOnServerRequest>, IReindexOnServerRequest
 	{ 
 			
 		///<summary>Should the effected indexes be refreshed?</summary>
-		public ReindexDescriptor<T> Refresh(bool refresh = true) => AssignParam(p=>p.Refresh(refresh));
+		public ReindexOnServerDescriptor Refresh(bool refresh = true) => AssignParam(p=>p.Refresh(refresh));
 
 		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
-		public ReindexDescriptor<T> Timeout(Time timeout) => AssignParam(p=>p.Timeout(timeout.ToTimeSpan()));
+		public ReindexOnServerDescriptor Timeout(Time timeout) => AssignParam(p=>p.Timeout(timeout.ToTimeSpan()));
 
 		///<summary>Explicit write consistency setting for the operation</summary>
-		public ReindexDescriptor<T> Consistency(Consistency consistency) => AssignParam(p=>p.Consistency(consistency));
+		public ReindexOnServerDescriptor Consistency(Consistency consistency) => AssignParam(p=>p.Consistency(consistency));
 
 		///<summary>Should the request should block until the reindex is complete.</summary>
-		public ReindexDescriptor<T> WaitForCompletion(bool wait_for_completion = true) => AssignParam(p=>p.WaitForCompletion(wait_for_completion));
-
-		///<summary>The URL-encoded request definition</summary>
-		public ReindexDescriptor<T> Source(string source) => AssignParam(p=>p.Source(source));
+		public ReindexOnServerDescriptor WaitForCompletion(bool wait_for_completion = true) => AssignParam(p=>p.WaitForCompletion(wait_for_completion));
 
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
-		public ReindexDescriptor<T> FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
+		public ReindexOnServerDescriptor FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
 	
 	}
 	
@@ -4432,13 +4429,13 @@ namespace Nest
 	///<summary>descriptor for TasksCancel <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html</pre></summary>
 	public partial class TasksCancelDescriptor  : RequestDescriptorBase<TasksCancelDescriptor,TasksCancelRequestParameters, ITasksCancelRequest>, ITasksCancelRequest
 	{ 
-		number_ ITasksCancelRequest.TaskId => Self.RouteValues.Get<number_>("task_id");
+		TaskId ITasksCancelRequest.TaskId => Self.RouteValues.Get<TaskId>("task_id");
 			/// <summary>/_tasks/_cancel</summary>
 		public TasksCancelDescriptor() : base(){}
 		
 
 			///<summary>Cancel the task with specified id</summary>
-		public TasksCancelDescriptor TaskId(number_ taskId) => Assign(a=>a.RouteValues.Optional("task_id", taskId));
+		public TasksCancelDescriptor TaskId(TaskId taskId) => Assign(a=>a.RouteValues.Optional("task_id", taskId));
 
 	
 		///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
@@ -4451,29 +4448,26 @@ namespace Nest
 		public TasksCancelDescriptor ParentNode(string parent_node) => AssignParam(p=>p.ParentNode(parent_node));
 
 		///<summary>Cancel tasks with specified parent task id. Set to -1 to cancel all.</summary>
-		public TasksCancelDescriptor ParentTask(long parent_task) => AssignParam(p=>p.ParentTask(parent_task));
+		public TasksCancelDescriptor ParentTask(string parent_task) => AssignParam(p=>p.ParentTask(parent_task));
 
 		///<summary>The URL-encoded request definition</summary>
 		public TasksCancelDescriptor Source(string source) => AssignParam(p=>p.Source(source));
 
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
 		public TasksCancelDescriptor FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
-
-		//TODO THIS METHOD IS UNMAPPED!
-		
 	
 	}
 	
 	///<summary>descriptor for TasksList <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html</pre></summary>
 	public partial class TasksListDescriptor  : RequestDescriptorBase<TasksListDescriptor,TasksListRequestParameters, ITasksListRequest>, ITasksListRequest
 	{ 
-		number_ ITasksListRequest.TaskId => Self.RouteValues.Get<number_>("task_id");
+		TaskId ITasksListRequest.TaskId => Self.RouteValues.Get<TaskId>("task_id");
 			/// <summary>/_tasks</summary>
 		public TasksListDescriptor() : base(){}
 		
 
 			///<summary>Return the task with specified id</summary>
-		public TasksListDescriptor TaskId(number_ taskId) => Assign(a=>a.RouteValues.Optional("task_id", taskId));
+		public TasksListDescriptor TaskId(TaskId taskId) => Assign(a=>a.RouteValues.Optional("task_id", taskId));
 
 	
 		///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
@@ -4489,7 +4483,7 @@ namespace Nest
 		public TasksListDescriptor ParentNode(string parent_node) => AssignParam(p=>p.ParentNode(parent_node));
 
 		///<summary>Return tasks with specified parent task id. Set to -1 to return all.</summary>
-		public TasksListDescriptor ParentTask(long parent_task) => AssignParam(p=>p.ParentTask(parent_task));
+		public TasksListDescriptor ParentTask(string parent_task) => AssignParam(p=>p.ParentTask(parent_task));
 
 		///<summary>Wait for the matching tasks to complete (default: false)</summary>
 		public TasksListDescriptor WaitForCompletion(bool wait_for_completion = true) => AssignParam(p=>p.WaitForCompletion(wait_for_completion));
@@ -4499,9 +4493,6 @@ namespace Nest
 
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
 		public TasksListDescriptor FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
-
-		//TODO THIS METHOD IS UNMAPPED!
-		
 	
 	}
 	
@@ -4673,181 +4664,179 @@ namespace Nest
 	}
 	
 	///<summary>descriptor for UpdateByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
-	public partial class UpdateByQueryDescriptor  : RequestDescriptorBase<UpdateByQueryDescriptor,UpdateByQueryRequestParameters, IUpdateByQueryRequest>, IUpdateByQueryRequest
+	public partial class UpdateByQueryDescriptor<T>  : RequestDescriptorBase<UpdateByQueryDescriptor<T>,UpdateByQueryRequestParameters, IUpdateByQueryRequest>, IUpdateByQueryRequest
 	{ 
 		Indices IUpdateByQueryRequest.Index => Self.RouteValues.Get<Indices>("index");
 		Types IUpdateByQueryRequest.Type => Self.RouteValues.Get<Types>("type");
 			/// <summary>/{index}/_update_by_query</summary>
-		public UpdateByQueryDescriptor() {}
+///<param name="index"> this parameter is required</param>
+		public UpdateByQueryDescriptor(Indices index) : base(r=>r.Required("index", index)){}
 		
 
 			///<summary>A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</summary>
-		public UpdateByQueryDescriptor Index(Indices index) => Assign(a=>a.RouteValues.Optional("index", index));
+		public UpdateByQueryDescriptor<T> Index(Indices index) => Assign(a=>a.RouteValues.Optional("index", index));
 
 		///<summary>A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</summary>
-		public UpdateByQueryDescriptor Index<TOther>() where TOther : class => Assign(a=>a.RouteValues.Optional("index", (Indices)typeof(TOther)));
+		public UpdateByQueryDescriptor<T> Index<TOther>() where TOther : class => Assign(a=>a.RouteValues.Optional("index", (Indices)typeof(TOther)));
 
 		///<summary>A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</summary>
-		public UpdateByQueryDescriptor AllIndices() => this.Index(Indices.All);
+		public UpdateByQueryDescriptor<T> AllIndices() => this.Index(Indices.All);
 
 		///<summary>A comma-separated list of document types to search; leave empty to perform the operation on all types</summary>
-		public UpdateByQueryDescriptor Type(Types type) => Assign(a=>a.RouteValues.Optional("type", type));
+		public UpdateByQueryDescriptor<T> Type(Types type) => Assign(a=>a.RouteValues.Optional("type", type));
 
 		///<summary>A comma-separated list of document types to search; leave empty to perform the operation on all types</summary>
-		public UpdateByQueryDescriptor Type<TOther>() where TOther : class => Assign(a=>a.RouteValues.Optional("type", (Types)typeof(TOther)));
+		public UpdateByQueryDescriptor<T> Type<TOther>() where TOther : class => Assign(a=>a.RouteValues.Optional("type", (Types)typeof(TOther)));
 
 		///<summary>A comma-separated list of document types to search; leave empty to perform the operation on all types</summary>
-		public UpdateByQueryDescriptor AllTypes() => this.Type(Types.All);
+		public UpdateByQueryDescriptor<T> AllTypes() => this.Type(Types.All);
 
 	
 		///<summary>The analyzer to use for the query string</summary>
-		public UpdateByQueryDescriptor Analyzer(string analyzer) => AssignParam(p=>p.Analyzer(analyzer));
+		public UpdateByQueryDescriptor<T> Analyzer(string analyzer) => AssignParam(p=>p.Analyzer(analyzer));
 
 		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
-		public UpdateByQueryDescriptor AnalyzeWildcard(bool analyze_wildcard = true) => AssignParam(p=>p.AnalyzeWildcard(analyze_wildcard));
+		public UpdateByQueryDescriptor<T> AnalyzeWildcard(bool analyze_wildcard = true) => AssignParam(p=>p.AnalyzeWildcard(analyze_wildcard));
 
 		///<summary>The default operator for query string query (AND or OR)</summary>
-		public UpdateByQueryDescriptor DefaultOperator(DefaultOperator default_operator) => AssignParam(p=>p.DefaultOperator(default_operator));
+		public UpdateByQueryDescriptor<T> DefaultOperator(DefaultOperator default_operator) => AssignParam(p=>p.DefaultOperator(default_operator));
 
 		///<summary>The field to use as default where no field prefix is given in the query string</summary>
-		public UpdateByQueryDescriptor Df(string df) => AssignParam(p=>p.Df(df));
+		public UpdateByQueryDescriptor<T> Df(string df) => AssignParam(p=>p.Df(df));
 
 		///<summary>Specify whether to return detailed information about score computation as part of a hit</summary>
-		public UpdateByQueryDescriptor Explain(bool explain = true) => AssignParam(p=>p.Explain(explain));
+		public UpdateByQueryDescriptor<T> Explain(bool explain = true) => AssignParam(p=>p.Explain(explain));
 
 		///<summary>A comma-separated list of fields to return as part of a hit</summary>
-		public UpdateByQueryDescriptor Fields(params string[] fields) => AssignParam(p=>p.Fields(fields));
+		public UpdateByQueryDescriptor<T> Fields(params string[] fields) => AssignParam(p=>p.Fields(fields));
 			
 		///<summary>A comma-separated list of fields to return as part of a hit</summary>
-		public UpdateByQueryDescriptor Fields<T>(params Expression<Func<T, object>>[] fields) where T : class =>
+		public UpdateByQueryDescriptor<T> Fields(params Expression<Func<T, object>>[] fields)  =>
 			AssignParam(p=>p._Fields(fields));
 
 		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
-		public UpdateByQueryDescriptor FielddataFields(params string[] fielddata_fields) => AssignParam(p=>p.FielddataFields(fielddata_fields));
+		public UpdateByQueryDescriptor<T> FielddataFields(params string[] fielddata_fields) => AssignParam(p=>p.FielddataFields(fielddata_fields));
 			
 		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
-		public UpdateByQueryDescriptor FielddataFields<T>(params Expression<Func<T, object>>[] fields) where T : class =>
+		public UpdateByQueryDescriptor<T> FielddataFields(params Expression<Func<T, object>>[] fields)  =>
 			AssignParam(p=>p._FielddataFields(fields));
 
 		///<summary>Starting offset (default: 0)</summary>
-		public UpdateByQueryDescriptor From(long from) => AssignParam(p=>p.From(from));
+		public UpdateByQueryDescriptor<T> From(long from) => AssignParam(p=>p.From(from));
 
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
-		public UpdateByQueryDescriptor IgnoreUnavailable(bool ignore_unavailable = true) => AssignParam(p=>p.IgnoreUnavailable(ignore_unavailable));
+		public UpdateByQueryDescriptor<T> IgnoreUnavailable(bool ignore_unavailable = true) => AssignParam(p=>p.IgnoreUnavailable(ignore_unavailable));
 
 		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
-		public UpdateByQueryDescriptor AllowNoIndices(bool allow_no_indices = true) => AssignParam(p=>p.AllowNoIndices(allow_no_indices));
+		public UpdateByQueryDescriptor<T> AllowNoIndices(bool allow_no_indices = true) => AssignParam(p=>p.AllowNoIndices(allow_no_indices));
 
 		///<summary>What to do when the reindex hits version conflicts?</summary>
-		public UpdateByQueryDescriptor Conflicts(Conflicts conflicts) => AssignParam(p=>p.Conflicts(conflicts));
+		public UpdateByQueryDescriptor<T> Conflicts(Conflicts conflicts) => AssignParam(p=>p.Conflicts(conflicts));
 
 		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
-		public UpdateByQueryDescriptor ExpandWildcards(ExpandWildcards expand_wildcards) => AssignParam(p=>p.ExpandWildcards(expand_wildcards));
+		public UpdateByQueryDescriptor<T> ExpandWildcards(ExpandWildcards expand_wildcards) => AssignParam(p=>p.ExpandWildcards(expand_wildcards));
 
 		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
-		public UpdateByQueryDescriptor Lenient(bool lenient = true) => AssignParam(p=>p.Lenient(lenient));
+		public UpdateByQueryDescriptor<T> Lenient(bool lenient = true) => AssignParam(p=>p.Lenient(lenient));
 
 		///<summary>Specify whether query terms should be lowercased</summary>
-		public UpdateByQueryDescriptor LowercaseExpandedTerms(bool lowercase_expanded_terms = true) => AssignParam(p=>p.LowercaseExpandedTerms(lowercase_expanded_terms));
+		public UpdateByQueryDescriptor<T> LowercaseExpandedTerms(bool lowercase_expanded_terms = true) => AssignParam(p=>p.LowercaseExpandedTerms(lowercase_expanded_terms));
 
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
-		public UpdateByQueryDescriptor Preference(string preference) => AssignParam(p=>p.Preference(preference));
+		public UpdateByQueryDescriptor<T> Preference(string preference) => AssignParam(p=>p.Preference(preference));
 
 		///<summary>Query in the Lucene query string syntax</summary>
-		public UpdateByQueryDescriptor QueryOnQueryString(string query_on_query_string) => AssignParam(p=>p.QueryOnQueryString(query_on_query_string));
+		public UpdateByQueryDescriptor<T> QueryOnQueryString(string query_on_query_string) => AssignParam(p=>p.QueryOnQueryString(query_on_query_string));
 
 		///<summary>A comma-separated list of specific routing values</summary>
-		public UpdateByQueryDescriptor Routing(params string[] routing) => AssignParam(p=>p.Routing(routing));
+		public UpdateByQueryDescriptor<T> Routing(params string[] routing) => AssignParam(p=>p.Routing(routing));
 
 		///<summary>Specify how long a consistent view of the index should be maintained for scrolled search</summary>
-		public UpdateByQueryDescriptor Scroll(Time scroll) => AssignParam(p=>p.Scroll(scroll.ToTimeSpan()));
+		public UpdateByQueryDescriptor<T> Scroll(Time scroll) => AssignParam(p=>p.Scroll(scroll.ToTimeSpan()));
 
 		///<summary>Search operation type</summary>
-		public UpdateByQueryDescriptor SearchType(SearchType search_type) => AssignParam(p=>p.SearchType(search_type));
+		public UpdateByQueryDescriptor<T> SearchType(SearchType search_type) => AssignParam(p=>p.SearchType(search_type));
 
 		///<summary>Explicit timeout for each search request. Defaults to no timeout.</summary>
-		public UpdateByQueryDescriptor SearchTimeout(Time search_timeout) => AssignParam(p=>p.SearchTimeout(search_timeout.ToTimeSpan()));
+		public UpdateByQueryDescriptor<T> SearchTimeout(Time search_timeout) => AssignParam(p=>p.SearchTimeout(search_timeout.ToTimeSpan()));
 
 		///<summary>Number of hits to return (default: 10)</summary>
-		public UpdateByQueryDescriptor Size(long size) => AssignParam(p=>p.Size(size));
+		public UpdateByQueryDescriptor<T> Size(long size) => AssignParam(p=>p.Size(size));
 
 		///<summary>A comma-separated list of &lt;field&gt;:&lt;direction&gt; pairs</summary>
-		public UpdateByQueryDescriptor Sort(params string[] sort) => AssignParam(p=>p.Sort(sort));
+		public UpdateByQueryDescriptor<T> Sort(params string[] sort) => AssignParam(p=>p.Sort(sort));
 
 		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
-		public UpdateByQueryDescriptor SourceEnabled(params string[] source_enabled) => AssignParam(p=>p.SourceEnabled(source_enabled));
+		public UpdateByQueryDescriptor<T> SourceEnabled(params string[] source_enabled) => AssignParam(p=>p.SourceEnabled(source_enabled));
 
 		///<summary>A list of fields to exclude from the returned _source field</summary>
-		public UpdateByQueryDescriptor SourceExclude(params string[] source_exclude) => AssignParam(p=>p.SourceExclude(source_exclude));
+		public UpdateByQueryDescriptor<T> SourceExclude(params string[] source_exclude) => AssignParam(p=>p.SourceExclude(source_exclude));
 			
 		///<summary>A list of fields to exclude from the returned _source field</summary>
-		public UpdateByQueryDescriptor SourceExclude<T>(params Expression<Func<T, object>>[] fields) where T : class =>
+		public UpdateByQueryDescriptor<T> SourceExclude(params Expression<Func<T, object>>[] fields)  =>
 			AssignParam(p=>p._SourceExclude(fields));
 
 		///<summary>A list of fields to extract and return from the _source field</summary>
-		public UpdateByQueryDescriptor SourceInclude(params string[] source_include) => AssignParam(p=>p.SourceInclude(source_include));
+		public UpdateByQueryDescriptor<T> SourceInclude(params string[] source_include) => AssignParam(p=>p.SourceInclude(source_include));
 			
 		///<summary>A list of fields to extract and return from the _source field</summary>
-		public UpdateByQueryDescriptor SourceInclude<T>(params Expression<Func<T, object>>[] fields) where T : class =>
+		public UpdateByQueryDescriptor<T> SourceInclude(params Expression<Func<T, object>>[] fields)  =>
 			AssignParam(p=>p._SourceInclude(fields));
 
 		///<summary>The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.</summary>
-		public UpdateByQueryDescriptor TerminateAfter(long terminate_after) => AssignParam(p=>p.TerminateAfter(terminate_after));
+		public UpdateByQueryDescriptor<T> TerminateAfter(long terminate_after) => AssignParam(p=>p.TerminateAfter(terminate_after));
 
 		///<summary>Specific &#39;tag&#39; of the request for logging and statistical purposes</summary>
-		public UpdateByQueryDescriptor Stats(params string[] stats) => AssignParam(p=>p.Stats(stats));
+		public UpdateByQueryDescriptor<T> Stats(params string[] stats) => AssignParam(p=>p.Stats(stats));
 
 		///<summary>Specify which field to use for suggestions</summary>
-		public UpdateByQueryDescriptor SuggestField(string suggest_field) => AssignParam(p=>p.SuggestField(suggest_field));
+		public UpdateByQueryDescriptor<T> SuggestField(string suggest_field) => AssignParam(p=>p.SuggestField(suggest_field));
 
 		///<summary>Specify which field to use for suggestions</summary>
-		public UpdateByQueryDescriptor SuggestField<T>(Expression<Func<T, object>> field) where T : class =>
+		public UpdateByQueryDescriptor<T> SuggestField(Expression<Func<T, object>> field)  =>
 			AssignParam(p=>p._SuggestField(field));
 
 		///<summary>Specify suggest mode</summary>
-		public UpdateByQueryDescriptor SuggestMode(SuggestMode suggest_mode) => AssignParam(p=>p.SuggestMode(suggest_mode));
+		public UpdateByQueryDescriptor<T> SuggestMode(SuggestMode suggest_mode) => AssignParam(p=>p.SuggestMode(suggest_mode));
 
 		///<summary>How many suggestions to return in response</summary>
-		public UpdateByQueryDescriptor SuggestSize(long suggest_size) => AssignParam(p=>p.SuggestSize(suggest_size));
+		public UpdateByQueryDescriptor<T> SuggestSize(long suggest_size) => AssignParam(p=>p.SuggestSize(suggest_size));
 
 		///<summary>The source text for which the suggestions should be returned</summary>
-		public UpdateByQueryDescriptor SuggestText(string suggest_text) => AssignParam(p=>p.SuggestText(suggest_text));
+		public UpdateByQueryDescriptor<T> SuggestText(string suggest_text) => AssignParam(p=>p.SuggestText(suggest_text));
 
 		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
-		public UpdateByQueryDescriptor Timeout(Time timeout) => AssignParam(p=>p.Timeout(timeout.ToTimeSpan()));
+		public UpdateByQueryDescriptor<T> Timeout(Time timeout) => AssignParam(p=>p.Timeout(timeout.ToTimeSpan()));
 
 		///<summary>Whether to calculate and return scores even if they are not used for sorting</summary>
-		public UpdateByQueryDescriptor TrackScores(bool track_scores = true) => AssignParam(p=>p.TrackScores(track_scores));
+		public UpdateByQueryDescriptor<T> TrackScores(bool track_scores = true) => AssignParam(p=>p.TrackScores(track_scores));
 
 		///<summary>Specify whether to return document version as part of a hit</summary>
-		public UpdateByQueryDescriptor Version(bool version = true) => AssignParam(p=>p.Version(version));
+		public UpdateByQueryDescriptor<T> Version(bool version = true) => AssignParam(p=>p.Version(version));
 
 		///<summary>Should the document increment the version number (internal) on hit or not (reindex)</summary>
-		public UpdateByQueryDescriptor VersionType(bool version_type = true) => AssignParam(p=>p.VersionType(version_type));
+		public UpdateByQueryDescriptor<T> VersionType(bool version_type = true) => AssignParam(p=>p.VersionType(version_type));
 
 		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
-		public UpdateByQueryDescriptor RequestCache(bool request_cache = true) => AssignParam(p=>p.RequestCache(request_cache));
+		public UpdateByQueryDescriptor<T> RequestCache(bool request_cache = true) => AssignParam(p=>p.RequestCache(request_cache));
 
 		///<summary>Should the effected indexes be refreshed?</summary>
-		public UpdateByQueryDescriptor Refresh(bool refresh = true) => AssignParam(p=>p.Refresh(refresh));
+		public UpdateByQueryDescriptor<T> Refresh(bool refresh = true) => AssignParam(p=>p.Refresh(refresh));
 
 		///<summary>Explicit write consistency setting for the operation</summary>
-		public UpdateByQueryDescriptor Consistency(Consistency consistency) => AssignParam(p=>p.Consistency(consistency));
+		public UpdateByQueryDescriptor<T> Consistency(Consistency consistency) => AssignParam(p=>p.Consistency(consistency));
 
 		///<summary>Size on the scroll request powering the update_by_query</summary>
-		public UpdateByQueryDescriptor ScrollSize(integer scroll_size) => AssignParam(p=>p.ScrollSize(scroll_size));
+		public UpdateByQueryDescriptor<T> ScrollSize(long scroll_size) => AssignParam(p=>p.ScrollSize(scroll_size));
 
 		///<summary>Should the request should block until the reindex is complete.</summary>
-		public UpdateByQueryDescriptor WaitForCompletion(bool wait_for_completion = true) => AssignParam(p=>p.WaitForCompletion(wait_for_completion));
+		public UpdateByQueryDescriptor<T> WaitForCompletion(bool wait_for_completion = true) => AssignParam(p=>p.WaitForCompletion(wait_for_completion));
 
 		///<summary>The URL-encoded request definition</summary>
-		public UpdateByQueryDescriptor Source(string source) => AssignParam(p=>p.Source(source));
+		public UpdateByQueryDescriptor<T> Source(string source) => AssignParam(p=>p.Source(source));
 
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
-		public UpdateByQueryDescriptor FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
-
-		//TODO THIS METHOD IS UNMAPPED!
-		
+		public UpdateByQueryDescriptor<T> FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
 	
 	}
 }

--- a/src/Nest/_Generated/_Descriptors.generated.cs
+++ b/src/Nest/_Generated/_Descriptors.generated.cs
@@ -1715,9 +1715,9 @@ namespace Nest
 		public AnalyzeDescriptor Tokenizer(string tokenizer) => AssignParam(p=>p.Tokenizer(tokenizer));
 
 		///<summary>With `true`, outputs more advanced details. (default: false)</summary>
-		public AnalyzeDescriptor Detail(bool detail = true) => AssignParam(p=>p.Detail(detail));
+		public AnalyzeDescriptor Explain(bool explain = true) => AssignParam(p=>p.Explain(explain));
 
-		///<summary>A comma-separated list of token attributes to output, this parameter works only with `detail=true`</summary>
+		///<summary>A comma-separated list of token attributes to output, this parameter works only with `explain=true`</summary>
 		public AnalyzeDescriptor Attributes(params string[] attributes) => AssignParam(p=>p.Attributes(attributes));
 
 		///<summary>Format of the output</summary>
@@ -2702,7 +2702,7 @@ namespace Nest
 	
 	}
 	
-	///<summary>descriptor for IndicesOptimizeForAll <pre>https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html</pre></summary>
+	///<summary>descriptor for IndicesOptimizeForAll <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html</pre></summary>
 	public partial class OptimizeDescriptor  : RequestDescriptorBase<OptimizeDescriptor,OptimizeRequestParameters, IOptimizeRequest>, IOptimizeRequest
 	{ 
 		Indices IOptimizeRequest.Index => Self.RouteValues.Get<Indices>("index");
@@ -3822,6 +3822,30 @@ namespace Nest
 	
 	}
 	
+	///<summary>descriptor for Reindex <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
+	public partial class ReindexDescriptor<T>  : RequestDescriptorBase<ReindexDescriptor<T>,ReindexRequestParameters, IReindexRequest>, IReindexRequest
+	{ 
+			
+		///<summary>Should the effected indexes be refreshed?</summary>
+		public ReindexDescriptor<T> Refresh(bool refresh = true) => AssignParam(p=>p.Refresh(refresh));
+
+		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
+		public ReindexDescriptor<T> Timeout(Time timeout) => AssignParam(p=>p.Timeout(timeout.ToTimeSpan()));
+
+		///<summary>Explicit write consistency setting for the operation</summary>
+		public ReindexDescriptor<T> Consistency(Consistency consistency) => AssignParam(p=>p.Consistency(consistency));
+
+		///<summary>Should the request should block until the reindex is complete.</summary>
+		public ReindexDescriptor<T> WaitForCompletion(bool wait_for_completion = true) => AssignParam(p=>p.WaitForCompletion(wait_for_completion));
+
+		///<summary>The URL-encoded request definition</summary>
+		public ReindexDescriptor<T> Source(string source) => AssignParam(p=>p.Source(source));
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public ReindexDescriptor<T> FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
+	
+	}
+	
 	///<summary>descriptor for RenderSearchTemplate <pre>http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</pre></summary>
 	public partial class RenderSearchTemplateDescriptor  : RequestDescriptorBase<RenderSearchTemplateDescriptor,RenderSearchTemplateRequestParameters, IRenderSearchTemplateRequest>, IRenderSearchTemplateRequest
 	{ 
@@ -3952,7 +3976,7 @@ namespace Nest
 	
 	}
 	
-	///<summary>descriptor for SearchExists <pre>https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html</pre></summary>
+	///<summary>descriptor for SearchExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</pre></summary>
 	public partial class SearchExistsDescriptor<T>  : RequestDescriptorBase<SearchExistsDescriptor<T>,SearchExistsRequestParameters, ISearchExistsRequest>, ISearchExistsRequest
 	{ 
 		Indices ISearchExistsRequest.Index => Self.RouteValues.Get<Indices>("index");
@@ -4405,6 +4429,82 @@ namespace Nest
 	
 	}
 	
+	///<summary>descriptor for TasksCancel <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html</pre></summary>
+	public partial class TasksCancelDescriptor  : RequestDescriptorBase<TasksCancelDescriptor,TasksCancelRequestParameters, ITasksCancelRequest>, ITasksCancelRequest
+	{ 
+		number_ ITasksCancelRequest.TaskId => Self.RouteValues.Get<number_>("task_id");
+			/// <summary>/_tasks/_cancel</summary>
+		public TasksCancelDescriptor() : base(){}
+		
+
+			///<summary>Cancel the task with specified id</summary>
+		public TasksCancelDescriptor TaskId(number_ taskId) => Assign(a=>a.RouteValues.Optional("task_id", taskId));
+
+	
+		///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
+		public TasksCancelDescriptor NodeId(params string[] node_id) => AssignParam(p=>p.NodeId(node_id));
+
+		///<summary>A comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
+		public TasksCancelDescriptor Actions(params string[] actions) => AssignParam(p=>p.Actions(actions));
+
+		///<summary>Cancel tasks with specified parent node.</summary>
+		public TasksCancelDescriptor ParentNode(string parent_node) => AssignParam(p=>p.ParentNode(parent_node));
+
+		///<summary>Cancel tasks with specified parent task id. Set to -1 to cancel all.</summary>
+		public TasksCancelDescriptor ParentTask(long parent_task) => AssignParam(p=>p.ParentTask(parent_task));
+
+		///<summary>The URL-encoded request definition</summary>
+		public TasksCancelDescriptor Source(string source) => AssignParam(p=>p.Source(source));
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TasksCancelDescriptor FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
+
+		//TODO THIS METHOD IS UNMAPPED!
+		
+	
+	}
+	
+	///<summary>descriptor for TasksList <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html</pre></summary>
+	public partial class TasksListDescriptor  : RequestDescriptorBase<TasksListDescriptor,TasksListRequestParameters, ITasksListRequest>, ITasksListRequest
+	{ 
+		number_ ITasksListRequest.TaskId => Self.RouteValues.Get<number_>("task_id");
+			/// <summary>/_tasks</summary>
+		public TasksListDescriptor() : base(){}
+		
+
+			///<summary>Return the task with specified id</summary>
+		public TasksListDescriptor TaskId(number_ taskId) => Assign(a=>a.RouteValues.Optional("task_id", taskId));
+
+	
+		///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
+		public TasksListDescriptor NodeId(params string[] node_id) => AssignParam(p=>p.NodeId(node_id));
+
+		///<summary>A comma-separated list of actions that should be returned. Leave empty to return all.</summary>
+		public TasksListDescriptor Actions(params string[] actions) => AssignParam(p=>p.Actions(actions));
+
+		///<summary>Return detailed task information (default: false)</summary>
+		public TasksListDescriptor Detailed(bool detailed = true) => AssignParam(p=>p.Detailed(detailed));
+
+		///<summary>Return tasks with specified parent node.</summary>
+		public TasksListDescriptor ParentNode(string parent_node) => AssignParam(p=>p.ParentNode(parent_node));
+
+		///<summary>Return tasks with specified parent task id. Set to -1 to return all.</summary>
+		public TasksListDescriptor ParentTask(long parent_task) => AssignParam(p=>p.ParentTask(parent_task));
+
+		///<summary>Wait for the matching tasks to complete (default: false)</summary>
+		public TasksListDescriptor WaitForCompletion(bool wait_for_completion = true) => AssignParam(p=>p.WaitForCompletion(wait_for_completion));
+
+		///<summary>The URL-encoded request definition</summary>
+		public TasksListDescriptor Source(string source) => AssignParam(p=>p.Source(source));
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public TasksListDescriptor FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
+
+		//TODO THIS METHOD IS UNMAPPED!
+		
+	
+	}
+	
 	///<summary>descriptor for Termvectors <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</pre></summary>
 	public partial class TermVectorsDescriptor<TDocument>  : RequestDescriptorBase<TermVectorsDescriptor<TDocument>,TermVectorsRequestParameters, ITermVectorsRequest<TDocument>>, ITermVectorsRequest<TDocument>
 	{ 
@@ -4569,6 +4669,185 @@ namespace Nest
 
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
 		public UpdateDescriptor<TDocument, TPartialDocument> FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
+	
+	}
+	
+	///<summary>descriptor for UpdateByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
+	public partial class UpdateByQueryDescriptor  : RequestDescriptorBase<UpdateByQueryDescriptor,UpdateByQueryRequestParameters, IUpdateByQueryRequest>, IUpdateByQueryRequest
+	{ 
+		Indices IUpdateByQueryRequest.Index => Self.RouteValues.Get<Indices>("index");
+		Types IUpdateByQueryRequest.Type => Self.RouteValues.Get<Types>("type");
+			/// <summary>/{index}/_update_by_query</summary>
+		public UpdateByQueryDescriptor() {}
+		
+
+			///<summary>A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</summary>
+		public UpdateByQueryDescriptor Index(Indices index) => Assign(a=>a.RouteValues.Optional("index", index));
+
+		///<summary>A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</summary>
+		public UpdateByQueryDescriptor Index<TOther>() where TOther : class => Assign(a=>a.RouteValues.Optional("index", (Indices)typeof(TOther)));
+
+		///<summary>A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices</summary>
+		public UpdateByQueryDescriptor AllIndices() => this.Index(Indices.All);
+
+		///<summary>A comma-separated list of document types to search; leave empty to perform the operation on all types</summary>
+		public UpdateByQueryDescriptor Type(Types type) => Assign(a=>a.RouteValues.Optional("type", type));
+
+		///<summary>A comma-separated list of document types to search; leave empty to perform the operation on all types</summary>
+		public UpdateByQueryDescriptor Type<TOther>() where TOther : class => Assign(a=>a.RouteValues.Optional("type", (Types)typeof(TOther)));
+
+		///<summary>A comma-separated list of document types to search; leave empty to perform the operation on all types</summary>
+		public UpdateByQueryDescriptor AllTypes() => this.Type(Types.All);
+
+	
+		///<summary>The analyzer to use for the query string</summary>
+		public UpdateByQueryDescriptor Analyzer(string analyzer) => AssignParam(p=>p.Analyzer(analyzer));
+
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public UpdateByQueryDescriptor AnalyzeWildcard(bool analyze_wildcard = true) => AssignParam(p=>p.AnalyzeWildcard(analyze_wildcard));
+
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public UpdateByQueryDescriptor DefaultOperator(DefaultOperator default_operator) => AssignParam(p=>p.DefaultOperator(default_operator));
+
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public UpdateByQueryDescriptor Df(string df) => AssignParam(p=>p.Df(df));
+
+		///<summary>Specify whether to return detailed information about score computation as part of a hit</summary>
+		public UpdateByQueryDescriptor Explain(bool explain = true) => AssignParam(p=>p.Explain(explain));
+
+		///<summary>A comma-separated list of fields to return as part of a hit</summary>
+		public UpdateByQueryDescriptor Fields(params string[] fields) => AssignParam(p=>p.Fields(fields));
+			
+		///<summary>A comma-separated list of fields to return as part of a hit</summary>
+		public UpdateByQueryDescriptor Fields<T>(params Expression<Func<T, object>>[] fields) where T : class =>
+			AssignParam(p=>p._Fields(fields));
+
+		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
+		public UpdateByQueryDescriptor FielddataFields(params string[] fielddata_fields) => AssignParam(p=>p.FielddataFields(fielddata_fields));
+			
+		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
+		public UpdateByQueryDescriptor FielddataFields<T>(params Expression<Func<T, object>>[] fields) where T : class =>
+			AssignParam(p=>p._FielddataFields(fields));
+
+		///<summary>Starting offset (default: 0)</summary>
+		public UpdateByQueryDescriptor From(long from) => AssignParam(p=>p.From(from));
+
+		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
+		public UpdateByQueryDescriptor IgnoreUnavailable(bool ignore_unavailable = true) => AssignParam(p=>p.IgnoreUnavailable(ignore_unavailable));
+
+		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
+		public UpdateByQueryDescriptor AllowNoIndices(bool allow_no_indices = true) => AssignParam(p=>p.AllowNoIndices(allow_no_indices));
+
+		///<summary>What to do when the reindex hits version conflicts?</summary>
+		public UpdateByQueryDescriptor Conflicts(Conflicts conflicts) => AssignParam(p=>p.Conflicts(conflicts));
+
+		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+		public UpdateByQueryDescriptor ExpandWildcards(ExpandWildcards expand_wildcards) => AssignParam(p=>p.ExpandWildcards(expand_wildcards));
+
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public UpdateByQueryDescriptor Lenient(bool lenient = true) => AssignParam(p=>p.Lenient(lenient));
+
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public UpdateByQueryDescriptor LowercaseExpandedTerms(bool lowercase_expanded_terms = true) => AssignParam(p=>p.LowercaseExpandedTerms(lowercase_expanded_terms));
+
+		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
+		public UpdateByQueryDescriptor Preference(string preference) => AssignParam(p=>p.Preference(preference));
+
+		///<summary>Query in the Lucene query string syntax</summary>
+		public UpdateByQueryDescriptor QueryOnQueryString(string query_on_query_string) => AssignParam(p=>p.QueryOnQueryString(query_on_query_string));
+
+		///<summary>A comma-separated list of specific routing values</summary>
+		public UpdateByQueryDescriptor Routing(params string[] routing) => AssignParam(p=>p.Routing(routing));
+
+		///<summary>Specify how long a consistent view of the index should be maintained for scrolled search</summary>
+		public UpdateByQueryDescriptor Scroll(Time scroll) => AssignParam(p=>p.Scroll(scroll.ToTimeSpan()));
+
+		///<summary>Search operation type</summary>
+		public UpdateByQueryDescriptor SearchType(SearchType search_type) => AssignParam(p=>p.SearchType(search_type));
+
+		///<summary>Explicit timeout for each search request. Defaults to no timeout.</summary>
+		public UpdateByQueryDescriptor SearchTimeout(Time search_timeout) => AssignParam(p=>p.SearchTimeout(search_timeout.ToTimeSpan()));
+
+		///<summary>Number of hits to return (default: 10)</summary>
+		public UpdateByQueryDescriptor Size(long size) => AssignParam(p=>p.Size(size));
+
+		///<summary>A comma-separated list of &lt;field&gt;:&lt;direction&gt; pairs</summary>
+		public UpdateByQueryDescriptor Sort(params string[] sort) => AssignParam(p=>p.Sort(sort));
+
+		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
+		public UpdateByQueryDescriptor SourceEnabled(params string[] source_enabled) => AssignParam(p=>p.SourceEnabled(source_enabled));
+
+		///<summary>A list of fields to exclude from the returned _source field</summary>
+		public UpdateByQueryDescriptor SourceExclude(params string[] source_exclude) => AssignParam(p=>p.SourceExclude(source_exclude));
+			
+		///<summary>A list of fields to exclude from the returned _source field</summary>
+		public UpdateByQueryDescriptor SourceExclude<T>(params Expression<Func<T, object>>[] fields) where T : class =>
+			AssignParam(p=>p._SourceExclude(fields));
+
+		///<summary>A list of fields to extract and return from the _source field</summary>
+		public UpdateByQueryDescriptor SourceInclude(params string[] source_include) => AssignParam(p=>p.SourceInclude(source_include));
+			
+		///<summary>A list of fields to extract and return from the _source field</summary>
+		public UpdateByQueryDescriptor SourceInclude<T>(params Expression<Func<T, object>>[] fields) where T : class =>
+			AssignParam(p=>p._SourceInclude(fields));
+
+		///<summary>The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.</summary>
+		public UpdateByQueryDescriptor TerminateAfter(long terminate_after) => AssignParam(p=>p.TerminateAfter(terminate_after));
+
+		///<summary>Specific &#39;tag&#39; of the request for logging and statistical purposes</summary>
+		public UpdateByQueryDescriptor Stats(params string[] stats) => AssignParam(p=>p.Stats(stats));
+
+		///<summary>Specify which field to use for suggestions</summary>
+		public UpdateByQueryDescriptor SuggestField(string suggest_field) => AssignParam(p=>p.SuggestField(suggest_field));
+
+		///<summary>Specify which field to use for suggestions</summary>
+		public UpdateByQueryDescriptor SuggestField<T>(Expression<Func<T, object>> field) where T : class =>
+			AssignParam(p=>p._SuggestField(field));
+
+		///<summary>Specify suggest mode</summary>
+		public UpdateByQueryDescriptor SuggestMode(SuggestMode suggest_mode) => AssignParam(p=>p.SuggestMode(suggest_mode));
+
+		///<summary>How many suggestions to return in response</summary>
+		public UpdateByQueryDescriptor SuggestSize(long suggest_size) => AssignParam(p=>p.SuggestSize(suggest_size));
+
+		///<summary>The source text for which the suggestions should be returned</summary>
+		public UpdateByQueryDescriptor SuggestText(string suggest_text) => AssignParam(p=>p.SuggestText(suggest_text));
+
+		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
+		public UpdateByQueryDescriptor Timeout(Time timeout) => AssignParam(p=>p.Timeout(timeout.ToTimeSpan()));
+
+		///<summary>Whether to calculate and return scores even if they are not used for sorting</summary>
+		public UpdateByQueryDescriptor TrackScores(bool track_scores = true) => AssignParam(p=>p.TrackScores(track_scores));
+
+		///<summary>Specify whether to return document version as part of a hit</summary>
+		public UpdateByQueryDescriptor Version(bool version = true) => AssignParam(p=>p.Version(version));
+
+		///<summary>Should the document increment the version number (internal) on hit or not (reindex)</summary>
+		public UpdateByQueryDescriptor VersionType(bool version_type = true) => AssignParam(p=>p.VersionType(version_type));
+
+		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
+		public UpdateByQueryDescriptor RequestCache(bool request_cache = true) => AssignParam(p=>p.RequestCache(request_cache));
+
+		///<summary>Should the effected indexes be refreshed?</summary>
+		public UpdateByQueryDescriptor Refresh(bool refresh = true) => AssignParam(p=>p.Refresh(refresh));
+
+		///<summary>Explicit write consistency setting for the operation</summary>
+		public UpdateByQueryDescriptor Consistency(Consistency consistency) => AssignParam(p=>p.Consistency(consistency));
+
+		///<summary>Size on the scroll request powering the update_by_query</summary>
+		public UpdateByQueryDescriptor ScrollSize(integer scroll_size) => AssignParam(p=>p.ScrollSize(scroll_size));
+
+		///<summary>Should the request should block until the reindex is complete.</summary>
+		public UpdateByQueryDescriptor WaitForCompletion(bool wait_for_completion = true) => AssignParam(p=>p.WaitForCompletion(wait_for_completion));
+
+		///<summary>The URL-encoded request definition</summary>
+		public UpdateByQueryDescriptor Source(string source) => AssignParam(p=>p.Source(source));
+
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public UpdateByQueryDescriptor FilterPath(string filter_path) => AssignParam(p=>p.FilterPath(filter_path));
+
+		//TODO THIS METHOD IS UNMAPPED!
+		
 	
 	}
 }

--- a/src/Nest/_Generated/_LowLevelDispatch.generated.cs
+++ b/src/Nest/_Generated/_LowLevelDispatch.generated.cs
@@ -2504,7 +2504,7 @@ namespace Nest
 			throw InvalidDispatch("PutTemplate", p, new [] { PUT, POST }, "/_search/template/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> ReindexDispatch<T>(IRequest<ReindexRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> ReindexDispatch<T>(IRequest<ReindexOnServerRequestParameters> p , PostData<object> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2515,7 +2515,7 @@ namespace Nest
 			throw InvalidDispatch("Reindex", p, new [] { POST }, "/_reindex");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ReindexDispatchAsync<T>(IRequest<ReindexRequestParameters> p , PostData<object> body) where T : class
+		internal Task<ElasticsearchResponse<T>> ReindexDispatchAsync<T>(IRequest<ReindexOnServerRequestParameters> p , PostData<object> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3110,7 +3110,7 @@ namespace Nest
 			{
 				case POST:
 					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.UpdateByQuery<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.UpdateByQuery<T>(p.RouteValues.Index,body,u => p.RequestParameters);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.UpdateByQuery<T>(p.RouteValues.Index,body,u => p.RequestParameters);
 					break;
 
 			}
@@ -3123,7 +3123,7 @@ namespace Nest
 			{
 				case POST:
 					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters);
 					break;
 
 			}

--- a/src/Nest/_Generated/_LowLevelDispatch.generated.cs
+++ b/src/Nest/_Generated/_LowLevelDispatch.generated.cs
@@ -2504,6 +2504,28 @@ namespace Nest
 			throw InvalidDispatch("PutTemplate", p, new [] { PUT, POST }, "/_search/template/{id}");
 		}
 		
+		internal ElasticsearchResponse<T> ReindexDispatch<T>(IRequest<ReindexRequestParameters> p , PostData<object> body) where T : class
+		{
+			switch(p.HttpMethod)
+			{
+				case POST:
+					return _lowLevel.Reindex<T>(body,u => p.RequestParameters);
+
+			}
+			throw InvalidDispatch("Reindex", p, new [] { POST }, "/_reindex");
+		}
+		
+		internal Task<ElasticsearchResponse<T>> ReindexDispatchAsync<T>(IRequest<ReindexRequestParameters> p , PostData<object> body) where T : class
+		{
+			switch(p.HttpMethod)
+			{
+				case POST:
+					return _lowLevel.ReindexAsync<T>(body,u => p.RequestParameters);
+
+			}
+			throw InvalidDispatch("Reindex", p, new [] { POST }, "/_reindex");
+		}
+		
 		internal ElasticsearchResponse<T> RenderSearchTemplateDispatch<T>(IRequest<RenderSearchTemplateRequestParameters> p , PostData<object> body) where T : class
 		{
 			switch(p.HttpMethod)
@@ -2974,6 +2996,54 @@ namespace Nest
 			throw InvalidDispatch("Suggest", p, new [] { POST, GET }, "/_suggest", "/{index}/_suggest");
 		}
 		
+		internal ElasticsearchResponse<T> TasksCancelDispatch<T>(IRequest<TasksCancelRequestParameters> p ) where T : class
+		{
+			switch(p.HttpMethod)
+			{
+				case POST:
+					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.TasksCancel<T>(p.RouteValues.TaskId,u => p.RequestParameters);
+					return _lowLevel.TasksCancel<T>(u => p.RequestParameters);
+
+			}
+			throw InvalidDispatch("TasksCancel", p, new [] { POST }, "/_tasks/_cancel", "/_tasks/{task_id}/_cancel");
+		}
+		
+		internal Task<ElasticsearchResponse<T>> TasksCancelDispatchAsync<T>(IRequest<TasksCancelRequestParameters> p ) where T : class
+		{
+			switch(p.HttpMethod)
+			{
+				case POST:
+					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.TasksCancelAsync<T>(p.RouteValues.TaskId,u => p.RequestParameters);
+					return _lowLevel.TasksCancelAsync<T>(u => p.RequestParameters);
+
+			}
+			throw InvalidDispatch("TasksCancel", p, new [] { POST }, "/_tasks/_cancel", "/_tasks/{task_id}/_cancel");
+		}
+		
+		internal ElasticsearchResponse<T> TasksListDispatch<T>(IRequest<TasksListRequestParameters> p ) where T : class
+		{
+			switch(p.HttpMethod)
+			{
+				case GET:
+					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.TasksList<T>(p.RouteValues.TaskId,u => p.RequestParameters);
+					return _lowLevel.TasksList<T>(u => p.RequestParameters);
+
+			}
+			throw InvalidDispatch("TasksList", p, new [] { GET }, "/_tasks", "/_tasks/{task_id}");
+		}
+		
+		internal Task<ElasticsearchResponse<T>> TasksListDispatchAsync<T>(IRequest<TasksListRequestParameters> p ) where T : class
+		{
+			switch(p.HttpMethod)
+			{
+				case GET:
+					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.TasksListAsync<T>(p.RouteValues.TaskId,u => p.RequestParameters);
+					return _lowLevel.TasksListAsync<T>(u => p.RequestParameters);
+
+			}
+			throw InvalidDispatch("TasksList", p, new [] { GET }, "/_tasks", "/_tasks/{task_id}");
+		}
+		
 		internal ElasticsearchResponse<T> TermvectorsDispatch<T>(IRequest<TermVectorsRequestParameters> p , PostData<object> body) where T : class
 		{
 			switch(p.HttpMethod)
@@ -3032,6 +3102,32 @@ namespace Nest
 
 			}
 			throw InvalidDispatch("Update", p, new [] { POST }, "/{index}/{type}/{id}/_update");
+		}
+		
+		internal ElasticsearchResponse<T> UpdateByQueryDispatch<T>(IRequest<UpdateByQueryRequestParameters> p , PostData<object> body) where T : class
+		{
+			switch(p.HttpMethod)
+			{
+				case POST:
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.UpdateByQuery<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.UpdateByQuery<T>(p.RouteValues.Index,body,u => p.RequestParameters);
+					break;
+
+			}
+			throw InvalidDispatch("UpdateByQuery", p, new [] { POST }, "/{index}/_update_by_query", "/{index}/{type}/_update_by_query");
+		}
+		
+		internal Task<ElasticsearchResponse<T>> UpdateByQueryDispatchAsync<T>(IRequest<UpdateByQueryRequestParameters> p , PostData<object> body) where T : class
+		{
+			switch(p.HttpMethod)
+			{
+				case POST:
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters);
+					break;
+
+			}
+			throw InvalidDispatch("UpdateByQuery", p, new [] { POST }, "/{index}/_update_by_query", "/{index}/{type}/_update_by_query");
 		}
 		
 	}	

--- a/src/Nest/_Generated/_RequestParametersExtensions.Generated.cs
+++ b/src/Nest/_Generated/_RequestParametersExtensions.Generated.cs
@@ -107,6 +107,26 @@ namespace Nest
 		///<summary>A comma-separated list of fields to return.</summary>
 		internal static TermVectorsRequestParameters _Fields<T>(this TermVectorsRequestParameters qs, IEnumerable<Expression<Func<T, object>>>  fields) where T : class =>
 			qs.AddQueryString("fields", fields.Select(e=>(Field)e));
+		
+		///<summary>A comma-separated list of fields to return as part of a hit</summary>
+		internal static UpdateByQueryRequestParameters _Fields<T>(this UpdateByQueryRequestParameters qs, IEnumerable<Expression<Func<T, object>>>  fields) where T : class =>
+			qs.AddQueryString("fields", fields.Select(e=>(Field)e));
+		
+		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
+		internal static UpdateByQueryRequestParameters _FielddataFields<T>(this UpdateByQueryRequestParameters qs, IEnumerable<Expression<Func<T, object>>>  fielddata_fields) where T : class =>
+			qs.AddQueryString("fielddata_fields", fielddata_fields.Select(e=>(Field)e));
+		
+		///<summary>A list of fields to exclude from the returned _source field</summary>
+		internal static UpdateByQueryRequestParameters _SourceExclude<T>(this UpdateByQueryRequestParameters qs, IEnumerable<Expression<Func<T, object>>>  source_exclude) where T : class =>
+			qs.AddQueryString("_source_exclude", source_exclude.Select(e=>(Field)e));
+		
+		///<summary>A list of fields to extract and return from the _source field</summary>
+		internal static UpdateByQueryRequestParameters _SourceInclude<T>(this UpdateByQueryRequestParameters qs, IEnumerable<Expression<Func<T, object>>>  source_include) where T : class =>
+			qs.AddQueryString("_source_include", source_include.Select(e=>(Field)e));
+		
+		///<summary>Specify which field to use for suggestions</summary>
+		internal static UpdateByQueryRequestParameters _SuggestField<T>(this UpdateByQueryRequestParameters qs, Expression<Func<T, object>> suggest_field) where T : class =>
+			qs.AddQueryString("suggest_field", (Field)suggest_field);
 	}
 }
  

--- a/src/Nest/_Generated/_Requests.generated.cs
+++ b/src/Nest/_Generated/_Requests.generated.cs
@@ -4034,13 +4034,13 @@ namespace Nest
 		}
 	
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	public partial interface IReindexRequest : IRequest<ReindexRequestParameters> 
+	public partial interface IReindexOnServerRequest : IRequest<ReindexOnServerRequestParameters> 
 	{
 	 } 
 	///<summary>Request parameters for Reindex <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
-	public partial class ReindexRequest  : RequestBase<ReindexRequestParameters>, IReindexRequest
+	public partial class ReindexOnServerRequest  : RequestBase<ReindexOnServerRequestParameters>, IReindexOnServerRequest
 	{
-		protected IReindexRequest Self => this;
+		protected IReindexOnServerRequest Self => this;
 				///<summary>Should the effected indexes be refreshed?</summary>
 		public bool Refresh { get { return Q<bool>("refresh"); } set { Q("refresh", value); } }
 		
@@ -4052,9 +4052,6 @@ namespace Nest
 		
 		///<summary>Should the request should block until the reindex is complete.</summary>
 		public bool WaitForCompletion { get { return Q<bool>("wait_for_completion"); } set { Q("wait_for_completion", value); } }
-		
-		///<summary>The URL-encoded request definition</summary>
-		public string Source { get { return Q<string>("source"); } set { Q("source", value); } }
 		
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
 		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
@@ -4945,20 +4942,20 @@ namespace Nest
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface ITasksCancelRequest : IRequest<TasksCancelRequestParameters> 
 	{
-		number_ TaskId { get; }
+		TaskId TaskId { get; }
 	 } 
 	///<summary>Request parameters for TasksCancel <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html</pre></summary>
 	public partial class TasksCancelRequest  : RequestBase<TasksCancelRequestParameters>, ITasksCancelRequest
 	{
 		protected ITasksCancelRequest Self => this;
-		number_ ITasksCancelRequest.TaskId => Self.RouteValues.Get<number_>("task_id");
+		TaskId ITasksCancelRequest.TaskId => Self.RouteValues.Get<TaskId>("task_id");
 			/// <summary>/_tasks/_cancel</summary>
 		public TasksCancelRequest() : base(){}
 		
 
 		/// <summary>/_tasks/{task_id}/_cancel</summary>
 ///<param name="task_id">Optional, accepts null</param>
-		public TasksCancelRequest(number_ task_id) : base(r=>r.Optional("task_id", task_id)){}
+		public TasksCancelRequest(TaskId task_id) : base(r=>r.Optional("task_id", task_id)){}
 		
 
 			///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
@@ -4971,7 +4968,7 @@ namespace Nest
 		public string ParentNode { get { return Q<string>("parent_node"); } set { Q("parent_node", value); } }
 		
 		///<summary>Cancel tasks with specified parent task id. Set to -1 to cancel all.</summary>
-		public long ParentTask { get { return Q<long>("parent_task"); } set { Q("parent_task", value); } }
+		public string ParentTask { get { return Q<string>("parent_task"); } set { Q("parent_task", value); } }
 		
 		///<summary>The URL-encoded request definition</summary>
 		public string Source { get { return Q<string>("source"); } set { Q("source", value); } }
@@ -4979,27 +4976,25 @@ namespace Nest
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
 		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
 		
-		//TODO THIS METHOD IS UNMAPPED!
-	
-	}
+		}
 	
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface ITasksListRequest : IRequest<TasksListRequestParameters> 
 	{
-		number_ TaskId { get; }
+		TaskId TaskId { get; }
 	 } 
 	///<summary>Request parameters for TasksList <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html</pre></summary>
 	public partial class TasksListRequest  : RequestBase<TasksListRequestParameters>, ITasksListRequest
 	{
 		protected ITasksListRequest Self => this;
-		number_ ITasksListRequest.TaskId => Self.RouteValues.Get<number_>("task_id");
+		TaskId ITasksListRequest.TaskId => Self.RouteValues.Get<TaskId>("task_id");
 			/// <summary>/_tasks</summary>
 		public TasksListRequest() : base(){}
 		
 
 		/// <summary>/_tasks/{task_id}</summary>
 ///<param name="task_id">Optional, accepts null</param>
-		public TasksListRequest(number_ task_id) : base(r=>r.Optional("task_id", task_id)){}
+		public TasksListRequest(TaskId task_id) : base(r=>r.Optional("task_id", task_id)){}
 		
 
 			///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
@@ -5015,7 +5010,7 @@ namespace Nest
 		public string ParentNode { get { return Q<string>("parent_node"); } set { Q("parent_node", value); } }
 		
 		///<summary>Return tasks with specified parent task id. Set to -1 to return all.</summary>
-		public long ParentTask { get { return Q<long>("parent_task"); } set { Q("parent_task", value); } }
+		public string ParentTask { get { return Q<string>("parent_task"); } set { Q("parent_task", value); } }
 		
 		///<summary>Wait for the matching tasks to complete (default: false)</summary>
 		public bool WaitForCompletion { get { return Q<bool>("wait_for_completion"); } set { Q("wait_for_completion", value); } }
@@ -5026,9 +5021,7 @@ namespace Nest
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
 		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
 		
-		//TODO THIS METHOD IS UNMAPPED!
-	
-	}
+		}
 	
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface ITermVectorsRequest<TDocument> : IRequest<TermVectorsRequestParameters> 
@@ -5155,20 +5148,20 @@ namespace Nest
 		Types Type { get; }
 	 } 
 	///<summary>Request parameters for UpdateByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
-	public partial class UpdateByQueryRequest  : RequestBase<UpdateByQueryRequestParameters>, IUpdateByQueryRequest
+	public partial class UpdateByQueryRequest<T>  : RequestBase<UpdateByQueryRequestParameters>, IUpdateByQueryRequest
 	{
 		protected IUpdateByQueryRequest Self => this;
 		Indices IUpdateByQueryRequest.Index => Self.RouteValues.Get<Indices>("index");
 		Types IUpdateByQueryRequest.Type => Self.RouteValues.Get<Types>("type");
 			/// <summary>/{index}/_update_by_query</summary>
-///<param name="index">Optional, accepts null</param>
-		public UpdateByQueryRequest(Indices index) : base(r=>r.Optional("index", index)){}
+///<param name="index">this parameter is required</param>
+		public UpdateByQueryRequest(Indices index) : base(r=>r.Required("index", index)){}
 		
 
 		/// <summary>/{index}/{type}/_update_by_query</summary>
-///<param name="index">Optional, accepts null</param>		
+///<param name="index">this parameter is required</param>		
 ///<param name="type">Optional, accepts null</param>
-		public UpdateByQueryRequest(Indices index, Types type) : base(r=>r.Optional("index", index).Optional("type", type)){}
+		public UpdateByQueryRequest(Indices index, Types type) : base(r=>r.Required("index", index).Optional("type", type)){}
 		
 
 			///<summary>The analyzer to use for the query string</summary>
@@ -5286,7 +5279,7 @@ namespace Nest
 		public Consistency Consistency { get { return Q<Consistency>("consistency"); } set { Q("consistency", value); } }
 		
 		///<summary>Size on the scroll request powering the update_by_query</summary>
-		public integer ScrollSize { get { return Q<integer>("scroll_size"); } set { Q("scroll_size", value); } }
+		public long ScrollSize { get { return Q<long>("scroll_size"); } set { Q("scroll_size", value); } }
 		
 		///<summary>Should the request should block until the reindex is complete.</summary>
 		public bool WaitForCompletion { get { return Q<bool>("wait_for_completion"); } set { Q("wait_for_completion", value); } }
@@ -5297,9 +5290,151 @@ namespace Nest
 		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
 		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
 		
-		//TODO THIS METHOD IS UNMAPPED!
-	
-	}
+		}
+	///<summary>Request parameters for UpdateByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
+	public partial class UpdateByQueryRequest  : RequestBase<UpdateByQueryRequestParameters>, IUpdateByQueryRequest
+	{
+		protected IUpdateByQueryRequest Self => this;
+		Indices IUpdateByQueryRequest.Index => Self.RouteValues.Get<Indices>("index");
+		Types IUpdateByQueryRequest.Type => Self.RouteValues.Get<Types>("type");
+			/// <summary>/{index}/_update_by_query</summary>
+///<param name="index">this parameter is required</param>
+		public UpdateByQueryRequest(Indices index) : base(r=>r.Required("index", index)){}
+		
+
+		/// <summary>/{index}/{type}/_update_by_query</summary>
+///<param name="index">this parameter is required</param>		
+///<param name="type">Optional, accepts null</param>
+		public UpdateByQueryRequest(Indices index, Types type) : base(r=>r.Required("index", index).Optional("type", type)){}
+		
+
+			///<summary>The analyzer to use for the query string</summary>
+		public string Analyzer { get { return Q<string>("analyzer"); } set { Q("analyzer", value); } }
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public bool AnalyzeWildcard { get { return Q<bool>("analyze_wildcard"); } set { Q("analyze_wildcard", value); } }
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public DefaultOperator DefaultOperator { get { return Q<DefaultOperator>("default_operator"); } set { Q("default_operator", value); } }
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public string Df { get { return Q<string>("df"); } set { Q("df", value); } }
+		
+		///<summary>Specify whether to return detailed information about score computation as part of a hit</summary>
+		public bool Explain { get { return Q<bool>("explain"); } set { Q("explain", value); } }
+		
+		///<summary>A comma-separated list of fields to return as part of a hit</summary>
+		public Fields Fields { get { return Q<Fields>("fields"); } set { Q("fields", value); } }
+		
+		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
+		public Fields FielddataFields { get { return Q<Fields>("fielddata_fields"); } set { Q("fielddata_fields", value); } }
+		
+		///<summary>Starting offset (default: 0)</summary>
+		public long From { get { return Q<long>("from"); } set { Q("from", value); } }
+		
+		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
+		public bool IgnoreUnavailable { get { return Q<bool>("ignore_unavailable"); } set { Q("ignore_unavailable", value); } }
+		
+		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
+		public bool AllowNoIndices { get { return Q<bool>("allow_no_indices"); } set { Q("allow_no_indices", value); } }
+		
+		///<summary>What to do when the reindex hits version conflicts?</summary>
+		public Conflicts Conflicts { get { return Q<Conflicts>("conflicts"); } set { Q("conflicts", value); } }
+		
+		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+		public ExpandWildcards ExpandWildcards { get { return Q<ExpandWildcards>("expand_wildcards"); } set { Q("expand_wildcards", value); } }
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public bool Lenient { get { return Q<bool>("lenient"); } set { Q("lenient", value); } }
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public bool LowercaseExpandedTerms { get { return Q<bool>("lowercase_expanded_terms"); } set { Q("lowercase_expanded_terms", value); } }
+		
+		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
+		public string Preference { get { return Q<string>("preference"); } set { Q("preference", value); } }
+		
+		///<summary>Query in the Lucene query string syntax</summary>
+		public string QueryOnQueryString { get { return Q<string>("q"); } set { Q("q", value); } }
+		
+		///<summary>A comma-separated list of specific routing values</summary>
+		public  string[] Routing { get { return Q< string[]>("routing"); } set { Q("routing", value); } }
+		
+		///<summary>Specify how long a consistent view of the index should be maintained for scrolled search</summary>
+		public Time Scroll { get { return Q<Time>("scroll"); } set { Q("scroll", value.ToString()); } }
+		
+		///<summary>Search operation type</summary>
+		public SearchType SearchType { get { return Q<SearchType>("search_type"); } set { Q("search_type", value); } }
+		
+		///<summary>Explicit timeout for each search request. Defaults to no timeout.</summary>
+		public Time SearchTimeout { get { return Q<Time>("search_timeout"); } set { Q("search_timeout", value.ToString()); } }
+		
+		///<summary>Number of hits to return (default: 10)</summary>
+		public long Size { get { return Q<long>("size"); } set { Q("size", value); } }
+		
+		///<summary>A comma-separated list of &lt;field&gt;:&lt;direction&gt; pairs</summary>
+		public  string[] Sort { get { return Q< string[]>("sort"); } set { Q("sort", value); } }
+		
+		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
+		public  string[] SourceEnabled { get { return Q< string[]>("_source"); } set { Q("_source", value); } }
+		
+		///<summary>A list of fields to exclude from the returned _source field</summary>
+		public Fields SourceExclude { get { return Q<Fields>("_source_exclude"); } set { Q("_source_exclude", value); } }
+		
+		///<summary>A list of fields to extract and return from the _source field</summary>
+		public Fields SourceInclude { get { return Q<Fields>("_source_include"); } set { Q("_source_include", value); } }
+		
+		///<summary>The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.</summary>
+		public long TerminateAfter { get { return Q<long>("terminate_after"); } set { Q("terminate_after", value); } }
+		
+		///<summary>Specific &#39;tag&#39; of the request for logging and statistical purposes</summary>
+		public  string[] Stats { get { return Q< string[]>("stats"); } set { Q("stats", value); } }
+		
+		///<summary>Specify which field to use for suggestions</summary>
+		public Field SuggestField { get { return Q<Field>("suggest_field"); } set { Q("suggest_field", value); } }
+		
+		///<summary>Specify suggest mode</summary>
+		public SuggestMode SuggestMode { get { return Q<SuggestMode>("suggest_mode"); } set { Q("suggest_mode", value); } }
+		
+		///<summary>How many suggestions to return in response</summary>
+		public long SuggestSize { get { return Q<long>("suggest_size"); } set { Q("suggest_size", value); } }
+		
+		///<summary>The source text for which the suggestions should be returned</summary>
+		public string SuggestText { get { return Q<string>("suggest_text"); } set { Q("suggest_text", value); } }
+		
+		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
+		public Time Timeout { get { return Q<Time>("timeout"); } set { Q("timeout", value.ToString()); } }
+		
+		///<summary>Whether to calculate and return scores even if they are not used for sorting</summary>
+		public bool TrackScores { get { return Q<bool>("track_scores"); } set { Q("track_scores", value); } }
+		
+		///<summary>Specify whether to return document version as part of a hit</summary>
+		public bool Version { get { return Q<bool>("version"); } set { Q("version", value); } }
+		
+		///<summary>Should the document increment the version number (internal) on hit or not (reindex)</summary>
+		public bool VersionType { get { return Q<bool>("version_type"); } set { Q("version_type", value); } }
+		
+		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
+		public bool RequestCache { get { return Q<bool>("request_cache"); } set { Q("request_cache", value); } }
+		
+		///<summary>Should the effected indexes be refreshed?</summary>
+		public bool Refresh { get { return Q<bool>("refresh"); } set { Q("refresh", value); } }
+		
+		///<summary>Explicit write consistency setting for the operation</summary>
+		public Consistency Consistency { get { return Q<Consistency>("consistency"); } set { Q("consistency", value); } }
+		
+		///<summary>Size on the scroll request powering the update_by_query</summary>
+		public long ScrollSize { get { return Q<long>("scroll_size"); } set { Q("scroll_size", value); } }
+		
+		///<summary>Should the request should block until the reindex is complete.</summary>
+		public bool WaitForCompletion { get { return Q<bool>("wait_for_completion"); } set { Q("wait_for_completion", value); } }
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source { get { return Q<string>("source"); } set { Q("source", value); } }
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
+		
+		}
 	
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface IUpdateIndexSettingsRequest : IRequest<UpdateIndexSettingsRequestParameters> 

--- a/src/Nest/_Generated/_Requests.generated.cs
+++ b/src/Nest/_Generated/_Requests.generated.cs
@@ -104,9 +104,9 @@ namespace Nest
 		public string Tokenizer { get { return Q<string>("tokenizer"); } set { Q("tokenizer", value); } }
 		
 		///<summary>With `true`, outputs more advanced details. (default: false)</summary>
-		public bool Detail { get { return Q<bool>("detail"); } set { Q("detail", value); } }
+		public bool Explain { get { return Q<bool>("explain"); } set { Q("explain", value); } }
 		
-		///<summary>A comma-separated list of token attributes to output, this parameter works only with `detail=true`</summary>
+		///<summary>A comma-separated list of token attributes to output, this parameter works only with `explain=true`</summary>
 		public  string[] Attributes { get { return Q< string[]>("attributes"); } set { Q("attributes", value); } }
 		
 		///<summary>Format of the output</summary>
@@ -3468,7 +3468,7 @@ namespace Nest
 	{
 		Indices Index { get; }
 	 } 
-	///<summary>Request parameters for IndicesOptimizeForAll <pre>https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html</pre></summary>
+	///<summary>Request parameters for IndicesOptimizeForAll <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-optimize.html</pre></summary>
 	public partial class OptimizeRequest  : RequestBase<OptimizeRequestParameters>, IOptimizeRequest
 	{
 		protected IOptimizeRequest Self => this;
@@ -4034,6 +4034,34 @@ namespace Nest
 		}
 	
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	public partial interface IReindexRequest : IRequest<ReindexRequestParameters> 
+	{
+	 } 
+	///<summary>Request parameters for Reindex <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
+	public partial class ReindexRequest  : RequestBase<ReindexRequestParameters>, IReindexRequest
+	{
+		protected IReindexRequest Self => this;
+				///<summary>Should the effected indexes be refreshed?</summary>
+		public bool Refresh { get { return Q<bool>("refresh"); } set { Q("refresh", value); } }
+		
+		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
+		public Time Timeout { get { return Q<Time>("timeout"); } set { Q("timeout", value.ToString()); } }
+		
+		///<summary>Explicit write consistency setting for the operation</summary>
+		public Consistency Consistency { get { return Q<Consistency>("consistency"); } set { Q("consistency", value); } }
+		
+		///<summary>Should the request should block until the reindex is complete.</summary>
+		public bool WaitForCompletion { get { return Q<bool>("wait_for_completion"); } set { Q("wait_for_completion", value); } }
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source { get { return Q<string>("source"); } set { Q("source", value); } }
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
+		
+		}
+	
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface IRenderSearchTemplateRequest : IRequest<RenderSearchTemplateRequestParameters> 
 	{
 		Id Id { get; }
@@ -4130,7 +4158,7 @@ namespace Nest
 		Indices Index { get; }
 		Types Type { get; }
 	 } 
-	///<summary>Request parameters for SearchExists <pre>https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html</pre></summary>
+	///<summary>Request parameters for SearchExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</pre></summary>
 	public partial class SearchExistsRequest<T>  : RequestBase<SearchExistsRequestParameters>, ISearchExistsRequest
 	{
 		protected ISearchExistsRequest Self => this;
@@ -4199,7 +4227,7 @@ namespace Nest
 		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
 		
 		}
-	///<summary>Request parameters for SearchExists <pre>https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-exists.html</pre></summary>
+	///<summary>Request parameters for SearchExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html</pre></summary>
 	public partial class SearchExistsRequest  : RequestBase<SearchExistsRequestParameters>, ISearchExistsRequest
 	{
 		protected ISearchExistsRequest Self => this;
@@ -4915,6 +4943,94 @@ namespace Nest
 		}
 	
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	public partial interface ITasksCancelRequest : IRequest<TasksCancelRequestParameters> 
+	{
+		number_ TaskId { get; }
+	 } 
+	///<summary>Request parameters for TasksCancel <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html</pre></summary>
+	public partial class TasksCancelRequest  : RequestBase<TasksCancelRequestParameters>, ITasksCancelRequest
+	{
+		protected ITasksCancelRequest Self => this;
+		number_ ITasksCancelRequest.TaskId => Self.RouteValues.Get<number_>("task_id");
+			/// <summary>/_tasks/_cancel</summary>
+		public TasksCancelRequest() : base(){}
+		
+
+		/// <summary>/_tasks/{task_id}/_cancel</summary>
+///<param name="task_id">Optional, accepts null</param>
+		public TasksCancelRequest(number_ task_id) : base(r=>r.Optional("task_id", task_id)){}
+		
+
+			///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
+		public  string[] NodeId { get { return Q< string[]>("node_id"); } set { Q("node_id", value); } }
+		
+		///<summary>A comma-separated list of actions that should be cancelled. Leave empty to cancel all.</summary>
+		public  string[] Actions { get { return Q< string[]>("actions"); } set { Q("actions", value); } }
+		
+		///<summary>Cancel tasks with specified parent node.</summary>
+		public string ParentNode { get { return Q<string>("parent_node"); } set { Q("parent_node", value); } }
+		
+		///<summary>Cancel tasks with specified parent task id. Set to -1 to cancel all.</summary>
+		public long ParentTask { get { return Q<long>("parent_task"); } set { Q("parent_task", value); } }
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source { get { return Q<string>("source"); } set { Q("source", value); } }
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
+		
+		//TODO THIS METHOD IS UNMAPPED!
+	
+	}
+	
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	public partial interface ITasksListRequest : IRequest<TasksListRequestParameters> 
+	{
+		number_ TaskId { get; }
+	 } 
+	///<summary>Request parameters for TasksList <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html</pre></summary>
+	public partial class TasksListRequest  : RequestBase<TasksListRequestParameters>, ITasksListRequest
+	{
+		protected ITasksListRequest Self => this;
+		number_ ITasksListRequest.TaskId => Self.RouteValues.Get<number_>("task_id");
+			/// <summary>/_tasks</summary>
+		public TasksListRequest() : base(){}
+		
+
+		/// <summary>/_tasks/{task_id}</summary>
+///<param name="task_id">Optional, accepts null</param>
+		public TasksListRequest(number_ task_id) : base(r=>r.Optional("task_id", task_id)){}
+		
+
+			///<summary>A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you&#39;re connecting to, leave empty to get information from all nodes</summary>
+		public  string[] NodeId { get { return Q< string[]>("node_id"); } set { Q("node_id", value); } }
+		
+		///<summary>A comma-separated list of actions that should be returned. Leave empty to return all.</summary>
+		public  string[] Actions { get { return Q< string[]>("actions"); } set { Q("actions", value); } }
+		
+		///<summary>Return detailed task information (default: false)</summary>
+		public bool Detailed { get { return Q<bool>("detailed"); } set { Q("detailed", value); } }
+		
+		///<summary>Return tasks with specified parent node.</summary>
+		public string ParentNode { get { return Q<string>("parent_node"); } set { Q("parent_node", value); } }
+		
+		///<summary>Return tasks with specified parent task id. Set to -1 to return all.</summary>
+		public long ParentTask { get { return Q<long>("parent_task"); } set { Q("parent_task", value); } }
+		
+		///<summary>Wait for the matching tasks to complete (default: false)</summary>
+		public bool WaitForCompletion { get { return Q<bool>("wait_for_completion"); } set { Q("wait_for_completion", value); } }
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source { get { return Q<string>("source"); } set { Q("source", value); } }
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
+		
+		//TODO THIS METHOD IS UNMAPPED!
+	
+	}
+	
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface ITermVectorsRequest<TDocument> : IRequest<TermVectorsRequestParameters> 
 	{
 		IndexName Index { get; }
@@ -5031,6 +5147,159 @@ namespace Nest
 		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
 		
 		}
+	
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	public partial interface IUpdateByQueryRequest : IRequest<UpdateByQueryRequestParameters> 
+	{
+		Indices Index { get; }
+		Types Type { get; }
+	 } 
+	///<summary>Request parameters for UpdateByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html</pre></summary>
+	public partial class UpdateByQueryRequest  : RequestBase<UpdateByQueryRequestParameters>, IUpdateByQueryRequest
+	{
+		protected IUpdateByQueryRequest Self => this;
+		Indices IUpdateByQueryRequest.Index => Self.RouteValues.Get<Indices>("index");
+		Types IUpdateByQueryRequest.Type => Self.RouteValues.Get<Types>("type");
+			/// <summary>/{index}/_update_by_query</summary>
+///<param name="index">Optional, accepts null</param>
+		public UpdateByQueryRequest(Indices index) : base(r=>r.Optional("index", index)){}
+		
+
+		/// <summary>/{index}/{type}/_update_by_query</summary>
+///<param name="index">Optional, accepts null</param>		
+///<param name="type">Optional, accepts null</param>
+		public UpdateByQueryRequest(Indices index, Types type) : base(r=>r.Optional("index", index).Optional("type", type)){}
+		
+
+			///<summary>The analyzer to use for the query string</summary>
+		public string Analyzer { get { return Q<string>("analyzer"); } set { Q("analyzer", value); } }
+		
+		///<summary>Specify whether wildcard and prefix queries should be analyzed (default: false)</summary>
+		public bool AnalyzeWildcard { get { return Q<bool>("analyze_wildcard"); } set { Q("analyze_wildcard", value); } }
+		
+		///<summary>The default operator for query string query (AND or OR)</summary>
+		public DefaultOperator DefaultOperator { get { return Q<DefaultOperator>("default_operator"); } set { Q("default_operator", value); } }
+		
+		///<summary>The field to use as default where no field prefix is given in the query string</summary>
+		public string Df { get { return Q<string>("df"); } set { Q("df", value); } }
+		
+		///<summary>Specify whether to return detailed information about score computation as part of a hit</summary>
+		public bool Explain { get { return Q<bool>("explain"); } set { Q("explain", value); } }
+		
+		///<summary>A comma-separated list of fields to return as part of a hit</summary>
+		public Fields Fields { get { return Q<Fields>("fields"); } set { Q("fields", value); } }
+		
+		///<summary>A comma-separated list of fields to return as the field data representation of a field for each hit</summary>
+		public Fields FielddataFields { get { return Q<Fields>("fielddata_fields"); } set { Q("fielddata_fields", value); } }
+		
+		///<summary>Starting offset (default: 0)</summary>
+		public long From { get { return Q<long>("from"); } set { Q("from", value); } }
+		
+		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
+		public bool IgnoreUnavailable { get { return Q<bool>("ignore_unavailable"); } set { Q("ignore_unavailable", value); } }
+		
+		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
+		public bool AllowNoIndices { get { return Q<bool>("allow_no_indices"); } set { Q("allow_no_indices", value); } }
+		
+		///<summary>What to do when the reindex hits version conflicts?</summary>
+		public Conflicts Conflicts { get { return Q<Conflicts>("conflicts"); } set { Q("conflicts", value); } }
+		
+		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+		public ExpandWildcards ExpandWildcards { get { return Q<ExpandWildcards>("expand_wildcards"); } set { Q("expand_wildcards", value); } }
+		
+		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
+		public bool Lenient { get { return Q<bool>("lenient"); } set { Q("lenient", value); } }
+		
+		///<summary>Specify whether query terms should be lowercased</summary>
+		public bool LowercaseExpandedTerms { get { return Q<bool>("lowercase_expanded_terms"); } set { Q("lowercase_expanded_terms", value); } }
+		
+		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
+		public string Preference { get { return Q<string>("preference"); } set { Q("preference", value); } }
+		
+		///<summary>Query in the Lucene query string syntax</summary>
+		public string QueryOnQueryString { get { return Q<string>("q"); } set { Q("q", value); } }
+		
+		///<summary>A comma-separated list of specific routing values</summary>
+		public  string[] Routing { get { return Q< string[]>("routing"); } set { Q("routing", value); } }
+		
+		///<summary>Specify how long a consistent view of the index should be maintained for scrolled search</summary>
+		public Time Scroll { get { return Q<Time>("scroll"); } set { Q("scroll", value.ToString()); } }
+		
+		///<summary>Search operation type</summary>
+		public SearchType SearchType { get { return Q<SearchType>("search_type"); } set { Q("search_type", value); } }
+		
+		///<summary>Explicit timeout for each search request. Defaults to no timeout.</summary>
+		public Time SearchTimeout { get { return Q<Time>("search_timeout"); } set { Q("search_timeout", value.ToString()); } }
+		
+		///<summary>Number of hits to return (default: 10)</summary>
+		public long Size { get { return Q<long>("size"); } set { Q("size", value); } }
+		
+		///<summary>A comma-separated list of &lt;field&gt;:&lt;direction&gt; pairs</summary>
+		public  string[] Sort { get { return Q< string[]>("sort"); } set { Q("sort", value); } }
+		
+		///<summary>True or false to return the _source field or not, or a list of fields to return</summary>
+		public  string[] SourceEnabled { get { return Q< string[]>("_source"); } set { Q("_source", value); } }
+		
+		///<summary>A list of fields to exclude from the returned _source field</summary>
+		public Fields SourceExclude { get { return Q<Fields>("_source_exclude"); } set { Q("_source_exclude", value); } }
+		
+		///<summary>A list of fields to extract and return from the _source field</summary>
+		public Fields SourceInclude { get { return Q<Fields>("_source_include"); } set { Q("_source_include", value); } }
+		
+		///<summary>The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.</summary>
+		public long TerminateAfter { get { return Q<long>("terminate_after"); } set { Q("terminate_after", value); } }
+		
+		///<summary>Specific &#39;tag&#39; of the request for logging and statistical purposes</summary>
+		public  string[] Stats { get { return Q< string[]>("stats"); } set { Q("stats", value); } }
+		
+		///<summary>Specify which field to use for suggestions</summary>
+		public Field SuggestField { get { return Q<Field>("suggest_field"); } set { Q("suggest_field", value); } }
+		
+		///<summary>Specify suggest mode</summary>
+		public SuggestMode SuggestMode { get { return Q<SuggestMode>("suggest_mode"); } set { Q("suggest_mode", value); } }
+		
+		///<summary>How many suggestions to return in response</summary>
+		public long SuggestSize { get { return Q<long>("suggest_size"); } set { Q("suggest_size", value); } }
+		
+		///<summary>The source text for which the suggestions should be returned</summary>
+		public string SuggestText { get { return Q<string>("suggest_text"); } set { Q("suggest_text", value); } }
+		
+		///<summary>Time each individual bulk request should wait for shards that are unavailable.</summary>
+		public Time Timeout { get { return Q<Time>("timeout"); } set { Q("timeout", value.ToString()); } }
+		
+		///<summary>Whether to calculate and return scores even if they are not used for sorting</summary>
+		public bool TrackScores { get { return Q<bool>("track_scores"); } set { Q("track_scores", value); } }
+		
+		///<summary>Specify whether to return document version as part of a hit</summary>
+		public bool Version { get { return Q<bool>("version"); } set { Q("version", value); } }
+		
+		///<summary>Should the document increment the version number (internal) on hit or not (reindex)</summary>
+		public bool VersionType { get { return Q<bool>("version_type"); } set { Q("version_type", value); } }
+		
+		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
+		public bool RequestCache { get { return Q<bool>("request_cache"); } set { Q("request_cache", value); } }
+		
+		///<summary>Should the effected indexes be refreshed?</summary>
+		public bool Refresh { get { return Q<bool>("refresh"); } set { Q("refresh", value); } }
+		
+		///<summary>Explicit write consistency setting for the operation</summary>
+		public Consistency Consistency { get { return Q<Consistency>("consistency"); } set { Q("consistency", value); } }
+		
+		///<summary>Size on the scroll request powering the update_by_query</summary>
+		public integer ScrollSize { get { return Q<integer>("scroll_size"); } set { Q("scroll_size", value); } }
+		
+		///<summary>Should the request should block until the reindex is complete.</summary>
+		public bool WaitForCompletion { get { return Q<bool>("wait_for_completion"); } set { Q("wait_for_completion", value); } }
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source { get { return Q<string>("source"); } set { Q("source", value); } }
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
+		
+		//TODO THIS METHOD IS UNMAPPED!
+	
+	}
 	
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface IUpdateIndexSettingsRequest : IRequest<UpdateIndexSettingsRequestParameters> 

--- a/src/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelApiTests.cs
+++ b/src/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelApiTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Xunit;
+
+namespace Tests.Cluster.TaskManagement.TasksCancel
+{
+	[Collection(IntegrationContext.OwnIndex)]
+	public class TasksCancelApiTests : ApiIntegrationTestBase<ITasksCancelResponse, ITasksCancelRequest, TasksCancelDescriptor, TasksCancelRequest>
+	{
+		public class Test
+		{
+			public long Id { get; set; }
+			public string Flag { get; set; }
+		}
+
+		public TasksCancelApiTests(OwnIndexCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected IDictionary<string, TaskId> SetupTaskIds { get; } = new Dictionary<string, TaskId>();
+
+		protected override void BeforeAllCalls(IElasticClient client, IDictionary<ClientMethod, string> values)
+		{
+			foreach (var index in values.Values)
+			{
+				client.IndexMany(Enumerable.Range(0, 10000).Select(i => new Test { Id = i + 1, Flag = "bar" }), index);
+				client.Refresh(index);
+			}
+			foreach (var index in values.Values)
+			{
+				var reindex = client.ReindexOnServer(r => r
+					.Source(s => s.Index(index))
+					.Destination(s => s.Index($"{index}-clone"))
+					.WaitForCompletion(false)
+				);
+
+				var taskId = reindex.Task;
+				var taskInfo = client.TasksList(new TasksListRequest(taskId));
+				taskInfo.IsValid.Should().BeTrue();
+				this.SetupTaskIds[index] = taskId;
+			}
+		}
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.TasksCancel(f),
+			fluentAsync: (client, f) => client.TasksCancelAsync(f),
+			request: (client, r) => client.TasksCancel(r),
+			requestAsync: (client, r) => client.TasksCancelAsync(r)
+		);
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+
+		protected override string UrlPath => $"/_reindex?refresh=true";
+
+		protected override bool SupportsDeserialization => false;
+
+		protected override Func<TasksCancelDescriptor, ITasksCancelRequest> Fluent => d => d
+			.TaskId(this.SetupTaskIds[CallIsolatedValue]);
+
+		protected override TasksCancelRequest Initializer => new TasksCancelRequest(this.SetupTaskIds[CallIsolatedValue]);
+
+		protected override void ExpectResponse(ITasksCancelResponse response)
+		{
+			response.NodeFailures.Should().BeNullOrEmpty();
+			response.Nodes.Should().NotBeEmpty();
+			var tasks = response.Nodes.First().Value.Tasks;
+			tasks.Should().NotBeEmpty().And.ContainKey(this.SetupTaskIds[CallIsolatedValue]);
+		}
+	}
+}

--- a/src/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelUrlTests.cs
+++ b/src/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelUrlTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using Nest;
+using Tests.Framework;
+using static Tests.Framework.UrlTester;
+
+namespace Tests.Cluster.TaskManagement.TasksCancel
+{
+	public class TasksCancelUrlTests : IUrlTests
+	{
+		[U] public async Task Urls()
+		{
+			await POST("/_tasks/_cancel")
+				.Fluent(c => c.TasksCancel())
+				.Request(c => c.TasksCancel(new TasksCancelRequest()))
+				.FluentAsync(c => c.TasksCancelAsync())
+				.RequestAsync(c => c.TasksCancelAsync(new TasksCancelRequest()))
+				;
+
+			var taskId = "node:4";
+			await POST($"/_tasks/node%3A4/_cancel")
+				.Fluent(c => c.TasksCancel(t=>t.TaskId(taskId)))
+				.Request(c => c.TasksCancel(new TasksCancelRequest(taskId)))
+				.FluentAsync(c => c.TasksCancelAsync(t=>t.TaskId(taskId)))
+				.RequestAsync(c => c.TasksCancelAsync(new TasksCancelRequest(taskId)))
+				;
+
+			var nodes = new []{  "node1", "node2" };
+			var actions = new[] { "*reindex" };
+			await POST($"/_tasks/_cancel?node_id=node1%2Cnode2&actions=%2Areindex")
+				.Fluent(c => c.TasksCancel(t => t.NodeId(nodes).Actions(actions)))
+				.Request(c => c.TasksCancel(new TasksCancelRequest { NodeId = nodes, Actions = actions }))
+				.FluentAsync(c => c.TasksCancelAsync(t => t.NodeId(nodes).Actions(actions)))
+				.RequestAsync(c => c.TasksCancelAsync(new TasksCancelRequest { NodeId = nodes, Actions = actions }))
+				;
+		}
+	}
+}

--- a/src/Tests/Cluster/TaskManagement/TasksList/TasksListApiTests.cs
+++ b/src/Tests/Cluster/TaskManagement/TasksList/TasksListApiTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Xunit;
+
+namespace Tests.Cluster.TaskManagement.TasksList
+{
+	[Collection(IntegrationContext.ReadOnly)]
+	public class TasksListApiTests : ApiIntegrationTestBase<ITasksListResponse, ITasksListRequest, TasksListDescriptor, TasksListRequest>
+	{
+		public TasksListApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.TasksList(f),
+			fluentAsync: (client, f) => client.TasksListAsync(f),
+			request: (client, r) => client.TasksList(r),
+			requestAsync: (client, r) => client.TasksListAsync(r)
+		);
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+		protected override HttpMethod HttpMethod => HttpMethod.GET;
+		protected override string UrlPath => "/_tasks?actions=%2Alists%2A";
+
+		protected override Func<TasksListDescriptor, ITasksListRequest> Fluent => s => s
+			.Actions("*lists*");
+
+		protected override TasksListRequest Initializer => new TasksListRequest
+		{
+			Actions = new [] { "*lists*" }
+		};
+
+		protected override void ExpectResponse(ITasksListResponse response)
+		{
+			response.Nodes.Should().NotBeEmpty();
+			var taskExecutingNode = response.Nodes.First().Value;
+			taskExecutingNode.Host.Should().NotBeNullOrWhiteSpace();
+			taskExecutingNode.Ip.Should().NotBeNullOrWhiteSpace();
+			taskExecutingNode.Name.Should().NotBeNullOrWhiteSpace();
+			taskExecutingNode.TransportAddress.Should().NotBeNullOrWhiteSpace();
+			taskExecutingNode.Tasks.Should().NotBeEmpty();
+			taskExecutingNode.Tasks.Count().Should().BeGreaterOrEqualTo(2);
+
+			var task = taskExecutingNode.Tasks.Values.First(p => p.ParentTaskId != null);
+			task.Action.Should().NotBeNullOrWhiteSpace();
+			task.Type.Should().NotBeNullOrWhiteSpace();
+			task.Id.Should().BePositive();
+			task.Node.Should().NotBeNullOrWhiteSpace();
+			task.RunningTimeInNanoSeconds.Should().BeGreaterThan(0);
+			task.StartTimeInMilliseconds.Should().BeGreaterThan(0);
+			task.ParentTaskId.Should().NotBeNull();
+
+			var parentTask = taskExecutingNode.Tasks[task.ParentTaskId];
+			parentTask.Should().NotBeNull();
+			parentTask.ParentTaskId.Should().BeNull();
+
+
+		}
+	}
+}

--- a/src/Tests/Cluster/TaskManagement/TasksList/TasksListUrlTests.cs
+++ b/src/Tests/Cluster/TaskManagement/TasksList/TasksListUrlTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.Cluster.TaskManagement.TasksList
+{
+	public class TasksListUrlTests : IUrlTests
+	{
+		[U] public async Task Urls()
+		{
+			await UrlTester.GET("/_tasks")
+				.Fluent(c => c.TasksList())
+				.Request(c => c.TasksList(new TasksListRequest()))
+				.FluentAsync(c => c.TasksListAsync())
+				.RequestAsync(c => c.TasksListAsync(new TasksListRequest()))
+				;
+
+			var taskId = "node:4";
+			await UrlTester.GET($"/_tasks/node%3A4")
+				.Fluent(c => c.TasksList(t=>t.TaskId(taskId)))
+				.Request(c => c.TasksList(new TasksListRequest(taskId)))
+				.FluentAsync(c => c.TasksListAsync(t=>t.TaskId(taskId)))
+				.RequestAsync(c => c.TasksListAsync(new TasksListRequest(taskId)))
+				;
+		}
+	}
+}

--- a/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
+++ b/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.MockData;
+using Xunit;
+using static Nest.Infer;
+
+namespace Tests.Document.Multiple.ReindexOnServer
+{
+	[Collection(IntegrationContext.OwnIndex)]
+	public class ReindexOnServerApiTests : ApiIntegrationTestBase<IReindexOnServerResponse, IReindexOnServerRequest, ReindexOnServerDescriptor, ReindexOnServerRequest>
+	{
+		public class Test
+		{
+			public long Id { get; set; }
+			public string Flag { get; set; }
+		}
+
+		public ReindexOnServerApiTests(OwnIndexCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void BeforeAllCalls(IElasticClient client, IDictionary<ClientMethod, string> values)
+		{
+			foreach (var index in values.Values)
+			{
+				this.Client.Index(new Test { Id = 1, Flag = "bar" }, i=>i.Index(index));
+				this.Client.Index(new Test { Id = 2, Flag = "bar" }, i=>i.Index(index).Refresh());
+			}
+		}
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.ReindexOnServer(f),
+			fluentAsync: (client, f) => client.ReindexOnServerAsync(f),
+			request: (client, r) => client.ReindexOnServer(r),
+			requestAsync: (client, r) => client.ReindexOnServerAsync(r)
+		);
+		protected override void OnAfterCall(IElasticClient client) => client.Refresh(CallIsolatedValue);
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+
+		protected override string UrlPath => $"/_reindex?refresh=true";
+
+		protected override bool SupportsDeserialization => false;
+
+		private static string _script = "if (ctx._source.flag == 'bar') {ctx._source.remove('flag')}";
+
+		protected override Func<ReindexOnServerDescriptor, IReindexOnServerRequest> Fluent => d => d
+			.Source(s=>s
+				.Index(CallIsolatedValue)
+				.Type("test")
+				.Query<Test>(q=>q
+					.Match(m=>m
+						.Field(p=>p.Flag)
+						.Query("bar")
+					)
+				)
+				.Sort<Test>(sort=>sort
+					.Ascending("id")
+				)
+			)
+			.Destination(s=>s
+				.Index(CallIsolatedValue + "-clone")
+				.Type("test")
+				.OpType(OpType.Create)
+				.VersionType(VersionType.Internal)
+				.Routing(ReindexRouting.Discard)
+			)
+			.Script(_script)
+			.Refresh();
+
+		protected override ReindexOnServerRequest Initializer => new ReindexOnServerRequest()
+		{
+			Source = new ReindexSource
+			{
+				Index = CallIsolatedValue,
+				Type = "test",
+				Query = new MatchQuery { Field = Field<Test>(p=>p.Flag), Query = "bar"},
+				Sort = new List<ISort> { new SortField { Field = "id", Order = SortOrder.Ascending } }
+
+			},
+			Destination = new ReindexDestination
+			{
+				Index = CallIsolatedValue + "-clone",
+				Type = Type<Test>(),
+				OpType = OpType.Create,
+				VersionType = VersionType.Internal,
+				Routing = ReindexRouting.Discard
+			},
+			Script = new InlineScript(_script),
+			Refresh = true,
+		};
+
+
+		protected override void ExpectResponse(IReindexOnServerResponse response)
+		{
+			response.Task.Should().BeNull();
+			response.Took.Should().BeGreaterThan(TimeSpan.FromMilliseconds(0));
+			response.Total.Should().Be(2);
+			response.Updated.Should().Be(0);
+			response.Created.Should().Be(2);
+			response.Batches.Should().Be(1);
+
+			var search = this.Client.Search<Test>(s => s
+				.Index(CallIsolatedValue + "-clone")
+			);
+			search.Total.Should().BeGreaterThan(0);
+			search.Documents.Should().OnlyContain(t=>string.IsNullOrWhiteSpace(t.Flag));
+		}
+
+
+		protected override object ExpectJson =>
+			new {
+				dest = new {
+					index = $"{CallIsolatedValue}-clone",
+					op_type = "create",
+					routing = "discard",
+					type = "test",
+					version_type = "internal"
+				},
+				script = new {
+					inline = _script
+				},
+				source = new {
+					index = CallIsolatedValue,
+					query = new { match = new { flag = new { query = "bar" } } },
+					sort = new [] { new { id = new { order = "asc" } } },
+					type = new [] { "test" }
+				}
+			};
+	}
+}

--- a/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerUrlTests.cs
+++ b/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerUrlTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+using static Tests.Framework.UrlTester;
+
+namespace Tests.Document.Multiple.ReindexOnServer
+{
+	public class ReindexOnServerUrlTests : IUrlTests
+	{
+		[U] public async Task Urls()
+		{
+			await POST("/_reindex")
+				.Fluent(c => c.ReindexOnServer(f=>f))
+				.Request(c => c.ReindexOnServer(new ReindexOnServerRequest()))
+				.FluentAsync(c => c.ReindexOnServerAsync(f=>f))
+				.RequestAsync(c => c.ReindexOnServerAsync(new ReindexOnServerRequest()))
+				;
+
+		}
+	}
+}

--- a/src/Tests/Document/Multiple/UpdateByQuery/UpdateByQueryApiTests.cs
+++ b/src/Tests/Document/Multiple/UpdateByQuery/UpdateByQueryApiTests.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.MockData;
+using Xunit;
+using static Nest.Infer;
+
+namespace Tests.Document.Multiple.UpdateByQuery
+{
+	[Collection(IntegrationContext.OwnIndex)]
+	public class UpdateByQueryApiTests : ApiIntegrationTestBase<IUpdateByQueryResponse, IUpdateByQueryRequest, UpdateByQueryDescriptor<UpdateByQueryApiTests.Test>, UpdateByQueryRequest>
+	{
+		public class Test
+		{
+			public string Text { get; set; }
+			public string Flag { get; set; }
+		}
+
+		public UpdateByQueryApiTests(OwnIndexCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void BeforeAllCalls(IElasticClient client, IDictionary<ClientMethod, string> values)
+		{
+			foreach (var index in values.Values)
+			{
+				this.Client.CreateIndex(index, c => c
+					.Mappings(m => m
+						.Map<Test>(map => map
+							.Dynamic(false)
+							.Properties(props => props
+								.String(s => s.Name(p => p.Text))
+							)
+						)
+					)
+				);
+				this.Client.Index(new Test { Text = "words words", Flag = "bar" }, i=>i.Index(index).Refresh());
+				this.Client.Index(new Test { Text = "words words", Flag = "foo" }, i=>i.Index(index).Refresh());
+				this.Client.Map<Test>(m => m
+					.Index(index)
+					.Properties(props => props
+						.String(s => s.Name(p => p.Text))
+						.String(s => s.Name(p => p.Flag).Analyzer("keyword"))
+					)
+				);
+
+				var searchResults = this.SearchFlags(index);
+				searchResults.Total.Should().Be(0);
+			}
+		}
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.UpdateByQuery(CallIsolatedValue, Type<Test>(), f),
+			fluentAsync: (client, f) => client.UpdateByQueryAsync(CallIsolatedValue, Type<Test>(), f),
+			request: (client, r) => client.UpdateByQuery(r),
+			requestAsync: (client, r) => client.UpdateByQueryAsync(r)
+		);
+		protected override void OnAfterCall(IElasticClient client) => client.Refresh(CallIsolatedValue);
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+
+		protected override string UrlPath => $"/{CallIsolatedValue}/test/_update_by_query?refresh=true&conflicts=proceed";
+
+		protected override bool SupportsDeserialization => false;
+
+		protected override object ExpectJson { get; } = new { };
+
+		protected override UpdateByQueryDescriptor<Test> NewDescriptor() => new UpdateByQueryDescriptor<Test>(CallIsolatedValue).Type<Test>();
+
+		protected override Func<UpdateByQueryDescriptor<Test>, IUpdateByQueryRequest> Fluent => d => d
+			.Refresh()
+			.Conflicts(Conflicts.Proceed);
+
+		protected override UpdateByQueryRequest Initializer => new UpdateByQueryRequest(CallIsolatedValue, Type<Test>())
+		{
+			Refresh = true,
+			Conflicts = Conflicts.Proceed
+		};
+
+		private ISearchResponse<Test> SearchFlags(string index) =>
+			this.Client.Search<Test>(s => s
+				.Index(index)
+				.Query(q => q.Match(m => m.Field(p => p.Flag).Query("foo")))
+			);
+
+		protected override void ExpectResponse(IUpdateByQueryResponse response)
+		{
+			response.Task.Should().BeNull();
+			response.Took.Should().BeGreaterThan(0);
+			response.Total.Should().Be(2);
+			response.Updated.Should().Be(2);
+			response.Batches.Should().Be(1);
+
+			var searchResponse = this.SearchFlags(CallIsolatedValue);
+			searchResponse.Total.Should().Be(1);
+		}
+	}
+
+	[Collection(IntegrationContext.OwnIndex)]
+	public class UpdateByQueryWaitForCompletionApiTests : UpdateByQueryApiTests
+	{
+		public UpdateByQueryWaitForCompletionApiTests(OwnIndexCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override string UrlPath => $"/{CallIsolatedValue}/test/_update_by_query?wait_for_completion=false&conflicts=proceed";
+
+		protected override Func<UpdateByQueryDescriptor<Test>, IUpdateByQueryRequest> Fluent => d => d
+			.WaitForCompletion(false)
+			.Conflicts(Conflicts.Proceed);
+
+		protected override UpdateByQueryRequest Initializer => new UpdateByQueryRequest(CallIsolatedValue, Type<Test>())
+		{
+			WaitForCompletion = false,
+			Conflicts = Conflicts.Proceed
+		};
+
+		protected override void ExpectResponse(IUpdateByQueryResponse response)
+		{
+			response.Task.Should().NotBeNull();
+			response.Task.TaskNumber.Should().BeGreaterThan(0);
+			response.Task.NodeId.Should().NotBeNullOrWhiteSpace();
+			response.Task.FullyQualifiedId.Should().NotBeNullOrWhiteSpace();
+		}
+	}
+
+	[Collection(IntegrationContext.OwnIndex)]
+	public class UpdateByQueryWithFailuresApiTests : UpdateByQueryApiTests
+	{
+		public UpdateByQueryWithFailuresApiTests(OwnIndexCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void BeforeAllCalls(IElasticClient client, IDictionary<ClientMethod, string> values)
+		{
+			foreach (var index in values.Values)
+			{
+				this.Client.CreateIndex(index, c => c
+					.Settings(s=>s
+						.RefreshInterval(-1)
+					)
+				);
+				this.Client.Index(new Test { Text = "test1", Flag = "bar" }, i=>i.Index(index).Id(1).Refresh());
+				this.Client.Index(new Test { Text = "test2", Flag = "bar" }, i=>i.Index(index).Id(1));
+			}
+		}
+		private static string _script = "ctx._source.text = 'x'";
+
+		protected override bool ExpectIsValid => false;
+		protected override int ExpectStatusCode => 409;
+
+		protected override string UrlPath => $"/{CallIsolatedValue}/test/_update_by_query";
+		protected override object ExpectJson { get; } =
+			new
+			{
+				query = new { match = new { flag = new { query = "bar" } } },
+				script = new { inline = "ctx._source.text = 'x'" }
+			};
+
+		protected override Func<UpdateByQueryDescriptor<Test>, IUpdateByQueryRequest> Fluent => d => d
+			.Query(q=>q.Match(m=>m.Field(p=>p.Flag).Query("bar")))
+			.Script(_script)
+			;
+
+		protected override UpdateByQueryRequest Initializer => new UpdateByQueryRequest(CallIsolatedValue, Type<Test>())
+		{
+			Query = new MatchQuery
+			{
+				Field = Field<Test>(p=>p.Flag),
+				Query = "bar"
+			},
+			Script = new InlineScript(_script),
+		};
+
+		protected override void ExpectResponse(IUpdateByQueryResponse response)
+		{
+			response.VersionConflicts.Should().Be(1);
+			response.Failures.Should().NotBeEmpty();
+			var failure = response.Failures.First();
+			failure.Id.Should().NotBeNullOrWhiteSpace();
+			failure.Index.Should().NotBeNullOrWhiteSpace();
+			failure.Cause.Should().NotBeNull();
+			failure.Cause.Type.Should().NotBeNullOrWhiteSpace();
+			failure.Cause.Reason.Should().NotBeNullOrWhiteSpace();
+		}
+	}
+}

--- a/src/Tests/Document/Multiple/UpdateByQuery/UpdateByQueryUrlTests.cs
+++ b/src/Tests/Document/Multiple/UpdateByQuery/UpdateByQueryUrlTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+using static Tests.Framework.UrlTester;
+using static Nest.Infer;
+
+namespace Tests.Document.Multiple.UpdateByQuery
+{
+	public class UpdateByQueryUrlTests : IUrlTests
+	{
+		[U] public async Task Urls()
+		{
+			await POST("/project/_update_by_query")
+				.Fluent(c => c.UpdateByQuery<Project>("project", Types.All,d => d))
+				.Request(c => c.UpdateByQuery(new UpdateByQueryRequest<Project>("project")))
+				.FluentAsync(c => c.UpdateByQueryAsync<Project>("project", Types.All, d => d))
+				.RequestAsync(c => c.UpdateByQueryAsync(new UpdateByQueryRequest<Project>("project")))
+				;
+
+			await POST("/project/project/_update_by_query")
+				.Fluent(c => c.UpdateByQuery<Project>("project", Type<Project>(), d=>d))
+				.Request(c => c.UpdateByQuery(new UpdateByQueryRequest<Project>("project", "project")))
+				.FluentAsync(c => c.UpdateByQueryAsync<Project>(Index<Project>(), Type<Project>(), d=>d))
+				.RequestAsync(c => c.UpdateByQueryAsync(new UpdateByQueryRequest<Project>("project", "project")))
+				;
+		}
+	}
+}

--- a/src/Tests/Framework/Extensions/DiffExtensions.cs
+++ b/src/Tests/Framework/Extensions/DiffExtensions.cs
@@ -47,6 +47,7 @@ namespace Tests.Framework
 			approx = Regex.Replace(approx, @"^\s*\],?.*$", s => s.Value.Replace("]", "}"), RegexOptions.Multiline);
 			diff += approx + ";";
 
+
 			throw new Exception(diff);
 		}
 

--- a/src/Tests/Mapping/Types/Core/Number/NumberMappingTests.cs
+++ b/src/Tests/Mapping/Types/Core/Number/NumberMappingTests.cs
@@ -22,27 +22,27 @@ namespace Tests.Mapping.Types.Core.Number
 		[Number]
 		public double Minimal { get; set; }
 
-        public byte Byte { get; set; }
+		public byte Byte { get; set; }
 
-        public short Short { get; set; }
+		public short Short { get; set; }
 
-        public int Integer { get; set; }
+		public int Integer { get; set; }
 
-        public long Long { get; set; }
+		public long Long { get; set; }
 
-        public sbyte SignedByte { get; set; }
+		public sbyte SignedByte { get; set; }
 
-        public ushort UnsignedShort { get; set; }
+		public ushort UnsignedShort { get; set; }
 
-        public uint UnsignedInteger { get; set; }
+		public uint UnsignedInteger { get; set; }
 
-        public ulong UnsignedLong { get; set; }
+		public ulong UnsignedLong { get; set; }
 
-        public float Float { get; set; } 
+		public float Float { get; set; }
 
-        public double Double { get; set; }
+		public double Double { get; set; }
 
-        public decimal Decimal { get; set; }
+		public decimal Decimal { get; set; }
 
 		public TimeSpan TimeSpan { get; set; }
 	}
@@ -73,50 +73,50 @@ namespace Tests.Mapping.Types.Core.Number
 				{
 					type = "double"
 				},
-                @byte = new
-                {
-                    type = "short"
-			    },
-                @short = new
-                {
-                    type = "short"
-                },
-                integer = new
-                {
-                    type = "integer"  
-                },
-                @long = new
-                {
-                    type = "long"
-                },
-                signedByte = new
-			    {
-                    type = "byte"
-			    },
-                unsignedShort = new
-                {
-                    type = "integer"
-                },
-                unsignedInteger = new
-                {
-                    type = "long"
-                },
-                unsignedLong = new
-                {
-                    type = "double"
-                },
-                @float = new
-                {
-                    type = "float"
-                },             
-                @double = new
-                {
-                    type = "double"
-                },
-                @decimal = new
-                {
-                    type = "double"
-                },
+				@byte = new
+				{
+					type = "short"
+				},
+				@short = new
+				{
+					type = "short"
+				},
+				integer = new
+				{
+					type = "integer"
+				},
+				@long = new
+				{
+					type = "long"
+				},
+				signedByte = new
+				{
+					type = "byte"
+				},
+				unsignedShort = new
+				{
+					type = "integer"
+				},
+				unsignedInteger = new
+				{
+					type = "long"
+				},
+				unsignedLong = new
+				{
+					type = "double"
+				},
+				@float = new
+				{
+					type = "float"
+				},
+				@double = new
+				{
+					type = "double"
+				},
+				@decimal = new
+				{
+					type = "double"
+				},
 				timeSpan = new
 				{
 					type = "long"
@@ -124,68 +124,68 @@ namespace Tests.Mapping.Types.Core.Number
 			}
 		};
 
-	    protected override Func<PropertiesDescriptor<NumberTest>, IPromise<IProperties>> FluentProperties => m => m
-	        .Number(d => d
-	            .Name(o => o.Full)
-	            .DocValues()
-	            .IndexName("myindex")
-	            .Similarity(SimilarityOption.Default)
-	            .Store()
-	            .Index(NonStringIndexOption.No)
-	            .Boost(1.5)
-	            .NullValue(0.0)
-	            .IncludeInAll(false)
-	            .PrecisionStep(10)
-	            .IgnoreMalformed()
-	            .Coerce()
-	        )
-	        .Number(d => d
-	            .Name(o => o.Minimal)
-	        )
-	        .Number(d => d
-	            .Name(o => o.Byte)
-                .Type(NumberType.Short)
-	        )
-	        .Number(d => d
-	            .Name(o => o.Short)
-                .Type(NumberType.Short)
-            )
-	        .Number(d => d
-	            .Name(o => o.Integer)
-                .Type(NumberType.Integer)
-	        )
-	        .Number(d => d
-	            .Name(o => o.Long)
-                .Type(NumberType.Long)
-            )
-	        .Number(d => d
-	            .Name(o => o.SignedByte)
-                .Type(NumberType.Byte)
-            )
-	        .Number(d => d
-	            .Name(o => o.UnsignedShort)
-                .Type(NumberType.Integer)
-	        )
-	        .Number(d => d
-	            .Name(o => o.UnsignedInteger)
-                .Type(NumberType.Long)
-            )
-	        .Number(d => d
-	            .Name(o => o.UnsignedLong)
-                .Type(NumberType.Double)
-            )
-	        .Number(d => d
-	            .Name(o => o.Float)
-                .Type(NumberType.Float)
-            )
-	        .Number(d => d
-	            .Name(o => o.Double)
-	        )
+		protected override Func<PropertiesDescriptor<NumberTest>, IPromise<IProperties>> FluentProperties => m => m
 			.Number(d => d
-	            .Name(o => o.Decimal)
-	        )
+				.Name(o => o.Full)
+				.DocValues()
+				.IndexName("myindex")
+				.Similarity(SimilarityOption.Default)
+				.Store()
+				.Index(NonStringIndexOption.No)
+				.Boost(1.5)
+				.NullValue(0.0)
+				.IncludeInAll(false)
+				.PrecisionStep(10)
+				.IgnoreMalformed()
+				.Coerce()
+			)
 			.Number(d => d
-	            .Name(o => o.TimeSpan)
+				.Name(o => o.Minimal)
+			)
+			.Number(d => d
+				.Name(o => o.Byte)
+				.Type(NumberType.Short)
+			)
+			.Number(d => d
+				.Name(o => o.Short)
+				.Type(NumberType.Short)
+			)
+			.Number(d => d
+				.Name(o => o.Integer)
+				.Type(NumberType.Integer)
+			)
+			.Number(d => d
+				.Name(o => o.Long)
+				.Type(NumberType.Long)
+			)
+			.Number(d => d
+				.Name(o => o.SignedByte)
+				.Type(NumberType.Byte)
+			)
+			.Number(d => d
+				.Name(o => o.UnsignedShort)
+				.Type(NumberType.Integer)
+			)
+			.Number(d => d
+				.Name(o => o.UnsignedInteger)
+				.Type(NumberType.Long)
+			)
+			.Number(d => d
+				.Name(o => o.UnsignedLong)
+				.Type(NumberType.Double)
+			)
+			.Number(d => d
+				.Name(o => o.Float)
+				.Type(NumberType.Float)
+			)
+			.Number(d => d
+				.Name(o => o.Double)
+			)
+			.Number(d => d
+				.Name(o => o.Decimal)
+			)
+			.Number(d => d
+				.Name(o => o.TimeSpan)
 				.Type(NumberType.Long)
 			);
 	}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -544,7 +544,15 @@
     <Compile Include="ClientConcepts\HighLevel\Inference\IndexNameInference.doc.cs" />
     <Compile Include="ClientConcepts\HighLevel\Inference\IndicesPaths.doc.cs" />
     <Compile Include="ClientConcepts\HighLevel\Inference\PropertyInference.doc.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksCancel\TasksCancelApiTests.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksCancel\TasksCancelUrlTests.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksList\TasksListApiTests.cs" />
+    <Compile Include="Cluster\TaskManagement\TasksList\TasksListUrlTests.cs" />
     <Compile Include="CommonOptions\DistanceUnit\DistanceUnits.doc.cs" />
+    <Compile Include="Document\Multiple\ReindexOnServer\ReindexOnServerUrlTests.cs" />
+    <Compile Include="Document\Multiple\ReindexOnServer\ReindexOnServerApiTests.cs" />
+    <Compile Include="Document\Multiple\UpdateByQuery\UpdateByQueryApiTests.cs" />
+    <Compile Include="Document\Multiple\UpdateByQuery\UpdateByQueryUrlTests.cs" />
     <Compile Include="QueryDsl\BoolDsl\Operators\CombinatorialUsageTests.cs" />
     <Compile Include="QueryDsl\QueryDslIntegrationTestsBase.cs" />
     <Compile Include="QueryDsl\TermLevel\Terms\TermsListQueryUsageTests.cs" />
@@ -590,25 +598,9 @@
     <Content Include="ClientConcepts\LowLevel\class.png" />
     <Content Include="ClientConcepts\LowLevel\pipeline.png" />
     <Content Include="ClientConcepts\LowLevel\pipeline.xml" />
+    <Content Include="QueryDsl\BoolDsl\hadouken-indentation.jpg" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5.1'">
-      <PropertyGroup>
-        <__paket__xunit_core_props>win81\xunit.core</__paket__xunit_core_props>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
-      <PropertyGroup>
-        <__paket__xunit_core_props>wpa81\xunit.core</__paket__xunit_core_props>
-      </PropertyGroup>
-    </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <PropertyGroup>
-        <__paket__xunit_core_props>portable-net45+win8+wp8+wpa81\xunit.core</__paket__xunit_core_props>
-      </PropertyGroup>
-    </When>
-  </Choose>
   <Import Project="..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props" Condition="Exists('..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props')" Label="Paket" />
   <Import Project="..\..\.paket\paket.targets" />
   <Choose>

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: m
 # the elasticsearch version that should be started
 elasticsearch_version: 2.3.0
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
This commit adds support for the new 2.3 API's:

* tasks_list
* tasks_cancel
* update_by_query
* reindex

The spec changes have also been updated in core upstream.

The Reindex API is called `ReindexOnServer()` to offset it against our
current `Reindex()` implementation which is still very useful.

Both the reindex and update_by_query steal the status code from one of
the failures and return a valid json body that we need to deserialize.
To support this this AllowedStatusCodes now accepts a -1.

`.IsValid` for these API's inspects whether any failures have been
returned or not.