### PR TITLE
Performance Improvements

### DIFF
--- a/src/Nest/CommonAbstractions/Extensions/JsonExtensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/JsonExtensions.cs
@@ -14,7 +14,7 @@ namespace Nest
 		{
 			var contract = serializer.ContractResolver as ElasticContractResolver;
 			if (contract?.ConnectionSettings == null)
-				throw new Exception("If you use a custom contract resolver be sure to subclass from ElasticResolver");
+				throw new Exception("If you use a custom contract resolver be sure to subclass from " + nameof(ElasticContractResolver));
 			return contract.ConnectionSettings;
 		}
 

--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -160,8 +160,8 @@ namespace Nest
 			var nestSettings = settings as IConnectionSettingsValues;
 			if (nestSettings == null)
 				throw new Exception("Tried to pass field name on querysting but it could not be resolved because no nest settings are available");
-			var infer = new Inferrer(nestSettings);
-			return infer.Field(this);
+
+			return nestSettings.Inferrer.Field(this);
 		}
 
 		private void SetComparisonValue(object value)

--- a/src/Nest/CommonAbstractions/Infer/Id/IdJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/Id/IdJsonConverter.cs
@@ -17,12 +17,13 @@ namespace Nest
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
-			var id = value as Id;
-			if (id == null)
+			if (value == null)
 			{
 				writer.WriteNull();
 				return;
 			}
+
+			var id = (Id)value;
 			if (id.Document != null)
 			{
 				var settings = serializer.GetConnectionSettings();

--- a/src/Nest/CommonAbstractions/Infer/IndexName/IndexName.cs
+++ b/src/Nest/CommonAbstractions/Infer/IndexName/IndexName.cs
@@ -69,7 +69,14 @@ namespace Nest
 			return false;
 		}
 
-		public string GetString(IConnectionConfigurationValues settings) => ((IUrlParameter)(Indices)(Indices.Index(this))).GetString(settings);
+		public string GetString(IConnectionConfigurationValues settings)
+		{
+			var nestSettings = settings as IConnectionSettingsValues;
+			if (nestSettings == null)
+				throw new Exception("Tried to pass index name on querysting but it could not be resolved because no nest settings are available");
+
+			return nestSettings.Inferrer.IndexName(this);
+		}
 
 		public static IndexName From<T>() => typeof(T);
 

--- a/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
@@ -16,9 +16,9 @@ namespace Nest
 
 		public string Resolve(IndexName i)
 		{
-			if (i == null || string.IsNullOrEmpty(i.Name))
-				return this.Resolve(i.Type);
-			return i.Name;
+			return string.IsNullOrEmpty(i?.Name)
+				? this.Resolve(i.Type)
+				: i.Name;
 		}
 
 		public string Resolve(Type type)

--- a/src/Nest/CommonAbstractions/Infer/Indices/Indices.cs
+++ b/src/Nest/CommonAbstractions/Infer/Indices/Indices.cs
@@ -56,7 +56,7 @@ namespace Nest
 				{
 					var nestSettings = settings as IConnectionSettingsValues;
 					if (nestSettings == null)
-						throw new Exception("Tried to pass field name on querysting but it could not be resolved because no nest settings are available");
+						throw new Exception("Tried to pass index names on querysting but it could not be resolved because no nest settings are available");
 
 					var infer = nestSettings.Inferrer;
 					var indices = many.Indices.Select(i => infer.IndexName(i)).Distinct();

--- a/src/Nest/CommonAbstractions/Infer/TypeName/TypeName.cs
+++ b/src/Nest/CommonAbstractions/Infer/TypeName/TypeName.cs
@@ -79,7 +79,14 @@ namespace Nest
 			return !other.IsNullOrEmpty() && other == this.Name;
 		}
 
-		string IUrlParameter.GetString(IConnectionConfigurationValues settings) => ((IUrlParameter)(Types)(Types.Type(this))).GetString(settings);
+		string IUrlParameter.GetString(IConnectionConfigurationValues settings)
+		{
+			var nestSettings = settings as IConnectionSettingsValues;
+			if (nestSettings == null)
+				throw new Exception("Tried to pass type name on querystring but it could not be resolved because no nest settings are available");
+
+			return nestSettings.Inferrer.TypeName(this);
+		}
 
 		public static TypeName From<T>() => typeof(T);
 

