### PR TITLE
Add relation to geo_shape queries

### DIFF
--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -58,6 +58,8 @@ namespace Nest
 		internal static ConcurrentDictionary<string, object> _enumCache = new ConcurrentDictionary<string, object>();
 		internal static T? ToEnum<T>(this string str, StringComparison comparison = StringComparison.OrdinalIgnoreCase) where T : struct
 		{
+			if (str == null) return null;
+
 			var enumType = typeof(T);
 			var key = $"{enumType.Name}.{str}";
 			object value;

--- a/src/Nest/CommonOptions/Geo/GeoShapeRelation.cs
+++ b/src/Nest/CommonOptions/Geo/GeoShapeRelation.cs
@@ -12,6 +12,8 @@ namespace Nest
 		[EnumMember(Value = "disjoint")]
 		Disjoint,
 		[EnumMember(Value = "within")]
-		Within
+		Within,
+		[EnumMember(Value = "contains")]
+		Contains
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/Circle/GeoShapeCircleQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Circle/GeoShapeCircleQuery.cs
@@ -9,17 +9,18 @@ namespace Nest
 		ICircleGeoShape Shape { get; set; }
 	}
 
-	public class GeoShapeCircleQuery : FieldNameQueryBase, IGeoShapeCircleQuery
+	public class GeoShapeCircleQuery : GeoShapeQueryBase, IGeoShapeCircleQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public ICircleGeoShape Shape { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
+
 		internal static bool IsConditionless(IGeoShapeCircleQuery q) => q.Field.IsConditionless() || q.Shape == null || q.Shape.Coordinates == null;
 	}
 
-	public class GeoShapeCircleQueryDescriptor<T> 
-		: FieldNameQueryDescriptorBase<GeoShapeCircleQueryDescriptor<T>, IGeoShapeCircleQuery, T>
+	public class GeoShapeCircleQueryDescriptor<T>
+		: GeoShapeQueryDescriptorBase<GeoShapeCircleQueryDescriptor<T>, IGeoShapeCircleQuery, T>
 		, IGeoShapeCircleQuery where T : class
 	{
 		protected override bool Conditionless => GeoShapeCircleQuery.IsConditionless(this);

--- a/src/Nest/QueryDsl/Geo/Shape/Envelope/GeoShapeEnvelopeQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Envelope/GeoShapeEnvelopeQuery.cs
@@ -10,7 +10,7 @@ namespace Nest
 		IEnvelopeGeoShape Shape { get; set; }
 	}
 
-	public class GeoShapeEnvelopeQuery : FieldNameQueryBase, IGeoShapeEnvelopeQuery
+	public class GeoShapeEnvelopeQuery : GeoShapeQueryBase, IGeoShapeEnvelopeQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public IEnvelopeGeoShape Shape { get; set; }
@@ -19,8 +19,8 @@ namespace Nest
 		internal static bool IsConditionless(IGeoShapeEnvelopeQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
 	}
 
-	public class GeoShapeEnvelopeQueryDescriptor<T> 
-		: FieldNameQueryDescriptorBase<GeoShapeEnvelopeQueryDescriptor<T>, IGeoShapeEnvelopeQuery, T>
+	public class GeoShapeEnvelopeQueryDescriptor<T>
+		: GeoShapeQueryDescriptorBase<GeoShapeEnvelopeQueryDescriptor<T>, IGeoShapeEnvelopeQuery, T>
 		, IGeoShapeEnvelopeQuery where T : class
 	{
 		protected override bool Conditionless => GeoShapeEnvelopeQuery.IsConditionless(this);

--- a/src/Nest/QueryDsl/Geo/Shape/GeoShapeQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeoShapeQueryJsonConverter.cs
@@ -37,6 +37,7 @@ namespace Nest
 			JToken shape;
 			JToken indexedShape;
 			IGeoShapeQuery query = null;
+
 			if (jo.TryGetValue("shape", out shape))
 				query = ParseShape(shape, serializer);
 			else if (jo.TryGetValue("indexed_shape", out indexedShape))
@@ -45,9 +46,11 @@ namespace Nest
 			if (query == null) return null;
 			var boost = jo["boost"]?.Value<double>();
 			var name = jo["_name"]?.Value<string>();
+			var relation = jo["relation"]?.Value<string>().ToEnum<GeoShapeRelation>();
 			query.Boost = boost;
 			query.Name = name;
 			query.Field = field;
+			query.Relation = relation;
 			return query;
 		}
 

