### PR TITLE
mark IMappingTransform as deprecated (obsolete)

### DIFF
--- a/src/Nest/Indices/MappingManagement/PutMapping/PutMappingRequest.cs
+++ b/src/Nest/Indices/MappingManagement/PutMapping/PutMappingRequest.cs
@@ -48,10 +48,12 @@ namespace Nest
 		public ISizeField SizeField { get; set; }
 		/// <inheritdoc/>
 		public ISourceField SourceField { get; set; }
-		/// <inheritdoc/>
-		public IList<IMappingTransform> Transform { get; set; }
 
 #pragma warning disable 618
+		/// <inheritdoc/>
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
+		public IList<IMappingTransform> Transform { get; set; }
+
 		/// <inheritdoc/>
 		[Obsolete("use a normal date field and set its value explicitly")]
 		public ITimestampField TimestampField { get; set; }
@@ -98,10 +100,11 @@ namespace Nest
 		public ISizeField SizeField { get; set; }
 		/// <inheritdoc/>
 		public ISourceField SourceField { get; set; }
+#pragma warning disable 618
 		/// <inheritdoc/>
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 		public IList<IMappingTransform> Transform { get; set; }
 
-#pragma warning disable 618
 		/// <inheritdoc/>
 		[Obsolete("use a normal date field and set its value explicitly")]
 		public ITimestampField TimestampField { get; set; }
@@ -137,9 +140,10 @@ namespace Nest
 		ISizeField ITypeMapping.SizeField { get; set; }
 		ISourceField ITypeMapping.SourceField { get; set; }
 
+#pragma warning disable 618
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 		IList<IMappingTransform> ITypeMapping.Transform { get; set; }
 
-#pragma warning disable 618
 		[Obsolete("use a normal date field and set its value explicitly")]
 		ITimestampField ITypeMapping.TimestampField { get; set; }
 
@@ -202,13 +206,6 @@ namespace Nest
 		public PutMappingDescriptor<T> NumericDetection(bool detect = true) => Assign(a => a.NumericDetection = detect);
 
 		/// <inheritdoc/>
-		public PutMappingDescriptor<T> Transform(IEnumerable<IMappingTransform> transforms) => Assign(a => a.Transform = transforms.ToListOrNullIfEmpty());
-
-		/// <inheritdoc/>
-		public PutMappingDescriptor<T> Transform(Func<MappingTransformsDescriptor, IPromise<IList<IMappingTransform>>> selector) =>
-			Assign(a => a.Transform = selector?.Invoke(new MappingTransformsDescriptor())?.Value);
-
-		/// <inheritdoc/>
 		public PutMappingDescriptor<T> SourceField(Func<SourceFieldDescriptor, ISourceField> sourceFieldSelector) => Assign(a => a.SourceField = sourceFieldSelector?.Invoke(new SourceFieldDescriptor()));
 
 		/// <inheritdoc/>
@@ -218,6 +215,15 @@ namespace Nest
 		public PutMappingDescriptor<T> FieldNamesField(Func<FieldNamesFieldDescriptor<T>, IFieldNamesField> fieldNamesFieldSelector) => Assign(a => a.FieldNamesField = fieldNamesFieldSelector.Invoke(new FieldNamesFieldDescriptor<T>()));
 
 #pragma warning disable 618
+		/// <inheritdoc/>
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
+		public PutMappingDescriptor<T> Transform(IEnumerable<IMappingTransform> transforms) => Assign(a => a.Transform = transforms.ToListOrNullIfEmpty());
+
+		/// <inheritdoc/>
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
+		public PutMappingDescriptor<T> Transform(Func<MappingTransformsDescriptor, IPromise<IList<IMappingTransform>>> selector) =>
+			Assign(a => a.Transform = selector?.Invoke(new MappingTransformsDescriptor())?.Value);
+
 		/// <inheritdoc/>
 		[Obsolete("use a normal date field and set its value explicitly")]
 		public PutMappingDescriptor<T> TimestampField(Func<TimestampFieldDescriptor<T>, ITimestampField> timestampFieldSelector) => Assign(a => a.TimestampField = timestampFieldSelector?.Invoke(new TimestampFieldDescriptor<T>()));

