### PR TITLE
Correctly handle 400 status code response

### DIFF
--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -68,8 +68,8 @@ namespace Elasticsearch.Net
 		public List<Audit> AuditTrail { get; internal set; }
 
 		/// <summary>
-		/// The response is succesful or has a response code between 400-599 the call should not be retried.
-		/// Only on 502 and 503 will this return false;
+		/// The response is successful or has a response code between 400-599, the call should not be retried.
+		/// Only on 502,503 and 504 will this return false;
 		/// </summary>
 		public bool SuccessOrKnownError =>
 			this.Success || (HttpStatusCode >= 400 && HttpStatusCode < 599

--- a/src/Nest/CommonOptions/Failures/ShardFailure.cs
+++ b/src/Nest/CommonOptions/Failures/ShardFailure.cs
@@ -41,6 +41,7 @@ namespace Nest
 	public class CausedBy : IFailureReason
 	{
 		public string Type { get; internal set; }
+
 		public string Reason { get; internal set; }
 
 		[JsonProperty("caused_by")]

--- a/src/Nest/Document/Multiple/BulkIndexByScrollFailure.cs
+++ b/src/Nest/Document/Multiple/BulkIndexByScrollFailure.cs
@@ -41,5 +41,8 @@ namespace Nest
 
 		[JsonProperty("index")]
 		public string Index { get; internal set; }
+
+		[JsonProperty("caused_by")]
+		public CausedBy CausedBy { get; internal set; }
 	}
 }

--- a/src/Nest/Document/Multiple/ReindexOnServer/ElasticClient-ReindexOnServer.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ElasticClient-ReindexOnServer.cs
@@ -31,7 +31,7 @@ namespace Nest
 		/// <inheritdoc/>
 		public IReindexOnServerResponse ReindexOnServer(IReindexOnServerRequest request) =>
 			this.Dispatcher.Dispatch<IReindexOnServerRequest, ReindexOnServerRequestParameters, ReindexOnServerResponse>(
-				request,
+				this.ForceConfiguration<IReindexOnServerRequest, ReindexOnServerRequestParameters>(request, c => c.AllowedStatusCodes = new[] { -1 }),
 				this.LowLevelDispatch.ReindexDispatch<ReindexOnServerResponse>
 			);
 
@@ -42,7 +42,7 @@ namespace Nest
 		/// <inheritdoc/>
 		public Task<IReindexOnServerResponse> ReindexOnServerAsync(IReindexOnServerRequest request, CancellationToken cancellationToken = default(CancellationToken)) =>
 			this.Dispatcher.DispatchAsync<IReindexOnServerRequest, ReindexOnServerRequestParameters, ReindexOnServerResponse, IReindexOnServerResponse>(
-				request,
+				this.ForceConfiguration<IReindexOnServerRequest, ReindexOnServerRequestParameters>(request, c => c.AllowedStatusCodes = new[] { -1 }),
 				cancellationToken,
 				this.LowLevelDispatch.ReindexDispatchAsync<ReindexOnServerResponse>
 			);

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerResponse.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerResponse.cs
@@ -50,13 +50,12 @@ namespace Nest
 	[JsonObject(MemberSerialization.OptIn)]
 	public class ReindexOnServerResponse : ResponseBase, IReindexOnServerResponse
 	{
-
-		public override bool IsValid => !this.Failures.HasAny();
+		public override bool IsValid => base.IsValid && !this.Failures.HasAny();
 
 		public Time Took { get; internal set; }
 
 		/// <summary>
-		/// Only has a value if WaitForCompletion is set to false on the request
+		/// Only has a value if WaitForCompletion is set to <c>false</c> on the request
 		/// </summary>
 		public TaskId Task { get; internal set; }
 

--- a/src/Tests/Reproduce/GithubIssue2309.cs
+++ b/src/Tests/Reproduce/GithubIssue2309.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Text;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Xunit;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue2309 : IClusterFixture<ReadOnlyCluster>
+	{
+		private readonly ReadOnlyCluster _cluster;
+
+		public GithubIssue2309(ReadOnlyCluster cluster)
+		{
+			_cluster = cluster;
+		}
+
+		[U]
+		public void FailedReIndexResponseMarkedAsInvalidAndContainFailures()
+		{
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+			var json = @"{
+				""took"": 4,
+				""timed_out"": false,
+				""total"": 1,
+				""updated"": 0,
+				""created"": 0,
+				""deleted"": 0,
+				""batches"": 1,
+				""version_conflicts"": 0,
+				""noops"": 0,
+				""retries"": {
+					""bulk"": 0,
+					""search"": 0
+				},
+				""throttled_millis"": 0,
+				""requests_per_second"": -1.0,
+				""throttled_until_millis"": 0,
+				""failures"": [{
+					""index"": ""employees-v2"",
+					""type"": ""employee"",
+					""id"": ""57f7ce8df8a10336a0cf935b"",
+					""cause"": {
+						""type"": ""mapper_parsing_exception"",
+						""reason"": ""failed to parse [id]"",
+						""caused_by"": {
+							""type"": ""number_format_exception"",
+							""reason"": ""For input string: \""57f7ce8df8a10336a0cf935b\""""
+						}
+					},
+					""status"": 400
+				}]
+			}";
+
+			var connection = new InMemoryConnection(Encoding.UTF8.GetBytes(json), 400);
+			var settings = new ConnectionSettings(pool, connection);
+			var client = new ElasticClient(settings);
+
+			var reindexResponse = client.ReindexOnServer(r => r
+					.Source(s => s
+							.Index("employees-v1")
+							.Type("employee")
+					)
+					.Destination(d => d
+							.Index("employees-v2")
+					)
+					.Conflicts(Conflicts.Proceed)
+			);
+
+			reindexResponse.IsValid.Should().BeFalse();
+			reindexResponse.Failures.Should().NotBeNull().And.HaveCount(1);
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -598,6 +598,7 @@
     <Compile Include="QueryDsl\NotConditionlessWhen.cs" />
     <Compile Include="QueryDsl\Specialized\Percolate\PercolateQueryUsageTests.cs" />
     <Compile Include="Reproduce\GithubIssue2152.cs" />
+    <Compile Include="Reproduce\GithubIssue2309.cs" />
     <Compile Include="Search\MultiSearch\MultiSearchApiTests.cs" />
     <Compile Include="Search\MultiSearch\MultiSearchInvalidApiTests.cs" />
     <Compile Include="Framework\Extensions\UriExtensions.cs" />


### PR DESCRIPTION
When a `ReindexOnServerResponse` comes back as 400 status code, deserialize the response so that `Failures` is populated with more details for why things failed. 

Use the -1 special case in `AllowedStatusCodes` in the dispatch call, similar to `UpdateByQuery` and `DeleteByQuery`; `IsValid` will still be false as it checks `Failures` which will be deserialized and not be empty. `Success` on `ApiCallDetails` will be true however.

Closes #2309