### PR TITLE
Allow Rescore to accept multiple rescore queries

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -5,7 +5,6 @@
 --
 There are a number of breaking changes when going from 1.x to 2.x
 
-
 * <<elasticsearch-net-breaking-changes, Elasticsearch.Net Breaking Changes>>
 
 * <<nest-breaking-changes, NEST Breaking Changes>>

--- a/docs/client-concepts/high-level/inference/field-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/field-inference.asciidoc
@@ -130,7 +130,7 @@ var fieldExpression = Infer.Field<Project>(p => p.Name);
 ----
 
 this can be even shortened even further using a https://msdn.microsoft.com/en-us/library/sf0df423.aspx#Anchor_0[static import in C# 6] i.e.
-			`using static Nest.Infer;`
+			 `using static Nest.Infer;`
 
 [source,csharp]
 ----

--- a/docs/client-concepts/low-level/connecting.asciidoc
+++ b/docs/client-concepts/low-level/connecting.asciidoc
@@ -148,19 +148,22 @@ var settings = new ConnectionConfiguration(uri);
 
 There are three categories of exceptions that may be thrown:
 
-`ElasticsearchClientException`:: 
+`ElasticsearchClientException`::
+
 These are known exceptions, either an exception that occurred in the request pipeline
 (such as max retries or timeout reached, bad authentication, etc...) or Elasticsearch itself returned an error (could
 not parse the request, bad query, missing field, etc...). If it is an Elasticsearch error, the `ServerError` property
 on the response will contain the the actual error that was returned.  The inner exception will always contain the
 root causing exception.
 
-`UnexpectedElasticsearchClientException`:: 
+`UnexpectedElasticsearchClientException`::
+
 These are unknown exceptions, for instance a response from Elasticsearch not
 properly deserialized.  These are usually bugs and {github}/issues[should be reported]. This exception also inherits from `ElasticsearchClientException`
 so an additional catch block isn't necessary, but can be helpful in distinguishing between the two.
 
-Development time exceptions:: 
+Development time exceptions::
+
 These are CLR exceptions like `ArgumentException`, `ArgumentOutOfRangeException`, etc.
 that are thrown when an API in the client is misused.
 These should not be handled as you want to know about them during development.

--- a/docs/common-options.asciidoc
+++ b/docs/common-options.asciidoc
@@ -7,7 +7,6 @@
 --
 NEST has a number of types for working with Elasticsearch conventions for:
 
-
 * <<time-units, Time Units>>
 
 * <<distance-units, Distance Units>>

--- a/docs/high-level.asciidoc
+++ b/docs/high-level.asciidoc
@@ -6,23 +6,17 @@
 [partintro]
 --
 The high level client, `ElasticClient`, provides a strongly typed query DSL that maps one-to-one with the Elasticsearch query DSL.
-
 It can be installed from the Package Manager Console inside Visual Studio using
-
 
 [source,shell]
 ----
 Install-Package NEST
 ----
 
-
 Or by searching for https://www.nuget.org/packages/NEST[NEST] in the Package Manager GUI. 
-
 NEST internally uses and still exposes the low level client, `ElasticLowLevelClient`, from <<elasticsearch-net,Elasticsearch.Net>> via
 the `.LowLevel` property on `ElasticClient`.
-
 There are a number of conventions that NEST uses for inference of
-
 
 * <<index-name-inference, Index Names>>
 
@@ -36,9 +30,7 @@ There are a number of conventions that NEST uses for inference of
 
 * <<features-inference, API features>>
 
-
 In addition to features such as
-
 
 * <<auto-map, Auto Mapping C# types>>
 

--- a/docs/low-level.asciidoc
+++ b/docs/low-level.asciidoc
@@ -7,15 +7,12 @@
 --
 The low level client, `ElasticLowLevelClient`, is a low level, dependency free client that has no 
 opinions about how you build and represent your requests and responses. 
-
 It can be installed from the Package Manager Console inside Visual Studio using
-
 
 [source,shell]
 ----
 Install-Package Elasticsearch.Net
 ----
