### PR TITLE
Changes to queries for 5.0

### DIFF
--- a/src/Nest/CommonOptions/Fuzziness/Fuzziness.cs
+++ b/src/Nest/CommonOptions/Fuzziness/Fuzziness.cs
@@ -1,24 +1,24 @@
-﻿namespace Nest
+﻿using System;
+
+namespace Nest
 {
 	public class Fuzziness : IFuzziness
 	{
 		private bool _auto;
 		private int? _editDistance;
 		private double? _ratio;
-		bool IFuzziness.Auto { get { return this._auto; } }
-		int? IFuzziness.EditDistance { get { return this._editDistance; } }
-		double? IFuzziness.Ratio { get { return this._ratio; } }
+		bool IFuzziness.Auto => this._auto;
 
-		public static Fuzziness Auto { get { return new Fuzziness() { _auto = true }; } }
+		int? IFuzziness.EditDistance => this._editDistance;
 
-		public static Fuzziness EditDistance(int distance)
-		{
-			return new Fuzziness() { _editDistance = distance };
-		}
+		[Obsolete("Deprecated. Setting this is a noop")]
+		double? IFuzziness.Ratio => this._ratio;
 
-		public static Fuzziness Ratio(double ratio)
-		{
-			return new Fuzziness() { _ratio = ratio };
-		}
+		public static Fuzziness Auto => new Fuzziness { _auto = true };
+
+		public static Fuzziness EditDistance(int distance) => new Fuzziness { _editDistance = distance };
+
+		[Obsolete("Deprecated. Setting this is a noop")]
+		public static Fuzziness Ratio(double ratio) => new Fuzziness { _ratio = ratio };
 	}
 }

--- a/src/Nest/CommonOptions/Fuzziness/FuzzinessJsonConverter.cs
+++ b/src/Nest/CommonOptions/Fuzziness/FuzzinessJsonConverter.cs
@@ -12,10 +12,9 @@ namespace Nest
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
 			var v = value as IFuzziness;
-			if (v.Auto) writer.WriteValue("AUTO"); 
-			else if (v.EditDistance.HasValue) writer.WriteValue(v.EditDistance.Value); 
-			else if (v.Ratio.HasValue) writer.WriteValue(v.Ratio.Value);
-			else writer.WriteNull(); 
+			if (v.Auto) writer.WriteValue("AUTO");
+			else if (v.EditDistance.HasValue) writer.WriteValue(v.EditDistance.Value);
+			else writer.WriteNull();
 		}
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
@@ -26,11 +25,6 @@ namespace Nest
 			{
 				var editDistance = Convert.ToInt32(reader.Value);
 				return Fuzziness.EditDistance(editDistance);
-			}
-			if (reader.TokenType == JsonToken.Float)
-			{
-				var ratio = (reader.Value as double?).GetValueOrDefault(0);
-				return Fuzziness.Ratio(ratio);
 			}
 			return null;
 		}