--- a/src/Nest/CommonAbstractions/Infer/Types/Types.cs
+++ b/src/Nest/CommonAbstractions/Infer/Types/Types.cs
@@ -57,8 +57,8 @@ namespace Nest
 					var nestSettings = settings as IConnectionSettingsValues;
 					if (nestSettings == null)
 						throw new Exception("Tried to pass field name on querystring but it could not be resolved because no nest settings are available");
-					var infer = new Inferrer(nestSettings);
-					var types = this.Item2.Types.Select(t => infer.TypeName(t)).Distinct();
+
+					var types = this.Item2.Types.Select(t => nestSettings.Inferrer.TypeName(t)).Distinct();
 					return string.Join(",", types);
 				}
 			);

--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-MultiGet.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-MultiGet.cs
@@ -39,7 +39,7 @@ namespace Nest
 		public IMultiGetResponse MultiGet(IMultiGetRequest request) =>
 			this.Dispatcher.Dispatch<IMultiGetRequest, MultiGetRequestParameters, MultiGetResponse>(
 				request,
-				new MultiGetConverter((r, s) => this.DeserializeMultiGetResponse(r, s, CreateCovariantMultiGetConverter(request))),
+				(r, s) => this.DeserializeMultiGetResponse(r, s, CreateCovariantMultiGetConverter(request)),
 				this.LowLevelDispatch.MgetDispatch<MultiGetResponse>
 			);
 
@@ -51,7 +51,7 @@ namespace Nest
 		public Task<IMultiGetResponse> MultiGetAsync(IMultiGetRequest request) =>
 			this.Dispatcher.DispatchAsync<IMultiGetRequest, MultiGetRequestParameters, MultiGetResponse, IMultiGetResponse>(
 				request,
-				new MultiGetConverter((r, s) => this.DeserializeMultiGetResponse(r, s, CreateCovariantMultiGetConverter(request))),
+				(r, s) => this.DeserializeMultiGetResponse(r, s, CreateCovariantMultiGetConverter(request)),
 				this.LowLevelDispatch.MgetDispatchAsync<MultiGetResponse>
 			);
 		private MultiGetResponse DeserializeMultiGetResponse(IApiCallDetails response, Stream stream, JsonConverter converter) =>

--- a/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponseJsonConverter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
@@ -17,13 +18,15 @@ namespace Nest
 
 		private readonly IMultiSearchRequest _request;
 
-		private static readonly MethodInfo MakeDelegateMethodInfo = typeof(MultiSearchResponseJsonConverter).GetMethod(nameof(CreateMultiHit), BindingFlags.Static | BindingFlags.NonPublic);
+		private static readonly MethodInfo MakeDelegateMethodInfo =
+			typeof(MultiSearchResponseJsonConverter).GetMethod(nameof(CreateSearchResponse), BindingFlags.Static | BindingFlags.NonPublic);
+
 		private readonly IConnectionSettingsValues _settings;
 
 		public MultiSearchResponseJsonConverter(IConnectionSettingsValues settings, IMultiSearchRequest request)
 		{
 			this._settings = settings;
-			_request = request;
+			this._request = request;
 		}
 
 		public MultiSearchResponseJsonConverter() { }
@@ -33,8 +36,7 @@ namespace Nest
 			if (this._settings == null)
 			{
 				var realConverter = serializer.GetStatefulConverter<MultiSearchResponseJsonConverter>();
-				var mr = realConverter.ReadJson(reader, objectType, existingValue, serializer) as MultiSearchResponse;
-				return mr;
+				return realConverter.ReadJson(reader, objectType, existingValue, serializer);
 			}
 
 			var response = new MultiSearchResponse();
@@ -47,28 +49,41 @@ namespace Nest
 			if (this._request == null)
 				return multiSearchDescriptor;
 
