### PR TITLE
Extend query DSL with SpanFieldMaskingQuery

### DIFF
--- a/src/Nest/DSL/Query/IQueryContainer.cs
+++ b/src/Nest/DSL/Query/IQueryContainer.cs
@@ -128,6 +128,9 @@ namespace Nest
 		[JsonProperty(PropertyName = "span_multi")]
 		ISpanMultiTermQuery SpanMultiTerm { get; set; }
 
+        [JsonProperty(PropertyName = "field_masking_span")]
+		ISpanFieldMaskingQuery SpanFieldMasking { get; set; }
+
 		[JsonProperty(PropertyName = "top_children")]
 		ITopChildrenQuery TopChildren { get; set; }
 

--- a/src/Nest/DSL/Query/QueryContainer.cs
+++ b/src/Nest/DSL/Query/QueryContainer.cs
@@ -79,6 +79,8 @@ namespace Nest
 
 		ISpanMultiTermQuery IQueryContainer.SpanMultiTerm { get; set; }
 
+		ISpanFieldMaskingQuery IQueryContainer.SpanFieldMasking { get; set; }
+
 		ITopChildrenQuery IQueryContainer.TopChildren { get; set; }
 
 		INestedQuery IQueryContainer.Nested { get; set; }

--- a/src/Nest/DSL/Query/SpanFieldMaskingQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/SpanFieldMaskingQueryDescriptor.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Linq.Expressions;
+
+using Nest.DSL.Query.Behaviour;
+using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	[JsonConverter(typeof(ReadAsTypeConverter<SpanFieldMaskingQueryDescriptor<object>>))]
+	public interface ISpanFieldMaskingQuery : ISpanSubQuery, IFieldNameQuery
+    {
+        [JsonProperty(PropertyName = "field")]
+        PropertyPathMarker Field { get; set; }
+        
+        [JsonProperty(PropertyName = "query")]
+		ISpanQuery Query { get; set; }
+	}
+
+	public class SpanFieldMaskingQuery : PlainQuery, ISpanFieldMaskingQuery
+    {
+		protected override void WrapInContainer(IQueryContainer container)
+		{
+			container.SpanFieldMasking = this;
+		}
+
+		bool IQuery.IsConditionless { get { return false; } }
+
+        public string Name { get; set; }
+        public PropertyPathMarker Field { get; set; }
+        public ISpanQuery Query { get; set; }
+
+        PropertyPathMarker IFieldNameQuery.GetFieldName()
+        {
+            return this.Field;
+        }
+
+        void IFieldNameQuery.SetFieldName(string fieldName)
+        {
+            this.Field = fieldName;
+        }
+    }
+
+	public class SpanFieldMaskingQueryDescriptor<T> : ISpanFieldMaskingQuery where T : class
+	{
+		ISpanFieldMaskingQuery Self { get { return this; } }
+        bool IQuery.IsConditionless { get { return false; } }
+
+        ISpanQuery ISpanFieldMaskingQuery.Query { get; set; }
+        PropertyPathMarker ISpanFieldMaskingQuery.Field { get; set; }
+        string IQuery.Name { get; set; }
+        
+		public SpanFieldMaskingQueryDescriptor<T> Name(string name)
+		{
+			Self.Name = name;
+			return this;
+		}
+
+		public SpanFieldMaskingQueryDescriptor<T> Query(Func<SpanQuery<T>, SpanQuery<T>> selector)
+		{
+			if (selector == null) return this;
+			var span = new SpanQuery<T>();
+			Self.Query = selector(span); ;
+			return this;
+		}
+
+		public SpanFieldMaskingQueryDescriptor<T> OnField(string field)
+		{
+			Self.Field = field;
+			return this;
+		}
+
+        public SpanFieldMaskingQueryDescriptor<T> OnField(Expression<Func<T, object>> field)
+        {
+            Self.Field = field;
+            return this;
+        }
+
+        public SpanFieldMaskingQueryDescriptor<T> OnField<K>(Expression<Func<T, K>> field)
+        {
+            Self.Field = field;
+            return this;
+        }
+        
+        public PropertyPathMarker GetFieldName()
+        {
+            return Self.Field;
+        }
+
+        public void SetFieldName(string fieldName)
+        {
+            Self.Field = fieldName;
+        }
+    }
+}

--- a/src/Nest/DSL/Query/SpanQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/SpanQueryDescriptor.cs
@@ -28,6 +28,9 @@ namespace Nest
 
 		[JsonProperty(PropertyName = "span_multi")]
 		ISpanMultiTermQuery SpanMultiTerm { get; set; }
+
+        [JsonProperty(PropertyName = "field_masking_span")]
+		ISpanFieldMaskingQuery SpanFieldMasking { get; set; }
 	}
 
 	public class SpanQuery : ISpanQuery