--- a/src/Nest/QueryDsl/Geo/Shape/IGeoShapeQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/IGeoShapeQuery.cs
@@ -3,8 +3,26 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	[JsonConverter(typeof (CompositeJsonConverter<GeoShapeQueryJsonConverter, FieldNameQueryJsonConverter<GeoShapeCircleQuery>>))]
+	[JsonConverter(typeof(CompositeJsonConverter<GeoShapeQueryJsonConverter, FieldNameQueryJsonConverter<GeoShapeCircleQuery>>))]
 	public interface IGeoShapeQuery : IFieldNameQuery
 	{
+		[JsonProperty("relation")]
+		GeoShapeRelation? Relation { get; set; }
+	}
+
+	public abstract class GeoShapeQueryBase : FieldNameQueryBase, IGeoShapeQuery
+	{
+		public GeoShapeRelation? Relation { get; set; }
+	}
+
+	public abstract class GeoShapeQueryDescriptorBase<TDescriptor, TInterface, T>
+		: FieldNameQueryDescriptorBase<TDescriptor, TInterface, T>, IGeoShapeQuery
+		where TDescriptor : FieldNameQueryDescriptorBase<TDescriptor, TInterface, T>, TInterface
+		where TInterface : class, IGeoShapeQuery
+		where T : class
+	{
+		GeoShapeRelation? IGeoShapeQuery.Relation { get; set; }
+
+		public TDescriptor Relation(GeoShapeRelation relation) => Assign(a => a.Relation = relation);
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/IndexedShape/GeoIndexedShapeQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/IndexedShape/GeoIndexedShapeQuery.cs
@@ -10,20 +10,20 @@ namespace Nest
 		IFieldLookup IndexedShape { get; set; }
 	}
 
-	public class GeoIndexedShapeQuery : FieldNameQueryBase, IGeoIndexedShapeQuery
+	public class GeoIndexedShapeQuery : GeoShapeQueryBase, IGeoIndexedShapeQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public IFieldLookup IndexedShape { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 
-		internal static bool IsConditionless(IGeoIndexedShapeQuery q) => 
+		internal static bool IsConditionless(IGeoIndexedShapeQuery q) =>
 			q.Field.IsConditionless() || q.IndexedShape == null
 			|| q.IndexedShape.Id == null | q.IndexedShape.Index == null || q.IndexedShape.Type == null
 			|| q.IndexedShape.Path == null;
 	}
 
-	public class GeoIndexedShapeQueryDescriptor<T> : FieldNameQueryDescriptorBase<GeoIndexedShapeQueryDescriptor<T>, IGeoIndexedShapeQuery, T>
+	public class GeoIndexedShapeQueryDescriptor<T> : GeoShapeQueryDescriptorBase<GeoIndexedShapeQueryDescriptor<T>, IGeoIndexedShapeQuery, T>
 		, IGeoIndexedShapeQuery where T : class
 	{
 		protected override bool Conditionless => GeoIndexedShapeQuery.IsConditionless(this);

--- a/src/Nest/QueryDsl/Geo/Shape/LineString/GeoShapeLineStringQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/LineString/GeoShapeLineStringQuery.cs
@@ -10,7 +10,7 @@ namespace Nest
 		ILineStringGeoShape Shape { get; set; }
 	}
 
-	public class GeoShapeLineStringQuery : FieldNameQueryBase, IGeoShapeLineStringQuery
+	public class GeoShapeLineStringQuery : GeoShapeQueryBase, IGeoShapeLineStringQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public ILineStringGeoShape Shape { get; set; }
@@ -19,8 +19,8 @@ namespace Nest
 		internal static bool IsConditionless(IGeoShapeLineStringQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
 	}
 