--- a/src/Nest/CommonOptions/Fuzziness/IFuzziness.cs
+++ b/src/Nest/CommonOptions/Fuzziness/IFuzziness.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Nest
 {
@@ -7,6 +8,8 @@ namespace Nest
 	{
 		bool Auto { get;  }
 		int? EditDistance { get;  }
+
+		[Obsolete("Deprecated. Setting this is a noop")]
 		double? Ratio { get;  }
 	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Terms/TermsQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Terms/TermsQuery.cs
@@ -10,7 +10,9 @@ namespace Nest
 	[JsonConverter(typeof(TermsQueryJsonConverter))]
 	public interface ITermsQuery : IFieldNameQuery
 	{
+		[Obsolete("Will be removed in 5.0. Use bool query instead")]
 		MinimumShouldMatch MinimumShouldMatch { get; set; }
+		[Obsolete("Will be removed in 5.0. Use bool query instead")]
 		bool? DisableCoord { get; set; }
 		IEnumerable<object> Terms { get; set; }
 		IFieldLookup TermsLookup { get; set; }
@@ -19,7 +21,9 @@ namespace Nest
 	public class TermsQuery : FieldNameQueryBase, ITermsQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
+		[Obsolete("Will be removed in 5.0. Use bool query instead")]
 		public MinimumShouldMatch MinimumShouldMatch { get; set; }
+		[Obsolete("Will be removed in 5.0. Use bool query instead")]
 		public bool? DisableCoord { get; set; }
 		public IEnumerable<object> Terms { get; set; }
 		public IFieldLookup TermsLookup { get; set; }
@@ -54,7 +58,9 @@ namespace Nest
 		, ITermsQuery where T : class
 	{
 		protected override bool Conditionless => TermsQuery.IsConditionless(this);
+		[Obsolete("Will be removed in 5.0. Use bool query instead")]
 		MinimumShouldMatch ITermsQuery.MinimumShouldMatch { get; set; }
+		[Obsolete("Will be removed in 5.0. Use bool query instead")]
 		bool? ITermsQuery.DisableCoord { get; set; }
 		IEnumerable<object> ITermsQuery.Terms { get; set; }
 		IFieldLookup ITermsQuery.TermsLookup { get; set; }
@@ -62,8 +68,10 @@ namespace Nest
 		public TermsQueryDescriptor<T> TermsLookup<TOther>(Func<FieldLookupDescriptor<TOther>, IFieldLookup> selector)
 			where TOther : class => Assign(a => a.TermsLookup = selector(new FieldLookupDescriptor<TOther>()));
 
+		[Obsolete("Will be removed in 5.0. Use bool query instead")]
 		public TermsQueryDescriptor<T> MinimumShouldMatch(MinimumShouldMatch minMatch) => Assign(a => a.MinimumShouldMatch = minMatch);
 
+		[Obsolete("Will be removed in 5.0. Use bool query instead")]
 		public TermsQueryDescriptor<T> DisableCoord(bool? disable = true) => Assign(a => a.DisableCoord = disable);
 
 		public TermsQueryDescriptor<T> Terms<TValue>(IEnumerable<TValue> terms) => Assign(a => a.Terms = terms?.Cast<object>());

--- a/src/Nest/QueryDsl/TermLevel/Terms/TermsQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/TermLevel/Terms/TermsQueryJsonConverter.cs
@@ -32,6 +32,7 @@ namespace Nest
 					writer.WritePropertyName(field);
 					serializer.Serialize(writer, t.TermsLookup);
 				}
+#pragma warning disable 618
 				if (t.DisableCoord.HasValue)
 				{
 					writer.WritePropertyName("disable_coord");
@@ -42,6 +43,7 @@ namespace Nest
 					writer.WritePropertyName("minimum_should_match");
 					serializer.Serialize(writer, t.MinimumShouldMatch);
 				}
+#pragma warning restore 618
 				if (t.Boost.HasValue)
 				{
 					writer.WritePropertyName("boost");
@@ -68,6 +70,7 @@ namespace Nest
 				var property = reader.Value as string;
 				switch (property)
 				{
+#pragma warning disable 618
 					case "disable_coord":
 						reader.Read();
 						f.DisableCoord = reader.Value as bool?;
@@ -77,6 +80,7 @@ namespace Nest
 						var min = serializer.Deserialize<MinimumShouldMatch>(reader);
 						f.MinimumShouldMatch = min;
 						break;
+#pragma warning restore 618
 					case "boost":
 						reader.Read();
 						f.Boost = reader.Value as double?;

--- a/src/Tests/QueryDsl/TermLevel/Terms/TermsListQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Terms/TermsListQueryUsageTests.cs
@@ -7,6 +7,8 @@ using Tests.Framework;
 using Tests.Framework.Integration;
 using Tests.Framework.MockData;
 
+#pragma warning disable 618 // DisableCoord and MinimumShouldMatch
+
 namespace Tests.QueryDsl.TermLevel.Terms
 {
 	public class TermsListQueryUsageTests : QueryDslUsageTestsBase
@@ -80,7 +82,6 @@ namespace Tests.QueryDsl.TermLevel.Terms
 				.DisableCoord()
 				.Terms(_terms)
 			);
-
 	}
 
 	public class TermsListOfListStringAgainstNumericFieldIntegrationTests : QueryDslIntegrationTestsBase
@@ -132,7 +133,5 @@ namespace Tests.QueryDsl.TermLevel.Terms
 			var rootCause = rootCauses.First();
 			rootCause.Type.Should().Be("number_format_exception");
 		});
-
 	}
-
 }

--- a/src/Tests/QueryDsl/TermLevel/Terms/TermsQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Terms/TermsQueryUsageTests.cs
@@ -6,7 +6,9 @@ using Tests.Framework.MockData;
 
 namespace Tests.QueryDsl.TermLevel.Terms
 {
-	/** 
+#pragma warning disable 618 // DisableCoord and MinimumShouldMatch
+
+	/**
 	* Filters documents that have fields that match any of the provided terms (not analyzed).
 	*
 	* Be sure to read the Elasticsearch documentation on {ref_current}/query-dsl-terms-query.html[Terms query] for more information.
@@ -59,7 +61,7 @@ namespace Tests.QueryDsl.TermLevel.Terms
 	}
 
 	/**[float]
-	*== Single term Terms Query 
+	*== Single term Terms Query
 	*/
 	public class SingleTermTermsQueryUsageTests : TermsQueryUsageTests
 	{
@@ -77,6 +79,4 @@ namespace Tests.QueryDsl.TermLevel.Terms
 				.Terms("term1")
 			);
 	}
-
-
 }


### PR DESCRIPTION
See https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_50_search_changes.html#_changes_to_queries for details.

See https://github.com/elastic/elasticsearch-net/issues/1997

deprecate fuzziness `ratio` and make setting it a **noop** - It looks like this was deprecated in 1.7 and should have been removed in 2.0 - https://www.elastic.co/guide/en/elasticsearch/reference/1.7/common-options.html#fuzziness