@@ -40,6 +43,7 @@ namespace Nest
 		public ISpanOrQuery SpanOr { get; set; }
 		public ISpanNotQuery SpanNot { get; set; }
 		public ISpanMultiTermQuery SpanMultiTerm { get; set; }
+		public ISpanFieldMaskingQuery SpanFieldMasking { get; set; }
 	}
 
 	public class SpanQuery<T> : ISpanQuery where T : class
@@ -58,6 +62,8 @@ namespace Nest
 
 		ISpanMultiTermQuery ISpanQuery.SpanMultiTerm { get; set; }
 
+        ISpanFieldMaskingQuery ISpanQuery.SpanFieldMasking { get; set; }
+
 		string IQuery.Name { get; set; }
 
 		bool IQuery.IsConditionless
@@ -71,7 +77,8 @@ namespace Nest
 					Self.SpanNear as IQuery,
 					Self.SpanOr as IQuery,
 					Self.SpanNot as IQuery,
-					Self.SpanMultiTerm as IQuery
+					Self.SpanMultiTerm as IQuery,
+					Self.SpanFieldMasking as IQuery
 				};
 				return queries.All(q => q == null || q.IsConditionless);
 			}
@@ -133,6 +140,12 @@ namespace Nest
 			selector.ThrowIfNull("selector");
 			var q= selector(new SpanMultiTermQueryDescriptor<T>());
 			return CreateQuery(q, (sq) => sq.SpanMultiTerm = q);
+		}
+        public SpanQuery<T> SpanFieldMasking(Func<SpanFieldMaskingQueryDescriptor<T>, SpanFieldMaskingQueryDescriptor<T>> selector)
+		{
+			selector.ThrowIfNull("selector");
+			var q= selector(new SpanFieldMaskingQueryDescriptor<T>());
+			return CreateQuery(q, (sq) => sq.SpanFieldMasking = q);
 		}
 
 		private SpanQuery<T> CreateQuery<K>(K query, Action<ISpanQuery> setProperty) where K : ISpanSubQuery

--- a/src/Nest/DSL/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Nest/DSL/Visitor/DslPrettyPrintVisitor.cs
@@ -230,6 +230,11 @@ namespace Nest.DSL.Visitor
 			Write("span_term");
 		}
 
+        public virtual void Visit(ISpanFieldMaskingQuery query)
+		{
+			Write("field_masking_span");
+		}
+
 		public virtual void Visit(ITermQuery query)
 		{
 			Write("term", query.Field);

--- a/src/Nest/DSL/Visitor/QueryVisitor.cs
+++ b/src/Nest/DSL/Visitor/QueryVisitor.cs
@@ -68,6 +68,7 @@
 		void Visit(ISpanNotQuery query);
 		void Visit(ISpanOrQuery query);
 		void Visit(ISpanTermQuery query);
+		void Visit(ISpanFieldMaskingQuery query);
 		void Visit(ITermQuery query);
 		void Visit(IWildcardQuery query);
 		void Visit(ITermsQuery query);
@@ -256,6 +257,10 @@
 		}
 
 		public virtual void Visit(ISpanTermQuery customFiltersScore)
+		{
+		}
+
+        public virtual void Visit(ISpanFieldMaskingQuery customFiltersScore)
 		{
 		}
 

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -243,6 +243,7 @@
     <Compile Include="DSL\FieldStatsDescriptor.cs" />
     <Compile Include="DSL\Filter\IndicesFilterDescriptor.cs" />
     <Compile Include="Domain\DSL\NoMatchShortcut.cs" />
+    <Compile Include="DSL\Query\SpanFieldMaskingQueryDescriptor.cs" />
     <Compile Include="DSL\SyncedFlushDescriptor.cs" />
     <Compile Include="DSL\Query\Functions\WeightFunction.cs" />
     <Compile Include="DSL\Search\IGlobalInnerHit.cs" />

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Visitor/DslPrettyPrintVisitor.cs
@@ -236,6 +236,11 @@ namespace Nest.Tests.Unit.QueryParsers.Visitor
 			Write("span_term");
 		}
 
+        public virtual void Visit(ISpanFieldMaskingQuery query)
+		{
+			Write("field_masking_span");
+		}
+
 		public virtual void Visit(ITermQuery query)
 		{
 			Write("term", query.Field);


### PR DESCRIPTION
Hi guys!

This commit extends query DSL with new very important query. More details could be found [here](https://lucene.apache.org/core/2_9_4/api/core/org/apache/lucene/search/spans/FieldMaskingSpanQuery.html) and [here](https://github.com/elastic/elasticsearch/issues/471). 

This query is very important for us and I believe for many other people who use multifields or several fields to analyze text differently. We use   2 fields to analyze text - one with stemming and one as-is. This allows us to build very sophisticated queries for our scenarios.

It would be great if you accept it and push 1.9.1 soon. 

Thanks in advance!