### PR TITLE
Fix gzip compression when running on .NET core

### DIFF
--- a/src/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/src/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -1,0 +1,38 @@
+﻿using FluentAssertions;
+using Nest;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.MockData;
+using Xunit;
+
+namespace Tests.ClientConcepts.Connection
+{
+	[Collection(IntegrationContext.ReadOnly)]
+	public class HttpConnectionTests
+	{
+		ReadOnlyCluster _cluster;
+
+		public HttpConnectionTests(ReadOnlyCluster cluster, EndpointUsage usage)
+		{
+			_cluster = cluster;
+		}
+
+		[I]
+		public void HttpCompression()
+		{
+			var client = _cluster.Client(s => s.EnableHttpCompression());
+			var response = client.Search<Project>(s => s
+				.Index("project")
+				.Query(q => q
+					.Term("foo", "bar")
+				)
+			);
+			response.IsValid.Should().BeTrue();
+		}
+	}
+}

--- a/src/Tests/Framework/Integration/Process/ElasticsearchNode.cs
+++ b/src/Tests/Framework/Integration/Process/ElasticsearchNode.cs
@@ -135,6 +135,7 @@ namespace Tests.Framework.Integration
 				$"es.path.repo={this.RepositoryPath}",
 				$"es.script.inline=on",
 				$"es.script.indexed=on",
+				$"es.http.compression=true",
 				$"es.node.{attr}testingcluster=true",
 				$"es.shield.enabled=" + (shieldEnabled ? "true" : "false")
 			};

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -541,6 +541,7 @@
     <Compile Include="ClientConcepts\ConnectionPooling\RequestOverrides\RequestTimeoutsOverrides.doc.cs" />
     <Compile Include="ClientConcepts\ConnectionPooling\RequestOverrides\RespectsAllowedStatusCode.doc.cs" />
     <Compile Include="ClientConcepts\ConnectionPooling\RequestOverrides\RespectsForceNode.doc.cs" />
+    <Compile Include="ClientConcepts\Connection\HttpConnectionTests.cs" />
     <Compile Include="ClientConcepts\HighLevel\Caching\FieldResolverCacheTests.cs" />
     <Compile Include="ClientConcepts\HighLevel\Inference\DocumentPaths.doc.cs" />
     <Compile Include="ClientConcepts\HighLevel\Inference\FeaturesInference.doc.cs" />


### PR DESCRIPTION
 - Content-Encoding was being added to the wrong header
 - Stream was being closed pre-maturely

Closes #2150