### PR TITLE
Add not_analyzed to NonStringIndexOption and make it the default option

### DIFF
--- a/src/Nest/Mapping/NonStringIndexOption.cs
+++ b/src/Nest/Mapping/NonStringIndexOption.cs
@@ -7,6 +7,8 @@ namespace Nest
 	[JsonConverter(typeof(StringEnumConverter))]
 	public enum NonStringIndexOption
 	{
+		[EnumMember(Value = "not_analyzed")]
+		NotAnalyzed,
 		[EnumMember(Value = "no")]
 		No
 	}

--- a/src/Nest/Mapping/Types/Core/Boolean/BooleanProperty.cs
+++ b/src/Nest/Mapping/Types/Core/Boolean/BooleanProperty.cs
@@ -19,7 +19,7 @@ namespace Nest
 		[JsonProperty("fielddata")]
 		INumericFielddata Fielddata { get; set; }
 	}
-	
+
 	public class BooleanProperty : PropertyBase, IBooleanProperty
 	{
 		public BooleanProperty() : base("boolean") { }
@@ -42,7 +42,7 @@ namespace Nest
 		public BooleanPropertyDescriptor() : base("boolean") { }
 
 		public BooleanPropertyDescriptor<T> Boost(double boost) => Assign(a => a.Boost = boost);
-		public BooleanPropertyDescriptor<T> Index(NonStringIndexOption index) => Assign(a => a.Index = index);
+		public BooleanPropertyDescriptor<T> Index(NonStringIndexOption index = NonStringIndexOption.NotAnalyzed) => Assign(a => a.Index = index);
 		public BooleanPropertyDescriptor<T> NullValue(bool nullValue) => Assign(a => a.NullValue = nullValue);
 		public BooleanPropertyDescriptor<T> Fielddata(Func<NumericFielddataDescriptor, INumericFielddata> selector) =>
 			Assign(a => a.Fielddata = selector(new NumericFielddataDescriptor()));

--- a/src/Nest/Mapping/Types/Core/Date/DateProperty.cs
+++ b/src/Nest/Mapping/Types/Core/Date/DateProperty.cs
@@ -20,13 +20,13 @@ namespace Nest
 
 		[JsonProperty("precision_step")]
 		int? PrecisionStep { get; set; }
-		
+
 		[JsonProperty("ignore_malformed")]
 		bool? IgnoreMalformed { get; set; }
-		
+
 		[JsonProperty("format")]
 		string Format { get; set; }
-		
+
 		[JsonProperty("numeric_resolution")]
         NumericResolutionUnit? NumericResolution { get; set; }
 
@@ -49,7 +49,7 @@ namespace Nest
 		public INumericFielddata Fielddata { get; set; }
 	}
 
-	public class DatePropertyDescriptor<T> 
+	public class DatePropertyDescriptor<T>
 		: PropertyDescriptorBase<DatePropertyDescriptor<T>, IDateProperty, T>, IDateProperty
 		where T : class
 	{
@@ -65,7 +65,7 @@ namespace Nest
 
 		public DatePropertyDescriptor() : base("date") { }
 
-		public DatePropertyDescriptor<T> Index(NonStringIndexOption index = NonStringIndexOption.No) => Assign(a => a.Index = index);
+		public DatePropertyDescriptor<T> Index(NonStringIndexOption index = NonStringIndexOption.NotAnalyzed) => Assign(a => a.Index = index);
 		public DatePropertyDescriptor<T> Boost(double boost) => Assign(a => a.Boost = boost);
 		public DatePropertyDescriptor<T> NullValue(DateTime nullValue) => Assign(a => a.NullValue = nullValue);
 		public DatePropertyDescriptor<T> IncludeInAll(bool includeInAll = true) => Assign(a => a.IncludeInAll = includeInAll);

--- a/src/Nest/Mapping/Types/Core/Number/NumberProperty.cs
+++ b/src/Nest/Mapping/Types/Core/Number/NumberProperty.cs
@@ -68,7 +68,7 @@ namespace Nest
 
 		public TDescriptor Type(NumberType type) => Assign(a => a.Type = type.GetStringValue());
 
-		public TDescriptor Index(NonStringIndexOption index = NonStringIndexOption.No) => Assign(a => a.Index = index);
+		public TDescriptor Index(NonStringIndexOption index = NonStringIndexOption.NotAnalyzed) => Assign(a => a.Index = index);
 
 		public TDescriptor Boost(double boost) => Assign(a => a.Boost = boost);
 
@@ -86,7 +86,7 @@ namespace Nest
 			Assign(a => a.Fielddata = selector(new NumericFielddataDescriptor()));
 	}
 
