### PR TITLE
Deprecate fuzziness ratio

### DIFF
--- a/src/Nest/DSL/Suggest/Fuzziness.cs
+++ b/src/Nest/DSL/Suggest/Fuzziness.cs
@@ -1,4 +1,6 @@
-﻿namespace Nest
+﻿using System;
+
+namespace Nest
 {
 	public class Fuzziness : IFuzziness
 	{
@@ -7,6 +9,8 @@
 		private double? _ratio;
 		bool IFuzziness.Auto { get { return this._auto; } }
 		int? IFuzziness.EditDistance { get { return this._editDistance; } }
+
+		[Obsolete("Deprecated in Elasticsearch 2.0")]
 		double? IFuzziness.Ratio { get { return this._ratio; } }
 
 		public static Fuzziness Auto { get { return new Fuzziness() { _auto = true }; } }
@@ -16,6 +20,7 @@
 			return new Fuzziness() { _editDistance = distance };
 		}
 
+		[Obsolete("Deprecated in Elasticsearch 2.0")]
 		public static Fuzziness Ratio(double ratio)
 		{
 			return new Fuzziness() { _ratio = ratio };

--- a/src/Nest/DSL/Suggest/FuzzySuggestDescriptor.cs
+++ b/src/Nest/DSL/Suggest/FuzzySuggestDescriptor.cs
@@ -59,6 +59,8 @@ namespace Nest
 			Self.Fuzziness = Nest.Fuzziness.EditDistance(editDistance);
 			return this;
 		}
+
+		[Obsolete("Deprecated in Elasticsearch 2.0")]
 		public FuzzySuggestDescriptor<T> Fuzziness(double ratio)
 		{
 			Self.Fuzziness = Nest.Fuzziness.Ratio(ratio);

--- a/src/Nest/DSL/Suggest/IFuzziness.cs
+++ b/src/Nest/DSL/Suggest/IFuzziness.cs
@@ -1,4 +1,5 @@
-﻿using Nest.Resolvers.Converters;
+﻿using System;
+using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -8,6 +9,8 @@ namespace Nest
 	{
 		bool Auto { get;  }
 		int? EditDistance { get;  }
+
+		[Obsolete("Deprecated in Elasticsearch 2.0")]
 		double? Ratio { get;  }
 	}
 }

--- a/src/Nest/Resolvers/Converters/FuzzinessConverter.cs
+++ b/src/Nest/Resolvers/Converters/FuzzinessConverter.cs
@@ -15,8 +15,10 @@ namespace Nest.Resolvers.Converters
 		{
 			var v = value as IFuzziness;
 			if (v.Auto) writer.WriteValue("AUTO"); 
-			else if (v.EditDistance.HasValue) writer.WriteValue(v.EditDistance.Value); 
+			else if (v.EditDistance.HasValue) writer.WriteValue(v.EditDistance.Value);
+#pragma warning disable 618
 			else if (v.Ratio.HasValue) writer.WriteValue(v.Ratio.Value);
+#pragma warning restore 618
 			else writer.WriteNull(); 
 		}
 
@@ -32,7 +34,9 @@ namespace Nest.Resolvers.Converters
 			if (reader.TokenType == JsonToken.Float)
 			{
 				var ratio = (reader.Value as double?).GetValueOrDefault(0);
+#pragma warning disable 618
 				return Fuzziness.Ratio(ratio);
+#pragma warning restore 618
 			}
 			return null;
 		}

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Search/SearchRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Search/SearchRequestTests.cs
@@ -74,7 +74,9 @@ namespace Nest.Tests.Unit.ObjectInitializer.Search
 								ShardSize = 10,
 								Fuzzy = new FuzzySuggester
 								{
+#pragma warning disable 618
 									Fuzziness = Fuzziness.Ratio(0.3),
+#pragma warning restore 618
 									PrefixLength = 4
 								}
 

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Suggest/SuggestRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Suggest/SuggestRequestTests.cs
@@ -33,7 +33,9 @@ namespace Nest.Tests.Unit.ObjectInitializer.Suggest
 						ShardSize = 10,
 						Fuzzy = new FuzzySuggester
 						{
+#pragma warning disable 618
 							Fuzziness = Fuzziness.Ratio(0.3),
+#pragma warning restore 618
 							PrefixLength = 4
 						}
 					} 

--- a/src/Tests/Nest.Tests.Unit/Search/InitializerSyntax/InitializerExample.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/InitializerSyntax/InitializerExample.cs
@@ -94,7 +94,9 @@ namespace Nest.Tests.Unit.Search.InitializerSyntax
 								ShardSize = 10,
 								Fuzzy = new FuzzySuggester
 								{
+#pragma warning disable 618
 									Fuzziness = Fuzziness.Ratio(0.3),
+#pragma warning restore 618
 									PrefixLength = 4
 								}
 

--- a/src/Tests/Nest.Tests.Unit/Search/Suggest/CompletionSuggestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Suggest/CompletionSuggestTests.cs
@@ -93,7 +93,9 @@ namespace Nest.Tests.Unit.Search.Suggest
 			var completionSuggestDescriptor = new CompletionSuggestDescriptor<ElasticsearchProject>()
 				.OnField("suggest")
 				.Text("n")
+#pragma warning disable 618
 				.Fuzzy(f => f.Fuzziness(0.4));
+#pragma warning restore 618
 
 			var json = TestElasticClient.Serialize(completionSuggestDescriptor);
 


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch-net/issues/1997

It looks like this was deprecated in 1.7 and removed in 2.0 - https://www.elastic.co/guide/en/elasticsearch/reference/1.7/common-options.html#fuzziness
Since it still exists in NEST 2.x, I've marked as deprecated here - will no-op in NEST 2.x