### PR TITLE
Enhancement/2.x datetime serialization

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/ElasticContractResolver.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/ElasticContractResolver.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Elasticsearch.Net;
@@ -46,10 +47,8 @@ namespace Nest
 				else if (o == typeof(ServerError))
 					contract.Converter = new ServerErrorJsonConverter();
 				else if (o == typeof(DateTime) ||
-						 o == typeof(DateTime?) ||
-						 o == typeof(DateTimeOffset) ||
-						 o == typeof(DateTimeOffset?))
-					contract.Converter = new IsoDateTimeConverter();
+						 o == typeof(DateTime?))
+					contract.Converter = new IsoDateTimeConverter { Culture = CultureInfo.InvariantCulture };
 				else if (o == typeof(TimeSpan) ||
 						 o == typeof(TimeSpan?))
 					contract.Converter = new TimeSpanConverter();

--- a/src/Tests/ClientConcepts/Serializer/IsoDateTimeConverterTests.cs
+++ b/src/Tests/ClientConcepts/Serializer/IsoDateTimeConverterTests.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.Serializer
+{
+    /// <summary>
+    /// Tests for default DateTime zone serialization within NEST
+    /// </summary>
+    public class IsoDateTimeConverterHandlingTests
+    {
+        private readonly Flight _flight;
+        private readonly string _offset;
+        private readonly TimeSpan _timeSpanOffset;
+
+        public IsoDateTimeConverterHandlingTests()
+        {
+            var departureDateLocal = new DateTime(2013, 1, 21, 0, 0, 0, DateTimeKind.Local);
+            _timeSpanOffset = TimeZoneInfo.Local.GetUtcOffset(departureDateLocal);
+
+            _flight = new Flight
+            {
+                DepartureDate = new DateTime(2013, 1, 21, 0, 0, 0, DateTimeKind.Unspecified),
+                DepartureDateUtc = new DateTime(2013, 1, 21, 0, 0, 0, DateTimeKind.Utc),
+                DepartureDateLocal = departureDateLocal,
+                DepartureDateOffset = new DateTimeOffset(2013, 1, 21, 0, 0, 0, _timeSpanOffset),
+                DepartureDateOffsetZero = new DateTimeOffset(2013, 1, 21, 0, 0, 0, TimeSpan.Zero),
+                DepartureDateOffsetNonLocal = new DateTimeOffset(2013, 1, 21, 0, 0, 0, TimeSpan.FromHours(-6.25)),
+            };
+
+            _offset = $"{_timeSpanOffset.Hours.ToString("+00;-00;")}:{_timeSpanOffset.Minutes.ToString("00")}";
+        }
+
+        /// <remarks>
+        /// Timezone offset serialized is based on DateTimeKind
+        /// Unspecified = None
+        /// Utc = UTC Timezone identifier
+        /// Local = Local Timezone offset
+        /// Offset = Timezone offset specified 
+        /// </remarks>
+        [U]
+        public void RoundTripKind()
+        {
+            var dateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
+
+            var jsonWithRoundtripTimeZone = this.SerializeUsing(dateTimeZoneHandling);
+            var expected = @" {
+			   ""DepartureDate"": ""2013-01-21T00:00:00"",
+			   ""DepartureDateUtc"": ""2013-01-21T00:00:00Z"",
+			   ""DepartureDateLocal"": ""2013-01-21T00:00:00" + _offset + @""",
+			   ""DepartureDateOffset"": ""2013-01-21T00:00:00" + _offset + @""",
+			   ""DepartureDateOffsetZero"": ""2013-01-21T00:00:00+00:00"",
+			   ""DepartureDateOffsetNonLocal"": ""2013-01-21T00:00:00-06:15""
+			}";
+
+            jsonWithRoundtripTimeZone.JsonEquals(expected).Should().BeTrue("{0}", jsonWithRoundtripTimeZone);
+
+            var flight = this.DeserializeUsing(jsonWithRoundtripTimeZone, dateTimeZoneHandling);
+
+            flight.Should().Be(_flight);
+            flight.DepartureDate.Kind.Should().Be(_flight.DepartureDate.Kind);
+            flight.DepartureDateLocal.Kind.Should().Be(_flight.DepartureDateLocal.Kind);
+            flight.DepartureDateUtc.Kind.Should().Be(_flight.DepartureDateUtc.Kind);
+            flight.DepartureDateOffset.Offset.Should().Be(_flight.DepartureDateOffset.Offset);
+            flight.DepartureDateOffsetZero.Offset.Should().Be(_flight.DepartureDateOffsetZero.Offset);
+            flight.DepartureDateOffsetNonLocal.Offset.Should().Be(_flight.DepartureDateOffsetNonLocal.Offset);
+        }
+
+        /// <remarks>
+        /// Unspecified = Serialized as is with UTC offset
+        /// UTC = Serialized as is with UTC Offset
+        /// Local = Serialied as is with the local offset
+        /// Offset = Serialized as is with specified offset
+        /// </remarks>
+        [U]
+        public void Utc()
+        {
+            var dateTimeZoneHandling = DateTimeZoneHandling.Utc;
+            var dateTimeKind = DateTimeKind.Utc;
+
+            var departureDateLocalInUtc = TimeZoneInfo.ConvertTime(_flight.DepartureDateLocal, TimeZoneInfo.Local, TimeZoneInfo.Utc);
+
+            var jsonWithUtcTimeZone = this.SerializeUsing(dateTimeZoneHandling);
+            var expected = @" {
+			   ""DepartureDate"": ""2013-01-21T00:00:00Z"",
+			   ""DepartureDateUtc"": ""2013-01-21T00:00:00Z"",
+			   ""DepartureDateLocal"": ""2013-01-21T00:00:00" + _offset + @""",
+			   ""DepartureDateOffset"": ""2013-01-21T00:00:00" + _offset + @""",
+               ""DepartureDateOffsetZero"": ""2013-01-21T00:00:00+00:00"",
+               ""DepartureDateOffsetNonLocal"": ""2013-01-21T00:00:00-06:15""
+			}";
+
+            jsonWithUtcTimeZone.JsonEquals(expected).Should().BeTrue("{0}", jsonWithUtcTimeZone);
+
+            var flight = this.DeserializeUsing(jsonWithUtcTimeZone, dateTimeZoneHandling);
+
+            flight.DepartureDate.Should().Be(_flight.DepartureDate);
+            flight.DepartureDate.Kind.Should().Be(dateTimeKind);
+
+            // The deserialized local will be the UTC DateTime + the local timezone offset,
+            // and with a DateTimeKind of UTC when deserialized.
+            // 
+            // Calling .ToLocalTime() will return DepartureDateLocal with correct
+            // local datetime and DateTimeKind.Local
+            flight.DepartureDateLocal.Should().Be(departureDateLocalInUtc);
+            flight.DepartureDateLocal.Kind.Should().Be(dateTimeKind);
+
+            flight.DepartureDateUtc.Should().Be(_flight.DepartureDateUtc);
+            flight.DepartureDateUtc.Kind.Should().Be(dateTimeKind);
+
+            flight.DepartureDateOffset.Should().Be(_flight.DepartureDateOffset);
+            flight.DepartureDateOffset.Offset.Should().Be(_flight.DepartureDateOffset.Offset);
+
+            flight.DepartureDateOffsetZero.Should().Be(_flight.DepartureDateOffsetZero);
+            flight.DepartureDateOffsetZero.Offset.Should().Be(_flight.DepartureDateOffsetZero.Offset);
+
+            flight.DepartureDateOffsetNonLocal.Should().Be(_flight.DepartureDateOffsetNonLocal);
+            flight.DepartureDateOffsetNonLocal.Offset.Should().Be(_flight.DepartureDateOffsetNonLocal.Offset);
+        }
+
+        [U]
+        public void Unspecified()
+        {
+            var dateTimeZoneHandling = DateTimeZoneHandling.Unspecified;
+            var dateTimeKind = DateTimeKind.Unspecified;
+
+            var jsonWithUnspecifiedTimeZone = this.SerializeUsing(dateTimeZoneHandling);
+            var expected = @" {
+			   ""DepartureDate"": ""2013-01-21T00:00:00"",
+			   ""DepartureDateUtc"": ""2013-01-21T00:00:00"",
+			   ""DepartureDateLocal"": ""2013-01-21T00:00:00"",
+			   ""DepartureDateOffset"": ""2013-01-21T00:00:00" + _offset + @""",
+               ""DepartureDateOffsetZero"": ""2013-01-21T00:00:00+00:00"",
+               ""DepartureDateOffsetNonLocal"": ""2013-01-21T00:00:00-06:15""
+			 }";
+
+            jsonWithUnspecifiedTimeZone.JsonEquals(expected).Should().BeTrue("{0}", jsonWithUnspecifiedTimeZone);
+
+            var flight = this.DeserializeUsing(jsonWithUnspecifiedTimeZone, dateTimeZoneHandling);
+
+            flight.Should().Be(_flight);
+            flight.DepartureDate.Kind.Should().Be(dateTimeKind);
+            flight.DepartureDateLocal.Kind.Should().Be(dateTimeKind);
+            flight.DepartureDateUtc.Kind.Should().Be(dateTimeKind);
+            flight.DepartureDateOffset.Offset.Should().Be(_flight.DepartureDateOffset.Offset);
+            flight.DepartureDateOffsetZero.Offset.Should().Be(_flight.DepartureDateOffsetZero.Offset);
+            flight.DepartureDateOffsetNonLocal.Offset.Should().Be(_flight.DepartureDateOffsetNonLocal.Offset);
+        }
+
+        [U]
+        public void Local()
+        {
+            var dateTimeZoneHandling = DateTimeZoneHandling.Local;
+            var dateTimeKind = DateTimeKind.Local;
+
+            var jsonWithLocalTimeZone = this.SerializeUsing(dateTimeZoneHandling);
+            var departureDateUtcInLocal = TimeZoneInfo.ConvertTime(_flight.DepartureDateUtc, TimeZoneInfo.Utc, TimeZoneInfo.Local);
+
+            var expected = @"
+			{
+			  ""DepartureDate"": ""2013-01-21T00:00:00"",
+			  ""DepartureDateUtc"": ""2013-01-21T00:00:00Z"",
+			  ""DepartureDateLocal"": ""2013-01-21T00:00:00" + _offset + @""",
+			  ""DepartureDateOffset"": ""2013-01-21T00:00:00" + _offset + @""",
+              ""DepartureDateOffsetZero"": ""2013-01-21T00:00:00+00:00"",
+              ""DepartureDateOffsetNonLocal"": ""2013-01-21T00:00:00-06:15""
+			}";
+
+            jsonWithLocalTimeZone.JsonEquals(expected).Should().BeTrue("{0}", jsonWithLocalTimeZone);
+
+            var flight = this.DeserializeUsing(jsonWithLocalTimeZone, dateTimeZoneHandling);
+
+            flight.DepartureDate.Should().Be(_flight.DepartureDate);
+            flight.DepartureDate.Kind.Should().Be(dateTimeKind);
+
+
+            flight.DepartureDateLocal.Should().Be(_flight.DepartureDateLocal);
+            flight.DepartureDateLocal.Kind.Should().Be(dateTimeKind);
+
+            // The deserialized UTC will be the UTC DateTime + the local timezone offset
+            // and a DateTimeKind of LOCAL when deserialized.
+            //
+            // Calling .ToUniversalTime() will return DepartureDateUtc with correct
+            // UTC datetime and DateTimeKind.Utc
+            flight.DepartureDateUtc.Should().Be(departureDateUtcInLocal);
+            flight.DepartureDateUtc.Kind.Should().Be(dateTimeKind);
+
+            flight.DepartureDateOffset.Should().Be(_flight.DepartureDateOffset);
+            flight.DepartureDateOffset.Offset.Should().Be(_flight.DepartureDateOffset.Offset);
+
+            flight.DepartureDateOffsetZero.Should().Be(_flight.DepartureDateOffsetZero);
+            flight.DepartureDateOffsetZero.Offset.Should().Be(_flight.DepartureDateOffsetZero.Offset);
+
+            flight.DepartureDateOffsetNonLocal.Should().Be(_flight.DepartureDateOffsetNonLocal);
+            flight.DepartureDateOffsetNonLocal.Offset.Should().Be(_flight.DepartureDateOffsetNonLocal.Offset);
+        }
+
+        private string SerializeUsing(DateTimeZoneHandling handling)
+        {
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+            var settings = new ConnectionSettings(pool, new InMemoryConnection(), new SerializerFactory(
+                (serializerSettings, connectionSettings) =>
+                {
+                    serializerSettings.DateTimeZoneHandling = handling;
+                    serializerSettings.Formatting = Formatting.Indented;
+                }))
+                .DefaultFieldNameInferrer(p => p);
+
+            var client = new ElasticClient(settings);
+            return client.Serializer.SerializeToString(_flight);
+        }
+
+        private Flight DeserializeUsing(string json, DateTimeZoneHandling handling)
+        {
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+            var settings = new ConnectionSettings(pool, new InMemoryConnection(), new SerializerFactory(
+                (serializerSettings, connectionSettings) =>
+                {
+                    serializerSettings.DateTimeZoneHandling = handling;
+                }))
+                .DefaultFieldNameInferrer(p => p);
+
+            var client = new ElasticClient(settings);
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            {
+                return client.Serializer.Deserialize<Flight>(stream);
+            }
+        }
+    }
+
+    internal class Flight
+    {
+        public DateTime DepartureDate { get; set; }
+        public DateTime DepartureDateUtc { get; set; }
+        public DateTime DepartureDateLocal { get; set; }
+        public DateTimeOffset DepartureDateOffset { get; set; }
+        public DateTimeOffset DepartureDateOffsetZero { get; set; }
+        public DateTimeOffset DepartureDateOffsetNonLocal { get; set; }
+
+        protected bool Equals(Flight other)
+        {
+            return DepartureDate.Equals(other.DepartureDate) &&
+                   DepartureDateUtc.Equals(other.DepartureDateUtc) &&
+                   DepartureDateLocal.Equals(other.DepartureDateLocal) &&
+                   DepartureDateOffset.Equals(other.DepartureDateOffset) &&
+                   DepartureDateOffsetZero.Equals(other.DepartureDateOffsetZero) &&
+                   DepartureDateOffsetNonLocal.Equals(other.DepartureDateOffsetNonLocal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Flight)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = DepartureDate.GetHashCode();
+                hashCode = (hashCode * 397) ^ DepartureDateUtc.GetHashCode();
+                hashCode = (hashCode * 397) ^ DepartureDateLocal.GetHashCode();
+                hashCode = (hashCode * 397) ^ DepartureDateOffset.GetHashCode();
+                hashCode = (hashCode * 397) ^ DepartureDateOffsetZero.GetHashCode();
+                hashCode = (hashCode * 397) ^ DepartureDateOffsetNonLocal.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+
+    internal static class JsonExtensions
+    {
+        internal static bool JsonEquals(this string value, string other)
+        {
+            var valueToken = JObject.Parse(value);
+            var otherToken = JObject.Parse(other);
+            return JToken.DeepEquals(valueToken, otherToken);
+        }
+    }
+}

--- a/src/Tests/Reproduce/DateSerialization.cs
+++ b/src/Tests/Reproduce/DateSerialization.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Text;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.Reproduce
+{
+    public class DateSerialization
+    {
+        [U]
+        public void ShouldRoundtripDateTimeAndDateTimeOffsetWithSameKindAndOffset()
+        {
+            var dates = new Dates
+            {
+                DateTimeUtcKind = new DateTime(2016,1,1,1,1,1,DateTimeKind.Utc),
+                DateTimeOffset = new DateTimeOffset(1999, 1, 1, 1, 1, 1, 1, TimeSpan.FromHours(5))
+            };
+
+            var client = new ElasticClient();
+            var serializedDates = client.Serializer.SerializeToString(dates,SerializationFormatting.None);
+
+            serializedDates.Should()
+                .Be("{\"dateTimeUtcKind\":\"2016-01-01T01:01:01Z\",\"dateTimeOffset\":\"1999-01-01T01:01:01.001+05:00\"}");
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(serializedDates)))
+            {
+                var deserializedDates = client.Serializer.Deserialize<Dates>(stream);
+
+                deserializedDates.DateTimeUtcKind.Should().Be(dates.DateTimeUtcKind);
+                deserializedDates.DateTimeUtcKind.Kind.Should().Be(dates.DateTimeUtcKind.Kind);
+
+                deserializedDates.DateTimeOffset.Should().Be(dates.DateTimeOffset);
+                deserializedDates.DateTimeOffset.Offset.Should().Be(dates.DateTimeOffset.Offset);
+                deserializedDates.DateTimeOffset.Date.Kind.Should().Be(dates.DateTimeOffset.Date.Kind);
+            }
+        }
+
+        private class Dates
+        {
+            public DateTime DateTimeUtcKind { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
+        }
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -236,6 +236,7 @@
     <Compile Include=".\Framework\Extensions\WebClient-CoreFx.cs" />
     <Compile Include=".\Framework\Integration\Bootstrappers\Seeder.cs" />
     <Compile Include=".\Framework\Integration\Clusters\ClusterBase.cs" />
+    <Compile Include="ClientConcepts\Serializer\IsoDateTimeConverterTests.cs" />
     <Compile Include="Framework\Extensions\ShouldExtensions.cs" />
     <Compile Include="Framework\Integration\Clusters\WritableCluster.cs" />
     <Compile Include="Framework\Integration\Clusters\IntrusiveOperationCluster.cs" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -589,6 +589,7 @@
     <Compile Include="Reproduce\GithubIssue2152.cs" />
     <Compile Include="Reproduce\GithubIssue2052.cs" />
     <Compile Include="Reproduce\GithubIssue2173.cs" />
+    <Compile Include="Reproduce\DateSerialization.cs" />
     <Compile Include="Search\Search\Rescoring\RescoreUsageTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsApiTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsUrlTests.cs" />


### PR DESCRIPTION
Comparison of how NEST, which uses `IsoDateTimeConverter` for `DateTime`, serializes DateTime and DateTimeOffset.

This branch is branched from https://github.com/elastic/elasticsearch-net/tree/fix/2.x-datetimeoffset-deserialization which **removes the usage `IsoDateTimeConverter` to also serialize `DateTimeOffset`**; `IsoDateTimeConverter` applies the local offset to a `DateTimeOffset` on deserialization which, whilst still a correct representation, does not reflect the offset represented in the serialized form.

A summary of how NEST serializes, in conjunction with Json.Net's `DateTimeZoneHandling`

## `DateTime`

### `DateTimeZoneHandling.RoundTripKind` (Default)
`DateTimeKind` are handled differently:
**Unspecified**: 
- Serialized without any time zone id or offset.
- Deserialized to datetime represented by IS08601 string with `DateTimeKind.Unspecified`

**Utc**: 
- Serialized with `Z` UTC timezone identifier
- Deserialized to datetime represented by IS08601 string with `DateTimeKind.Utc`

**Local**: 
- Serialized with offset from UTC
- Deserialized to datetime represented by IS08601 string with `DateTimeKind.Local`

### `DateTimeZoneHandling.Unspecified`
Serialized without any time zone id or offset.
Deserialized to datetime represented by IS08601 string with `DateTimeKind.Unspecified`

### `DateTimeZoneHandling.Utc`

`DateTimeKind` are handled differently:
**Unspecified**: 
- Serialized with `Z` UTC timezone identifier
- Deserialized to datetime represented by IS08601 string with `DateTimeKind.Utc`

Essentially, `DateTimeKind.Unspecified` is serialized as though it were `DateTimeKind.Utc` and deserialized as though it were `DateTimeKind.Utc`

**Utc**: 
- Serialized with `Z` UTC timezone identifier
- Deserialized to datetime represented by IS08601 string with `DateTimeKind.Utc`

**Local**: 
- Serialized with offset from UTC
- Deserialized to UTC datetime with offset applied to IS08601 string representation, and `DateTimeKind.Utc`. Calling `.ToLocalTime()` on this instance would return a `DateTime` instance with `DateTimeKind.Local`.

### `DateTimeZoneHandling.Local`

`DateTimeKind` are handled differently:
**Unspecified**: 
- Serialized without any time zone id or offset.
- Deserialized to local datetime represented by IS08601 string with `DateTimeKind.Local`

Essentially, `DateTimeKind.Unspecified` is serialized as `DateTimeKind.Unspecified` and deserialized as though it were `DateTimeKind.Local`

**Utc**: 
- Serialized with `Z` UTC timezone identifier
- Deserialized to local datetime with local offset applied to the IS08601 string representation, and `DateTimeKind.Local`. Calling `.ToUniversalTime()` on this instance would return a `DateTime` instance with `DateTimeKind.Utc`.

**Local**: 
- Serialized with offset from UTC
- Deserialized to local datetime represented by IS08601 string with `DateTimeKind.Local`

## `DateTimeOffset`

`DateTimeOffset` always serialize to an ISO8601 string representation that includes the offset as per the `DateTimeOffset` instance.

`DateTimeOffset` always deserialize to datetime as represented by IS08601 string with an `Offset` set to the offset within the ISO8601 representation.
