### PR TITLE
Fix/serialization bind

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -151,7 +151,6 @@ namespace Elasticsearch.Net
 		IElasticsearchSerializer IConnectionConfigurationValues.Serializer => _serializer;
 
 		private readonly IConnectionPool _connectionPool;
-		private readonly Func<T, IElasticsearchSerializer> _serializerFactory;
 		IConnectionPool IConnectionConfigurationValues.ConnectionPool => _connectionPool;
 
 		private readonly IConnection _connection;
@@ -164,9 +163,8 @@ namespace Elasticsearch.Net
 		{
 			this._connectionPool = connectionPool;
 			this._connection = connection ?? new HttpConnection();
-			this._serializerFactory = serializerFactory ?? (c=>this.DefaultSerializer((T)this));
 			// ReSharper disable once VirtualMemberCallInContructor
-			this._serializer = _serializerFactory((T)this);
+			this._serializer = serializerFactory?.Invoke((T)this) ?? this.DefaultSerializer((T)this);
 
 			this._requestTimeout = ConnectionConfiguration.DefaultTimeout;
 			this._sniffOnConnectionFault = true;

--- a/src/Elasticsearch.Net/Serialization/IElasticsearchSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/IElasticsearchSerializer.cs
@@ -26,8 +26,7 @@ namespace Elasticsearch.Net
 				return ms.ToArray();
 			}
 		}
-		public static string SerializeToString(this IElasticsearchSerializer serializer, object data, SerializationFormatting formatting = SerializationFormatting.Indented) => 
+		public static string SerializeToString(this IElasticsearchSerializer serializer, object data, SerializationFormatting formatting = SerializationFormatting.Indented) =>
 			serializer.SerializeToBytes(data, formatting).Utf8String();
 	}
-
 }

--- a/src/Nest/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
@@ -16,5 +16,9 @@ namespace Nest
 		string DefaultIndex { get; }
 		Func<string, string> DefaultFieldNameInferrer { get; }
 		Func<Type, string> DefaultTypeNameInferrer { get; }
