### PR TITLE
Backwards compatible solution for #2200

### DIFF
--- a/src/Nest/Aggregations/Metric/TopHits/TopHitsAggregation.cs
+++ b/src/Nest/Aggregations/Metric/TopHits/TopHitsAggregation.cs
@@ -91,7 +91,7 @@ namespace Nest
 		});
 
 		public TopHitsAggregationDescriptor<T> Source(bool include = true) =>
-			Assign(a => a.Source = !include ? SourceFilter.ExcludeAll : null);
+			Assign(a => a.Source = new SourceFilter { Disable = !include });
 
 		public TopHitsAggregationDescriptor<T> Source(Func<SourceFilterDescriptor<T>, ISourceFilter> sourceSelector) =>
 			Assign(a => a.Source = sourceSelector?.Invoke(new SourceFilterDescriptor<T>()));

--- a/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
@@ -20,6 +20,8 @@ namespace Nest
 
 		public static implicit operator Fields(string[] fields) => new Fields(fields.Select(f => (Field)f));
 
+		public static implicit operator Fields(string field) => new Fields(new[] { (Field)field });
+
 		public static implicit operator Fields(Expression[] fields) => new Fields(fields.Select(f => (Field)f));
 
 		public static implicit operator Fields(Field[] fields) => new Fields(fields);

--- a/src/Nest/Search/Search/InnerHits/GlobalInnerHit.cs
+++ b/src/Nest/Search/Search/InnerHits/GlobalInnerHit.cs
@@ -38,10 +38,10 @@ namespace Nest
 		IList<Field> IInnerHits.FielddataFields { get; set; }
 		IScriptFields IInnerHits.ScriptFields { get; set; }
 
-		public GlobalInnerHitDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> querySelector) => 
+		public GlobalInnerHitDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> querySelector) =>
 			Assign(a => a.Query = querySelector?.Invoke(new QueryContainerDescriptor<T>()));
-		
-		public GlobalInnerHitDescriptor<T> InnerHits(Func<NamedInnerHitsDescriptor<T>, IPromise<INamedInnerHits>> selector) => 
+
+		public GlobalInnerHitDescriptor<T> InnerHits(Func<NamedInnerHitsDescriptor<T>, IPromise<INamedInnerHits>> selector) =>
 			Assign(a => a.InnerHits = selector?.Invoke(new NamedInnerHitsDescriptor<T>())?.Value);
 
 		public GlobalInnerHitDescriptor<T> From(int? from) => Assign(a => a.From = from);
@@ -52,7 +52,7 @@ namespace Nest
 
 		public GlobalInnerHitDescriptor<T> FielddataFields(params string[] fielddataFields) =>
 			Assign(a => a.FielddataFields = fielddataFields?.Select(f => (Field) f).ToListOrNullIfEmpty());
-		
+
 		public GlobalInnerHitDescriptor<T> FielddataFields(params Expression<Func<T, object>>[] fielddataFields) =>
 			Assign(a => a.FielddataFields = fielddataFields?.Select(f => (Field) f).ToListOrNullIfEmpty());
 
@@ -63,17 +63,17 @@ namespace Nest
 		public GlobalInnerHitDescriptor<T> Sort(Func<SortDescriptor<T>, IPromise<IList<ISort>>> sortSelector) => Assign(a => a.Sort = sortSelector?.Invoke(new SortDescriptor<T>())?.Value);
 
 		/// <summary>
-		/// Allow to highlight search results on one or more fields. The implementation uses the either lucene fast-vector-highlighter or highlighter. 
+		/// Allow to highlight search results on one or more fields. The implementation uses the either lucene fast-vector-highlighter or highlighter.
 		/// </summary>
 		public GlobalInnerHitDescriptor<T> Highlight(Func<HighlightDescriptor<T>, IHighlight> highlightSelector) =>
 			Assign(a => a.Highlight = highlightSelector?.Invoke(new HighlightDescriptor<T>()));
-		
-		public GlobalInnerHitDescriptor<T> Source(bool include = true)=> Assign(a => a.Source = !include ? SourceFilter.ExcludeAll : null);
-		
+
+		public GlobalInnerHitDescriptor<T> Source(bool include = true) => Assign(a => a.Source = new SourceFilter { Disable = !include });
+
 		public GlobalInnerHitDescriptor<T> Source(Func<SourceFilterDescriptor<T>, ISourceFilter> sourceSelector) =>
 			Assign(a => a.Source = sourceSelector?.Invoke(new SourceFilterDescriptor<T>()));
 
-		public GlobalInnerHitDescriptor<T> ScriptFields(Func<ScriptFieldsDescriptor, IPromise<IScriptFields>> selector) => 
+		public GlobalInnerHitDescriptor<T> ScriptFields(Func<ScriptFieldsDescriptor, IPromise<IScriptFields>> selector) =>
 			Assign(a => a.ScriptFields = selector?.Invoke(new ScriptFieldsDescriptor())?.Value);
 	}
 }

--- a/src/Nest/Search/Search/InnerHits/InnerHits.cs
+++ b/src/Nest/Search/Search/InnerHits/InnerHits.cs
@@ -96,18 +96,18 @@ namespace Nest
 		public InnerHitsDescriptor<T> Sort(Func<SortDescriptor<T>, IPromise<IList<ISort>>> sortSelector) => Assign(a => a.Sort = sortSelector?.Invoke(new SortDescriptor<T>())?.Value);
 
 		/// <summary>
