### PR TITLE
Fix compound query conditionless logic

### DIFF
--- a/src/CodeGeneration/CodeGeneration.LowLevelClient/CodeGeneration.LowLevelClient.project.lock.json
+++ b/src/CodeGeneration/CodeGeneration.LowLevelClient/CodeGeneration.LowLevelClient.project.lock.json
@@ -1,6 +1,6 @@
 {
   "locked": false,
-  "version": 2,
+  "version": 1,
   "targets": {
     ".NETFramework,Version=v4.5": {},
     ".NETFramework,Version=v4.5/win": {}

--- a/src/CodeGeneration/Nest.Litterateur/Nest.Litterateur.project.lock.json
+++ b/src/CodeGeneration/Nest.Litterateur/Nest.Litterateur.project.lock.json
@@ -1,6 +1,6 @@
 {
   "locked": false,
-  "version": 2,
+  "version": 1,
   "targets": {
     ".NETFramework,Version=v4.5": {},
     ".NETFramework,Version=v4.5/win": {}

--- a/src/Elasticsearch.Net/Elasticsearch.Net.project.lock.json
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.project.lock.json
@@ -1,6 +1,6 @@
 {
   "locked": false,
-  "version": 2,
+  "version": 1,
   "targets": {
     ".NETFramework,Version=v4.5": {},
     ".NETFramework,Version=v4.5/win": {}

--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -15,6 +15,10 @@ namespace Nest
 {
 	internal static class Extensions
 	{
+		internal static bool NotWritable(this QueryContainer q) => q == null || !q.IsWritable;
+
+		internal static bool NotWritable(this IEnumerable<QueryContainer> qs) => qs == null || qs.All(q => q.NotWritable());
+
 		internal static TReturn InvokeOrDefault<T, TReturn>(this Func<T, TReturn> func, T @default)
 			where T : class, TReturn where TReturn : class =>
 			func?.Invoke(@default) ?? @default;

--- a/src/Nest/QueryDsl/Compound/And/AndQuery.cs
+++ b/src/Nest/QueryDsl/Compound/And/AndQuery.cs
@@ -21,10 +21,7 @@ namespace Nest
 		public IEnumerable<QueryContainer> Filters { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.And = this;
-		internal static bool IsConditionless(IAndQuery q)
-		{
-			return !q.Filters.HasAny() || q.Filters.All(f => f.IsConditionless);
-		}
+		internal static bool IsConditionless(IAndQuery q) => q.Filters.NotWritable();
 	}
 
 	[Obsolete("Use the bool query with a must clause instead. The bool query should not have other clauses to be semantically correct")]

--- a/src/Nest/QueryDsl/Compound/Bool/BoolQuery.cs
+++ b/src/Nest/QueryDsl/Compound/Bool/BoolQuery.cs
@@ -95,21 +95,8 @@ namespace Nest
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Bool = this;
 
 		protected override bool Conditionless => IsConditionless(this);
-		internal static bool IsConditionless(IBoolQuery q)
-		{
-			var musts = q.Must == null || q.Must.All(qq => qq.IsConditionless());
-			if (!musts) return false;
-
-			var shoulds = q.Should == null || q.Should.All(qq => qq.IsConditionless());
-			if (!shoulds) return false;
-
-			var filters = q.Filter == null || q.Filter.All(qq => qq.IsConditionless());
-			if (!filters) return false;
-
-			var mustNots = q.MustNot == null || q.MustNot.All(qq => qq.IsConditionless());
-
-			return mustNots;
-		}
+		internal static bool IsConditionless(IBoolQuery q) =>
+			q.Must.NotWritable() && q.MustNot.NotWritable() && q.Should.NotWritable() && q.Filter.NotWritable();
 	}
 
 	public class BoolQueryDescriptor<T>

--- a/src/Nest/QueryDsl/Compound/Boosting/BoostingQuery.cs
+++ b/src/Nest/QueryDsl/Compound/Boosting/BoostingQuery.cs
@@ -27,11 +27,10 @@ namespace Nest
 		public double? NegativeBoost { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Boosting = this;
-		internal static bool IsConditionless(IBoostingQuery q) =>
-			q.NegativeQuery.IsConditionless() && q.PositiveQuery.IsConditionless();
+		internal static bool IsConditionless(IBoostingQuery q) => q.NegativeQuery.NotWritable() && q.PositiveQuery.NotWritable();
 	}
 
-	public class BoostingQueryDescriptor<T> 
+	public class BoostingQueryDescriptor<T>
 		: QueryDescriptorBase<BoostingQueryDescriptor<T>, IBoostingQuery>
 		, IBoostingQuery where T : class
 	{
@@ -42,10 +41,10 @@ namespace Nest
 
 		public BoostingQueryDescriptor<T> NegativeBoost(double? boost) => Assign(a => a.NegativeBoost = boost);
 
-		public BoostingQueryDescriptor<T> Positive(Func<QueryContainerDescriptor<T>, QueryContainer> selector) => 
+		public BoostingQueryDescriptor<T> Positive(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(a => a.PositiveQuery = selector?.Invoke(new QueryContainerDescriptor<T>()));
 
-		public BoostingQueryDescriptor<T> Negative(Func<QueryContainerDescriptor<T>, QueryContainer> selector) => 
+		public BoostingQueryDescriptor<T> Negative(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(a => a.NegativeQuery = selector?.Invoke(new QueryContainerDescriptor<T>()));
 	}
 }

--- a/src/Nest/QueryDsl/Compound/ConstantScore/ConstantScoreQuery.cs
+++ b/src/Nest/QueryDsl/Compound/ConstantScore/ConstantScoreQuery.cs
@@ -21,17 +21,17 @@ namespace Nest
 		public QueryContainer Filter { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.ConstantScore = this;
-		internal static bool IsConditionless(IConstantScoreQuery q) => q.Filter.IsConditionless();
+		internal static bool IsConditionless(IConstantScoreQuery q) => q.Filter.NotWritable();
 	}
 
-	public class ConstantScoreQueryDescriptor<T> 
+	public class ConstantScoreQueryDescriptor<T>
 		: QueryDescriptorBase<ConstantScoreQueryDescriptor<T>, IConstantScoreQuery>
 		, IConstantScoreQuery where T : class
 	{
 		protected override bool Conditionless => ConstantScoreQuery.IsConditionless(this);
 		QueryContainer IConstantScoreQuery.Filter { get; set; }
 
-		public ConstantScoreQueryDescriptor<T> Filter(Func<QueryContainerDescriptor<T>, QueryContainer> selector) => 
+		public ConstantScoreQueryDescriptor<T> Filter(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(a => a.Filter = selector?.Invoke(new QueryContainerDescriptor<T>()));
 	}
 }

--- a/src/Nest/QueryDsl/Compound/Dismax/DismaxQuery.cs
+++ b/src/Nest/QueryDsl/Compound/Dismax/DismaxQuery.cs
@@ -23,10 +23,10 @@ namespace Nest
 		public IEnumerable<QueryContainer> Queries { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.DisMax = this;
-		internal static bool IsConditionless(IDisMaxQuery q) => !q.Queries.HasAny() || q.Queries.All(qq => qq.IsConditionless);
+		internal static bool IsConditionless(IDisMaxQuery q) => q.Queries.NotWritable();
 	}
 
-	public class DisMaxQueryDescriptor<T> 
+	public class DisMaxQueryDescriptor<T>
 		: QueryDescriptorBase<DisMaxQueryDescriptor<T>, IDisMaxQuery>
 		, IDisMaxQuery where T : class
 	{
@@ -34,10 +34,10 @@ namespace Nest
 		double? IDisMaxQuery.TieBreaker { get; set; }
 		IEnumerable<QueryContainer> IDisMaxQuery.Queries { get; set; }
 
-		public DisMaxQueryDescriptor<T> Queries(params Func<QueryContainerDescriptor<T>, QueryContainer>[] querySelectors) => 
+		public DisMaxQueryDescriptor<T> Queries(params Func<QueryContainerDescriptor<T>, QueryContainer>[] querySelectors) =>
 			Assign(a => a.Queries = querySelectors.Select(q=>q?.Invoke(new QueryContainerDescriptor<T>())).Where(q => q != null).ToListOrNullIfEmpty());
 
-		public DisMaxQueryDescriptor<T> Queries(IEnumerable<Func<QueryContainerDescriptor<T>, QueryContainer>> querySelectors) => 
+		public DisMaxQueryDescriptor<T> Queries(IEnumerable<Func<QueryContainerDescriptor<T>, QueryContainer>> querySelectors) =>
 			Assign(a => a.Queries = querySelectors.Select(q=>q?.Invoke(new QueryContainerDescriptor<T>())).Where(q => q != null).ToListOrNullIfEmpty());
 
 		public DisMaxQueryDescriptor<T> Queries(params QueryContainer[] queries) => Assign(a => a.Queries = queries.Where(q => q != null).ToListOrNullIfEmpty());

--- a/src/Nest/QueryDsl/Compound/Filtered/FilteredQuery.cs
+++ b/src/Nest/QueryDsl/Compound/Filtered/FilteredQuery.cs
@@ -24,31 +24,22 @@ namespace Nest
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Filtered = this;
 
-		internal static bool IsConditionless(IFilteredQuery q)
-		{
-			if (q.Query == null && q.Filter == null)
-				return true;
-			if (q.Filter == null && q.Query != null)
-				return q.Query.IsConditionless;
-			if (q.Filter != null && q.Query == null)
-				return q.Filter.IsConditionless;
-			return q.Query.IsConditionless() && q.Filter.IsConditionless();
-		}
+		internal static bool IsConditionless(IFilteredQuery q) => q.Query.NotWritable() && q.Filter.NotWritable();
 	}
 
 	[Obsolete("Use the bool query instead with a must clause for the query and a filter clause for the filter.")]
-	public class FilteredQueryDescriptor<T> 
-		: QueryDescriptorBase<FilteredQueryDescriptor<T>, IFilteredQuery>  
+	public class FilteredQueryDescriptor<T>
+		: QueryDescriptorBase<FilteredQueryDescriptor<T>, IFilteredQuery>
 		, IFilteredQuery where T : class
 	{
 		protected override bool Conditionless => FilteredQuery.IsConditionless(this);
 		QueryContainer IFilteredQuery.Query { get; set; }
 		QueryContainer IFilteredQuery.Filter { get; set; }
 
-		public FilteredQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> selector) => 
+		public FilteredQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(a => a.Query = selector?.Invoke(new QueryContainerDescriptor<T>()));
 
-		public FilteredQueryDescriptor<T> Filter(Func<QueryContainerDescriptor<T>, QueryContainer> selector) => 
+		public FilteredQueryDescriptor<T> Filter(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(a => a.Filter = selector?.Invoke(new QueryContainerDescriptor<T>()));
 	}
 }

--- a/src/Nest/QueryDsl/Compound/Indices/IndicesQuery.cs
+++ b/src/Nest/QueryDsl/Compound/Indices/IndicesQuery.cs
@@ -36,12 +36,12 @@ namespace Nest
 		public Indices Indices { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Indices = this;
-		internal static bool IsConditionless(IIndicesQuery q) => 
-			q.Indices == null || (q.NoMatchQuery.IsConditionless() && q.Query.IsConditionless());
+		internal static bool IsConditionless(IIndicesQuery q) =>
+			q.Indices == null || q.NoMatchQuery.NotWritable() && q.Query.NotWritable();
 	}
 
-	public class IndicesQueryDescriptor<T> 
-		: QueryDescriptorBase<IndicesQueryDescriptor<T>, IIndicesQuery> 
+	public class IndicesQueryDescriptor<T>
+		: QueryDescriptorBase<IndicesQueryDescriptor<T>, IIndicesQuery>
 		, IIndicesQuery where T : class
 	{
 		protected override bool Conditionless => IndicesQuery.IsConditionless(this);
@@ -49,10 +49,10 @@ namespace Nest
 		QueryContainer IIndicesQuery.NoMatchQuery { get; set; }
 		Indices IIndicesQuery.Indices { get; set; }
 
-		public IndicesQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> selector) => 
+		public IndicesQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(a => a.Query = selector?.Invoke(new QueryContainerDescriptor<T>()));
 
-		public IndicesQueryDescriptor<T> Query<TOther>(Func<QueryContainerDescriptor<TOther>, QueryContainer> selector) where TOther : class => 
+		public IndicesQueryDescriptor<T> Query<TOther>(Func<QueryContainerDescriptor<TOther>, QueryContainer> selector) where TOther : class =>
 			Assign(a => a.Query = selector?.Invoke(new QueryContainerDescriptor<TOther>()));
 
 		public IndicesQueryDescriptor<T> NoMatchQuery(NoMatchShortcut shortcut) =>
@@ -61,7 +61,7 @@ namespace Nest
 		public IndicesQueryDescriptor<T> NoMatchQuery(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(a => a.NoMatchQuery = selector?.Invoke(new QueryContainerDescriptor<T>()));
 
-		public IndicesQueryDescriptor<T> NoMatchQuery<TOther>(Func<QueryContainerDescriptor<TOther>, QueryContainer> selector) where TOther : class => 
+		public IndicesQueryDescriptor<T> NoMatchQuery<TOther>(Func<QueryContainerDescriptor<TOther>, QueryContainer> selector) where TOther : class =>
 			Assign(a => a.NoMatchQuery = selector?.Invoke(new QueryContainerDescriptor<TOther>()));
 
 		public IndicesQueryDescriptor<T> Indices(Indices indices) => Assign(a => a.Indices = indices);

--- a/src/Nest/QueryDsl/Compound/Not/NotQuery.cs
+++ b/src/Nest/QueryDsl/Compound/Not/NotQuery.cs
@@ -21,10 +21,7 @@ namespace Nest
 		public IEnumerable<QueryContainer> Filters { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Not = this;
-		internal static bool IsConditionless(INotQuery q)
-		{
-			return !q.Filters.HasAny() || q.Filters.All(f => f.IsConditionless);
-		}
+		internal static bool IsConditionless(INotQuery q) => q.Filters.NotWritable();
 	}
 
 	[Obsolete("Use the bool query with must_not clause instead")]

--- a/src/Nest/QueryDsl/Compound/Or/OrQuery.cs
+++ b/src/Nest/QueryDsl/Compound/Or/OrQuery.cs
@@ -21,10 +21,7 @@ namespace Nest
 		public IEnumerable<QueryContainer> Filters { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Or = this;
-		internal static bool IsConditionless(IOrQuery q)
-		{
-			return !q.Filters.HasAny() || q.Filters.All(f => f.IsConditionless);
-		}
+		internal static bool IsConditionless(IOrQuery q) => q.Filters.NotWritable();
 	}
 
 	[Obsolete("Use the bool query instead with a should clause for the query")]

--- a/src/Tests/QueryDsl/Compound/Bool/BoolQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/Compound/Bool/BoolQueryUsageTests.cs
@@ -2,6 +2,9 @@
 using Nest;
 using Tests.Framework.Integration;
 using Tests.Framework.MockData;
+using System;
+using Tests.Framework;
+using FluentAssertions;
 
 namespace Tests.QueryDsl.Compound.Bool
 {
@@ -75,5 +78,21 @@ namespace Tests.QueryDsl.Compound.Bool
 				q.Filter = new [] { ConditionlessQuery };
 			},
 		};
+
+		[U]
+		public void NullQueryDoesNotCauseANullReferenceException()
+		{
+			Action query = () => this.Client.Search<Project>(s => s
+					.Query(q => q
+						.Bool(b => b
+							.Filter(f => f
+								.Term(t => t.Name, null)
+							)
+						)
+					)
+				);
+
+			query.ShouldNotThrow();
+		}
 	}
 }

--- a/src/Tests/QueryDsl/Compound/Dismax/DismaxQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/Compound/Dismax/DismaxQueryUsageTests.cs
@@ -2,6 +2,9 @@
 using Nest;
 using Tests.Framework.Integration;
 using Tests.Framework.MockData;
+using Tests.Framework;
+using System;
+using FluentAssertions;
 
 #pragma warning disable 618 //Testing an obsolete method
 
@@ -53,5 +56,21 @@ namespace Tests.QueryDsl.Compound.Dismax
 			q => q.Queries = Enumerable.Empty<QueryContainer>(),
 			q => q.Queries = new [] { ConditionlessQuery },
 		};
+
+		[U]
+		public void NullQueryDoesNotCauseANullReferenceException()
+		{
+			Action query = () => this.Client.Search<Project>(s => s
+				.Query(q => q
+					.DisMax(dm => dm
+						.Queries(
+							dmq => dmq.Term(t => t.Name, null)
+						)
+					)
+				)
+			);
+
+			query.ShouldNotThrow();
+		}
 	}
 }

--- a/src/Tests/QueryDsl/QueryDslUsageTestsBase.cs
+++ b/src/Tests/QueryDsl/QueryDslUsageTestsBase.cs
@@ -84,36 +84,7 @@ namespace Tests.QueryDsl
 			((IQueryContainer)this.QueryInitializer).IsConditionless.Should().BeFalse();
 		}
 
-		[U]
-		public void NullQueryDoesNotCauseANullReferenceException()
-		{
-			Action query = () => this.Client.Search<Project>(s => s
-					.Query(q => q
-						.Bool(b => b
-							.Filter(f => f
-								.Term(t => t.Name, null)
-							)
-						)
-					)
-				);
-
-			query.ShouldNotThrow();
-
-			query = () => this.Client.Search<Project>(s => s
-				.Query(q => q
-					.DisMax(dm => dm
-						.Queries(
-							dmq => dmq.Term(t => t.Name, null)
-						)
-					)
-				)
-			);
-
-			query.ShouldNotThrow();
-		}
-
 		private void IsConditionless(IQueryContainer q, bool be) => q.IsConditionless.Should().Be(be);
-
 	}
 
 	public abstract class ConditionlessWhen : List<Action<QueryContainer>>