+
+		ISerializerFactory SerializerFactory { get; }
+
+		IElasticsearchSerializer StatefulSerializer(JsonConverter converter);
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
@@ -15,40 +15,69 @@ namespace Nest
 	{
 		private static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
 
+
 		protected IConnectionSettingsValues Settings { get; }
 		protected ElasticContractResolver ContractResolver { get; }
 
 		//todo this internal smells
 		internal JsonSerializer Serializer => _defaultSerializer;
 
-		private readonly Dictionary<SerializationFormatting, JsonSerializer> _defaultSerializers;
-		private readonly JsonSerializer _defaultSerializer;
+		private Dictionary<SerializationFormatting, JsonSerializer> _defaultSerializers;
+		private JsonSerializer _defaultSerializer;
 
+		[Obsolete("Use the connection settings constructor that takes an ISerializerFactory")]
 		protected virtual void ModifyJsonSerializerSettings(JsonSerializerSettings settings) { }
+
 		protected virtual IList<Func<Type, JsonConverter>> ContractConverters => null;
 
 		public JsonNetSerializer(IConnectionSettingsValues settings) : this(settings, null) { }
 
 		/// <summary>
-		/// this constructor is only here for stateful (de)serialization 
+		/// this constructor is only here for stateful (de)serialization
 		/// </summary>
-		internal JsonNetSerializer(IConnectionSettingsValues settings, JsonConverter stateFullConverter)
+		protected internal JsonNetSerializer(
+			IConnectionSettingsValues settings,
+			JsonConverter statefulConverter
+			)
 		{
 			this.Settings = settings;
-			var piggyBackState = stateFullConverter == null ? null : new JsonConverterPiggyBackState { ActualJsonConverter = stateFullConverter };
+
+			var piggyBackState = statefulConverter == null ? null : new JsonConverterPiggyBackState { ActualJsonConverter = statefulConverter };
 			// ReSharper disable once VirtualMemberCallInContructor
 			this.ContractResolver = new ElasticContractResolver(this.Settings, this.ContractConverters) { PiggyBackState = piggyBackState };
 
 			this._defaultSerializer = JsonSerializer.Create(this.CreateSettings(SerializationFormatting.None));
-			//this._defaultSerializer.Formatting = Formatting.None; 
 			var indentedSerializer = JsonSerializer.Create(this.CreateSettings(SerializationFormatting.Indented));
-			//indentedSerializer.Formatting = Formatting.Indented; 
 			this._defaultSerializers = new Dictionary<SerializationFormatting, JsonSerializer>
 			{
 				{ SerializationFormatting.None, this._defaultSerializer },
 				{ SerializationFormatting.Indented, indentedSerializer }
 			};
 		}
+
+		/// <summary>
+		/// If you subclass JsonNetSerializer and want to apply state passed in the constructor call this to
+		/// overwrite the DefaultSerializers's JsonSerializerSettings and/or connectionsettings.
+		/// </summary>
+		/// <param name="settingsModifier"></param>
+		protected void OverwriteDefaultSerializers(Action<JsonSerializerSettings, IConnectionSettingsValues> settingsModifier)
+		{
+			settingsModifier.ThrowIfNull(nameof(settingsModifier));
+			var collapsed = this.CreateSettings(SerializationFormatting.None);
+			var indented = this.CreateSettings(SerializationFormatting.Indented);
+			settingsModifier(collapsed, this.Settings);
+			settingsModifier(indented, this.Settings);
+
+			this._defaultSerializer = JsonSerializer.Create(collapsed);
+			var indentedSerializer = JsonSerializer.Create(indented);
+			this._defaultSerializers = new Dictionary<SerializationFormatting, JsonSerializer>
+			{
+				{ SerializationFormatting.None, this._defaultSerializer },
+				{ SerializationFormatting.Indented, indentedSerializer }
+			};
+
+		}
+
 
 		public virtual void Serialize(object data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.Indented)
 		{

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SerializerFactory.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SerializerFactory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	public interface ISerializerFactory
+	{
+		IElasticsearchSerializer Create(IConnectionSettingsValues settings);
+
+		IElasticsearchSerializer CreateStateful(IConnectionSettingsValues settings, JsonConverter converter);
+	}
+
+	public class SerializerFactory : ISerializerFactory
+	{
+		private Func<IConnectionSettingsValues, IElasticsearchSerializer> _serializerFactoryFunc;
+
+		public SerializerFactory()
+		{
+
+		}
+		public SerializerFactory(Func<IConnectionSettingsValues , IElasticsearchSerializer> serializerFactoryFunc)
+		{
+			this._serializerFactoryFunc = serializerFactoryFunc;
+		}
+
+		public IElasticsearchSerializer Create(IConnectionSettingsValues settings) =>
+			this._serializerFactoryFunc?.Invoke(settings) ?? new JsonNetSerializer(settings);
+
+		public IElasticsearchSerializer CreateStateful(IConnectionSettingsValues settings, JsonConverter converter) =>
+			new JsonNetSerializer(settings, converter);
+	}
+}

--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-MultiGet.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-MultiGet.cs
@@ -7,12 +7,12 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	using MultiGetConverter = Func<IApiCallDetails, Stream, MultiGetResponse>;
-	
+
 	public partial interface IElasticClient
 	{
 		/// <summary>
-		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing). 
-		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document 
+		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
+		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
@@ -36,7 +36,7 @@ namespace Nest
 			this.MultiGet(selector.InvokeOrDefault(new MultiGetDescriptor()));
 
 		/// <inheritdoc/>
-		public IMultiGetResponse MultiGet(IMultiGetRequest request) => 
+		public IMultiGetResponse MultiGet(IMultiGetRequest request) =>
 			this.Dispatcher.Dispatch<IMultiGetRequest, MultiGetRequestParameters, MultiGetResponse>(
 				request,
 				new MultiGetConverter((r, s) => this.DeserializeMultiGetResponse(r, s, CreateCovariantMultiGetConverter(request))),
@@ -48,14 +48,14 @@ namespace Nest
 			this.MultiGetAsync(selector.InvokeOrDefault(new MultiGetDescriptor()));
 
 		/// <inheritdoc/>
-		public Task<IMultiGetResponse> MultiGetAsync(IMultiGetRequest request) => 
+		public Task<IMultiGetResponse> MultiGetAsync(IMultiGetRequest request) =>
 			this.Dispatcher.DispatchAsync<IMultiGetRequest, MultiGetRequestParameters, MultiGetResponse, IMultiGetResponse>(
 				request,
 				new MultiGetConverter((r, s) => this.DeserializeMultiGetResponse(r, s, CreateCovariantMultiGetConverter(request))),
 				this.LowLevelDispatch.MgetDispatchAsync<MultiGetResponse>
 			);
-		private MultiGetResponse DeserializeMultiGetResponse(IApiCallDetails response, Stream stream, JsonConverter converter)=>
-			new JsonNetSerializer(this.ConnectionSettings, converter).Deserialize<MultiGetResponse>(stream);
+		private MultiGetResponse DeserializeMultiGetResponse(IApiCallDetails response, Stream stream, JsonConverter converter) =>
+			this.ConnectionSettings.StatefulSerializer(converter).Deserialize<MultiGetResponse>(stream);
 
 		private JsonConverter CreateCovariantMultiGetConverter(IMultiGetRequest descriptor) => new MultiGetHitJsonConverter(descriptor);
 

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -456,6 +456,7 @@
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\VerbatimDictionaryKeysConverter.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\JsonNetSerializer.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\JsonReaderExtensions.cs" />
+    <Compile Include="CommonAbstractions\SerializationBehavior\SerializerFactory.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\StatefulDeserialization\ConcreteTypeConverter.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\StatefulDeserialization\JsonConverterPiggyBackState.cs" />
     <Compile Include="CommonAbstractions\Static\Static.cs" />

--- a/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
+++ b/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
@@ -41,7 +41,7 @@ namespace Nest
 				(p, d) =>
 				{
 					var converter = CreateMultiSearchDeserializer(p);
-					var serializer = new JsonNetSerializer(this.ConnectionSettings, converter);
+					var serializer = this.ConnectionSettings.StatefulSerializer(converter);
 					var json = serializer.SerializeToBytes(p).Utf8String();
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);
@@ -63,7 +63,7 @@ namespace Nest
 				(p, d) =>
 				{
 					var converter = CreateMultiSearchDeserializer(p);
-					var serializer = new JsonNetSerializer(this.ConnectionSettings, converter);
+					var serializer = this.ConnectionSettings.StatefulSerializer(converter);
 					var json = serializer.SerializeToBytes(p).Utf8String();
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);

--- a/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
@@ -54,7 +54,7 @@ namespace Nest
 				var descriptor = m.Descriptor.Value;
 				var concreteTypeSelector = descriptor.TypeSelector;
 				var baseType = m.Descriptor.Value.ClrType ?? typeof(object);
-				
+
 				var generic = MakeDelegateMethodInfo.MakeGenericMethod(baseType);
 
 				if (concreteTypeSelector != null)
@@ -62,15 +62,15 @@ namespace Nest
 					var state = typeof(ConcreteTypeConverter<>).CreateGenericInstance(baseType, concreteTypeSelector) as JsonConverter;
 					if (state != null)
 					{
-						var elasticSerializer = new JsonNetSerializer(this._settings, state);
+						var elasticSerializer = this._settings.StatefulSerializer(state);
 
-						generic.Invoke(null, new object[] { m, elasticSerializer.Serializer, response.Responses, this._settings });
+						generic.Invoke(null, new object[] { m, elasticSerializer, response.Responses, this._settings });
 						continue;
 					}
 				}
 				generic.Invoke(null, new object[] { m, serializer, response.Responses, this._settings });
 			}
