### PR TITLE
Do not use IsoDateTimeConverter to handle DateTimeOffset

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/ElasticContractResolver.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/ElasticContractResolver.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Elasticsearch.Net;
@@ -46,10 +47,8 @@ namespace Nest
 				else if (o == typeof(ServerError))
 					contract.Converter = new ServerErrorJsonConverter();
 				else if (o == typeof(DateTime) ||
-						 o == typeof(DateTime?) ||
-						 o == typeof(DateTimeOffset) ||
-						 o == typeof(DateTimeOffset?))
-					contract.Converter = new IsoDateTimeConverter();
+						 o == typeof(DateTime?))
+					contract.Converter = new IsoDateTimeConverter { Culture = CultureInfo.InvariantCulture };
 				else if (o == typeof(TimeSpan) ||
 						 o == typeof(TimeSpan?))
 					contract.Converter = new TimeSpanConverter();

--- a/src/Tests/Reproduce/DateSerialization.cs
+++ b/src/Tests/Reproduce/DateSerialization.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Text;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.Reproduce
+{
+    public class DateSerialization
+    {
+        [U]
+        public void ShouldRoundtripDateTimeAndDateTimeOffsetWithSameKindAndOffset()
+        {
+            var dates = new Dates
+            {
+                DateTimeUtcKind = new DateTime(2016,1,1,1,1,1,DateTimeKind.Utc),
+                DateTimeOffset = new DateTimeOffset(1999, 1, 1, 1, 1, 1, 1, TimeSpan.FromHours(5))
+            };
+
+            var client = new ElasticClient();
+            var serializedDates = client.Serializer.SerializeToString(dates,SerializationFormatting.None);
+
+            serializedDates.Should()
+                .Be("{\"dateTimeUtcKind\":\"2016-01-01T01:01:01Z\",\"dateTimeOffset\":\"1999-01-01T01:01:01.001+05:00\"}");
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(serializedDates)))
+            {
+                var deserializedDates = client.Serializer.Deserialize<Dates>(stream);
+
+                deserializedDates.DateTimeUtcKind.Should().Be(dates.DateTimeUtcKind);
+                deserializedDates.DateTimeUtcKind.Kind.Should().Be(dates.DateTimeUtcKind.Kind);
+
+                deserializedDates.DateTimeOffset.Should().Be(dates.DateTimeOffset);
+                deserializedDates.DateTimeOffset.Offset.Should().Be(dates.DateTimeOffset.Offset);
+                deserializedDates.DateTimeOffset.Date.Kind.Should().Be(dates.DateTimeOffset.Date.Kind);
+            }
+        }
+
+        private class Dates
+        {
+            public DateTime DateTimeUtcKind { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
+        }
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -589,6 +589,7 @@
     <Compile Include="Reproduce\GithubIssue2152.cs" />
     <Compile Include="Reproduce\GithubIssue2052.cs" />
     <Compile Include="Reproduce\GithubIssue2173.cs" />
+    <Compile Include="Reproduce\DateSerialization.cs" />
     <Compile Include="Search\Search\Rescoring\RescoreUsageTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsApiTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsUrlTests.cs" />


### PR DESCRIPTION
`IsoDateTimeConverter` deserializes a `DateTimeOffset` represented according ISO8601 into a `DateTimeOffset` with a local offset. For example `"1999-01-01T01:01:01.001+05:00"` deserializes to a `DateTimeOffset` with a value of `01/01/1999 07:01:01 +11:00`. The +11 offset is my local offset (Australia). The default deserialization for a `DateTimeOffset` not using `IsoDateTimeConverter` deserializes into a `DateTimeOffset` with an offset that reflects the one in the ISO8601 string representation. 

This seems more appropriate behaviour.

Use `CultureInfo.InvariantCulture` in `IsoDateTimeConverter` when deserializing `DateTime`