### PR TITLE
Return of the reindex helper, this was partially removed in the alpha…

### DIFF
--- a/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
@@ -1,16 +1,17 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Elasticsearch.Net;
 
 namespace Nest
 {
-	// TODO re-implement this now that ES has a reindex API
-
 	public class ReindexObservable<T> : IDisposable, IObservable<IReindexResponse<T>> where T : class
 	{
 		private readonly IReindexRequest _reindexRequest;
 		private readonly IConnectionSettingsValues _connectionSettings;
 
 		private IElasticClient _client { get; set; }
+		public Action<IHit<T>, T, IBulkIndexOperation<T>> Alter { get; private set; }
 
 		public ReindexObservable(IElasticClient client, IConnectionSettingsValues connectionSettings, IReindexRequest reindexRequest)
 		{
@@ -18,10 +19,122 @@ namespace Nest
 			this._reindexRequest = reindexRequest;
 			this._client = client;
 		}
+		public IDisposable Subscribe(ReindexObserver<T> observer)
+		{
+			this.Alter = observer.Alter;
+			return this.Subscribe((IObserver<IReindexResponse<T>>)observer);
+		}
 
 		public IDisposable Subscribe(IObserver<IReindexResponse<T>> observer)
 		{
+			observer.ThrowIfNull(nameof(observer));
+			try
+			{
+				this.Reindex(observer);
+			}
+			catch (Exception e)
+			{
+				observer.OnError(e);
+			}
 			return this;
+		}
+
+		private void Reindex(IObserver<IReindexResponse<T>> observer)
+		{
+			var fromIndex = this._reindexRequest.From.Resolve(this._connectionSettings);
+			fromIndex.ThrowIfNullOrEmpty(nameof(fromIndex));
+			var toIndex = this._reindexRequest.To.Resolve(this._connectionSettings);
+			toIndex.ThrowIfNullOrEmpty(nameof(toIndex));
+
+			this.CreateIndex(fromIndex, toIndex);
+
+			var scroll = this._reindexRequest.Scroll ?? TimeSpan.FromMinutes(2);
+
+			var searchResult = this.InitiateSearch(fromIndex, fromIndex, scroll);
+
+			this.ScrollToCompletion(observer, fromIndex, toIndex, scroll, searchResult);
+
+			observer.OnCompleted();
+		}
+
+		private void ScrollToCompletion(IObserver<IReindexResponse<T>> observer, string fromIndex, string toIndex, Time scroll, ISearchResponse<T> searchResult)
+		{
+			if (searchResult == null || !searchResult.IsValid)
+				throw new ElasticsearchClientException(PipelineFailure.BadResponse, $"Reindexing to {toIndex} failed unexpectedly during searching index {fromIndex}.", searchResult.ApiCall);
+			IBulkResponse indexResult = null;
+			int page = 0;
+			while (searchResult.IsValid && searchResult.Documents.HasAny())
+			{
+				indexResult = this.IndexSearchResults(searchResult, observer, toIndex, page);
+				if (indexResult == null || !indexResult.IsValid)
+					throw new ElasticsearchClientException(PipelineFailure.BadResponse, $"Reindexing to {toIndex} failed unexpectedly during bulk indexing.", indexResult?.ApiCall);
+				observer.OnNext(new ReindexResponse<T>()
+				{
+					BulkResponse = indexResult,
+					SearchResponse = searchResult,
+					Scroll = page
+				});
+				page++;
+				searchResult = this._client.Scroll<T>(scroll, searchResult.ScrollId);
+				if (searchResult == null || !searchResult.IsValid)
+					throw new ElasticsearchClientException(PipelineFailure.BadResponse, $"Reindexing to {toIndex} failed unexpectedly during searching index {fromIndex}.", searchResult.ApiCall);
+			}
+		}
+
+		private ISearchResponse<T> InitiateSearch(string fromIndex, string toIndex, Time scroll)
+		{
+			var size = this._reindexRequest.Size ?? 100;
+			var searchResult = this._client.Search<T>(new SearchRequest<T>(fromIndex, this._reindexRequest.Type)
+			{
+				From = 0,
+				Size = size,
+				Query = this._reindexRequest.Query,
+				Scroll = scroll
+			});
+			if (searchResult.Total <= 0)
+				throw new ElasticsearchClientException(PipelineFailure.BadResponse, $"Source index {fromIndex} doesn't contain any documents.", searchResult.ApiCall);
+			return searchResult;
+		}
+
+
+		private void CreateIndex(string resolvedFrom, string resolvedTo)
+		{
+			var originalIndexSettings = this._client.GetIndex(resolvedFrom);
+			var originalIndexState = originalIndexSettings.Indices[resolvedFrom];
+			var createIndexRequest = this._reindexRequest.CreateIndexRequest ?? new CreateIndexRequest(resolvedTo, originalIndexState);
+			var createIndexResponse = this._client.CreateIndex(createIndexRequest);
+			if (!createIndexResponse.IsValid)
+				throw new ElasticsearchClientException(PipelineFailure.BadResponse, $"Failed to create destination index {resolvedTo}.", createIndexResponse.ApiCall);
+		}
+
+		public IBulkResponse IndexSearchResults(ISearchResponse<T> searchResult, IObserver<IReindexResponse<T>> observer, IndexName toIndex, int page)
+		{
+			if (!searchResult.IsValid)
+				throw new ElasticsearchClientException(PipelineFailure.BadResponse, $"Indexing failed on scroll #{page}.", searchResult.ApiCall);
+
+			var hits = searchResult.Hits.ToList();
+			var bulkOperations = new List<IBulkOperation>(hits.Count);
+			foreach (var h in hits)
+			{
+				var item = new BulkIndexOperation<T>(h.Source)
+				{
+					Type = h.Type,
+					Index = toIndex,
+					Id = h.Id,
+					Routing = h.Routing,
+					Timestamp = h.Timestamp
+				};
+				if (h.Parent != null) item.Parent = h.Parent;
+				if (h.Ttl.HasValue) item.Ttl = h.Ttl;
+				this.Alter?.Invoke(h, h.Source, item);
+				bulkOperations.Add(item);
+			}
+
+			var indexResult = this._client.Bulk(new BulkRequest { Operations = bulkOperations });
+			if (!indexResult.IsValid)
+				throw new ElasticsearchClientException(PipelineFailure.BadResponse, $"Failed indexing page {page}.", indexResult.ApiCall);
+
+			return indexResult;
 		}
 
 		public void Dispose()

--- a/src/Nest/Document/Multiple/Reindex/ReindexObserver.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexObserver.cs
@@ -4,12 +4,16 @@ namespace Nest
 {
 	public class ReindexObserver<T> : CoordinatedRequestObserverBase<IReindexResponse<T>> where T : class
 	{
+		public Action<IHit<T>, T, IBulkIndexOperation<T>> Alter { get; }
+
 		public ReindexObserver(
-			Action<IReindexResponse<T>> onNext = null, 
-			Action<Exception> onError = null, 
-			Action completed = null)
+			Action<IReindexResponse<T>> onNext = null,
+			Action<Exception> onError = null,
+			Action completed = null,
+			Action<IHit<T>, T, IBulkIndexOperation<T>> alter = null)
 			: base(onNext, onError, completed)
 		{
+			this.Alter = null;
 		}
 
 	}

--- a/src/Nest/Document/Multiple/Reindex/ReindexRequest.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexRequest.cs
@@ -93,16 +93,9 @@ namespace Nest
 		public ReindexDescriptor<T> AllTypes() => this.Type(Types.AllTypes);
 
 		/// <summary>
-		/// CreateIndex selector, will be passed the a descriptor initialized with the settings from
-		/// the index we're reindexing from
+		/// CreateIndex selector if not explicitly specified will reuse settings from the originating index
 		/// </summary>
 		public ReindexDescriptor<T> CreateIndex(Func<CreateIndexDescriptor, ICreateIndexRequest> createIndexSelector) =>
 			Assign(a => a.CreateIndexRequest = createIndexSelector.InvokeOrDefault(new CreateIndexDescriptor(a.From)));
-
-		/// <summary>
-		/// CreateIndex selector, will be passed the a descriptor initialized with the settings from
-		/// the index we're reindexing from
-		/// </summary>
-		public ReindexDescriptor<T> CreateIndex(ICreateIndexRequest createIndexRequest) => Assign(a => a.CreateIndexRequest = createIndexRequest);
 	}
 }

