### PR TITLE
Round down to floor value when converting TimeSpan or Time to DateMath

### DIFF
--- a/src/Nest/CommonOptions/DateMath/DateMathExpression.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMathExpression.cs
@@ -18,19 +18,19 @@ namespace Nest
 
 		public DateMathExpression Add(Time expression)
 		{
-			Self.Ranges.Add(Tuple.Create(DateMathOperation.Add, expression));
+			Self.Ranges.Add(Tuple.Create(DateMathOperation.Add, Floor(expression)));
 			return this;
 		}
 
 		public DateMathExpression Subtract(Time expression)
 		{
-			Self.Ranges.Add(Tuple.Create(DateMathOperation.Subtract, expression));
+			Self.Ranges.Add(Tuple.Create(DateMathOperation.Subtract, Floor(expression)));
 			return this;
 		}
 
 		public DateMathExpression Operation(Time expression, DateMathOperation operation)
 		{
-			Self.Ranges.Add(Tuple.Create(operation, expression));
+			Self.Ranges.Add(Tuple.Create(operation, Floor(expression)));
 			return this;
 		}
 
@@ -39,5 +39,9 @@ namespace Nest
 			this.Round = round;
 			return this;
 		}
+
+		/// Time may result in a fractional factor, which date math expressions do not support.
+		/// Thus we need take the floor of the current factor, for instance: 1.04d => 1d
+		private Time Floor(Time expression) => new Time(Math.Floor(expression.Factor.Value), expression.Interval.Value);
 	}
 }

--- a/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
+++ b/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
@@ -10,32 +10,32 @@ namespace Tests.CommonOptions.DateMath
 	{
 		/** == Date Math Expressions
 		 * The date type supports using date math expression when using it in a query/filter
-		 * Whenever durations need to be specified, eg for a timeout parameter, the duration can be specified 
+		 * Whenever durations need to be specified, eg for a timeout parameter, the duration can be specified
 		 *
-		 * The expression starts with an "anchor" date, which can be either now or a date string (in the applicable format) ending with `||`. 
-		 * It can then follow by a math expression, supporting `+`, `-` and `/` (rounding). 
-		 * The units supported are 
+		 * The expression starts with an "anchor" date, which can be either now or a date string (in the applicable format) ending with `||`.
+		 * It can then follow by a math expression, supporting `+`, `-` and `/` (rounding).
+		 * The units supported are
 		 *
 		 * - `y` (year)
 		 * - `M` (month)
-		 * - `w` (week) 
-		 * - `d` (day) 
-		 * - `h` (hour) 
+		 * - `w` (week)
+		 * - `d` (day)
+		 * - `h` (hour)
 		 * - `m` (minute)
 		 * - `s` (second)
-		 * 
-		 * as a whole number representing time in milliseconds, or as a time value like `2d` for 2 days. 
+		 *
+		 * as a whole number representing time in milliseconds, or as a time value like `2d` for 2 days.
 		 * :datemath: {ref_current}/common-options.html#date-math
 		 * Be sure to read the Elasticsearch documentation on {datemath}[Date Math].
 		 */
 		[U] public void SimpleExpressions()
 		{
 			/** === Simple Expressions
-			* You can create simple expressions using any of the static methods on `DateMath` 
+			* You can create simple expressions using any of the static methods on `DateMath`
 			*/
 			Expect("now").WhenSerializing(Nest.DateMath.Now);
 			Expect("2015-05-05T00:00:00").WhenSerializing(Nest.DateMath.Anchored(new DateTime(2015,05, 05)));
-			
+
 			/** strings implicitly convert to `DateMath` */
 			Expect("now").WhenSerializing<Nest.DateMath>("now");
 
@@ -46,18 +46,18 @@ namespace Tests.CommonOptions.DateMath
 				/** the resulting date math will assume the whole string is the anchor */
 				.Result(dateMath => ((IDateMath)dateMath)
 					.Anchor.Match(
-						d => d.Should().NotBe(default(DateTime)), 
+						d => d.Should().NotBe(default(DateTime)),
 						s => s.Should().Be(nonsense)
 					)
 				);
-			
+
 			/** `DateTime` also implicitly convert to simple date math expressions */
 			var date = new DateTime(2015, 05, 05);
 			Expect("2015-05-05T00:00:00").WhenSerializing<Nest.DateMath>(date)
 				/** the anchor will be an actual `DateTime`, even after a serialization/deserialization round trip */
 				.Result(dateMath => ((IDateMath)dateMath)
 				.	Anchor.Match(
-						d => d.Should().Be(date), 
+						d => d.Should().Be(date),
 						s => s.Should().BeNull()
 					)
 				);
@@ -66,7 +66,7 @@ namespace Tests.CommonOptions.DateMath
 		[U] public void ComplexExpressions()
 		{
 			/** === Complex Expressions
-			* Ranges can be chained on to simple expressions 
+			* Ranges can be chained on to simple expressions
 			*/
 			Expect("now+1d").WhenSerializing(
 				Nest.DateMath.Now.Add("1d"));
@@ -80,9 +80,9 @@ namespace Tests.CommonOptions.DateMath
 				Nest.DateMath.Now.Add("1d")
 					.Subtract(TimeSpan.FromMinutes(1))
 					.RoundTo(Nest.TimeUnit.Day));
-			
+
 			/** When anchoring dates, a `||` needs to be appended as clear separator between the anchor and ranges.
-			* Again, multiple ranges can be chained 
+			* Again, multiple ranges can be chained
 			*/
 			Expect("2015-05-05T00:00:00||+1d-1m").WhenSerializing(
 				Nest.DateMath.Anchored(new DateTime(2015,05,05))
@@ -90,5 +90,26 @@ namespace Tests.CommonOptions.DateMath
 					.Subtract(TimeSpan.FromMinutes(1)));
 		}
 
+
+		[U]
+		/* === Rounding
+		 * Date math expressions do not support fractional values, therefore when converting from
+		 * a Time or TimeSpan value, the resulting factor will always be rounded down to the integer
+		 * value (floor). For instance, `now-1.04d` or `now-1.923d` will round down to `now-1d`.
+		 */
+		public void NeverSerializeToFractions()
+		{
+			Expect("now-1d").WhenSerializing(Nest.DateMath.Now.Subtract(TimeSpan.FromHours(24)));
+			Expect("now-1d").WhenSerializing(Nest.DateMath.Now.Subtract(TimeSpan.FromHours(25)));
+
+			Expect("now+1d").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromHours(24)));
+			Expect("now+1d").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromHours(25)));
+
+			Expect("now-2d").WhenSerializing(Nest.DateMath.Now.Subtract(TimeSpan.FromHours(48)));
+			Expect("now-2d").WhenSerializing(Nest.DateMath.Now.Subtract(TimeSpan.FromHours(50)));
+
+			Expect("now+2d").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromHours(48)));
+			Expect("now+2d").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromHours(50)));
+		}
 	}
 }


### PR DESCRIPTION
Since fractional date math expressions are not supported.

Closes #2170