### PR TITLE
mark doc_values obsolete for string field data format

### DIFF
--- a/src/Nest/Modules/Indices/Fielddata/String/StringFielddataFormat.cs
+++ b/src/Nest/Modules/Indices/Fielddata/String/StringFielddataFormat.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 
 namespace Nest
 {
@@ -6,6 +7,7 @@ namespace Nest
 	{
 		[EnumMember(Value = "paged_bytes")]
 		PagedBytes,
+		[Obsolete("Deprecated in 2.0, will be removed in next major version release")]
 		[EnumMember(Value = "doc_values")]
 		DocValues,
 		[EnumMember(Value = "disabled")]


### PR DESCRIPTION
This looks to have been removed for Elasticsearch 2.0 -
[Exists in 1.7 docs](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/fielddata-formats.html#_string_field_data_types) 
[Missing in 2.0 docs]( https://www.elastic.co/guide/en/elasticsearch/reference/2.0/fielddata.html#fielddata-format)
Has been removed for NEST 5.x

Discovered as part of https://github.com/elastic/elasticsearch-net/issues/2005