-			
+
 			return response;
 		}
 
@@ -86,9 +86,9 @@ namespace Nest
 		}
 
 		private static void CreateMultiHit<T>(
-			MultiHitTuple tuple, 
-			JsonSerializer serializer, 
-			IDictionary<string, object> collection, 
+			MultiHitTuple tuple,
+			JsonSerializer serializer,
+			IDictionary<string, object> collection,
 			IConnectionSettingsValues settings
 		)
 			where T : class

--- a/src/Nest/Search/Search/ElasticClient-ResponseCovariance.cs
+++ b/src/Nest/Search/Search/ElasticClient-ResponseCovariance.cs
@@ -10,7 +10,7 @@ namespace Nest
 		private TRequest CovariantConverterWhenNeeded<T, TResult, TRequest, TRequestParameters>(RouteValues p, TRequest d)
 			where T : class
 			where TResult : class
-			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest 
+			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest
 			where TRequestParameters : IRequestParameters, new()
 		{
 			d.RequestParameters.DeserializationOverride = this.CreateSearchDeserializer<T, TResult, TRequest, TRequestParameters>(d);;
@@ -20,7 +20,7 @@ namespace Nest
 		private Func<IApiCallDetails, Stream, SearchResponse<TResult>> CreateSearchDeserializer<T, TResult, TRequest, TRequestParameters>(TRequest request)
 			where T : class
 			where TResult : class
-			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest 
+			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest
 			where TRequestParameters : IRequestParameters, new()
 		{
 			CovariantSearch.CloseOverAutomagicCovariantResultSelector(this.Infer, request);
@@ -30,12 +30,12 @@ namespace Nest
 
 		private SearchResponse<TResult> FieldsSearchDeserializer<T, TResult, TRequest, TRequestParameters>(IApiCallDetails response, Stream stream, TRequest d)
 			where T : class
-			where TResult : class 
-			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest 
+			where TResult : class
+			where TRequest : IRequest<TRequestParameters>, ICovariantSearchRequest
 			where TRequestParameters : IRequestParameters, new() =>
 			!response.Success
 				? null
-				: new JsonNetSerializer(this.ConnectionSettings, new ConcreteTypeConverter<TResult>(d.TypeSelector))
+				: this.ConnectionSettings.StatefulSerializer(new ConcreteTypeConverter<TResult>(d.TypeSelector))
 					.Deserialize<SearchResponse<TResult>>(stream);
 
 	}

--- a/src/Nest/Search/SearchTemplate/ElasticClient-SearchTemplate.cs
+++ b/src/Nest/Search/SearchTemplate/ElasticClient-SearchTemplate.cs
@@ -9,7 +9,7 @@ namespace Nest
 	public partial interface IElasticClient
 	{
 		/// <summary>
-		/// The /_search/template endpoint allows to use the mustache language to pre render search 
+		/// The /_search/template endpoint allows to use the mustache language to pre render search
 		/// requests, before they are executed and fill existing templates with template parameters.
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the index and typename as well describe the query strongly typed</typeparam>
@@ -99,7 +99,7 @@ namespace Nest
 		{
 			var converter = this.CreateCovariantSearchSelector<T, TResult>(d);
 			var dict = response.Success
-				? new JsonNetSerializer(this.ConnectionSettings, converter).Deserialize<SearchResponse<TResult>>(stream)
+				? this.ConnectionSettings.StatefulSerializer(converter).Deserialize<SearchResponse<TResult>>(stream)
 				: null;
 			return dict;
 		}

--- a/src/Tests/ClientConcepts/Serializer/CustomConstructorSerializerSettingsTests.cs
+++ b/src/Tests/ClientConcepts/Serializer/CustomConstructorSerializerSettingsTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using System.Threading.Tasks;
+using Tests.Framework;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Xunit;
+using Nest;
+using Newtonsoft.Json;
+using System.Text;
+
+namespace Tests.ClientConcepts.Serializer
+{
+
+	/// <summary>
+	/// Here we get into a bind because our constructor runs too late
+	/// </summary>
+	public class CustomConstrcutorSerializerSettingsTests : SerializationTestBase
+	{
+		public class MyCystomResolver : ElasticContractResolver
+		{
+			public MyCystomResolver(IConnectionSettingsValues connectionSettings, IList<Func<Type, JsonConverter>> contractConverters) : base(connectionSettings, contractConverters)
+			{
+			}
+
+			protected override string ResolvePropertyName(string fieldName)
+			{
+				return fieldName.ToUpperInvariant();
+			}
+		}
+
+		private sealed class LocalJsonNetSerializer : JsonNetSerializer
+		{
+			private Action<JsonSerializerSettings, IConnectionSettingsValues> _settingsOverride;
+
+			public LocalJsonNetSerializer(
+				IConnectionSettingsValues settings,
+				Action<JsonSerializerSettings, IConnectionSettingsValues> settingsOverride
+			) : base(settings)
+			{
+				this._settingsOverride = settingsOverride;
+			}
+
+#pragma warning disable CS0672 // Member overrides obsolete member
+			protected override void ModifyJsonSerializerSettings(JsonSerializerSettings settings)
+#pragma warning restore CS0672 // Member overrides obsolete member
+			{
+				this._settingsOverride.Should().BeNull("the value assigned in our custom constructor has not been assigned yet");
+			}
+		}
+
+		public class HasDateString
+		{
+			public string DateString { get; set; }
+			public DateTime? Date { get; set; }
+		}
+
+		public IElasticClient CreateClient(string jsonResponse, Action<JsonSerializerSettings, IConnectionSettingsValues> settingsOverride)
+		{
+			var connection = new InMemoryConnection(Encoding.UTF8.GetBytes(jsonResponse));
+			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+#pragma warning disable CS0618 // Type or member is obsolete
+			var connectionSettings = new ConnectionSettings(connectionPool, connection, settings =>
+				new LocalJsonNetSerializer(settings.DefaultIndex("default-index"), settingsOverride));
+#pragma warning restore CS0618 // Type or member is obsolete
+			var client = new ElasticClient(connectionSettings);
+			return client;
+		}
+
+		[U] public void RespectsContractResolver()
+		{
+			var client = this.CreateClient("{}",
+				(jsonSettings, nestSettings)=> jsonSettings.ContractResolver = new MyCystomResolver(nestSettings, null));
+			var serialized = client.Serializer.SerializeToString(new HasDateString { DateString = "1" }, SerializationFormatting.None);
+
+			serialized.Should().NotBe($@"{{""DATESTRING"":""1""}}");
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/Serializer/FactorySerializerCallCountTests.cs
+++ b/src/Tests/ClientConcepts/Serializer/FactorySerializerCallCountTests.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using System.Threading.Tasks;
+using Tests.Framework;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Xunit;
+using Nest;
+using Newtonsoft.Json;
+using System.Text;
+
+namespace Tests.ClientConcepts.Serializer
+{
+	public class FactorySettingsTests : SerializationTestBase
+	{
+		public class MyCustomJsonFactory : ISerializerFactory
+		{
+			private Action<JsonSerializerSettings, IConnectionSettingsValues> _settingsOverride;
+
+			public MyCustomJsonFactory(Action<JsonSerializerSettings, IConnectionSettingsValues> settingsOverride)
+			{
+				this._settingsOverride = settingsOverride;
+			}
+
+			public IElasticsearchSerializer Create(IConnectionSettingsValues settings) =>
+				new LocalJsonNetSerializer(settings, this._settingsOverride);
+
+			public IElasticsearchSerializer CreateStateful(IConnectionSettingsValues settings, JsonConverter converter) =>
+				new LocalJsonNetSerializer(settings, this._settingsOverride, converter);
+		}
+
+		public class MyCystomResolver : ElasticContractResolver
+		{
+			public MyCystomResolver(IConnectionSettingsValues connectionSettings, IList<Func<Type, JsonConverter>> contractConverters) : base(connectionSettings, contractConverters)
+			{
+			}
+
+			protected override string ResolvePropertyName(string fieldName)
+			{
+				return fieldName.ToUpperInvariant();
+			}
+		}
+
+		private sealed class LocalJsonNetSerializer : JsonNetSerializer
+		{
+			public LocalJsonNetSerializer(IConnectionSettingsValues settings, Action<JsonSerializerSettings, IConnectionSettingsValues> s)
+				: base(settings)
+			{
+				this.CreateCustomJsonSerializers(s);
+			}
+
+			public LocalJsonNetSerializer(IConnectionSettingsValues settings, Action<JsonSerializerSettings, IConnectionSettingsValues> s, JsonConverter converter)
+				: base(settings, converter)
+			{
+				this.CreateCustomJsonSerializers(s);
+			}
+		}
+
+		public class HasDateString
+		{
+			public string DateString { get; set; }
+			public DateTime? Date { get; set; }
+		}
+
+		public IElasticClient CreateClient(string jsonResponse, Action<JsonSerializerSettings, IConnectionSettingsValues> settingsOverride)
+		{
+			var connection = new InMemoryConnection(Encoding.UTF8.GetBytes(jsonResponse));
+			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(connectionPool, connection, new MyCustomJsonFactory(settingsOverride))
+				.DefaultIndex("default-index");
+			var client = new ElasticClient(connectionSettings);
+			return client;
+		}
+
+		[U] public void RespectsDateParseHandling()
+		{
+			var expectedDateString = "2015-02-06T23:45:05Z";
+			var jsonResponse = $@"{{ ""_id"": ""1"", ""_source"": {{ ""dateString"": ""{expectedDateString}"" }}}}";
+			var client = this.CreateClient(jsonResponse, (jsonSettings, nestSettings) => jsonSettings.DateParseHandling = DateParseHandling.None);
+
+			var hit = client.Get<HasDateString>(1);
+			hit.Should().NotBeNull();
+			hit.Source.Should().NotBeNull();
+			hit.Source.DateString.Should().Be(expectedDateString);
+		}
+
+		[U] public void RespectsMaxDepth()
+		{
+			var expectedDateString = "12-06-06 12:32:01";
+			var jsonResponse = $@"{{ ""_id"": ""1"", ""_source"": {{ ""dateString"": ""{expectedDateString}"" }}}}";
+			var client = this.CreateClient(jsonResponse, (jsonSettings, nestSettings) => jsonSettings.MaxDepth = 1);
+
+			Action act = () => client.Get<HasDateString>(1);
+			act.ShouldThrow<UnexpectedElasticsearchClientException>()
+				.WithMessage("The reader's MaxDepth of 1 has been exceeded. Path '_source', line 1, position 26.");
+		}
+
+		[U] public void RespectsContractResolver()
+		{
+			var client = this.CreateClient("{}",
+				(jsonSettings, nestSettings)=> jsonSettings.ContractResolver = new MyCystomResolver(nestSettings, null));
+			var serialized = client.Serializer.SerializeToString(new HasDateString { DateString = "1" }, SerializationFormatting.None);
+
+			serialized.Should().Be($@"{{""DATESTRING"":""1""}}");
+		}
+
+		[U] public void DoesNotRespectDateTimeHandling()
+		{
+			var client = this.CreateClient("{}", (jsonSettings, nestSettings) => jsonSettings.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat);
+			var date = new DateTime(1999, 12, 30, 1, 2, 3);
+			var serialized = client.Serializer.SerializeToString(new HasDateString { Date = date }, SerializationFormatting.None);
+
+			serialized.Should().Be($@"{{""date"":""1999-12-30T01:02:03""}}");
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/Serializer/FactorySerializerTests.cs
+++ b/src/Tests/ClientConcepts/Serializer/FactorySerializerTests.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using System.Threading.Tasks;
+using Tests.Framework;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Xunit;
+using Nest;
+using Newtonsoft.Json;
+using System.Text;
+
+namespace Tests.ClientConcepts.Serializer
+{
+	public class FactorySettingsTests : SerializationTestBase
+	{
+		public class MyCustomJsonFactory : ISerializerFactory
+		{
+			private Action<JsonSerializerSettings, IConnectionSettingsValues> _settingsOverride;
+
+			public MyCustomJsonFactory(Action<JsonSerializerSettings, IConnectionSettingsValues> settingsOverride)
+			{
+				this._settingsOverride = settingsOverride;
+			}
+
+			public IElasticsearchSerializer Create(IConnectionSettingsValues settings) =>
+				new LocalJsonNetSerializer(settings, this._settingsOverride);
+
+			public IElasticsearchSerializer CreateStateful(IConnectionSettingsValues settings, JsonConverter converter) =>
+				new LocalJsonNetSerializer(settings, this._settingsOverride, converter);
+		}
+
+		public class MyCystomResolver : ElasticContractResolver
+		{
+			public MyCystomResolver(IConnectionSettingsValues connectionSettings, IList<Func<Type, JsonConverter>> contractConverters) : base(connectionSettings, contractConverters)
+			{
+			}
+
+			protected override string ResolvePropertyName(string fieldName)
+			{
+				return fieldName.ToUpperInvariant();
+			}
+		}
+
+		private sealed class LocalJsonNetSerializer : JsonNetSerializer
+		{
+			public LocalJsonNetSerializer(IConnectionSettingsValues settings, Action<JsonSerializerSettings, IConnectionSettingsValues> s)
+				: base(settings)
+			{
+				this.OverwriteDefaultSerializers(s);
+			}
+
+			public LocalJsonNetSerializer(IConnectionSettingsValues settings, Action<JsonSerializerSettings, IConnectionSettingsValues> s, JsonConverter converter)
+				: base(settings, converter)
+			{
+				this.OverwriteDefaultSerializers(s);
+			}
+		}
+
+		public class HasDateString
+		{
+			public string DateString { get; set; }
+			public DateTime? Date { get; set; }
+		}
+
+		public IElasticClient CreateClient(string jsonResponse, Action<JsonSerializerSettings, IConnectionSettingsValues> settingsOverride)
+		{
+			var connection = new InMemoryConnection(Encoding.UTF8.GetBytes(jsonResponse));
+			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(connectionPool, connection, new MyCustomJsonFactory(settingsOverride))
+				.DefaultIndex("default-index");
+			var client = new ElasticClient(connectionSettings);
+			return client;
+		}
+
+		[U] public void RespectsDateParseHandling()
+		{
+			var expectedDateString = "2015-02-06T23:45:05Z";
+			var jsonResponse = $@"{{ ""_id"": ""1"", ""_source"": {{ ""dateString"": ""{expectedDateString}"" }}}}";
+			var client = this.CreateClient(jsonResponse, (jsonSettings, nestSettings) => jsonSettings.DateParseHandling = DateParseHandling.None);
+
+			var hit = client.Get<HasDateString>(1);
+			hit.Should().NotBeNull();
+			hit.Source.Should().NotBeNull();
+			hit.Source.DateString.Should().Be(expectedDateString);
+		}
+
+		[U] public void RespectsMaxDepth()
+		{
+			var expectedDateString = "12-06-06 12:32:01";
+			var jsonResponse = $@"{{ ""_id"": ""1"", ""_source"": {{ ""dateString"": ""{expectedDateString}"" }}}}";
+			var client = this.CreateClient(jsonResponse, (jsonSettings, nestSettings) => jsonSettings.MaxDepth = 1);
+
+			Action act = () => client.Get<HasDateString>(1);
+			act.ShouldThrow<UnexpectedElasticsearchClientException>()
+				.WithMessage("The reader's MaxDepth of 1 has been exceeded. Path '_source', line 1, position 26.");
+		}
+
+		[U] public void RespectsContractResolver()
+		{
+			var client = this.CreateClient("{}",
+				(jsonSettings, nestSettings)=> jsonSettings.ContractResolver = new MyCystomResolver(nestSettings, null));
+			var serialized = client.Serializer.SerializeToString(new HasDateString { DateString = "1" }, SerializationFormatting.None);
+
+			serialized.Should().Be($@"{{""DATESTRING"":""1""}}");
+		}
+
+		[U] public void DoesNotRespectDateTimeHandling()
+		{
+			var client = this.CreateClient("{}", (jsonSettings, nestSettings) => jsonSettings.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat);
+			var date = new DateTime(1999, 12, 30, 1, 2, 3);
+			var serialized = client.Serializer.SerializeToString(new HasDateString { Date = date }, SerializationFormatting.None);
+
+			serialized.Should().Be($@"{{""date"":""1999-12-30T01:02:03""}}");
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/Serializer/ModifySerializationSettingsTests.cs
+++ b/src/Tests/ClientConcepts/Serializer/ModifySerializationSettingsTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using System.Threading.Tasks;
+using Tests.Framework;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Xunit;
+using Nest;
+using Newtonsoft.Json;
+using System.Text;
+
+namespace Tests.ClientConcepts.Serializer
+{
+
+	/// <summary>
+	/// This is the happy flow for the now deprecated ModifyJsonSerializerSettings override
+	/// </summary>
+	public class ModifySerializationSettingsTests : SerializationTestBase
+	{
+
+		public class MyCystomResolver : ElasticContractResolver
+		{
+			public MyCystomResolver(IConnectionSettingsValues connectionSettings, IList<Func<Type, JsonConverter>> contractConverters) : base(connectionSettings, contractConverters) { }
+
+			protected override string ResolvePropertyName(string fieldName)
+			{
+				return fieldName.ToUpperInvariant();
+			}
+		}
+
+		private sealed class LocalJsonNetSerializer : JsonNetSerializer
+		{
+			public LocalJsonNetSerializer(IConnectionSettingsValues settings) : base(settings) { }
+
+#pragma warning disable CS0672 // Member overrides obsolete member
+			protected override void ModifyJsonSerializerSettings(JsonSerializerSettings settings)
+#pragma warning restore CS0672 // Member overrides obsolete member
+			{
+				settings.DateParseHandling = DateParseHandling.None;
+				settings.MaxDepth = 1;
+				settings.ContractResolver = new MyCystomResolver(this.Settings, null);
+				settings.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat;
+			}
+		}
+
+		public class HasDateString
+		{
+			public string DateString { get; set; }
+			public DateTime? Date { get; set; }
+		}
+
+		public IElasticClient CreateClient(string jsonResponse)
+		{
+			var connection = new InMemoryConnection(Encoding.UTF8.GetBytes(jsonResponse));
+			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+#pragma warning disable CS0618 // Type or member is obsolete
+			var connectionSettings = new ConnectionSettings(connectionPool, connection, settings => new LocalJsonNetSerializer(settings
+				.DefaultIndex("default-index")
+			));
+#pragma warning restore CS0618 // Type or member is obsolete
+			var client = new ElasticClient(connectionSettings);
+			return client;
+		}
+
+		[U]
+		public void RespectsDateParseHandling()
+		{
+			var expectedDateString = "2015-02-06T23:45:05Z";
+			var jsonResponse = $@"{{ ""dateString"": ""{expectedDateString}"" }}";
+			var client = this.CreateClient(jsonResponse);
+
+			var hit = client.Source<HasDateString>(1);
+			hit.Should().NotBeNull();
+			hit.DateString.Should().Be(expectedDateString);
+		}
+
+		[U]
+		public void RespectsMaxDepth()
+		{
+			var expectedDateString = "12-06-06 12:32:01";
+			var jsonResponse = $@"{{ ""_id"": ""1"", ""_source"": {{ ""dateString"": ""{expectedDateString}"" }}}}";
+			var client = this.CreateClient(jsonResponse);
+
+			Action act = () => client.Get<HasDateString>(1);
+			act.ShouldThrow<UnexpectedElasticsearchClientException>()
+				.WithMessage("The reader's MaxDepth of 1 has been exceeded. Path '_source', line 1, position 26.");
+		}
+
+		[U]
+		public void RespectsContractResolver()
+		{
+			var client = this.CreateClient("{}");
+			var serialized = client.Serializer.SerializeToString(new HasDateString { DateString = "1" }, SerializationFormatting.None);
+
+			serialized.Should().Be($@"{{""DATESTRING"":""1""}}");
+		}
+
+		[U]
+		public void DoesNotRespectDateTimeHandling()
+		{
+			// our contract converters are pretty aggressive in making sure datetimes get written to IsoDateTime
+			// not intending on supporting json.net various dateformats
+
+			var client = this.CreateClient("{}");
+			var date = new DateTime(1999, 12, 30, 1, 2, 3);
+			var serialized = client.Serializer.SerializeToString(new HasDateString { Date = date }, SerializationFormatting.None);
+
+			serialized.Should().Be($@"{{""DATE"":""1999-12-30T01:02:03""}}");
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/ServerError/ServerErrorTests.cs
+++ b/src/Tests/ClientConcepts/ServerError/ServerErrorTests.cs
@@ -10,12 +10,12 @@ using Xunit;
 
 namespace Tests.ClientConcepts.ServerError
 {
-    public class ServerErrorTests : SerializationTestBase
-    {
+	public class ServerErrorTests : SerializationTestBase
+	{
 		[U]
-	    public void CanDeserializeServerError()
-	    {
-		    var serverErrorJson = @"{
+		public void CanDeserializeServerError()
+		{
+			var serverErrorJson = @"{
 			   ""error"": {
 				  ""root_cause"": [
 					 {
@@ -33,14 +33,14 @@ namespace Tests.ClientConcepts.ServerError
 			   ""status"": 400
 			}";
 
-		    var serverError = this.Deserialize<Elasticsearch.Net.ServerError>(serverErrorJson);
+			var serverError = this.Deserialize<Elasticsearch.Net.ServerError>(serverErrorJson);
 
-		    serverError.Should().NotBeNull();
+			serverError.Should().NotBeNull();
 			serverError.Status.Should().Be(400);
 
 			serverError.Error.Should().NotBeNull();
 			serverError.Error.RootCause.Count.Should().Be(1);
 			serverError.Error.CausedBy.Should().NotBeNull();
-	    }
-    }
+		}
+	}
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -553,6 +553,9 @@
     <Compile Include="ClientConcepts\HighLevel\Inference\IndexNameInference.doc.cs" />
     <Compile Include="ClientConcepts\HighLevel\Inference\IndicesPaths.doc.cs" />
     <Compile Include="ClientConcepts\HighLevel\Inference\PropertyInference.doc.cs" />
+    <Compile Include="ClientConcepts\Serializer\CustomConstructorSerializerSettingsTests.cs" />
+    <Compile Include="ClientConcepts\Serializer\FactorySerializerTests.cs" />
+    <Compile Include="ClientConcepts\Serializer\ModifySerializationSettingsTests.cs" />
     <Compile Include="Cluster\TaskManagement\TasksCancel\TasksCancelApiTests.cs" />
     <Compile Include="Cluster\TaskManagement\TasksCancel\TasksCancelUrlTests.cs" />
     <Compile Include="Cluster\TaskManagement\TasksList\TasksListApiTests.cs" />

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
+mode: u
 # the elasticsearch version that should be started
 elasticsearch_version: 2.3.5
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
Yet another take on 

#2189
#2183
#2182

That does not require locking patterns and construct then init like composition.

This introduces an ISerializerFactory that gets set on IConnectionSettings which we can then use to instantiate the IElasticsearchSerializer the user provided throughout, getting rid of hardcoded `new JsonNetSerializer()` in some custom converters. 

Obsoletes the func based factory and wraps it to our default `SerializerFactory` 

The way you have to reset serializers is a tad clunky though

https://github.com/elastic/elasticsearch-net/compare/2.x...fix/serialization-bind?expand=1#diff-37181b379c228340d8420dc00e71cd63R57

And implementers should now also implement the stateful constructor to be correct. 

If they don't we fall back on the current (broken but bwc) behaviour.

Keen to hear your thoughts @gmarz @tsliang @mitchknife @russcam 
 
