### PR TITLE
Infer index and type from T for GetMany

### DIFF
--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-GetMany.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-GetMany.cs
@@ -11,8 +11,8 @@ namespace Nest
 	public static class GetManyExtensions
 	{
 		/// <summary>
-		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing). 
-		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document 
+		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
+		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
@@ -24,13 +24,13 @@ namespace Nest
 		public static IEnumerable<IMultiGetHit<T>> GetMany<T>(this IElasticClient client, IEnumerable<string> ids, string index = null, string type = null)
 			where T : class
 		{
-			var result = client.MultiGet(s => s.GetMany<T>(ids, (gs, i) => gs.Index(index).Type(type)));
+			var result = client.MultiGet(s => s.GetMany<T>(ids).Index(index).Type(type));
 			return result.GetMany<T>(ids);
 		}
-		
+
 		/// <summary>
-		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing). 
-		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document 
+		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
+		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
@@ -46,8 +46,8 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing). 
-		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document 
+		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
+		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
@@ -59,13 +59,13 @@ namespace Nest
 		public static async Task<IEnumerable<IMultiGetHit<T>>> GetManyAsync<T>(this IElasticClient client, IEnumerable<string> ids, string index = null, string type = null)
 			where T : class
 		{
-			var response = await client.MultiGetAsync(s => s.GetMany<T>(ids, (gs, i) => gs.Index(index).Type(type))).ConfigureAwait(false);
+			var response = await client.MultiGetAsync(s => s.GetMany<T>(ids).Index(index).Type(type)).ConfigureAwait(false);
 			return response.GetMany<T>(ids);
 		}
 
 		/// <summary>
-		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing). 
-		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document 
+		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
+		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -540,7 +540,7 @@
     <Compile Include="Document\Multiple\DeleteByQuery\ElasticClient-DeleteByQuery.cs" />
     <Compile Include="Document\Multiple\MultiGet\ElasticClient-MultiGet.cs" />
     <Compile Include="Document\Multiple\MultiGet\ElasticClient-SourceMany.cs" />
-    <Compile Include="Document\Multiple\MultiGet\EllasticClient-GetMany.cs" />
+    <Compile Include="Document\Multiple\MultiGet\ElasticClient-GetMany.cs" />
     <Compile Include="Document\Multiple\MultiGet\Request\IMultiGetOperation.cs" />
     <Compile Include="Document\Multiple\MultiGet\Request\MultiGetOperation.cs" />
     <Compile Include="Document\Multiple\MultiGet\Request\MultiGetRequest.cs" />

--- a/src/Tests/Document/Multiple/MultiGet/GetManyApiTests.cs
+++ b/src/Tests/Document/Multiple/MultiGet/GetManyApiTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.MockData;
+using Xunit;
+using static Nest.Infer;
+
+namespace Tests.Document.Multiple.MultiGet
+{
+	[Collection(IntegrationContext.ReadOnly)]
+	public class GetManyApiTests
+	{
+		private readonly ReadOnlyCluster _cluster;
+		private readonly IEnumerable<long> _ids = Developer.Developers.Select(d => (long)d.Id).Take(10);
+		private readonly IElasticClient _client;
+
+		public GetManyApiTests(ReadOnlyCluster cluster)
+		{
+			_cluster = cluster;
+			_client = _cluster.Client();
+		}
+
+		[I]
+		public void UsesDefaultIndexAndInferredType()
+		{
+			var response = _client.GetMany<Developer>(_ids);
+			response.Count().Should().Be(10);
+			foreach (var hit in response)
+			{
+				hit.Index.Should().NotBeNullOrWhiteSpace();
+				hit.Type.Should().NotBeNullOrWhiteSpace();
+				hit.Id.Should().NotBeNullOrWhiteSpace();
+				hit.Found.Should().BeTrue();
+			}
+		}
+
+		[I]
+		public async Task UsesDefaultIndexAndInferredTypeAsync()
+		{
+			var response = await _client.GetManyAsync<Developer>(_ids);
+			response.Count().Should().Be(10);
+			foreach (var hit in response)
+			{
+				hit.Index.Should().NotBeNullOrWhiteSpace();
+				hit.Type.Should().NotBeNullOrWhiteSpace();
+				hit.Id.Should().NotBeNullOrWhiteSpace();
+				hit.Found.Should().BeTrue();
+			}
+		}
+	}
+}

--- a/src/Tests/Document/Multiple/MultiGet/GetManyUrlTests.cs
+++ b/src/Tests/Document/Multiple/MultiGet/GetManyUrlTests.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+using static Tests.Framework.CapturingUrlTester;
+
+namespace Tests.Document.Multiple.MultiGet
+{
+	public class GetManyUrlTests : IUrlTests
+	{
+		private static readonly string[] StringIds = { "1" };
+		private static readonly long[] LongIds = { 1 };
+
+		[U]
+		public async Task Urls()
+		{
+			await POST("/_mget")
+				.Request(c => c.GetMany<Project>(StringIds))
+				.Request(c => c.GetMany<Project>(LongIds))
+				.RequestAsync(c => c.GetManyAsync<Project>(StringIds))
+				.RequestAsync(c => c.GetManyAsync<Project>(LongIds))
+				;
+
+			await POST("/project/_mget")
+				.Request(c => c.GetMany<Project>(StringIds, "project"))
+				.Request(c => c.GetMany<Project>(LongIds, "project"))
+				.RequestAsync(c => c.GetManyAsync<Project>(StringIds, "project"))
+				.RequestAsync(c => c.GetManyAsync<Project>(LongIds, "project"))
+				;
+
+			await POST("/project/project/_mget")
+				.Request(c => c.GetMany<Project>(StringIds, "project", "project"))
+				.Request(c => c.GetMany<Project>(LongIds, "project", "project"))
+				.RequestAsync(c => c.GetManyAsync<Project>(StringIds, "project", "project"))
+				.RequestAsync(c => c.GetManyAsync<Project>(LongIds, "project", "project"))
+				;
+		}
+	}
+}

