### PR TITLE
Custom IGetAliasesResponse converter

### DIFF
--- a/src/Nest/Indices/AliasManagement/GetAlias/ElasticClient-GetAlias.cs
+++ b/src/Nest/Indices/AliasManagement/GetAlias/ElasticClient-GetAlias.cs
@@ -36,7 +36,6 @@ namespace Nest
 		public IGetAliasesResponse GetAlias(IGetAliasRequest request) =>
 			this.Dispatcher.Dispatch<IGetAliasRequest, GetAliasRequestParameters, GetAliasesResponse>(
 				request,
-				DeserializeGetAliasesResponse,
 				(p, d) => this.LowLevelDispatch.IndicesGetAliasDispatch<GetAliasesResponse>(p)
 			);
 
@@ -48,7 +47,6 @@ namespace Nest
 		public Task<IGetAliasesResponse> GetAliasAsync(IGetAliasRequest request) =>
 			this.Dispatcher.DispatchAsync<IGetAliasRequest, GetAliasRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
 				request,
-				DeserializeGetAliasesResponse,
 				(p, d) => this.LowLevelDispatch.IndicesGetAliasDispatchAsync<GetAliasesResponse>(p)
 			);
 	}

--- a/src/Nest/Indices/AliasManagement/GetAliases/ElasticClient-GetAliases.cs
+++ b/src/Nest/Indices/AliasManagement/GetAliases/ElasticClient-GetAliases.cs
@@ -7,30 +7,27 @@ using Elasticsearch.Net;
 
 namespace Nest
 {
-	using GetAliasesConverter = Func<IApiCallDetails, Stream, GetAliasesResponse>;
-	using CrazyAliasesResponse = Dictionary<string, Dictionary<string, Dictionary<string, AliasDefinition>>>;
-
 	public partial interface IElasticClient
 	{
 		/// <summary>
-		/// The get index alias api allows to filter by alias name and index name. This api redirects to the master and fetches 
+		/// The get index alias api allows to filter by alias name and index name. This api redirects to the master and fetches
 		/// the requested index aliases, if available. This api only serialises the found index aliases.
 		/// <para> </para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html#alias-retrieving
 		/// </summary>
 		/// <param name="selector">A descriptor that describes which aliases/indexes we are interested int</param>
-		[Obsolete("Deprecated since 1.0, will be removed in 3.0. Use GetAlias which accepts multiple aliases and indices")]
+		[Obsolete("Deprecated since 1.0, will be removed in 5.0. Use GetAlias which accepts multiple aliases and indices")]
 		IGetAliasesResponse GetAliases(Func<GetAliasesDescriptor, IGetAliasesRequest> selector = null);
 
 		/// <inheritdoc/>
-		[Obsolete("Deprecated since 1.0, will be removed in 3.0. Use GetAlias which accepts multiple aliases and indices")]
+		[Obsolete("Deprecated since 1.0, will be removed in 5.0. Use GetAlias which accepts multiple aliases and indices")]
 		IGetAliasesResponse GetAliases(IGetAliasesRequest request);
 
 		/// <inheritdoc/>
-		[Obsolete("Deprecated since 1.0, will be removed in 3.0. Use GetAlias which accepts multiple aliases and indices")]
+		[Obsolete("Deprecated since 1.0, will be removed in 5.0. Use GetAlias which accepts multiple aliases and indices")]
 		Task<IGetAliasesResponse> GetAliasesAsync(Func<GetAliasesDescriptor, IGetAliasesRequest> selector = null);
 
 		/// <inheritdoc/>
-		[Obsolete("Deprecated since 1.0, will be removed in 3.0. Use GetAlias which accepts multiple aliases and indices")]
+		[Obsolete("Deprecated since 1.0, will be removed in 5.0. Use GetAlias which accepts multiple aliases and indices")]
 		Task<IGetAliasesResponse> GetAliasesAsync(IGetAliasesRequest request);
 
 	}
@@ -38,64 +35,29 @@ namespace Nest
 	public partial class ElasticClient
 	{
 		/// <inheritdoc/>
-		[Obsolete("Deprecated since 1.0, will be removed in 3.0. Use GetAlias which accepts multiple aliases and indices")]
+		[Obsolete("Deprecated since 1.0, will be removed in 5.0. Use GetAlias which accepts multiple aliases and indices")]
 		public IGetAliasesResponse GetAliases(Func<GetAliasesDescriptor, IGetAliasesRequest> selector = null) =>
 			this.GetAliases(selector.InvokeOrDefault(new GetAliasesDescriptor()));
 
 		/// <inheritdoc/>
-		[Obsolete("Deprecated since 1.0, will be removed in 3.0. Use GetAlias which accepts multiple aliases and indices")]
-		public IGetAliasesResponse GetAliases(IGetAliasesRequest request) => 
+		[Obsolete("Deprecated since 1.0, will be removed in 5.0. Use GetAlias which accepts multiple aliases and indices")]
+		public IGetAliasesResponse GetAliases(IGetAliasesRequest request) =>
 			this.Dispatcher.Dispatch<IGetAliasesRequest, GetAliasesRequestParameters, GetAliasesResponse>(
 				request,
-				new GetAliasesConverter(DeserializeGetAliasesResponse),
 				(p, d) => this.LowLevelDispatch.IndicesGetAliasesDispatch<GetAliasesResponse>(p)
 			);
 
 		/// <inheritdoc/>
-		[Obsolete("Deprecated since 1.0, will be removed in 3.0. Use GetAlias which accepts multiple aliases and indices")]
+		[Obsolete("Deprecated since 1.0, will be removed in 5.0. Use GetAlias which accepts multiple aliases and indices")]
 		public Task<IGetAliasesResponse> GetAliasesAsync(Func<GetAliasesDescriptor, IGetAliasesRequest> selector = null) =>
 			this.GetAliasesAsync(selector.InvokeOrDefault(new GetAliasesDescriptor()));
 
 		/// <inheritdoc/>
-		[Obsolete("Deprecated since 1.0, will be removed in 3.0. Use GetAlias which accepts multiple aliases and indices")]
-		public Task<IGetAliasesResponse> GetAliasesAsync(IGetAliasesRequest request) => 
+		[Obsolete("Deprecated since 1.0, will be removed in 5.0. Use GetAlias which accepts multiple aliases and indices")]
+		public Task<IGetAliasesResponse> GetAliasesAsync(IGetAliasesRequest request) =>
 			this.Dispatcher.DispatchAsync<IGetAliasesRequest, GetAliasesRequestParameters, GetAliasesResponse, IGetAliasesResponse>(
 				request,
-				new GetAliasesConverter(DeserializeGetAliasesResponse),
 				(p, d) => this.LowLevelDispatch.IndicesGetAliasesDispatchAsync<GetAliasesResponse>(p)
 			);
-		
-		//TODO map the response properly, remove list flattening
-		/// <inheritdoc/>
-		private GetAliasesResponse DeserializeGetAliasesResponse(IApiCallDetails apiCallDetails, Stream stream)
-		{
-			if (!apiCallDetails.Success)
-				return new GetAliasesResponse();
-
-			var dict = this.Serializer.Deserialize<CrazyAliasesResponse>(stream);
-
-			var d = new Dictionary<string, IList<AliasDefinition>>();
-
-			foreach (var kv in dict)
-			{
-				var indexDict = kv.Key;
-				var aliases = new List<AliasDefinition>();
-				if (kv.Value != null && kv.Value.ContainsKey("aliases"))
-				{
-					var aliasDict = kv.Value["aliases"];
-					if (aliasDict != null)
-						aliases = aliasDict.Select(kva =>
-						{
-							var alias = kva.Value;
-							alias.Name = kva.Key;
-							return alias;
-						}).ToList();
-				}
-
-				d.Add(indexDict, aliases);
-			}
-
-			return new GetAliasesResponse() { Indices = d };
-		}
 	}
 }