-	public class GeoShapeLineStringQueryDescriptor<T> 
-		: FieldNameQueryDescriptorBase<GeoShapeLineStringQueryDescriptor<T>, IGeoShapeLineStringQuery, T>
+	public class GeoShapeLineStringQueryDescriptor<T>
+		: GeoShapeQueryDescriptorBase<GeoShapeLineStringQueryDescriptor<T>, IGeoShapeLineStringQuery, T>
 		, IGeoShapeLineStringQuery where T : class
 	{
 		protected override bool Conditionless => GeoShapeLineStringQuery.IsConditionless(this);

--- a/src/Nest/QueryDsl/Geo/Shape/MultiLineString/GeoShapeMultiLineStringQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiLineString/GeoShapeMultiLineStringQuery.cs
@@ -10,7 +10,7 @@ namespace Nest
 		IMultiLineStringGeoShape Shape { get; set; }
 	}
 
-	public class GeoShapeMultiLineStringQuery : FieldNameQueryBase, IGeoShapeMultiLineStringQuery
+	public class GeoShapeMultiLineStringQuery : GeoShapeQueryBase, IGeoShapeMultiLineStringQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public IMultiLineStringGeoShape Shape { get; set; }
@@ -19,8 +19,8 @@ namespace Nest
 		internal static bool IsConditionless(IGeoShapeMultiLineStringQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
 	}
 
-	public class GeoShapeMultiLineStringQueryDescriptor<T> 
-		: FieldNameQueryDescriptorBase<GeoShapeMultiLineStringQueryDescriptor<T>, IGeoShapeMultiLineStringQuery, T>
+	public class GeoShapeMultiLineStringQueryDescriptor<T>
+		: GeoShapeQueryDescriptorBase<GeoShapeMultiLineStringQueryDescriptor<T>, IGeoShapeMultiLineStringQuery, T>
 		, IGeoShapeMultiLineStringQuery where T : class
 	{
 		protected override bool Conditionless => GeoShapeMultiLineStringQuery.IsConditionless(this);

--- a/src/Nest/QueryDsl/Geo/Shape/MultiPoint/GeoShapeMultiPointQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiPoint/GeoShapeMultiPointQuery.cs
@@ -10,7 +10,7 @@ namespace Nest
 		IMultiPointGeoShape Shape { get; set; }
 	}
 
-	public class GeoShapeMultiPointQuery : FieldNameQueryBase, IGeoShapeMultiPointQuery
+	public class GeoShapeMultiPointQuery : GeoShapeQueryBase, IGeoShapeMultiPointQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public IMultiPointGeoShape Shape { get; set; }
@@ -18,9 +18,9 @@ namespace Nest
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 		internal static bool IsConditionless(IGeoShapeMultiPointQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
 	}
-	
-	public class GeoShapeMultiPointQueryDescriptor<T> 
-		: FieldNameQueryDescriptorBase<GeoShapeMultiPointQueryDescriptor<T>, IGeoShapeMultiPointQuery, T>
+
+	public class GeoShapeMultiPointQueryDescriptor<T>
+		: GeoShapeQueryDescriptorBase<GeoShapeMultiPointQueryDescriptor<T>, IGeoShapeMultiPointQuery, T>
 		, IGeoShapeMultiPointQuery where T : class
 	{
 		protected override bool Conditionless => GeoShapeMultiPointQuery.IsConditionless(this);

--- a/src/Nest/QueryDsl/Geo/Shape/MultiPolygon/GeoShapeMultiPolygonQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiPolygon/GeoShapeMultiPolygonQuery.cs
@@ -10,7 +10,7 @@ namespace Nest
 		IMultiPolygonGeoShape Shape { get; set; }
 	}
 
-	public class GeoShapeMultiPolygonQuery : FieldNameQueryBase, IGeoShapeMultiPolygonQuery
+	public class GeoShapeMultiPolygonQuery : GeoShapeQueryBase, IGeoShapeMultiPolygonQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public IMultiPolygonGeoShape Shape { get; set; }
@@ -19,8 +19,8 @@ namespace Nest
 		internal static bool IsConditionless(IGeoShapeMultiPolygonQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
 	}
 
