### PR TITLE
Fix double evaluation of IEnumerable methods

### DIFF
--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -161,8 +161,11 @@ namespace Nest
 			foreach (T item in enumerable) handler(item);
 		}
 
-		internal static List<T> ToListOrNullIfEmpty<T>(this IEnumerable<T> enumerable) =>
-			enumerable.HasAny() ? enumerable.ToList() : null;
+		internal static List<T> ToListOrNullIfEmpty<T>(this IEnumerable<T> enumerable)
+		{
+			var list = enumerable?.ToList();
+			return list.HasAny() ? list : null;
+		}
 
 		internal static void AddIfNotNull<T>(this IList<T> list, T item) where T : class
 		{

--- a/src/Tests/Reproduce/GithubIssue2101.cs
+++ b/src/Tests/Reproduce/GithubIssue2101.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using Nest;
+using FluentAssertions;
+using Tests.Framework;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue2101
+	{
+
+		[U]
+		public void BoolClausesShouldEvaluateOnlyOnce()
+		{
+			var must = 0;
+			var mustNot = 0;
+			var should = 0;
+			var filter = 0;
+
+			new BoolQueryDescriptor<object>()
+				.Must(m =>
+				{
+					must++;
+					return m;
+				})
+				.MustNot(mn =>
+				{
+					mustNot++;
+					return mn;
+				})
+				.Should(sh =>
+				{
+					should++;
+					return sh;
+				})
+				.Filter(f =>
+				{
+					filter++;
+					return f;
+				});
+
+			filter.Should().Be(1);
+			should.Should().Be(1);
+			must.Should().Be(1);
+			mustNot.Should().Be(1);
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -560,6 +560,7 @@
     <Compile Include="Framework\Integration\Process\ElasticsearchNodeInfo.cs" />
     <Compile Include="Framework\Integration\Process\ElasticsearchVersionInfo.cs" />
     <Compile Include="QueryDsl\Verbatim\VerbatimAndStrictQueryUsageTests.cs" />
+    <Compile Include="Reproduce\GithubIssue2101.cs" />
     <Compile Include="Search\Search\Rescoring\RescoreUsageTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsApiTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsUrlTests.cs" />

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: u
 # the elasticsearch version that should be started
 elasticsearch_version: 2.3.0
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
The ToListOrNullIfEmpty() extension method called .Any() and .ToList()
which both evaluate the IEnumerable.  This caused funcs to be executed
twice when applied to an IEnumerable<Func<>>.

Closes #2101