--- a/src/Nest/Indices/AliasManagement/GetAliases/GetAliasesResponse.cs
+++ b/src/Nest/Indices/AliasManagement/GetAliases/GetAliasesResponse.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
 
 namespace Nest
 {
+	[JsonConverter(typeof(GetAliasResponseConverter))]
 	public interface IGetAliasesResponse : IResponse
 	{
 		IDictionary<string, IList<AliasDefinition>> Indices { get; }
@@ -9,6 +13,45 @@ namespace Nest
 
 	public class GetAliasesResponse : ResponseBase, IGetAliasesResponse
 	{
-		public IDictionary<string, IList<AliasDefinition>> Indices { get; internal set; } = new Dictionary<string, IList<AliasDefinition>>();
+		public IDictionary<string, IList<AliasDefinition>> Indices { get; internal set; }
+	}
+
+	internal class GetAliasResponseConverter : JsonConverter
+	{
+		public override bool CanWrite => false;
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			throw new NotSupportedException();
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var dict = serializer.Deserialize<Dictionary<string, Dictionary<string, Dictionary<string, AliasDefinition>>>>(reader);
+			var indices = new Dictionary<string, IList<AliasDefinition>>();
+
+			foreach (var kv in dict)
+			{
+				var indexDict = kv.Key;
+				var aliases = new List<AliasDefinition>();
+				if (kv.Value != null && kv.Value.ContainsKey("aliases"))
+				{
+					var aliasDict = kv.Value["aliases"];
+					if (aliasDict != null)
+						aliases = aliasDict.Select(kva =>
+						{
+							var alias = kva.Value;
+							alias.Name = kva.Key;
+							return alias;
+						}).ToList();
+				}
+
+				indices.Add(indexDict, aliases);
+			}
+
+			return new GetAliasesResponse { Indices = indices };
+		}
+
+		public override bool CanConvert(Type objectType) => true;
 	}
 }