-
 
 Or by searching for https://www.nuget.org/packages/Elasticsearch.Net[Elasticsearch.Net] in the Package Manager GUI.
 

--- a/docs/search-usage.asciidoc
+++ b/docs/search-usage.asciidoc
@@ -1,4 +1,4 @@
-:includes-from-dirs: search/request
+:includes-from-dirs: search/request,search/search/rescoring
 
 include::search/request/explain-usage.asciidoc[]
 
@@ -29,4 +29,6 @@ include::search/request/sort-usage.asciidoc[]
 include::search/request/source-filtering-usage.asciidoc[]
 
 include::search/request/suggest-usage.asciidoc[]
+
+include::search/search/rescoring/rescore-usage.asciidoc[]
 

--- a/docs/search.asciidoc
+++ b/docs/search.asciidoc
@@ -35,6 +35,8 @@ NEST exposes all of the search request parameters available in Elasticsearch
 
 * <<suggest-usage,Suggest Usage>>
 
+* <<rescore-usage,Rescore Usage>>
+
 --
 
 include::search-usage.asciidoc[]

--- a/docs/search/request/from-and-size-usage.asciidoc
+++ b/docs/search/request/from-and-size-usage.asciidoc
@@ -9,10 +9,12 @@
 
 Pagination of results can be done by using the `from` and `size` parameters.
 
-`from` parameter:: 
+`from` parameter::
+
 defines the offset from the first result you want to fetch.
 
-`size` parameter:: 
+`size` parameter::
+
 allows you to configure the maximum amount of hits to be returned.
 
 === Object Initializer Syntax Example