-	public class GeoShapeMultiPolygonQueryDescriptor<T> 
-		: FieldNameQueryDescriptorBase<GeoShapeMultiPolygonQueryDescriptor<T>, IGeoShapeMultiPolygonQuery, T>
+	public class GeoShapeMultiPolygonQueryDescriptor<T>
+		: GeoShapeQueryDescriptorBase<GeoShapeMultiPolygonQueryDescriptor<T>, IGeoShapeMultiPolygonQuery, T>
 		, IGeoShapeMultiPolygonQuery where T : class
 	{
 		protected override bool Conditionless => GeoShapeMultiPolygonQuery.IsConditionless(this);
@@ -28,5 +28,7 @@ namespace Nest
 
 		public GeoShapeMultiPolygonQueryDescriptor<T> Coordinates(IEnumerable<IEnumerable<IEnumerable<GeoCoordinate>>> coordinates) =>
 			Assign(a => a.Shape = new MultiPolygonGeoShape { Coordinates = coordinates });
+
+
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/Point/GeoShapePointQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Point/GeoShapePointQuery.cs
@@ -9,7 +9,7 @@ namespace Nest
 		IPointGeoShape Shape { get; set; }
 	}
 
-	public class GeoShapePointQuery : FieldNameQueryBase, IGeoShapePointQuery
+	public class GeoShapePointQuery : GeoShapeQueryBase, IGeoShapePointQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public IPointGeoShape Shape { get; set; }
@@ -18,8 +18,8 @@ namespace Nest
 		internal static bool IsConditionless(IGeoShapePointQuery q) => q.Field.IsConditionless() || q.Shape?.Coordinates == null;
 	}
 
-	public class GeoShapePointQueryDescriptor<T> 
-		: FieldNameQueryDescriptorBase<GeoShapePointQueryDescriptor<T>, IGeoShapePointQuery, T>
+	public class GeoShapePointQueryDescriptor<T>
+		: GeoShapeQueryDescriptorBase<GeoShapePointQueryDescriptor<T>, IGeoShapePointQuery, T>
 		, IGeoShapePointQuery where T : class
 	{
 		protected override bool Conditionless => GeoShapePointQuery.IsConditionless(this);

--- a/src/Nest/QueryDsl/Geo/Shape/Polygon/GeoShapePolygonQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Polygon/GeoShapePolygonQuery.cs
@@ -10,7 +10,7 @@ namespace Nest
 		IPolygonGeoShape Shape { get; set; }
 	}
 
-	public class GeoShapePolygonQuery : FieldNameQueryBase, IGeoShapePolygonQuery
+	public class GeoShapePolygonQuery : GeoShapeQueryBase, IGeoShapePolygonQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
 		public IPolygonGeoShape Shape { get; set; }
@@ -19,8 +19,8 @@ namespace Nest
 		internal static bool IsConditionless(IGeoShapePolygonQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
 	}
 
