### PR TITLE
Use custom connection serialization settings, if available.

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
@@ -24,7 +24,14 @@ namespace Nest
 		private readonly Dictionary<SerializationFormatting, JsonSerializer> _defaultSerializers;
 		private readonly JsonSerializer _defaultSerializer;
 
-		protected virtual void ModifyJsonSerializerSettings(JsonSerializerSettings settings) { }
+		protected virtual void ModifyJsonSerializerSettings(JsonSerializerSettings settings)
+		{
+			// Apply custom serialization settings from the connection serializer, if any; avoiding infinite loop with 'this' check.
+			var jsonNetSerializer = this.Settings?.Serializer as JsonNetSerializer;
+			if (jsonNetSerializer != null && jsonNetSerializer != this)
+				jsonNetSerializer.ModifyJsonSerializerSettings(settings);
+		}
+
 		protected virtual IList<Func<Type, JsonConverter>> ContractConverters => null;
 
 		public JsonNetSerializer(IConnectionSettingsValues settings) : this(settings, null) { }


### PR DESCRIPTION
This solves a problem similar to #2155 but for multi-get. My date strings were not round tripping correctly.

Digging into it I found that my custom `JsonSerializationSettings` were being ignored in `JsonNetSerializer` (`DateParseHandling.None` specifically) during a multi-get call.

This is more of a comprehensive solution than #2155 since the problem looks to be a bit more systemic than it did at first.

I was unable to run *all* tests at once (before and after the change), but ran a number of them individually.