### PR TITLE
Fixes for custom serialization settings

### DIFF
--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -71,6 +71,10 @@ namespace Nest
 			this._defaultIndices = new FluentDictionary<Type, string>();
 			this._defaultTypeNames = new FluentDictionary<Type, string>();
 
+			var serializer = ((IConnectionConfigurationValues)this).Serializer as JsonNetSerializer;
+			if (serializer != null)
+				serializer.Initialize();
+
 			this._inferrer = new Inferrer(this);
 		}
 
@@ -78,7 +82,12 @@ namespace Nest
 		/// The default serializer for requests and responses
 		/// </summary>
 		/// <returns></returns>
-		protected override IElasticsearchSerializer DefaultSerializer(TConnectionSettings settings) => new JsonNetSerializer(settings);
+		protected override IElasticsearchSerializer DefaultSerializer(TConnectionSettings settings)
+		{
+			var serializer = new JsonNetSerializer(settings);
+			serializer.Initialize();
+			return serializer;
+		}
 
 		/// <summary>
 		/// This calls SetDefaultTypenameInferrer with an implementation that will pluralize type names. This used to be the default prior to Nest 0.90
@@ -92,7 +101,7 @@ namespace Nest
 		/// <summary>
 		/// The default index to use when no index is specified.
 		/// </summary>
-		/// <param name="defaultIndex">When null/empty/not set might throw 
+		/// <param name="defaultIndex">When null/empty/not set might throw
 		/// <see cref="NullReferenceException"/> later on when not specifying index explicitly while indexing.
 		/// </param>
 		public TConnectionSettings DefaultIndex(string defaultIndex)
@@ -180,7 +189,7 @@ namespace Nest
 			return (TConnectionSettings) this;
 		}
 
-		private void ApplyPropertyMappings<TDocument>(IList<IClrTypePropertyMapping<TDocument>> mappings) 
+		private void ApplyPropertyMappings<TDocument>(IList<IClrTypePropertyMapping<TDocument>> mappings)
 			where TDocument : class
 		{
 			foreach (var mapping in mappings)
@@ -228,11 +237,11 @@ namespace Nest
 			if (inferMapping.IdProperty != null)
 #pragma warning disable CS0618 // Type or member is obsolete but will be private in the future OK to call here
 				this.MapIdPropertyFor<TDocument>(inferMapping.IdProperty);
-#pragma warning restore CS0618 
+#pragma warning restore CS0618
 
 			if (inferMapping.Properties != null)
 				this.ApplyPropertyMappings<TDocument>(inferMapping.Properties);
-			
+
 			return (TConnectionSettings) this;
 		}
 

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
@@ -16,27 +16,25 @@ namespace Nest
 		private static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
 
 		protected IConnectionSettingsValues Settings { get; }
-		protected ElasticContractResolver ContractResolver { get; }
+		protected ElasticContractResolver ContractResolver { get; private set; }
 
 		//todo this internal smells
 		internal JsonSerializer Serializer => _defaultSerializer;
 
-		private readonly Dictionary<SerializationFormatting, JsonSerializer> _defaultSerializers;
-		private readonly JsonSerializer _defaultSerializer;
+		private Dictionary<SerializationFormatting, JsonSerializer> _defaultSerializers;
+		private JsonSerializer _defaultSerializer;
 
 		protected virtual void ModifyJsonSerializerSettings(JsonSerializerSettings settings) { }
 		protected virtual IList<Func<Type, JsonConverter>> ContractConverters => null;
 