-	public class GeoShapePolygonQueryDescriptor<T> 
-		: FieldNameQueryDescriptorBase<GeoShapePolygonQueryDescriptor<T>, IGeoShapePolygonQuery, T>
+	public class GeoShapePolygonQueryDescriptor<T>
+		: GeoShapeQueryDescriptorBase<GeoShapePolygonQueryDescriptor<T>, IGeoShapePolygonQuery, T>
 		, IGeoShapePolygonQuery where T : class
 	{
 		protected override bool Conditionless => GeoShapePolygonQuery.IsConditionless(this);

--- a/src/Tests/QueryDsl/Geo/Shape/Circle/GeoShapeCircleUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/Circle/GeoShapeCircleUsageTests.cs
@@ -23,7 +23,8 @@ namespace Tests.QueryDsl.Geo.Shape.Circle
 			Name = "named_query",
 			Boost = 1.1,
 			Field = Field<Project>(p=>p.Location),
-			Shape = new CircleGeoShape(this._coordinates) { Radius = "100m" }
+			Shape = new CircleGeoShape(this._coordinates) { Radius = "100m" },
+			Relation = GeoShapeRelation.Intersects
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -33,6 +34,7 @@ namespace Tests.QueryDsl.Geo.Shape.Circle
 				.Field(p=>p.Location)
 				.Coordinates(this._coordinates)
 				.Radius("100m")
+				.Relation(GeoShapeRelation.Intersects)
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IGeoShapeCircleQuery>(a => a.GeoShape as IGeoShapeCircleQuery)

--- a/src/Tests/QueryDsl/Geo/Shape/Envelope/GeoEnvelopeUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/Envelope/GeoEnvelopeUsageTests.cs
@@ -27,7 +27,8 @@ namespace Tests.QueryDsl.Geo.Shape.Envelope
 			Name = "named_query",
 			Boost = 1.1,
 			Field = Field<Project>(p=>p.Location),
-			Shape = new EnvelopeGeoShape(this._coordinates)
+			Shape = new EnvelopeGeoShape(this._coordinates),
+			Relation = GeoShapeRelation.Intersects
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -36,6 +37,7 @@ namespace Tests.QueryDsl.Geo.Shape.Envelope
 				.Boost(1.1)
 				.Field(p=>p.Location)
 				.Coordinates(this._coordinates)
+				.Relation(GeoShapeRelation.Intersects)
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IGeoShapeEnvelopeQuery>(a => a.GeoShape as IGeoShapeEnvelopeQuery)

--- a/src/Tests/QueryDsl/Geo/Shape/IndexedShape/GeoIndexedShapeUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/IndexedShape/GeoIndexedShapeUsageTests.cs
@@ -17,13 +17,14 @@ namespace Tests.QueryDsl.Geo.Shape.IndexedShape
 				{
 					_name="named_query",
 					boost = 1.1,
-					indexed_shape = new 
+					indexed_shape = new
 					{
 						id = 2,
 						type = "project",
 						index = "project",
 						path = "location"
-					}
+					},
+					relation = "intersects"
 				}
 			}
 		};
@@ -38,8 +39,9 @@ namespace Tests.QueryDsl.Geo.Shape.IndexedShape
 				Id = 2,
 				Index = Index<Project>(),
 				Type = Type<Project>(),
-				Path = Field<Project>(p=>p.Location)
-			}
+				Path = Field<Project>(p=>p.Location),
+			},
+			Relation = GeoShapeRelation.Intersects
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -51,6 +53,7 @@ namespace Tests.QueryDsl.Geo.Shape.IndexedShape
 					.Id(2)
 					.Path(pp=>pp.Location)
 				)
+				.Relation(GeoShapeRelation.Intersects)
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IGeoIndexedShapeQuery>(a => a.GeoShape as IGeoIndexedShapeQuery)

--- a/src/Tests/QueryDsl/Geo/Shape/LineString/GeoLineStringUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/LineString/GeoLineStringUsageTests.cs
@@ -27,7 +27,8 @@ namespace Tests.QueryDsl.Geo.Shape.LineString
 			Name = "named_query",
 			Boost = 1.1,
 			Field = Field<Project>(p=>p.Location),
-			Shape = new LineStringGeoShape(this._coordinates)
+			Shape = new LineStringGeoShape(this._coordinates),
+			Relation = GeoShapeRelation.Intersects
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -36,6 +37,7 @@ namespace Tests.QueryDsl.Geo.Shape.LineString
 				.Boost(1.1)
 				.Field(p=>p.Location)
 				.Coordinates(this._coordinates)
+				.Relation(GeoShapeRelation.Intersects)
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IGeoShapeLineStringQuery>(a => a.GeoShape as IGeoShapeLineStringQuery)

--- a/src/Tests/QueryDsl/Geo/Shape/MultiLineString/GeoMultiLineStringUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/MultiLineString/GeoMultiLineStringUsageTests.cs
@@ -28,7 +28,8 @@ namespace Tests.QueryDsl.Geo.Shape.MultiLineString
 			Name = "named_query",
 			Boost = 1.1,
 			Field = Field<Project>(p=>p.Location),
-			Shape = new MultiLineStringGeoShape(this._coordinates)
+			Shape = new MultiLineStringGeoShape(this._coordinates),
+			Relation = GeoShapeRelation.Intersects
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -37,6 +38,7 @@ namespace Tests.QueryDsl.Geo.Shape.MultiLineString
 				.Boost(1.1)
 				.Field(p=>p.Location)
 				.Coordinates(this._coordinates)