-	public class NumberPropertyDescriptor<T> 
+	public class NumberPropertyDescriptor<T>
 		: NumberPropertyDescriptorBase<NumberPropertyDescriptor<T>, INumberProperty, T>, INumberProperty
 		where T : class
 	{

--- a/src/Nest/Mapping/Types/Specialized/Ip/IpProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/Ip/IpProperty.cs
@@ -44,7 +44,7 @@ namespace Nest
 
 		public IpPropertyDescriptor() : base("ip") { }
 
-		public IpPropertyDescriptor<T> Index(NonStringIndexOption? index) => Assign(a => a.Index = index);
+		public IpPropertyDescriptor<T> Index(NonStringIndexOption? index = NonStringIndexOption.NotAnalyzed) => Assign(a => a.Index = index);
 
 		public IpPropertyDescriptor<T> Boost(double boost) => Assign(a => a.Boost = boost);
 

--- a/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
@@ -16,7 +16,7 @@ namespace Nest
 		public string Analyzer { get; set; }
 	}
 
-	public class TokenCountPropertyDescriptor<T> 
+	public class TokenCountPropertyDescriptor<T>
 		: NumberPropertyDescriptorBase<TokenCountPropertyDescriptor<T>, ITokenCountProperty, T>, ITokenCountProperty
 		where T : class
 	{

--- a/src/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
+++ b/src/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
@@ -123,11 +123,13 @@ namespace Tests.Indices.MappingManagement.PutMapping
 				},
 				numberOfCommits = new
 				{
-					type = "integer"
+					type = "integer",
+					index = "not_analyzed"
 				},
 				startedOn = new
 				{
-					type = "date"
+					type = "date",
+					index = "no"
 				},
 				state = new
 				{
@@ -160,6 +162,15 @@ namespace Tests.Indices.MappingManagement.PutMapping
 			.Index(CallIsolatedValue)
 			.AutoMap()
 			.Properties(prop => prop
+				.Number(n => n
+					.Name(p => p.NumberOfCommits)
+					.Type(NumberType.Integer)
+					.Index()
+				)
+				.Date(dt => dt
+					.Name(p => p.StartedOn)
+					.Index(NonStringIndexOption.No)
+				)
 				.String(s => s
 					.Name(p => p.Name)
 					.NotAnalyzed()
@@ -211,8 +222,8 @@ namespace Tests.Indices.MappingManagement.PutMapping
 				},
 				{ p => p.Metadata, new ObjectProperty() },
 				{ p => p.Name, new StringProperty { Index = FieldIndexOption.NotAnalyzed }  },
-				{ p => p.NumberOfCommits, new NumberProperty(NumberType.Integer) },
-				{ p => p.StartedOn, new DateProperty() },
+				{ p => p.NumberOfCommits, new NumberProperty(NumberType.Integer) { Index = NonStringIndexOption.NotAnalyzed } },
+				{ p => p.StartedOn, new DateProperty { Index = NonStringIndexOption.No } },
 				{ p => p.State, new NumberProperty(NumberType.Integer) },
 				{ p => p.Suggest, new CompletionProperty() },
 				{ p => p.Tags, new ObjectProperty


### PR DESCRIPTION
This PR is questionable because it changes the default behavior of `Index()`, which previously defaulted to `no`, but now will default to `not_analyzed`.

@Mpdreamz @russcam thoughts?

Closes #1979