-		/// Allow to highlight search results on one or more fields. The implementation uses the either lucene fast-vector-highlighter or highlighter. 
+		/// Allow to highlight search results on one or more fields. The implementation uses the either lucene fast-vector-highlighter or highlighter.
 		/// </summary>
 		public InnerHitsDescriptor<T> Highlight(Func<HighlightDescriptor<T>, IHighlight> highlightSelector) =>
 			Assign(a => a.Highlight = highlightSelector?.Invoke(new HighlightDescriptor<T>()));
 
 		//TODO map source of union bool/SourceFileter
-		public InnerHitsDescriptor<T> Source(bool include = true) => Assign(a => a.Source = !include ? SourceFilter.ExcludeAll : null);
+		public InnerHitsDescriptor<T> Source(bool include = true) => Assign(a => a.Source = new SourceFilter { Disable = !include });
 
 		public InnerHitsDescriptor<T> Source(Func<SourceFilterDescriptor<T>, ISourceFilter> sourceSelector) =>
 			Assign(a => a.Source = sourceSelector?.Invoke(new SourceFilterDescriptor<T>()));
 
-		public InnerHitsDescriptor<T> ScriptFields(Func<ScriptFieldsDescriptor, IPromise<IScriptFields>> selector) => 
+		public InnerHitsDescriptor<T> ScriptFields(Func<ScriptFieldsDescriptor, IPromise<IScriptFields>> selector) =>
 			Assign(a => a.ScriptFields = selector?.Invoke(new ScriptFieldsDescriptor())?.Value);
 	}
 }

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -64,7 +64,6 @@ namespace Nest
 		IScriptFields ScriptFields { get; set; }
 
 		[JsonProperty(PropertyName = "_source")]
-		[JsonConverter(typeof(ReadAsTypeJsonConverter<SourceFilter>))]
 		ISourceFilter Source { get; set; }
 
 		[JsonProperty(PropertyName = "aggs")]
@@ -224,7 +223,7 @@ namespace Nest
 		public SearchDescriptor<T> Aggregations(Func<AggregationContainerDescriptor<T>, IAggregationContainer> aggregationsSelector) =>
 			Assign(a => a.Aggregations = aggregationsSelector(new AggregationContainerDescriptor<T>())?.Aggregations);
 
-		public SearchDescriptor<T> Source(bool include = true) => Assign(a => a.Source = !include ? SourceFilter.ExcludeAll : null);
+		public SearchDescriptor<T> Source(bool include = true) => Assign(a => a.Source = new SourceFilter { Disable = !include });
 
 		public SearchDescriptor<T> Source(Func<SourceFilterDescriptor<T>, ISourceFilter> sourceSelector) =>
 			Assign(a => a.Source = sourceSelector?.Invoke(new SourceFilterDescriptor<T>()));
@@ -416,8 +415,8 @@ namespace Nest
 		public SearchDescriptor<T> Rescore(Func<RescoreDescriptor<T>, IRescore> rescoreSelector) =>
 			Assign(a =>
 			{
-				a.Rescore = a.Rescore != null 
-					? new MultiRescore { a.Rescore, rescoreSelector?.Invoke(new RescoreDescriptor<T>()) } 
+				a.Rescore = a.Rescore != null
+					? new MultiRescore { a.Rescore, rescoreSelector?.Invoke(new RescoreDescriptor<T>()) }
 					: rescoreSelector?.Invoke(new RescoreDescriptor<T>());
 			});
 

--- a/src/Nest/Search/Search/SourceFiltering/SourceFilter.cs
+++ b/src/Nest/Search/Search/SourceFiltering/SourceFilter.cs
@@ -11,6 +11,9 @@ namespace Nest
 
 		[JsonProperty("exclude")]
 		Fields Exclude { get; set; }
+
+		[JsonIgnore]
+		bool Disable { get; set; }
 	}
 
 	public class SourceFilter : ISourceFilter
@@ -20,6 +23,8 @@ namespace Nest
 
 		public Fields Include { get; set; }
 		public Fields Exclude { get; set; }
+
+		public bool Disable { get; set; }
 	}
 
 	public class SourceFilterDescriptor<T> : DescriptorBase<SourceFilterDescriptor<T>, ISourceFilter>, ISourceFilter
@@ -29,11 +34,19 @@ namespace Nest
 
 		Fields ISourceFilter.Exclude { get; set; }
 
-		public SourceFilterDescriptor<T> Include(Func<FieldsDescriptor<T>, IPromise<Fields>> fields) => 
+		bool ISourceFilter.Disable { get; set; }
+
+
+		public SourceFilterDescriptor<T> Include(Func<FieldsDescriptor<T>, IPromise<Fields>> fields) =>
 			Assign(a => a.Include = fields?.Invoke(new FieldsDescriptor<T>())?.Value);
 
-		public SourceFilterDescriptor<T> Exclude(Func<FieldsDescriptor<T>, IPromise<Fields>> fields) => 
+		public SourceFilterDescriptor<T> IncludeAll() => Assign(a => a.Include = new[] { "*" });
+
+		public SourceFilterDescriptor<T> Exclude(Func<FieldsDescriptor<T>, IPromise<Fields>> fields) =>
 			Assign(a => a.Exclude = fields?.Invoke(new FieldsDescriptor<T>())?.Value);
 
+		public SourceFilterDescriptor<T> ExcludeAll() => Assign(a => a.Exclude = new[] { "*" });
+
+		public SourceFilterDescriptor<T> Disable(bool disable = true) => Assign(a => a.Disable = disable);
 	}
 }

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: u
 # the elasticsearch version that should be started
 elasticsearch_version: 2.3.5
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
SourceFilter now has a Disable property which can be used to enable or
disable _source.  Instances that accepted Source(bool) now set this
property rather than ExcludeAll (which doesn't truly disable _source).

This is more of a workaround to maintain BWC in 2.x  In master, we will
use Union<bool, ISourceFilter> instead as proposed in #2200.