--- a/src/Nest/Indices/IndexManagement/CreateIndex/CreateIndexRequest.cs
+++ b/src/Nest/Indices/IndexManagement/CreateIndex/CreateIndexRequest.cs
@@ -13,6 +13,31 @@ namespace Nest
 		//TODO Only here for ReadAsType new() constraint needs to be updated
 		public CreateIndexRequest() { }
 
+		public CreateIndexRequest(IndexName index, IndexState state) : this(index)
+		{
+			this.Settings = state.Settings;
+			this.Mappings = state.Mappings;
+			this.Aliases = state.Aliases;
+			this.Similarity = state.Similarity;
+			CreateIndexRequest.RemoveReadOnlySettings(this.Settings);
+		}
+
+		private static string[] ReadOnlySettings =
+		{
+			"index.creation_date",
+			"index.uuid",
+			"index.version.created",
+		};
+		internal static void RemoveReadOnlySettings (IIndexSettings settings)
+		{
+			if (settings == null) return;
+			foreach(var bad in ReadOnlySettings)
+			{
+				if (settings.Contains(bad))
+					settings.Remove(bad);
+			}
+		}
+
 		public IIndexSettings Settings { get; set; }
 
 		public IMappings Mappings { get; set; }
@@ -38,6 +63,8 @@ namespace Nest
 			a.Settings = indexSettings.Settings;
 			a.Mappings = indexSettings.Mappings;
 			a.Aliases = indexSettings.Aliases;