--- a/src/Tests/Indices/AliasManagement/GetAlias/GetAliasApiTests.cs
+++ b/src/Tests/Indices/AliasManagement/GetAlias/GetAliasApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
@@ -11,7 +12,7 @@ namespace Tests.Indices.AliasManagement.GetAlias
 {
 	public class GetAliasApiTests : ApiIntegrationTestBase<ReadOnlyCluster, IGetAliasesResponse, IGetAliasRequest, GetAliasDescriptor, GetAliasRequest>
 	{
-		private static readonly Names Names = Infer.Names("alias, x", "y");
+		private static readonly Names Names = Infer.Names("projects-alias", "alias, x", "y");
 
 		public GetAliasApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
@@ -25,10 +26,13 @@ namespace Tests.Indices.AliasManagement.GetAlias
 		protected override bool ExpectIsValid => true;
 		protected override int ExpectStatusCode => 200;
 		protected override HttpMethod HttpMethod => HttpMethod.GET;
-		protected override string UrlPath => $"/_all/_alias/alias%2Cx%2Cy";
+		protected override string UrlPath => $"/_all/_alias/projects-alias%2Calias%2Cx%2Cy";
 		protected override void ExpectResponse(IGetAliasesResponse response)
 		{
-			response.Indices.Should().NotBeNull();
+			response.Indices.Should().NotBeNull().And.ContainKey("project");
+			var projectIndex = response.Indices["project"];
+			projectIndex.Should().HaveCount(1);
+			projectIndex.First().Name.Should().Be("projects-alias");
 		}
 		protected override bool SupportsDeserialization => false;
 


### PR DESCRIPTION
- Move the deserialization into a custom converter

This is a tidying up of the deserialization, moving it from a method on `ElasticClient` into a json converter.

- Add a valid alias to the integration tests

All aliases used in the integration test do not exist, so Elasticsearch returns `{}`. Add an alias known to exist as a better test of deserialization logic.