### PR TITLE
fix #2170, DateMath should not serialize time as fractional

### DIFF
--- a/src/Nest/CommonOptions/DateMath/DateMath.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMath.cs
@@ -94,7 +94,8 @@ namespace Nest
 			foreach (var r in Self.Ranges)
 			{
 				sb.Append(r.Item1.GetStringValue());
-				sb.Append(r.Item2);
+				//date math does not support fractional time units so e.g TimeSpan.FromHours(25) should not yield 1.04d
+				sb.Append(Time.ToFirstUnitYieldingInteger(r.Item2));
 			}
 			if (Self.Round.HasValue)
 				sb.Append("/" + Self.Round.Value.GetStringValue());

--- a/src/Nest/CommonOptions/TimeUnit/Time.cs
+++ b/src/Nest/CommonOptions/TimeUnit/Time.cs
@@ -72,6 +72,43 @@ namespace Nest
 			return 1;
 		}
 
+		public static Time ToFirstUnitYieldingInteger(Time fractionalTime)
+		{
+			var fraction = fractionalTime.Factor.GetValueOrDefault(double.Epsilon);
+			if (IsIntegerGreaterThen0(fraction)) return fractionalTime;
+
+			var ms = fractionalTime.Milliseconds;
+			if (ms > _week)
+			{
+				fraction = ms / _week;
+				if (IsIntegerGreaterThen0(fraction)) return new Time(fraction, TimeUnit.Week);
+			}
+			if (ms > _day)
+			{
+				fraction = ms / _day;
+				if (IsIntegerGreaterThen0(fraction)) return new Time(fraction, TimeUnit.Day);
+			}
+			if (ms > _hour)
+			{
+				fraction = ms / _hour;
+				if (IsIntegerGreaterThen0(fraction)) return new Time(fraction, TimeUnit.Hour);
+			}
+			if (ms > _minute)
+			{
+				fraction = ms / _minute;
+				if (IsIntegerGreaterThen0(fraction)) return new Time(fraction, TimeUnit.Minute);
+			}
+			if (ms > _second)
+			{
+				fraction = ms / _second;
+				if (IsIntegerGreaterThen0(fraction)) return new Time(fraction, TimeUnit.Second);
+			}
+			return new Time(ms, TimeUnit.Millisecond);
+		}
+
+		private static bool IsIntegerGreaterThen0(double d) => Math.Abs(d % 1) < double.Epsilon;
+
+
 		public static bool operator <(Time left, Time right) => left.CompareTo(right) < 0;
 		public static bool operator <=(Time left, Time right) => left.CompareTo(right) < 0 || left.Equals(right);
 
@@ -81,7 +118,7 @@ namespace Nest
 		public static bool operator ==(Time left, Time right) =>
 			ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
 
-	    public static bool operator !=(Time left, Time right) => !(left == right);
+		public static bool operator !=(Time left, Time right) => !(left == right);
 
 		public TimeSpan ToTimeSpan() => TimeSpan.FromMilliseconds(this.Milliseconds);
 