+				.Relation(GeoShapeRelation.Intersects)
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IGeoShapeMultiLineStringQuery>(a => a.GeoShape as IGeoShapeMultiLineStringQuery)

--- a/src/Tests/QueryDsl/Geo/Shape/MultiPoint/GeoMultiPointUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/MultiPoint/GeoMultiPointUsageTests.cs
@@ -27,7 +27,8 @@ namespace Tests.QueryDsl.Geo.Shape.MultiPoint
 			Name = "named_query",
 			Boost = 1.1,
 			Field = Field<Project>(p=>p.Location),
-			Shape = new MultiPointGeoShape(this._coordinates)
+			Shape = new MultiPointGeoShape(this._coordinates),
+			Relation = GeoShapeRelation.Intersects
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -36,6 +37,7 @@ namespace Tests.QueryDsl.Geo.Shape.MultiPoint
 				.Boost(1.1)
 				.Field(p=>p.Location)
 				.Coordinates(this._coordinates)
+				.Relation(GeoShapeRelation.Intersects)
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IGeoShapeMultiPointQuery>(a => a.GeoShape as IGeoShapeMultiPointQuery)

--- a/src/Tests/QueryDsl/Geo/Shape/Point/GeoPointUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/Point/GeoPointUsageTests.cs
@@ -22,7 +22,8 @@ namespace Tests.QueryDsl.Geo.Shape.Point
 			Name = "named_query",
 			Boost = 1.1,
 			Field = Field<Project>(p=>p.Location),
-			Shape = new PointGeoShape(this._coordinates)
+			Shape = new PointGeoShape(this._coordinates),
+			Relation = GeoShapeRelation.Intersects
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -31,6 +32,7 @@ namespace Tests.QueryDsl.Geo.Shape.Point
 				.Boost(1.1)
 				.Field(p=>p.Location)
 				.Coordinates(this._coordinates)
+				.Relation(GeoShapeRelation.Intersects)
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IGeoShapePointQuery>(a => a.GeoShape as IGeoShapePointQuery)

--- a/src/Tests/QueryDsl/Geo/Shape/Polygon/GeoPolygonUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/Polygon/GeoPolygonUsageTests.cs
@@ -33,7 +33,8 @@ namespace Tests.QueryDsl.Geo.Shape.Polygon
 			Name = "named_query",
 			Boost = 1.1,
 			Field = Field<Project>(p => p.Location),
-			Shape = new PolygonGeoShape(this._coordinates) { }
+			Shape = new PolygonGeoShape(this._coordinates) { },
+			Relation = GeoShapeRelation.Intersects
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -42,6 +43,7 @@ namespace Tests.QueryDsl.Geo.Shape.Polygon
 				.Boost(1.1)
 				.Field(p => p.Location)
 				.Coordinates(this._coordinates)
+				.Relation(GeoShapeRelation.Intersects)
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IGeoShapePolygonQuery>(a => a.GeoShape as IGeoShapePolygonQuery)

--- a/src/Tests/QueryDsl/Geo/Shape/ShapeQueryUsageTestsBase.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/ShapeQueryUsageTestsBase.cs
@@ -6,17 +6,22 @@ namespace Tests.QueryDsl
 	[Collection(IntegrationContext.ReadOnly)]
 	public abstract class ShapeQueryUsageTestsBase : QueryDslUsageTestsBase
 	{
-		public ShapeQueryUsageTestsBase(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+		protected ShapeQueryUsageTestsBase(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
 		protected override object QueryJson => new
 		{
 			geo_shape = new
 			{
-				location = new { _name="named_query", boost = 1.1, shape = this.ShapeJson }
+				location = new
+				{
+					_name="named_query",
+					boost = 1.1,
+					shape = this.ShapeJson,
+					relation = "intersects"
+				}
 			}
 		};
 
 		protected abstract object ShapeJson { get; }
-
 	}
 }


### PR DESCRIPTION
- Add `Relation` to geo_shape queries

  GeoShapeRelation was in the codebase but looks like it was missed in the geo refactoring

- Add `contains` to geoshape relations.

Needs to be forward ported to 5.x