--- a/src/Tests/Framework/UrlTests.cs
+++ b/src/Tests/Framework/UrlTests.cs
@@ -102,4 +102,69 @@ namespace Tests.Framework
 		public UrlTester DELETE(string url) =>  new UrlTester(HttpMethod.DELETE, url, _connectionSettingsModifier);
 	}
 
+	public static class CapturingUrlTesterExtensions
+	{
+		public static async Task<CapturingUrlTester> RequestAsync<TResponse>(this Task<CapturingUrlTester> tester, Func<IElasticClient, Task<TResponse>> call)
+			=> await (await tester).WhenCallingAsync(call, "request async");
+
+		public static async Task<CapturingUrlTester> FluentAsync<TResponse>(this Task<CapturingUrlTester> tester, Func<IElasticClient, Task<TResponse>> call)
+			=> await (await tester).WhenCallingAsync(call, "fluent async");
+	}
+
+	public class CapturingUrlTester : SerializationTestBase
+	{
+		protected string ExpectedUrl { get; set; }
+		protected HttpMethod ExpectedHttpMethod { get; set; }
+		protected IApiCallDetails CallDetails { get; set; }
+
+		protected override object ExpectJson => null;
+
+		internal CapturingUrlTester(HttpMethod method, string expectedUrl)
+		{
+			this.ExpectedHttpMethod = method;
+			this.ExpectedUrl = expectedUrl;
+			this._connectionSettingsModifier = (c => c
+				.PrettyJson(false)
+				.OnRequestCompleted(h => CallDetails = h));
+		}
+
+		public CapturingUrlTester Fluent<TResponse>(Func<IElasticClient, TResponse> call) => WhenCalling(call, "fluent");
+
+		public Task<CapturingUrlTester> FluentAsync<TResponse>(Func<IElasticClient, Task<TResponse>> call)
+			=> WhenCallingAsync(call, "fluent async");
+
+		public CapturingUrlTester Request<TResponse>(Func<IElasticClient, TResponse> call)
+			=> WhenCalling(call, "request");
+
+		public Task<CapturingUrlTester> RequestAsync<TResponse>(Func<IElasticClient, Task<TResponse>> call)
+			=> WhenCallingAsync(call, "request async");
+
+		internal CapturingUrlTester WhenCalling<TResponse>(Func<IElasticClient, TResponse> call, string typeOfCall)
+		{
+			call(this.GetClient());
+			return Assert(typeOfCall, CallDetails);
+		}
+
+		internal async Task<CapturingUrlTester> WhenCallingAsync<TResponse>(Func<IElasticClient, Task<TResponse>> call, string typeOfCall)
+		{
+			await call(this.GetClient());
+			return Assert(typeOfCall, CallDetails);
+		}
+
+		private CapturingUrlTester Assert(string typeOfCall, IApiCallDetails callDetails)
+		{
+			var url = callDetails.Uri.PathAndQuery;
+			url.Should().Be(this.ExpectedUrl, $"when calling the {typeOfCall} Api");
+			callDetails.HttpMethod.Should().Be(this.ExpectedHttpMethod, typeOfCall);
+			return this;
+		}
+
+		public static CapturingUrlTester ExpectUrl(HttpMethod method, string url) => new CapturingUrlTester(method, url);
+		public static CapturingUrlTester POST(string url) => new CapturingUrlTester(HttpMethod.POST, url);
+		public static CapturingUrlTester PUT(string url) => new CapturingUrlTester(HttpMethod.PUT, url);
+		public static CapturingUrlTester GET(string url) => new CapturingUrlTester(HttpMethod.GET, url);
+		public static CapturingUrlTester HEAD(string url) => new CapturingUrlTester(HttpMethod.HEAD, url);
+		public static CapturingUrlTester DELETE(string url) => new CapturingUrlTester(HttpMethod.DELETE, url);
+		public static string EscapeUriString(string s) => Uri.EscapeDataString(s);
+	}
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -550,6 +550,8 @@
     <Compile Include="Cluster\TaskManagement\TasksList\TasksListApiTests.cs" />
     <Compile Include="Cluster\TaskManagement\TasksList\TasksListUrlTests.cs" />
     <Compile Include="CommonOptions\DistanceUnit\DistanceUnits.doc.cs" />
+    <Compile Include="Document\Multiple\MultiGet\GetManyApiTests.cs" />
+    <Compile Include="Document\Multiple\MultiGet\GetManyUrlTests.cs" />
     <Compile Include="Document\Multiple\ReindexOnServer\ReindexOnServerUrlTests.cs" />
     <Compile Include="Document\Multiple\ReindexOnServer\ReindexOnServerApiTests.cs" />
     <Compile Include="Document\Multiple\UpdateByQuery\UpdateByQueryApiTests.cs" />


### PR DESCRIPTION
Set Index and Type on MultiGetDescriptor. If they have values, the specific index and type will be overridden on each get operation with them.

Fixes https://github.com/elastic/elasticsearch-net/issues/2093