--- a/src/Tests/QueryDsl/Verbatim/VerbatimAndStrictQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/Verbatim/VerbatimAndStrictQueryUsageTests.cs
@@ -279,6 +279,85 @@ namespace Tests.QueryDsl.Verbatim
 			);
 	}
 
+	public class CompoundVerbatimInnerQueryUsageTests : QueryDslUsageTestsBase
+	{
+		public CompoundVerbatimInnerQueryUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override bool SupportsDeserialization => false;
+
+		protected override object QueryJson => new
+		{
+			@bool = new
+			{
+				filter = new []
+				{
+					new
+					{
+						@bool = new
+						{
+							must = new []
+							{
+								new
+								{
+									exists = new
+									{
+										field = "numberOfCommits"
+									}
+								}
+							},
+							must_not = new []
+							{
+								new
+								{
+									term = new
+									{
+										name = new
+										{
+											value = ""
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		};
+
+
+
+		protected override QueryContainer QueryInitializer => new BoolQuery
+		{
+			Filter = new QueryContainer[] {
+				!new TermQuery
+				{
+					IsVerbatim = true,
+					Field = "name",
+					Value = ""
+				} &&
+				new ExistsQuery
+				{
+					Field = "numberOfCommits"
+				}
+			}
+		};
+
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.Bool(b => b
+				.Filter(f => !f
+					.Term(t => t
+						.Verbatim()
+						.Field(p => p.Name)
+						.Value("")
+					) && f
+					.Exists(e => e
+						.Field(p => p.NumberOfCommits)
+					)
+				)
+			);
+	}
+
 	public class StrictQueryUsageTests
 	{
 		[U]

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: u
 # the elasticsearch version that should be started
 elasticsearch_version: 2.3.0
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
A compound query should only be conditionless when any of its inner
queries are not writable.  Previously we were only checking if the inner
queries were also not conditionless.

Closes #2086