+			a.Similarity = indexSettings.Similarity;
+			CreateIndexRequest.RemoveReadOnlySettings(a.Settings);
 		});
 
 		public CreateIndexDescriptor Settings(Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> selector) =>

--- a/src/Nest/Search/Count/CountRequest.cs
+++ b/src/Nest/Search/Count/CountRequest.cs
@@ -5,24 +5,24 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<CountRequest>))]
-	public partial interface ICountRequest 
+	public partial interface ICountRequest
 	{
 		[JsonProperty("query")]
 		QueryContainer Query { get; set; }
 	}
 	public partial interface ICountRequest<T> : ICountRequest
-		where T :class
+		where T : class
 	{
 
 	}
 
-	public partial class CountRequest 
+	public partial class CountRequest
 	{
 		private CountRequestParameters QueryString => ((IRequest<CountRequestParameters>)this).RequestParameters;
 		protected override HttpMethod HttpMethod =>
 			this.QueryString.ContainsKey("_source") || this.QueryString.ContainsKey("q") ? HttpMethod.GET : HttpMethod.POST;
 
-		public QueryContainer Query { get; set; }
+		public QueryContainer Query { get; set; } = new MatchAllQuery();
 	}
 
 	public partial class CountRequest<T>
@@ -31,7 +31,7 @@ namespace Nest
 		protected override HttpMethod HttpMethod =>
 			this.QueryString.ContainsKey("_source") || this.QueryString.ContainsKey("q") ? HttpMethod.GET : HttpMethod.POST;
 
-		public QueryContainer Query { get; set; }
+		public QueryContainer Query { get; set; } = new MatchAllQuery();
 	}
 
 	[DescriptorFor("Count")]
