### PR TITLE
fix #2119 allow custom per field similarity in the mapping other then…

### DIFF
--- a/src/Nest/Mapping/AttributeBased/ElasticsearchPropertyAttributeBase.cs
+++ b/src/Nest/Mapping/AttributeBased/ElasticsearchPropertyAttributeBase.cs
@@ -18,7 +18,11 @@ namespace Nest
 		bool? IProperty.Store { get; set; }
 		bool? IProperty.DocValues { get; set; }
 		IProperties IProperty.Fields { get; set; }
-		SimilarityOption? IProperty.Similarity { get; set; }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+		SimilarityOption? IProperty.Similarity { get { return Self.CustomSimilarity?.ToEnum<SimilarityOption>(); } set { Self.CustomSimilarity = value.GetStringValue(); } }
+#pragma warning restore CS0618 // Type or member is obsolete
+		string IProperty.CustomSimilarity { get; set; }
 		Fields IProperty.CopyTo { get; set; }
 
 		public string Name { get; set; }
@@ -26,6 +30,11 @@ namespace Nest
 		public bool DocValues { get { return Self.DocValues.GetValueOrDefault(); } set { Self.DocValues = value; } }
 		public string IndexName { get { return Self.IndexName; } set { Self.IndexName = value; } }
 		public SimilarityOption Similarity { get { return Self.Similarity.GetValueOrDefault(); } set { Self.Similarity = value; } }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+		[Obsolete("This is a temporary binary backwards compatible hack to make sure you can specify named similarities in 2.x, scheduled for removal in 5.0")]
+		public string CustomSimilarity { get { return Self.CustomSimilarity; } set { Self.CustomSimilarity = value; } }
+#pragma warning restore CS0618 // Type or member is obsolete
 		public bool Store { get { return Self.Store.GetValueOrDefault(); } set { Self.Store = value; } }
 
 		protected ElasticsearchPropertyAttributeBase(string typeName)

--- a/src/Nest/Mapping/Types/PropertyBase.cs
+++ b/src/Nest/Mapping/Types/PropertyBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -24,8 +25,11 @@ namespace Nest
 		[JsonProperty("fields", DefaultValueHandling = DefaultValueHandling.Ignore)]
 		IProperties Fields { get; set; }
 
-		[JsonProperty("similarity")]
 		SimilarityOption? Similarity { get; set; }
+
+		[JsonProperty("similarity")]
+		[Obsolete("This is a temporary binary backwards compatible hack to make sure you can specify named similarities in 2.x, scheduled for removal in 5.0")]
+		string CustomSimilarity { get; set; }
 
 		[JsonProperty("copy_to")]
 		Fields CopyTo { get; set; }
@@ -50,7 +54,8 @@ namespace Nest
 		public bool? DocValues { get; set; }
 		public IProperties Fields { get; set; }
 		public string IndexName { get; set; }
-		public SimilarityOption? Similarity { get; set; }
+		public SimilarityOption? Similarity { get { return this.CustomSimilarity?.ToEnum<SimilarityOption>(); } set { this.CustomSimilarity = value.GetStringValue(); } }
+		public string CustomSimilarity { get; set; }
 		public bool? Store { get; set; }
 		PropertyInfo IPropertyWithClrOrigin.ClrOrigin { get; set; }
 	}

--- a/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
+++ b/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
@@ -14,7 +14,12 @@ namespace Nest
 		string IProperty.IndexName { get; set; }
 		bool? IProperty.Store { get; set; }
 		bool? IProperty.DocValues { get; set; }
-		SimilarityOption? IProperty.Similarity { get; set; }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+		SimilarityOption? IProperty.Similarity { get { return Self.CustomSimilarity?.ToEnum<SimilarityOption>(); } set { Self.CustomSimilarity = value.GetStringValue(); } }
+#pragma warning restore CS0618 // Type or member is obsolete
+		string IProperty.CustomSimilarity { get; set; }
+
 		Fields IProperty.CopyTo { get; set; }
 		IProperties IProperty.Fields { get; set; }
 
@@ -33,6 +38,9 @@ namespace Nest
 		public TDescriptor Fields(Func<PropertiesDescriptor<T>, IPromise<IProperties>> selector) => Assign(a => a.Fields = selector?.Invoke(new PropertiesDescriptor<T>())?.Value);
 
 		public TDescriptor Similarity(SimilarityOption similarity) => Assign(a => a.Similarity = similarity);
+#pragma warning disable CS0618 // Type or member is obsolete
+		public TDescriptor Similarity(string similarity) => Assign(a => a.CustomSimilarity = similarity);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		public TDescriptor CopyTo(Func<FieldsDescriptor<T>, IPromise<Fields>> fields) => Assign(a => a.CopyTo = fields?.Invoke(new FieldsDescriptor<T>())?.Value);
 	}

--- a/src/Tests/Mapping/Types/Core/String/StringMappingTests.cs
+++ b/src/Tests/Mapping/Types/Core/String/StringMappingTests.cs
@@ -19,7 +19,9 @@ namespace Tests.Mapping.Types.Core.String
 			PositionIncrementGap = 5,
 #pragma warning restore 618
 			SearchAnalyzer = "mysearchanalyzer",
-			Similarity = SimilarityOption.BM25,
+#pragma warning disable CS0618 // Type or member is obsolete
+			CustomSimilarity = "my_custom_similarity",
+#pragma warning restore CS0618 // Type or member is obsolete
 			Store = true,
 			TermVector = TermVectorOption.WithPositionsOffsets)]
 		public string Full { get; set; }
@@ -53,7 +55,7 @@ namespace Tests.Mapping.Types.Core.String
 					null_value = "na",
 					position_increment_gap = 5,
 					search_analyzer = "mysearchanalyzer",
-					similarity = "BM25",
+					similarity = "my_custom_similarity",
 					store = true,
 					term_vector = "with_positions_offsets"
 				},
@@ -89,7 +91,7 @@ namespace Tests.Mapping.Types.Core.String
 				.NullValue("na")
 				.PositionIncrementGap(5)
 				.SearchAnalyzer("mysearchanalyzer")
-				.Similarity(SimilarityOption.BM25)
+				.Similarity("my_custom_similarity")
 				.Store(true)
 				.TermVector(TermVectorOption.WithPositionsOffsets)
 			)


### PR DESCRIPTION
Tad hacky binary bwc fix but this allows you to specify a per field custom similarity in a fields mapping. 

The put mapping and create settings already allowed you to create custom similarities but you had no way to apply them. Super silly. 
