### PR TITLE
Add Percent metric in OperatingSystemStats

### DIFF
--- a/src/Nest/Cluster/NodesStats/NodeStats.cs
+++ b/src/Nest/Cluster/NodesStats/NodeStats.cs
@@ -87,6 +87,8 @@ namespace Nest
 		public long Timestamp { get; internal set; }
 		[JsonProperty("load_average")]
 		public float LoadAverage { get; internal set; }
+		[JsonProperty("cpu_percent")]
+		public int CpuPercent { get; internal set; }
 
 		[JsonProperty("mem")]
 		public ExtendedMemoryStats Memory { get; internal set; }

--- a/src/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
+++ b/src/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
@@ -99,6 +99,7 @@ namespace Tests.Cluster.NodesStats
 
 			os.Timestamp.Should().BeGreaterThan(0);
 			os.LoadAverage.Should().NotBe(0);
+			os.CpuPercent.Should().NotBe(0);
 
 			os.Memory.Should().NotBeNull();
 			os.Memory.TotalInBytes.Should().BeGreaterThan(0);


### PR DESCRIPTION
Add Percent metric in OperatingSystemStats to solve this issue:
https://github.com/elastic/elasticsearch-net/issues/2181

In one commit so we can close this pull request: https://github.com/elastic/elasticsearch-net/pull/2185