@@ -40,8 +40,8 @@ namespace Nest
 		private CountRequestParameters QueryString => ((IRequest<CountRequestParameters>)this).RequestParameters;
 		protected override HttpMethod HttpMethod =>
 			this.QueryString.ContainsKey("_source") || this.QueryString.ContainsKey("q") ? HttpMethod.GET : HttpMethod.POST;
-		
-		QueryContainer ICountRequest.Query { get; set; }
+
+		QueryContainer ICountRequest.Query { get; set; } = new MatchAllQuery();
 
 		public CountDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> querySelector) =>
 			Assign(a => a.Query = querySelector?.Invoke(new QueryContainerDescriptor<T>()));

--- a/src/Nest/Search/Suggesters/ContextSuggester/SuggestContextJsonConverter.cs
+++ b/src/Nest/Search/Suggesters/ContextSuggester/SuggestContextJsonConverter.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -25,11 +23,11 @@ namespace Nest
 					return g;
 
 				case "category":
+				default:
 					var c = new CategorySuggestContext();
 					serializer.Populate(jo.CreateReader(), c);
 					return c;
 			}
-			return null;
 		}
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) { }

--- a/src/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
+++ b/src/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
@@ -1,18 +1,15 @@
 ﻿using System;
 using System.Linq;
 using System.Threading;
-using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Framework;
 using Tests.Framework.Integration;
 using Tests.Framework.MockData;
 using Xunit;