--- a/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
+++ b/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
@@ -10,32 +10,32 @@ namespace Tests.CommonOptions.DateMath
 	{
 		/** == Date Math Expressions
 		 * The date type supports using date math expression when using it in a query/filter
-		 * Whenever durations need to be specified, eg for a timeout parameter, the duration can be specified 
+		 * Whenever durations need to be specified, eg for a timeout parameter, the duration can be specified
 		 *
-		 * The expression starts with an "anchor" date, which can be either now or a date string (in the applicable format) ending with `||`. 
-		 * It can then follow by a math expression, supporting `+`, `-` and `/` (rounding). 
-		 * The units supported are 
+		 * The expression starts with an "anchor" date, which can be either now or a date string (in the applicable format) ending with `||`.
+		 * It can then follow by a math expression, supporting `+`, `-` and `/` (rounding).
+		 * The units supported are
 		 *
 		 * - `y` (year)
 		 * - `M` (month)
-		 * - `w` (week) 
-		 * - `d` (day) 
-		 * - `h` (hour) 
+		 * - `w` (week)
+		 * - `d` (day)
+		 * - `h` (hour)
 		 * - `m` (minute)
 		 * - `s` (second)
-		 * 
-		 * as a whole number representing time in milliseconds, or as a time value like `2d` for 2 days. 
+		 *
+		 * as a whole number representing time in milliseconds, or as a time value like `2d` for 2 days.
 		 * :datemath: {ref_current}/common-options.html#date-math
 		 * Be sure to read the Elasticsearch documentation on {datemath}[Date Math].
 		 */
 		[U] public void SimpleExpressions()
 		{
 			/** === Simple Expressions
-			* You can create simple expressions using any of the static methods on `DateMath` 
+			* You can create simple expressions using any of the static methods on `DateMath`
 			*/
 			Expect("now").WhenSerializing(Nest.DateMath.Now);
 			Expect("2015-05-05T00:00:00").WhenSerializing(Nest.DateMath.Anchored(new DateTime(2015,05, 05)));
-			
+
 			/** strings implicitly convert to `DateMath` */
 			Expect("now").WhenSerializing<Nest.DateMath>("now");
 
@@ -46,18 +46,18 @@ namespace Tests.CommonOptions.DateMath
 				/** the resulting date math will assume the whole string is the anchor */
 				.Result(dateMath => ((IDateMath)dateMath)
 					.Anchor.Match(
-						d => d.Should().NotBe(default(DateTime)), 
+						d => d.Should().NotBe(default(DateTime)),
 						s => s.Should().Be(nonsense)
 					)
 				);
-			
+
 			/** `DateTime` also implicitly convert to simple date math expressions */
 			var date = new DateTime(2015, 05, 05);
 			Expect("2015-05-05T00:00:00").WhenSerializing<Nest.DateMath>(date)
 				/** the anchor will be an actual `DateTime`, even after a serialization/deserialization round trip */
 				.Result(dateMath => ((IDateMath)dateMath)
 				.	Anchor.Match(
-						d => d.Should().Be(date), 
+						d => d.Should().Be(date),
 						s => s.Should().BeNull()
 					)
 				);
@@ -66,7 +66,7 @@ namespace Tests.CommonOptions.DateMath
 		[U] public void ComplexExpressions()
 		{
 			/** === Complex Expressions
-			* Ranges can be chained on to simple expressions 
+			* Ranges can be chained on to simple expressions
 			*/
 			Expect("now+1d").WhenSerializing(
 				Nest.DateMath.Now.Add("1d"));
@@ -80,15 +80,42 @@ namespace Tests.CommonOptions.DateMath
 				Nest.DateMath.Now.Add("1d")
 					.Subtract(TimeSpan.FromMinutes(1))
 					.RoundTo(Nest.TimeUnit.Day));
-			
+
 			/** When anchoring dates, a `||` needs to be appended as clear separator between the anchor and ranges.
-			* Again, multiple ranges can be chained 
+			* Again, multiple ranges can be chained
 			*/
 			Expect("2015-05-05T00:00:00||+1d-1m").WhenSerializing(
 				Nest.DateMath.Anchored(new DateTime(2015,05,05))
 					.Add("1d")
 					.Subtract(TimeSpan.FromMinutes(1)));
 		}
+
+		[U] public void FractionalsUnitsAreDroppeToIntegerPart()
+		{
+			/** === Fractional times
+			* DateMath expressions do not support fractional numbers so unlike `Time` DateMath will
+			* pick the biggest integer unit it can represent
+			*/
+			Expect("now+25h").WhenSerializing(
+				Nest.DateMath.Now.Add(TimeSpan.FromHours(25)));
+
+			/** where as `Time` on its own serializes like this */
+			Expect("1.04d").WhenSerializing(new Time(TimeSpan.FromHours(25)));
+
+			Expect("now+90001s").WhenSerializing(
+				Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromSeconds(1))));
+
+			Expect("now+90000001ms").WhenSerializing(
+				Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromMilliseconds(1))));
+
+			Expect("now+1y").WhenSerializing(
+				Nest.DateMath.Now.Add("1y"));
+
+			Expect("now+52w").WhenSerializing(
+				Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+
+		}
+
 
 	}
 }


### PR DESCRIPTION
e.g new Time(TimeSpan.FromHours(25)) might serialize as 1.04h on its own but in datemath it should serialize to the lowest non fractional time unit we can represent it in 25h

This is the port the `master`