--- a/src/Nest/Mapping/Transform/MappingTransform.cs
+++ b/src/Nest/Mapping/Transform/MappingTransform.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<MappingTransform>))]
+	[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 	public interface IMappingTransform
 	{
 		[JsonProperty("script")]
@@ -20,6 +21,7 @@ namespace Nest
 		string Language { get; set; }
 	}
 
+	[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 	public class MappingTransform: IMappingTransform
 	{
 		public string Script { get; set; }
@@ -31,6 +33,7 @@ namespace Nest
 		public string Language { get; set; }
 	}
 
+	[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 	public class MappingTransformDescriptor : DescriptorBase<MappingTransformDescriptor, IMappingTransform>, IMappingTransform
 	{
 		string IMappingTransform.Script { get; set; }
@@ -53,6 +56,7 @@ namespace Nest
 
 	}
 
+	[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 	public class MappingTransformsDescriptor: DescriptorPromiseBase<MappingTransformsDescriptor, IList<IMappingTransform>>
 	{
 		public MappingTransformsDescriptor() : base(new List<IMappingTransform>()) { }

--- a/src/Nest/Mapping/Transform/MappingTransformJsonConverter.cs
+++ b/src/Nest/Mapping/Transform/MappingTransformJsonConverter.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+#pragma warning disable 618 // IMappingTransform
+
 namespace Nest
 {
 	internal class MappingTransformCollectionJsonConverter : JsonConverter

--- a/src/Nest/Mapping/TypeMapping.cs
+++ b/src/Nest/Mapping/TypeMapping.cs
@@ -19,6 +19,7 @@ namespace Nest
 
 		[JsonProperty("transform")]
 		[JsonConverter(typeof(MappingTransformCollectionJsonConverter))]
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 		IList<IMappingTransform> Transform { get; set; }
 
 		[JsonProperty("analyzer")]
@@ -108,6 +109,7 @@ namespace Nest
 		[Obsolete("use a normal date field and set its value explicitly")]
 		public ITimestampField TimestampField { get; set; }
 		/// <inheritdoc/>
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 		public IList<IMappingTransform> Transform { get; set; }
 		/// <inheritdoc/>
 		[Obsolete("will be replaced with a different implementation in a future version of Elasticsearch")]
@@ -136,6 +138,7 @@ namespace Nest
 		ISourceField ITypeMapping.SourceField { get; set; }
 		[Obsolete("use a normal date field and set its value explicitly")]
 		ITimestampField ITypeMapping.TimestampField { get; set; }
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
 		IList<IMappingTransform> ITypeMapping.Transform { get; set; }
 		[Obsolete("will be replaced with a different implementation in a future version of Elasticsearch")]
 		ITtlField ITypeMapping.TtlField { get; set; }
@@ -198,25 +201,25 @@ namespace Nest
 		public TypeMappingDescriptor<T> NumericDetection(bool detect = true) => Assign(a => a.NumericDetection = detect);
 
 		/// <inheritdoc/>
-		public TypeMappingDescriptor<T> Transform(IEnumerable<IMappingTransform> transforms) => Assign(a => a.Transform = transforms.ToListOrNullIfEmpty());
-
-		/// <inheritdoc/>
-		public TypeMappingDescriptor<T> Transform(Func<MappingTransformsDescriptor, IPromise<IList<IMappingTransform>>> selector) =>
-			Assign(a => a.Transform = selector?.Invoke(new MappingTransformsDescriptor())?.Value);
-
-		/// <inheritdoc/>
 		public TypeMappingDescriptor<T> RoutingField(Func<RoutingFieldDescriptor<T>, IRoutingField> routingFieldSelector) => Assign(a => a.RoutingField = routingFieldSelector?.Invoke(new RoutingFieldDescriptor<T>()));
-
-#pragma warning disable 618
-		/// <inheritdoc/>
-		[Obsolete("use a normal date field and set its value explicitly")]
-		public TypeMappingDescriptor<T> TimestampField(Func<TimestampFieldDescriptor<T>, ITimestampField> timestampFieldSelector) => Assign(a => a.TimestampField = timestampFieldSelector?.Invoke(new TimestampFieldDescriptor<T>()));
-#pragma warning restore 618
 
 		/// <inheritdoc/>
 		public TypeMappingDescriptor<T> FieldNamesField(Func<FieldNamesFieldDescriptor<T>, IFieldNamesField> fieldNamesFieldSelector) => Assign(a => a.FieldNamesField = fieldNamesFieldSelector.Invoke(new FieldNamesFieldDescriptor<T>()));
 
 #pragma warning disable 618
+		/// <inheritdoc/>
+		[Obsolete("use a normal date field and set its value explicitly")]
+		public TypeMappingDescriptor<T> TimestampField(Func<TimestampFieldDescriptor<T>, ITimestampField> timestampFieldSelector) => Assign(a => a.TimestampField = timestampFieldSelector?.Invoke(new TimestampFieldDescriptor<T>()));
+
+		/// <inheritdoc/>
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
+		public TypeMappingDescriptor<T> Transform(IEnumerable<IMappingTransform> transforms) => Assign(a => a.Transform = transforms.ToListOrNullIfEmpty());
+
+		/// <inheritdoc/>
+		[Obsolete("Deprecated in 2.0. Will be removed in the next major version release.")]
+		public TypeMappingDescriptor<T> Transform(Func<MappingTransformsDescriptor, IPromise<IList<IMappingTransform>>> selector) =>
+			Assign(a => a.Transform = selector?.Invoke(new MappingTransformsDescriptor())?.Value);
+
 		/// <inheritdoc/>
 		[Obsolete("will be replaced with a different implementation in a future version of Elasticsearch")]
 		public TypeMappingDescriptor<T> TtlField(Func<TtlFieldDescriptor, ITtlField> ttlFieldSelector) => Assign(a => a.TtlField = ttlFieldSelector?.Invoke(new TtlFieldDescriptor()));


### PR DESCRIPTION
This is [deprecated in 2.0](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/mapping-transform.html) 
[Removed in 5.0](https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_50_mapping_changes.html#_source_transform_removed)

See https://github.com/elastic/elasticsearch-net/issues/2006 