-		public JsonNetSerializer(IConnectionSettingsValues settings) : this(settings, null) { }
-
-		/// <summary>
-		/// this constructor is only here for stateful (de)serialization
-		/// </summary>
-		internal JsonNetSerializer(IConnectionSettingsValues settings, JsonConverter stateFullConverter)
+		public JsonNetSerializer(IConnectionSettingsValues settings)
 		{
 			this.Settings = settings;
-			var piggyBackState = stateFullConverter == null ? null : new JsonConverterPiggyBackState { ActualJsonConverter = stateFullConverter };
-			// ReSharper disable once VirtualMemberCallInContructor
+		}
+
+		public void Initialize(JsonConverter statefulConverter = null)
+		{
+			var piggyBackState = statefulConverter == null ? null : new JsonConverterPiggyBackState { ActualJsonConverter = statefulConverter };
 			this.ContractResolver = new ElasticContractResolver(this.Settings, this.ContractConverters) { PiggyBackState = piggyBackState };
 
 			this._defaultSerializer = JsonSerializer.Create(this.CreateSettings(SerializationFormatting.None));

--- a/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
+++ b/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
@@ -42,7 +42,8 @@ namespace Nest
 				(p, d) =>
 				{
 					var converter = CreateMultiSearchDeserializer(p);
-					var serializer = new JsonNetSerializer(this.ConnectionSettings, converter);
+					var serializer = this.Serializer as JsonNetSerializer ?? new JsonNetSerializer(this.ConnectionSettings);
+					serializer.Initialize(converter);
 					var json = serializer.SerializeToBytes(p).Utf8String();
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);
@@ -65,7 +66,8 @@ namespace Nest
 				(p, d, c) =>
 				{
 					var converter = CreateMultiSearchDeserializer(p);
-					var serializer = new JsonNetSerializer(this.ConnectionSettings, converter);
+					var serializer = this.Serializer as JsonNetSerializer ?? new JsonNetSerializer(this.ConnectionSettings);
+					serializer.Initialize(converter);
 					var json = serializer.SerializeToBytes(p).Utf8String();
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);

--- a/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
@@ -54,7 +54,7 @@ namespace Nest
 				var descriptor = m.Descriptor.Value;
 				var concreteTypeSelector = descriptor.TypeSelector;
 				var baseType = m.Descriptor.Value.ClrType ?? typeof(object);
-				
+
 				var generic = MakeDelegateMethodInfo.MakeGenericMethod(baseType);
 
 				if (concreteTypeSelector != null)
@@ -62,7 +62,8 @@ namespace Nest
 					var state = typeof(ConcreteTypeConverter<>).CreateGenericInstance(baseType, concreteTypeSelector) as JsonConverter;
 					if (state != null)
 					{
-						var elasticSerializer = new JsonNetSerializer(this._settings, state);
+						var elasticSerializer = new JsonNetSerializer(this._settings);
+						elasticSerializer.Initialize(state);
 
 						generic.Invoke(null, new object[] { m, elasticSerializer.Serializer, response.Responses, this._settings });
 						continue;
@@ -70,7 +71,7 @@ namespace Nest
 				}
 				generic.Invoke(null, new object[] { m, serializer, response.Responses, this._settings });
 			}
-			
+
 			return response;
 		}
 
@@ -86,9 +87,9 @@ namespace Nest
 		}
 
 		private static void CreateMultiHit<T>(
-			MultiHitTuple tuple, 
-			JsonSerializer serializer, 
-			IDictionary<string, object> collection, 
+			MultiHitTuple tuple,
+			JsonSerializer serializer,
+			IDictionary<string, object> collection,
 			IConnectionSettingsValues settings
 		)
 			where T : class

--- a/src/Nest/Search/Search/ElasticClient-ResponseCovariance.cs
+++ b/src/Nest/Search/Search/ElasticClient-ResponseCovariance.cs
@@ -10,7 +10,7 @@ namespace Nest
 		private TRequest CovariantConverterWhenNeeded<T, TResult, TRequest, TRequestParameters>(RouteValues p, TRequest d)
 			where T : class
 			where TResult : class
-			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest 
+			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest
 			where TRequestParameters : IRequestParameters, new()
 		{
 			d.RequestParameters.DeserializationOverride = this.CreateSearchDeserializer<T, TResult, TRequest, TRequestParameters>(d);;
@@ -20,7 +20,7 @@ namespace Nest
 		private Func<IApiCallDetails, Stream, SearchResponse<TResult>> CreateSearchDeserializer<T, TResult, TRequest, TRequestParameters>(TRequest request)
 			where T : class
 			where TResult : class
-			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest 
+			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest
 			where TRequestParameters : IRequestParameters, new()
 		{
 			CovariantSearch.CloseOverAutomagicCovariantResultSelector(this.Infer, request);
@@ -30,13 +30,16 @@ namespace Nest
 
 		private SearchResponse<TResult> FieldsSearchDeserializer<T, TResult, TRequest, TRequestParameters>(IApiCallDetails response, Stream stream, TRequest d)
 			where T : class
-			where TResult : class 
-			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest 
-			where TRequestParameters : IRequestParameters, new() =>
-			!response.Success
+			where TResult : class
+			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest
+			where TRequestParameters : IRequestParameters, new()
+		{
+			var converter = new ConcreteTypeConverter<TResult>(d.TypeSelector);
+			var serializer = this.Serializer as JsonNetSerializer ?? new JsonNetSerializer(this.ConnectionSettings);
+			serializer.Initialize(converter);
+			return !response.Success
 				? null
-				: new JsonNetSerializer(this.ConnectionSettings, new ConcreteTypeConverter<TResult>(d.TypeSelector))
-					.Deserialize<SearchResponse<TResult>>(stream);
-
+				: serializer.Deserialize<SearchResponse<TResult>>(stream);
+		}
 	}
 }