-using static Nest.Infer;
 
 namespace Tests.Document.Multiple.Reindex
 {
-	// TODO re-implement these tests once Reindex is implemented
 	[CollectionDefinition(TypeOfCluster.Reindex)]
 	public class ReindexCluster : ClusterBase, ICollectionFixture<ReindexCluster>, IClassFixture<EndpointUsage>
 	{
@@ -27,17 +24,132 @@ namespace Tests.Document.Multiple.Reindex
 	[Collection(TypeOfCluster.Reindex)]
 	public class ReindexApiTests : SerializationTestBase
 	{
-		//private readonly IObservable<IReindexResponse<ILazyDocument>> _reindexManyTypesResult;
-		//private readonly IObservable<IReindexResponse<Project>> _reindexSingleTypeResult;
-		//private readonly IElasticClient _client;
+		private readonly IObservable<IReindexResponse<ILazyDocument>> _reindexManyTypesResult;
+		private readonly IObservable<IReindexResponse<Project>> _reindexSingleTypeResult;
+		private readonly IElasticClient _client;
+
+		private static string NewManyTypesIndexName { get; } = $"project-copy-{Guid.NewGuid().ToString("N").Substring(8)}";
+
+		private static string NewSingleTypeIndexName { get; } = $"project-copy-{Guid.NewGuid().ToString("N").Substring(8)}";
+
+		private static string IndexName { get; } = "project";
 
 		public ReindexApiTests(ReindexCluster cluster, EndpointUsage usage)
 		{
+			this._client = cluster.Client();
+
+			// create a couple of projects
+			var projects = Project.Generator.Generate(2).ToList();
+			var indexProjectsResponse = this._client.IndexMany(projects, IndexName);
+			this._client.Refresh(IndexName);
+
+			// create a thousand commits and associate with the projects
+			var commits = CommitActivity.Generator.Generate(1000).ToList();
+			var bb = new BulkDescriptor();
+			for (int index = 0; index < commits.Count; index++)
+			{
+				var commit = commits[index];
+				var project = index % 2 == 0
+					? projects[0].Name
+					: projects[1].Name;
+
+				bb.Index<CommitActivity>(bi => bi
+					.Document(commit)
+					.Index(IndexName)
+					.Id(commit.Id)
+					.Routing(project)
+					.Parent(project)
+				);
+			}
+
+			var bulkResult = this._client.Bulk(b => bb);
+			bulkResult.IsValid.Should().BeTrue();
+
+			this._client.Refresh(IndexName);
+
+			this._reindexManyTypesResult = this._client.Reindex<ILazyDocument>(IndexName, NewManyTypesIndexName, r => r.AllTypes());
+			this._reindexSingleTypeResult = this._client.Reindex<Project>(IndexName, NewSingleTypeIndexName);
 		}
 
 		[I]
 		public void ReturnsExpectedResponse()
 		{
+			var handles = new[]
+			{
+				new ManualResetEvent(false),
+				new ManualResetEvent(false)
+			};
+
+			var manyTypesObserver = new ReindexObserver<ILazyDocument>(
+				onError: (e) => { throw e; },
+				completed: () => ReindexManyTypesCompleted(handles),
+				alter: (h, d, i) =>
+				{
+					//This would be a great place to alter the
+					// BulkIndexOperation i (use pipeline perhaps)
+					// Source Document d
+					// h is the whole hit including the documents metadata
+					//
+					// on a per document basis
+					i.RetriesOnConflict = 2;
+				}
+			);
+
+			this._reindexManyTypesResult.Subscribe(manyTypesObserver);
+
+			var singleTypeObserver = new ReindexObserver<Project>(
+				onError: (e) => { throw e; },
+				completed: () => ReindexSingleTypeCompleted(handles)
+			);
+
+			this._reindexSingleTypeResult.Subscribe(singleTypeObserver);
+
+			WaitHandle.WaitAll(handles, TimeSpan.FromMinutes(3));
+		}
+
+		private void ReindexSingleTypeCompleted(ManualResetEvent[] handles)
+		{
+			var refresh = this._client.Refresh(NewSingleTypeIndexName);
+			var originalIndexCount = this._client.Count<Project>(c => c.Index(IndexName));
+
+			// new index should only contain project document types
+			var newIndexCount = this._client.Count<Project>(c => c.Index(NewSingleTypeIndexName).AllTypes());
+
+			originalIndexCount.Count.Should().BeGreaterThan(0).And.Be(newIndexCount.Count);
+
+			handles[1].Set();
+		}
+
+		private void ReindexManyTypesCompleted(ManualResetEvent[] handles)
+		{
+			var refresh = this._client.Refresh(NewManyTypesIndexName);
+			var originalIndexCount = this._client.Count<CommitActivity>(c => c.Index(IndexName));
+			var newIndexCount = this._client.Count<CommitActivity>(c => c.Index(NewManyTypesIndexName));
+
+			originalIndexCount.Count.Should().BeGreaterThan(0).And.Be(newIndexCount.Count);
+
+			var scroll = "20s";
+
+			var searchResult = this._client.Search<CommitActivity>(s => s
+				.Index(NewManyTypesIndexName)
+				.From(0)
+				.Size(100)
+				.Query(q => q.MatchAll())
+				.Scroll(scroll)
+			);
+
+			do
+			{
+				var result = searchResult;
+				searchResult = this._client.Scroll<CommitActivity>(scroll, result.ScrollId);
+				foreach (var hit in searchResult.Hits)
+				{
+					hit.Timestamp.Should().HaveValue();
+					hit.Parent.Should().NotBeNullOrEmpty();
+					hit.Routing.Should().NotBeNullOrEmpty();
+				}
+			} while (searchResult.IsValid && searchResult.Documents.Any());
+			handles[0].Set();
 		}
 	}
 }

--- a/src/Tests/Framework/ManagedElasticsearch/Process/ElasticsearchNode.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Process/ElasticsearchNode.cs
@@ -2,15 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Threading;
 using Elasticsearch.Net;
 using Nest;
-using Tests.Framework;
-using System.Xml.Linq;
 using Tests.Framework.Versions;
 #if !DOTNETCORE
 using XplatManualResetEvent = System.Threading.ManualResetEvent;

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: m
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.0.0-alpha3


### PR DESCRIPTION
…s while we figured out how it interacted with the new reindex api's

Refactored it a tad and introduced an option to alter the index operation / document when using the `ReindexObserver`

Fixed CountRequest for 5.0 alpha we now default to an explicit match_all query

pending https://github.com/elastic/elasticsearch/issues/19422