### PR TITLE
fix #2178, can now add custom similarities using both fluent and ois …

### DIFF
--- a/src/Nest/IndexModules/Similarity/CustomSimilarity.cs
+++ b/src/Nest/IndexModules/Similarity/CustomSimilarity.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	public interface ICustomSimilarity : ISimilarity, IIsADictionary<string, object> { }
+
+	/// <inheritdoc/>
+	public class CustomSimilarity : IsADictionaryBase<string, object>, ICustomSimilarity
+	{
+		public string Type { get { return this["type"] as string; } set { this.Add("type", value); } }
+
+		public CustomSimilarity(string type) : base()
+		{
+			if (!string.IsNullOrEmpty(type)) this.Type = type;
+		}
+		internal CustomSimilarity(IDictionary<string, object> container) : base(container) { }
+		internal CustomSimilarity(Dictionary<string, object> container)
+			: base(container.Select(kv => kv).ToDictionary(kv => kv.Key, kv => kv.Value))
+		{ }
+
+		public void Add(string key, object value) => BackingDictionary.Add(key, value);
+	}
+	/// <inheritdoc/>
+	public class CustomSimilarityDescriptor
+		: IsADictionaryDescriptorBase<CustomSimilarityDescriptor, ICustomSimilarity, string, object>
+	{
+
+		public CustomSimilarityDescriptor() : base(new CustomSimilarity(string.Empty)) { }
+
+		internal CustomSimilarityDescriptor Type(string type) => Assign("type", type);
+		public CustomSimilarityDescriptor Add(string key, object value) => Assign(key, value);
+	}
+
+}

--- a/src/Nest/IndexModules/Similarity/Similarities.cs
+++ b/src/Nest/IndexModules/Similarity/Similarities.cs
@@ -22,7 +22,7 @@ namespace Nest
 		public void Add(string type, ISimilarity mapping) => BackingDictionary.Add(type, mapping);
 
 	}
-	
+
 	public class SimilaritiesDescriptor : IsADictionaryDescriptorBase<SimilaritiesDescriptor, ISimilarities, string, ISimilarity>
 	{
 		public SimilaritiesDescriptor() : base(new Similarities()) { }
@@ -33,6 +33,8 @@ namespace Nest
 		public SimilaritiesDescriptor LMJelinek(string name, Func<LMJelinekMercerSimilarityDescriptor, ILMJelinekMercerSimilarity> selector) => Assign(name, selector?.Invoke(new LMJelinekMercerSimilarityDescriptor()));
 		public SimilaritiesDescriptor DFR(string name, Func<DFRSimilarityDescriptor, IDFRSimilarity> selector) => Assign(name, selector?.Invoke(new DFRSimilarityDescriptor()));
 		public SimilaritiesDescriptor IB(string name, Func<IBSimilarityDescriptor, IIBSimilarity> selector) => Assign(name, selector?.Invoke(new IBSimilarityDescriptor()));
+		public SimilaritiesDescriptor Custom(string name, string type, Func<CustomSimilarityDescriptor, IPromise<ICustomSimilarity>> selector) =>
+			Assign(name, selector?.Invoke(new CustomSimilarityDescriptor().Type(type))?.Value);
 	}
 
 }

--- a/src/Nest/IndexModules/Similarity/SimilarityJsonConverter.cs
+++ b/src/Nest/IndexModules/Similarity/SimilarityJsonConverter.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Reflection;
+using System.Collections.Generic;
 
 namespace Nest
 {
@@ -20,7 +21,10 @@ namespace Nest
 
 			var typePropertyValue = typeProperty.Value.ToString();
 			var itemType = Type.GetType("Nest." + typePropertyValue + "Similarity", false, true);
-			return o.ToObject(itemType, ElasticContractResolver.Empty);
+			if (itemType != null) return o.ToObject(itemType, ElasticContractResolver.Empty);
+
+			var dict = o.ToObject<Dictionary<string, object>>();
+			return new CustomSimilarity(dict);
 		}
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -635,6 +635,7 @@
     <Compile Include="IndexModules\IndexSettings\Translog\TranslogDurability.cs" />
     <Compile Include="IndexModules\IndexSettings\Translog\TranslogFlushSettings.cs" />
     <Compile Include="IndexModules\IndexSettings\Translog\TranslogSettings.cs" />
+    <Compile Include="IndexModules\Similarity\CustomSimilarity.cs" />
     <Compile Include="IndexModules\Similarity\BM25Similarity.cs" />
     <Compile Include="IndexModules\Similarity\DefaultSimilarity.cs" />
     <Compile Include="IndexModules\Similarity\DFR\DFRAfterEffect.cs" />

--- a/src/Tests/IndexModules/Similarity/SimilaritySettings.cs
+++ b/src/Tests/IndexModules/Similarity/SimilaritySettings.cs
@@ -49,11 +49,16 @@ namespace Tests.IndexModules.Similarity
 				{
 					lambda = 2.0,
 					type = "LMJelinekMercer"
+				},
+				my_name = new
+				{
+					type = "plugin_sim",
+					some_property = "some value"
 				}
 			};
 
 			/**
-			 * 
+			 *
 			 */
 			protected override Func<SimilaritiesDescriptor, IPromise<ISimilarities>> Fluent => s => s
 				.BM25("bm25", b => b
@@ -73,7 +78,10 @@ namespace Tests.IndexModules.Similarity
 					.Distribution(IBDistribution.LogLogistic)
 				)
 				.LMDirichlet("lmd", d => d.Mu(2))
-				.LMJelinek("lmj", d => d.Lamdba(2.0));
+				.LMJelinek("lmj", d => d.Lamdba(2.0))
+				.Custom("my_name", "plugin_sim", d => d
+					.Add("some_property", "some value")
+				);
 			/**
 			 */
 			protected override Similarities Initializer =>
@@ -96,7 +104,10 @@ namespace Tests.IndexModules.Similarity
 						NormalizationH1C = 1.2
 					} },
 					{ "lmd", new LMDirichletSimilarity { Mu = 2 } },
-					{ "lmj", new LMJelinekMercerSimilarity { Lambda = 2.0 } }
+					{ "lmj", new LMJelinekMercerSimilarity { Lambda = 2.0 } },
+					{ "my_name", new CustomSimilarity("plugin_sim") {
+						{ "some_property", "some value" }
+					} }
 				};
 		}
 	}


### PR DESCRIPTION
…syntax in a matter that roundtrips (won't break get index settings)

this pr targets `master`