--- a/docs/search/search/rescoring/rescore-usage.asciidoc
+++ b/docs/search/search/rescoring/rescore-usage.asciidoc
@@ -1,0 +1,248 @@
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/2.3
+
+:github: https://github.com/elastic/elasticsearch-net
+
+:nuget: https://www.nuget.org/packages
+
+[[rescore-usage]]
+== Rescore Usage
+
+Rescoring can help to improve precision by reordering just the top (eg 100 - 500) documents
+returned by the query and post_filter phases, using a secondary (usually more costly) algorithm,
+instead of applying the costly algorithm to all documents in the index.
+
+See the Elasticsearch documentation on {ref_current}/search-request-rescore.html[Rescoring] for more detail.
+
+[[single-rescore-query]]
+[float]
+== Single rescore query
+
+=== Fluent DSL Example
+
+[source,csharp]
+----
+s => s
+.From(10)
+.Size(20)
+.Query(q => q
+    .MatchAll()
+)
+.Rescore(r => r
+    .WindowSize(20)
+    .RescoreQuery(rq => rq
+        .ScoreMode(ScoreMode.Multiply)
+        .Query(q => q
+            .ConstantScore(cs => cs
+                .Filter(f => f
+                    .Terms(t => t
+                        .Field(p => p.Tags.First())
+                        .Terms("eos", "sit", "sed")
+                    )
+                )
+            )
+        )
+    )
+)
+----
+
+=== Object Initializer Syntax Example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    From = 10,
+    Size = 20,
+    Query = new QueryContainer(new MatchAllQuery()),
+    Rescore = new Rescore
+    {
+        WindowSize = 20,
+        Query = new RescoreQuery
+        {
+            ScoreMode = ScoreMode.Multiply,
+            Query = new ConstantScoreQuery
+            {
+                Filter = new TermsQuery
+                {
+                    Field = Infer.Field<Project>(p => p.Tags.First()),
+                    Terms = new[] { "eos", "sit", "sed" }
+                }
+            }
+        }
+    }
+
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "from": 10,
+  "size": 20,
+  "query": {
+    "match_all": {}
+  },
+  "rescore": {
+    "window_size": 20,
+    "query": {
+      "score_mode": "multiply",
+      "rescore_query": {
+        "constant_score": {
+          "filter": {
+            "terms": {
+              "tags": [
+                "eos",
+                "sit",
+                "sed"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+----
+
+[[multiple-rescore-queries]]
+[float]
+== Multiple rescore queries
+
+=== Fluent DSL Example
+
+[source,csharp]
+----
+s => s
+.From(10)
+.Size(20)
+.Query(q => q
+    .MatchAll()
+)
+.Rescore(r => r
+    .WindowSize(20)
+    .RescoreQuery(rq => rq
+        .ScoreMode(ScoreMode.Multiply)
+        .Query(q => q
+            .ConstantScore(cs => cs
+                .Filter(f => f
+                    .Terms(t => t
+                        .Field(p => p.Tags.First())
+                        .Terms("eos", "sit", "sed")
+                    )
+                )
+            )
+        )
+    )
+)
+.Rescore(rr => rr
+    .RescoreQuery(rq => rq
+        .ScoreMode(ScoreMode.Total)
+        .Query(q => q
+            .FunctionScore(fs => fs
+                .Functions(f => f
+                    .RandomScore(1337)
+                )
+            )
+        )
+    )
+)
+----
+
+=== Object Initializer Syntax Example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    From = 10,
+    Size = 20,
+    Query = new QueryContainer(new MatchAllQuery()),
+    Rescore = new MultiRescore
+    {
+        new Rescore
+        {
+            WindowSize = 20,
+            Query = new RescoreQuery
+            {
+                ScoreMode = ScoreMode.Multiply,
+                Query = new ConstantScoreQuery
+                {
+                    Filter = new TermsQuery
+                    {
+                        Field = Infer.Field<Project>(p => p.Tags.First()),
+                        Terms = new[] { "eos", "sit", "sed" }
+                    }
+                }
+            }
+        },
+        new Rescore
+        {
+            Query = new RescoreQuery
+            {
+                ScoreMode = ScoreMode.Total,
+                Query = new FunctionScoreQuery
+                {
+                    Functions = new List<IScoreFunction>
+                    {
+                        new RandomScoreFunction
+                        {
+                            Seed = 1337
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "from": 10,
+  "size": 20,
+  "query": {
+    "match_all": {}
+  },
+  "rescore": [
+    {
+      "window_size": 20,
+      "query": {
+        "score_mode": "multiply",
+        "rescore_query": {
+          "constant_score": {
+            "filter": {
+              "terms": {
+                "tags": [
+                  "eos",
+                  "sit",
+                  "sed"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "query": {
+        "score_mode": "total",
+        "rescore_query": {
+          "function_score": {
+            "functions": [
+              {
+                "random_score": {
+                  "seed": 1337
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}
+----
+

--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/CodeGeneration.LowLevelClient.project.lock.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/CodeGeneration.LowLevelClient.project.lock.json
@@ -1,6 +1,6 @@
 {
   "locked": false,
-  "version": 1,
+  "version": 2,
   "targets": {
     ".NETFramework,Version=v4.5": {},
     ".NETFramework,Version=v4.5/win": {}

--- a/src/CodeGeneration/Nest.Litterateur/Nest.Litterateur.project.lock.json
+++ b/src/CodeGeneration/Nest.Litterateur/Nest.Litterateur.project.lock.json
@@ -1,6 +1,6 @@
 {
   "locked": false,
-  "version": 1,
+  "version": 2,
   "targets": {
     ".NETFramework,Version=v4.5": {},
     ".NETFramework,Version=v4.5/win": {}

--- a/src/CodeGeneration/Nest.Litterateur/Program.cs
+++ b/src/CodeGeneration/Nest.Litterateur/Program.cs
@@ -14,8 +14,8 @@ namespace Nest.Litterateur
 			}
 			else
 			{
-				InputDirPath = @"..\..\..\..\..\src\Tests";
-				OutputDirPath = @"..\..\..\..\..\docs";
+				InputDirPath = @"..\..\..\..\..\..\src\Tests";
+				OutputDirPath = @"..\..\..\..\..\..\docs";
 			}
 		}
 

--- a/src/Elasticsearch.Net/Elasticsearch.Net.project.lock.json
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.project.lock.json
@@ -1,6 +1,6 @@
 {
   "locked": false,
-  "version": 1,
+  "version": 2,
   "targets": {
     ".NETFramework,Version=v4.5": {},
     ".NETFramework,Version=v4.5/win": {}

--- a/src/Nest/Search/Search/Rescoring/Rescore.cs
+++ b/src/Nest/Search/Search/Rescoring/Rescore.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<Rescore>))]
+	[JsonConverter(typeof(RescoreConverter))]
 	public interface IRescore
 	{
 		[JsonProperty("window_size")]
@@ -13,10 +15,11 @@ namespace Nest
 		[JsonProperty("query")]
 		IRescoreQuery Query { get; set; }
 	}
-	
+
 	public class Rescore : IRescore
 	{
 		public int? WindowSize { get; set; }
+
 		public IRescoreQuery Query { get; set; }
 	}
 
@@ -30,6 +33,105 @@ namespace Nest
 			Assign(a=>a.Query = rescoreQuerySelector?.Invoke(new RescoreQueryDescriptor<T>()));
 
 		public virtual RescoreDescriptor<T> WindowSize(int? windowSize) => Assign(a => a.WindowSize = windowSize);
-	
+	}
+
+	public class MultiRescore : IRescore, IEnumerable<IRescore>
+	{
+		private readonly List<IRescore> _rescore = new List<IRescore>();
+
+		public MultiRescore() {}
+
+		internal MultiRescore(IEnumerable<IRescore> recore)
+		{
+			_rescore = recore.ToList();
+		}
+
+		[JsonIgnore]
+		int? IRescore.WindowSize
+		{
+			get { return _rescore.FirstOrDefault()?.WindowSize; }
+			set
+			{
+				if (_rescore.Any())
+				{
+					_rescore.First().WindowSize = value;
+				}
+			}
+		}
+
+		[JsonIgnore]
+		IRescoreQuery IRescore.Query
+		{
+			get { return _rescore.FirstOrDefault()?.Query; }
+			set
+			{
+				if (_rescore.Any())
+				{
+					_rescore.First().Query = value;
+				}
+			}
+		}
+
+		public void Add(IRescore rescore)
+		{
+			var multiRescore = rescore as MultiRescore;
+			if (multiRescore != null)
+				_rescore.AddRange(multiRescore);
+			else 
+				_rescore.Add(rescore);
+		}
+
+		public IEnumerator<IRescore> GetEnumerator() => _rescore.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+
+	public class RescoreConverter : JsonConverter
+	{
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var multiRescore = value as MultiRescore;
+			if (multiRescore != null)
+			{
+				writer.WriteStartArray();
+				foreach (var rescore in multiRescore)
+					SerializeRescore(writer, rescore, serializer);
+				writer.WriteEndArray();
+			}
+			else
+			{
+				var rescore = (IRescore)value;
+				SerializeRescore(writer, rescore, serializer);
+			}
+		}
+
+		private void SerializeRescore(JsonWriter writer, IRescore rescore, JsonSerializer serializer)
+		{
+			writer.WriteStartObject();
+			if (rescore.WindowSize.HasValue)
+			{
+				writer.WritePropertyName("window_size");
+				writer.WriteValue(rescore.WindowSize.Value);
+			}
+			if (rescore.Query != null)
+			{
+				writer.WritePropertyName("query");
+				serializer.Serialize(writer, rescore.Query);
+			}
+			writer.WriteEndObject();
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType == JsonToken.StartArray)
+			{
+				var rescores = FromJson.ReadAs<List<Rescore>>(reader, objectType, existingValue, serializer);
+				return new MultiRescore(rescores);
+			}
+
+			return FromJson.ReadAs<Rescore>(reader, objectType, existingValue, serializer);
+		}
+
+		public override bool CanConvert(Type objectType) => true;
 	}
 }

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -414,7 +414,12 @@ namespace Nest
 		/// Allows you to specify a rescore query
 		/// </summary>
 		public SearchDescriptor<T> Rescore(Func<RescoreDescriptor<T>, IRescore> rescoreSelector) =>
-			Assign(a => a.Rescore = rescoreSelector?.Invoke(new RescoreDescriptor<T>()));
+			Assign(a =>
+			{
+				a.Rescore = a.Rescore != null 
+					? new MultiRescore { a.Rescore, rescoreSelector?.Invoke(new RescoreDescriptor<T>()) } 
+					: rescoreSelector?.Invoke(new RescoreDescriptor<T>());
+			});
 
 		public SearchDescriptor<T> ConcreteTypeSelector(Func<dynamic, Hit<dynamic>, Type> typeSelector) =>
 			Assign(a => a.TypeSelector = typeSelector);

--- a/src/Tests/Search/Search/Rescoring/RescoreUsageTests.cs
+++ b/src/Tests/Search/Search/Rescoring/RescoreUsageTests.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.MockData;
+using Xunit;
+
+namespace Tests.Search.Search.Rescoring
+{
+	/**
+	 * Rescoring can help to improve precision by reordering just the top (eg 100 - 500) documents
+	 * returned by the query and post_filter phases, using a secondary (usually more costly) algorithm,
+	 * instead of applying the costly algorithm to all documents in the index.
+	 *
+	 * See the Elasticsearch documentation on {ref_current}/search-request-rescore.html[Rescoring] for more detail.
+	 *
+	 * [float]
+	 * == Single rescore query
+	 */
+	[Collection(IntegrationContext.ReadOnly)]
+	public class RescoreUsageTests : SearchUsageTestBase
+	{
+		public RescoreUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			from = 10,
+			size = 20,
+			query = new
+			{
+				match_all = new { }
+			},
+			rescore = new
+			{
+				window_size = 20,
+				query = new
+				{
+					score_mode = "multiply",
+					rescore_query = new
+					{
+						constant_score = new
+						{
+							filter = new
+							{
+								terms = new
+								{
+									tags = new [] { "eos", "sit", "sed" }
+								}
+							}
+						}
+					}
+				}
+			}
+		};
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.From(10)
+			.Size(20)
+			.Query(q => q
+				.MatchAll()
+			)
+			.Rescore(r => r
+				.WindowSize(20)
+				.RescoreQuery(rq => rq
+					.ScoreMode(ScoreMode.Multiply)
+					.Query(q => q
+						.ConstantScore(cs => cs
+							.Filter(f => f
+								.Terms(t => t
+									.Field(p => p.Tags.First())
+									.Terms("eos", "sit", "sed")
+								)
+							)
+						)
+					)
+				)
+			);
+
+		protected override SearchRequest<Project> Initializer => new SearchRequest<Project>
+		{
+			From = 10,
+			Size = 20,
+			Query = new QueryContainer(new MatchAllQuery()),
+			Rescore = new Rescore
+			{
+				WindowSize = 20,
+				Query = new RescoreQuery
+				{
+					ScoreMode = ScoreMode.Multiply,
+					Query = new ConstantScoreQuery
+					{
+						Filter = new TermsQuery
+						{
+							Field = Infer.Field<Project>(p => p.Tags.First()),
+							Terms = new[] { "eos", "sit", "sed" }
+						}
+					}
+				}
+			}
+
+		};
+	}
+
+	/**[float]
+	 *== Multiple rescore queries
+	 */
+	[Collection(IntegrationContext.ReadOnly)]
+	public class MultiRescoreUsageTests : SearchUsageTestBase
+	{
+		public MultiRescoreUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			from = 10,
+			size = 20,
+			query = new
+			{
+				match_all = new { }
+			},
+			rescore = new object[]
+			{
+				new
+				{
+					window_size = 20,
+					query = new
+					{
+						score_mode = "multiply",
+						rescore_query = new
+						{
+							constant_score = new
+							{
+								filter = new
+								{
+									terms = new
+									{
+										tags = new [] { "eos", "sit", "sed" }
+									}
+								}
+							}
+						}
+					}
+				},
+				new
+				{
+					query = new
+					{
+						score_mode = "total",
+						rescore_query = new
+						{
+							function_score = new
+							{
+								functions = new object[]
+								{
+									new
+									{
+										random_score = new
+										{
+											seed = 1337
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+			}
+		};
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.From(10)
+			.Size(20)
+			.Query(q => q
+				.MatchAll()
+			)
+			.Rescore(r => r
+				.WindowSize(20)
+				.RescoreQuery(rq => rq
+					.ScoreMode(ScoreMode.Multiply)
+					.Query(q => q
+						.ConstantScore(cs => cs
+							.Filter(f => f
+								.Terms(t => t
+									.Field(p => p.Tags.First())
+									.Terms("eos", "sit", "sed")
+								)
+							)
+						)
+					)
+				)
+			)
+			.Rescore(rr => rr
+				.RescoreQuery(rq => rq
+					.ScoreMode(ScoreMode.Total)
+					.Query(q => q
+						.FunctionScore(fs => fs
+							.Functions(f => f
+								.RandomScore(1337)
+							)
+						)
+					)
+				)
+			);
+
+		protected override SearchRequest<Project> Initializer => new SearchRequest<Project>
+		{
+			From = 10,
+			Size = 20,
+			Query = new QueryContainer(new MatchAllQuery()),
+			Rescore = new MultiRescore
+			{
+				new Rescore
+				{
+					WindowSize = 20,
+					Query = new RescoreQuery
+					{
+						ScoreMode = ScoreMode.Multiply,
+						Query = new ConstantScoreQuery
+						{
+							Filter = new TermsQuery
+							{
+								Field = Infer.Field<Project>(p => p.Tags.First()),
+								Terms = new[] { "eos", "sit", "sed" }
+							}
+						}
+					}
+				},
+				new Rescore
+				{
+					Query = new RescoreQuery
+					{
+						ScoreMode = ScoreMode.Total,
+						Query = new FunctionScoreQuery
+						{
+							Functions = new List<IScoreFunction>
+							{
+								new RandomScoreFunction
+								{
+									Seed = 1337
+								}
+							}
+						}
+					}
+				}
+			}
+		};
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -560,6 +560,7 @@
     <Compile Include="Framework\Integration\Process\ElasticsearchNodeInfo.cs" />
     <Compile Include="Framework\Integration\Process\ElasticsearchVersionInfo.cs" />
     <Compile Include="QueryDsl\Verbatim\VerbatimAndStrictQueryUsageTests.cs" />
+    <Compile Include="Search\Search\Rescoring\RescoreUsageTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsApiTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsUrlTests.cs" />
     <Compile Include="XPack\Security\Role\ClearCachedRoles\ClearCachedRolesApiTests.cs" />

--- a/src/Tests/search-usage.asciidoc
+++ b/src/Tests/search-usage.asciidoc
@@ -1,4 +1,4 @@
-﻿:includes-from-dirs: search/request
+﻿:includes-from-dirs: search/request,search/search/rescoring
 
 
 


### PR DESCRIPTION
The interface for rescore, IRescore, cannot be changed in 2.x as it would break binary compatibility for 2.x.
A new concrete implementation of `IRescore`, `MultiRescore`, is introduced that allows for multiple rescore queries to be specified. When using OIS syntax, a new instance of `MultiRescore` should be used. When using the fluent API, the descriptor takes care of combining multiple rescore queries. A custom json converter takes care of serialization when a single or multiple rescore queries are specified.

The slightly awkward part with having `Rescore` and `MultiRescore` is that when an `IRescore` instance is deserialized from json, it is not known if this is a `Rescore` or `MultiRescore` without checking the type; a consumer would need to know to do this, as `MultiRescore` maps only the first `Rescore`'s properties to properties of the `IRescore` interface.

Add usage tests for both single Rescore and multiple Rescore queries.

Closes https://github.com/elastic/elasticsearch-net/issues/2088