--- a/src/Nest/Search/SearchTemplate/ElasticClient-SearchTemplate.cs
+++ b/src/Nest/Search/SearchTemplate/ElasticClient-SearchTemplate.cs
@@ -100,8 +100,10 @@ namespace Nest
 			where TResult : class
 		{
 			var converter = this.CreateCovariantSearchSelector<T, TResult>(d);
+			var serializer = this.Serializer as JsonNetSerializer ?? new JsonNetSerializer(this.ConnectionSettings);
+			serializer.Initialize(converter);
 			var dict = response.Success
-				? new JsonNetSerializer(this.ConnectionSettings, converter).Deserialize<SearchResponse<TResult>>(stream)
+				? serializer.Deserialize<SearchResponse<TResult>>(stream)
 				: null;
 			return dict;
 		}

--- a/src/Tests/ClientConcepts/LowLevel/Connecting.doc.cs
+++ b/src/Tests/ClientConcepts/LowLevel/Connecting.doc.cs
@@ -275,11 +275,22 @@ namespace Tests.ClientConcepts.LowLevel
 		*/
 		public class MyJsonNetSerializer : JsonNetSerializer
 		{
-			public MyJsonNetSerializer(IConnectionSettingsValues settings) : base(settings) { }
+			private string _assignedInConstructor;
+			public MyJsonNetSerializer(IConnectionSettingsValues settings) : base(settings)
+			{
+				this._assignedInConstructor = "foo";
+			}
 
 			public int CallToModify { get; set; } = 0;
 
-			protected override void ModifyJsonSerializerSettings(JsonSerializerSettings settings) => ++CallToModify; //<1> Override ModifyJsonSerializerSettings if you need access to `JsonSerializerSettings`
+			public string MyProperty { get; set; }
+
+			//<1> Override ModifyJsonSerializerSettings if you need access to `JsonSerializerSettings`
+			protected override void ModifyJsonSerializerSettings(JsonSerializerSettings settings)
+			{
+				++CallToModify;
+				MyProperty = _assignedInConstructor;
+			}
 
 			public int CallToContractConverter { get; set; } = 0;
 
@@ -307,7 +318,7 @@ namespace Tests.ClientConcepts.LowLevel
 			client.RootNodeInfo();
 			var serializer = ((IConnectionSettingsValues)settings).Serializer as MyJsonNetSerializer;
 			serializer.CallToModify.Should().BeGreaterThan(0);
-
+			serializer.MyProperty.Should().Be("foo");
 			serializer.SerializeToString(new Project { });
 			serializer.CallToContractConverter.Should().BeGreaterThan(0);
 		}

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -54,11 +54,12 @@ namespace Tests.Framework
 			string contentType = "application/json",
 			Exception exception = null)
 		{
-			var serializer = new JsonNetSerializer(new ConnectionSettings());
 			byte[] fixedResult;
 
 			if (contentType == "application/json")
 			{
+				var serializer = new JsonNetSerializer(new ConnectionSettings());
+				serializer.Initialize();
 				using (var ms = new MemoryStream())
 				{
 					serializer.Serialize(response, ms);

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: u
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.0.0-alpha3


### PR DESCRIPTION
Previously, ModifyJsonSerializationSettings() did not respect properties
initialized in a custom serializer's constructor, since it was being
called in the base class constructor. This is bad practice (hence the
ReSharper warning).  This change moves all of the initialization code
that was in the ctor to a new method Initialize() which must be called
after the serializer is instantiated.

This change also fixes another issue where our stateful converters were
totally disregarding any registered custom serializer.  For this reason,
Initialize() also accepts an optional JsonConverter which is used to
return a new serializer (custom or default) with the stateful converter
applied.

Relates #2183
Relates #2182