-			var withMeta = docsJarray.Zip(this._request.Operations, (doc, desc) => new MultiHitTuple { Hit = doc, Descriptor = desc });
-			var originalResolver = serializer.ContractResolver;
+			var withMeta = docsJarray.Zip(this._request.Operations, (doc, desc) => new SearchHitTuple { Hit = doc, Descriptor = desc });
+
 			foreach (var m in withMeta)
 			{
 				var descriptor = m.Descriptor.Value;
 				var concreteTypeSelector = descriptor.TypeSelector;
 				var baseType = m.Descriptor.Value.ClrType ?? typeof(object);
-
-				var generic = MakeDelegateMethodInfo.MakeGenericMethod(baseType);
+				var cachedDelegate = serializer.GetConnectionSettings().Inferrer.CreateSearchResponseDelegates.GetOrAdd(baseType, t =>
+				{
+					// Compile a delegate from an expression
+					var methodInfo = MakeDelegateMethodInfo.MakeGenericMethod(t);
+					var tupleParameter = Expression.Parameter(typeof(SearchHitTuple), "tuple");
+					var serializerParameter = Expression.Parameter(typeof(JsonSerializer), "serializer");
+					var multiHitCollection = Expression.Parameter(typeof(IDictionary<string, object>), "collection");
+					var parameterExpressions = new[] { tupleParameter, serializerParameter, multiHitCollection };
+					var call = Expression.Call(null, methodInfo, parameterExpressions);
+					var lambda = Expression.Lambda<Action<SearchHitTuple, JsonSerializer, IDictionary<string, object>>>(call, parameterExpressions);
+					return lambda.Compile();
+				});
 
 				if (concreteTypeSelector != null)
 				{
 					var state = typeof(ConcreteTypeConverter<>).CreateGenericInstance(baseType, concreteTypeSelector) as JsonConverter;
 					if (state != null)
 					{
-						var elasticSerializer = this._settings.StatefulSerializer(state);
-
-						generic.Invoke(null, new object[] { m, elasticSerializer, response.Responses, this._settings });
-						continue;
+						var elasticSerializer = this._settings.StatefulSerializer(state) as JsonNetSerializer;
+						if (elasticSerializer != null)
+						{
+							cachedDelegate(m, elasticSerializer.Serializer, response.Responses);
+							continue;
+						}
 					}
 				}
-				generic.Invoke(null, new object[] { m, serializer, response.Responses, this._settings });
+
+				cachedDelegate(m, serializer, response.Responses);
 			}
 
 			return response;
@@ -79,27 +94,22 @@ namespace Nest
 			throw new NotSupportedException();
 		}
 
-		private class MultiHitTuple
+		internal class SearchHitTuple
 		{
 			public JToken Hit { get; set; }
 			public KeyValuePair<string, ISearchRequest> Descriptor { get; set; }
 		}
 
-		private static void CreateMultiHit<T>(
-			MultiHitTuple tuple,
+		private static void CreateSearchResponse<T>(
+			SearchHitTuple tuple,
 			JsonSerializer serializer,
-			IDictionary<string, object> collection,
-			IConnectionSettingsValues settings
-		)
-			where T : class
+			IDictionary<string, object> collection) where T : class
 		{
-			var response = new SearchResponse<T>();
-			var reader = tuple.Hit.CreateReader();
-			serializer.Populate(reader, response);
+			var response = tuple.Hit.ToObject<SearchResponse<T>>(serializer);
 
 			ServerError error;
 			if (tuple.Hit.TryParseServerError(serializer, out error))
-				response.MultiSearchError = error ;
+				response.MultiSearchError = error;
 
 			collection.Add(tuple.Descriptor.Key, response);
 		}


### PR DESCRIPTION
- Cache JsonContracts per ConnectionSettings
- Cache Delegates per ConnectionSettings for constructing items in a MultiGetResponse
- Cache Delegates per ConnectionSettings for constructing items in a MultiSearchResponse
- Reuse Inferrer on ConnectionSettings
- Reduce complexity in getting IUrlParameter.GetString() for IndexName and TypeName