### PR TITLE
fix #2311 null GetResponseStream() on HttpWebException

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Text;
@@ -141,6 +142,9 @@ namespace Elasticsearch.Net
 				var response = (HttpWebResponse)request.GetResponse();
 				builder.StatusCode = (int)response.StatusCode;
 				builder.Stream = response.GetResponseStream();
+				// https://github.com/elastic/elasticsearch-net/issues/2311
+				// if stream is null call dispose on response instead.
+				if (builder.Stream == null || builder.Stream == Stream.Null) response.Dispose();
 			}
 			catch (WebException e)
 			{
@@ -178,6 +182,9 @@ namespace Elasticsearch.Net
 				var response = (HttpWebResponse)(await request.GetResponseAsync().ConfigureAwait(false));
 				builder.StatusCode = (int)response.StatusCode;
 				builder.Stream = response.GetResponseStream();
+				// https://github.com/elastic/elasticsearch-net/issues/2311
+				// if stream is null call dispose on response instead.
+				if (builder.Stream == null || builder.Stream == Stream.Null) response.Dispose();
 			}
 			catch (WebException e)
 			{
@@ -196,6 +203,9 @@ namespace Elasticsearch.Net
 			{
 				builder.StatusCode = (int)response.StatusCode;
 				builder.Stream = response.GetResponseStream();
+				// https://github.com/elastic/elasticsearch-net/issues/2311
+				// if stream is null call dispose on response instead.
+				if (builder.Stream == null || builder.Stream == Stream.Null) response.Dispose();
 			}
 		}
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -21,7 +21,7 @@ namespace Elasticsearch.Net
 		public AuditEvent OnFailureAuditEvent => this.MadeItToResponse ? AuditEvent.BadResponse : AuditEvent.BadRequest;
 		public PipelineFailure OnFailurePipelineFailure => this.MadeItToResponse ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;
 
-		public Node Node { get; internal set; }
+		public Node Node { get; set; }
 		public TimeSpan RequestTimeout { get; }
 		public TimeSpan PingTimeout { get; }
 		public int KeepAliveTime { get; }

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -156,7 +156,7 @@ namespace Elasticsearch.Net
             var success = await semaphore.WaitAsync(this._settings.RequestTimeout, _cancellationToken).ConfigureAwait(false);
             if (!success)
             {
-                if (this.FirstPoolUsageNeedsSniffing)
+				if(this.FirstPoolUsageNeedsSniffing)
                     throw new PipelineException(PipelineFailure.CouldNotStartSniffOnStartup, null);
                 return;
             }

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -63,6 +63,8 @@ namespace Elasticsearch.Net
 				bytes = this.SwapStreams(ref stream, ref inMemoryStream);
 			}
 
+			using (stream)
+			{
 			if (response.Success)
 			{
 				if (!SetSpecialTypes(stream, response, bytes))
@@ -80,6 +82,7 @@ namespace Elasticsearch.Net
 					response.ResponseBodyInBytes = bytes;
 			}
 		}
+		}
 
 		private async Task SetBodyAsync(ElasticsearchResponse<TReturn> response, Stream stream)
 		{
@@ -91,6 +94,8 @@ namespace Elasticsearch.Net
 				bytes = this.SwapStreams(ref stream, ref inMemoryStream);
 			}
 
+			using (stream)
+			{
 			if (response.Success)
 			{
 				if (!SetSpecialTypes(stream, response, bytes))
@@ -105,6 +110,7 @@ namespace Elasticsearch.Net
 				if (this._requestData.ConnectionSettings.DisableDirectStreaming)
 					response.ResponseBodyInBytes = bytes;
 			}
+		}
 		}
 
 		private void Finalize(ElasticsearchResponse<TReturn> response)

--- a/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
@@ -39,17 +39,17 @@ namespace Tests.ClientConcepts.ConnectionPooling.Exceptions
 			}
 		}
 
-		[U] public async Task ResponseWithHttpStatusCode() => await ResponseBuilderAssert(false, r => r.StatusCode = 1);
+		[U] public async Task ResponseWithHttpStatusCode() => await AssertRegularResponse(false, r => r.StatusCode = 1);
 
-		[U] public async Task ResponseBuilderWithNoHttpStatusCode() => await ResponseBuilderAssert(false);
+		[U] public async Task ResponseBuilderWithNoHttpStatusCode() => await AssertRegularResponse(false);
 
 		[U] public async Task ResponseWithHttpStatusCodeDisableDirectStreaming() =>
-			await ResponseBuilderAssert(true, r => r.StatusCode = 1);
+			await AssertRegularResponse(true, r => r.StatusCode = 1);
 
 		[U] public async Task ResponseBuilderWithNoHttpStatusCodeDisableDirectStreaming() =>
-			await ResponseBuilderAssert(true);
+			await AssertRegularResponse(true);
 
-		private async Task ResponseBuilderAssert(bool disableDirectStreaming, Action<ResponseBuilder<RootNodeInfoResponse>> mutate = null)
+		private async Task AssertRegularResponse(bool disableDirectStreaming, Action<ResponseBuilder<RootNodeInfoResponse>> mutate = null)
 		{
 			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
 			var memoryStreamFactory = new TrackMemoryStreamFactory();
@@ -87,6 +87,46 @@ namespace Tests.ClientConcepts.ConnectionPooling.Exceptions
 				memoryStream.IsDisposed.Should().BeTrue();
 			}
 			stream.IsDisposed.Should().BeTrue();
+		}
+
+		[U] public async Task StreamResponseWithHttpStatusCode() => await AssertStreamResponse(false, r => r.StatusCode = 200);
+
+		[U] public async Task StreamResponseBuilderWithNoHttpStatusCode() => await AssertStreamResponse(false);
+
+		[U] public async Task StreamResponseWithHttpStatusCodeDisableDirectStreaming() =>
+			await AssertStreamResponse(true, r => r.StatusCode = 1);
+
+		[U] public async Task StreamResponseBuilderWithNoHttpStatusCodeDisableDirectStreaming() =>
+			await AssertStreamResponse(true);
+
+		private async Task AssertStreamResponse(bool disableDirectStreaming, Action<ResponseBuilder<Stream>> mutate = null)
+		{
+			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
+			var memoryStreamFactory = new TrackMemoryStreamFactory();
+
+			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, (IRequestParameters)null, memoryStreamFactory)
+			{
+				Node = new Node(new Uri("http://localhost:9200"))
+			};
+
+			var responseBuilder = new ResponseBuilder<Stream>(requestData)
+			{
+			};
+			mutate?.Invoke(responseBuilder);
+
+			var stream = new TrackDisposeStream();
+			responseBuilder.Stream = stream;
+
+			var response = responseBuilder.ToResponse();
+			memoryStreamFactory.Created.Count().Should().Be(disableDirectStreaming ? 1 : 0);
+			stream.IsDisposed.Should().Be(disableDirectStreaming ? true : false);
+
+
+			stream = new TrackDisposeStream();
+			responseBuilder.Stream = stream;
+			response = await responseBuilder.ToResponseAsync();
+			memoryStreamFactory.Created.Count().Should().Be(disableDirectStreaming ? 2 : 0);
+			stream.IsDisposed.Should().Be(disableDirectStreaming ? true : false);
 		}
 
 	}

--- a/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.ConnectionPooling.Exceptions
+{
+	public class ResponseBuilderDisposeTests
+	{
+		private IConnectionSettingsValues _settings = TestClient.CreateSettings(forceInMemory: true);
+		private IConnectionSettingsValues _settingsDisableDirectStream =
+			TestClient.CreateSettings(modifySettings: s=>s.DisableDirectStreaming(), forceInMemory: true);
+
+		private class TrackDisposeStream : MemoryStream
+		{
+			public bool IsDisposed { get; private set; }
+			protected override void Dispose(bool disposing)
+			{
+				this.IsDisposed = true;
+				base.Dispose(disposing);
+			}
+		}
+
+		private class TrackMemoryStreamFactory : IMemoryStreamFactory
+		{
+			public IList<TrackDisposeStream> Created { get; } = new List<TrackDisposeStream>();
+
+			public MemoryStream Create()
+			{
+				var stream = new TrackDisposeStream();
+				this.Created.Add(stream);
+				return stream;
+			}
+		}
+
+		[U] public async Task ResponseWithHttpStatusCode() => await ResponseBuilderAssert(false, r => r.StatusCode = 1);
+
+		[U] public async Task ResponseBuilderWithNoHttpStatusCode() => await ResponseBuilderAssert(false);
+
+		[U] public async Task ResponseWithHttpStatusCodeDisableDirectStreaming() =>
+			await ResponseBuilderAssert(true, r => r.StatusCode = 1);
+
+		[U] public async Task ResponseBuilderWithNoHttpStatusCodeDisableDirectStreaming() =>
+			await ResponseBuilderAssert(true);
+
+		private async Task ResponseBuilderAssert(bool disableDirectStreaming, Action<ResponseBuilder<RootNodeInfoResponse>> mutate = null)
+		{
+			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
+			var memoryStreamFactory = new TrackMemoryStreamFactory();
+
+			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, (IRequestParameters)null, memoryStreamFactory)
+			{
+				Node = new Node(new Uri("http://localhost:9200"))
+			};
+
+			var responseBuilder = new ResponseBuilder<RootNodeInfoResponse>(requestData)
+			{
+			};
+			mutate?.Invoke(responseBuilder);
+
+			var stream = new TrackDisposeStream();
+			responseBuilder.Stream = stream;
+
+			var response = responseBuilder.ToResponse();
+			memoryStreamFactory.Created.Count().Should().Be(disableDirectStreaming ? 1 : 0);
+			if (disableDirectStreaming)
+			{
+				var memoryStream = memoryStreamFactory.Created[0];
+				memoryStream.IsDisposed.Should().BeTrue();
+			}
+			stream.IsDisposed.Should().BeTrue();
+
+
+			stream = new TrackDisposeStream();
+			responseBuilder.Stream = stream;
+			response = await responseBuilder.ToResponseAsync();
+			memoryStreamFactory.Created.Count().Should().Be(disableDirectStreaming ? 2 : 0);
+			if (disableDirectStreaming)
+			{
+				var memoryStream = memoryStreamFactory.Created[1];
+				memoryStream.IsDisposed.Should().BeTrue();
+			}
+			stream.IsDisposed.Should().BeTrue();
+		}
+
+	}
+
+
+}

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -62,8 +62,11 @@ namespace Tests.Framework
 				.Ignore(p => p.PrivateValue)
 				.Rename(p => p.OnlineHandle, "nickname")
 			)
+			//.EnableTcpKeepAlive(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2))
+			//.PrettyJson()
 			//TODO make this random
 			//.EnableHttpCompression()
+
 			.OnRequestDataCreated(data=> data.Headers.Add("TestMethod", ExpensiveTestNameForIntegrationTests()));
 
 

--- a/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
@@ -84,11 +84,11 @@ namespace Tests.Framework
 			return new SealedVirtualCluster(this, new SniffingConnectionPool(nodes, randomize: false, dateTimeProvider: this.DateTimeProvider), this.DateTimeProvider);
 		}
 
-        public SealedVirtualCluster StickyConnectionPool(Func<IList<Node>, IEnumerable<Node>> seedNodesSelector = null)
-        {
-            var nodes = seedNodesSelector?.Invoke(this._nodes) ?? this._nodes;
-            return new SealedVirtualCluster(this, new StickyConnectionPool(nodes, dateTimeProvider: this.DateTimeProvider), this.DateTimeProvider);
-        }
-    }
+		public SealedVirtualCluster StickyConnectionPool(Func<IList<Node>, IEnumerable<Node>> seedNodesSelector = null)
+		{
+			var nodes = seedNodesSelector?.Invoke(this._nodes) ?? this._nodes;
+			return new SealedVirtualCluster(this, new StickyConnectionPool(nodes, dateTimeProvider: this.DateTimeProvider), this.DateTimeProvider);
+		}
+	}
 
 }

--- a/src/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
@@ -207,14 +207,17 @@ namespace Tests.Framework
 			if (rule?.ReturnResponse != null)
 				return rule.ReturnResponse;
 
+			if (DefaultResponseBytes != null) return DefaultResponseBytes;
 			var response = DefaultResponse;
 			using (var ms = new MemoryStream())
 			{
 				new ElasticsearchDefaultSerializer().Serialize(response, ms);
-				return ms.ToArray();
+				DefaultResponseBytes = ms.ToArray();
 			}
+			return DefaultResponseBytes;
 		}
 
+		private static byte[] DefaultResponseBytes;
 		private static object DefaultResponse
 		{
 			get

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -236,6 +236,7 @@
     <Compile Include=".\Framework\Extensions\WebClient-CoreFx.cs" />
     <Compile Include=".\Framework\Integration\Bootstrappers\Seeder.cs" />
     <Compile Include=".\Framework\Integration\Clusters\ClusterBase.cs" />
+    <Compile Include="ClientConcepts\ConnectionPooling\Dispose\ResponseBuilderDisposeTests.cs" />
     <Compile Include="Document\Multiple\ReindexRethrottle\ReindexRethrottleApiTests.cs" />
     <Compile Include="Document\Multiple\ReindexRethrottle\ReindexRethrottleUrlTests.cs" />
     <Compile Include="Framework\Extensions\ShouldExtensions.cs" />

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: u
 # the elasticsearch version that should be started
 elasticsearch_version: 2.4.0
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
Confirmed we do not handle the case where `response.GetResponseStream()` returns null in our `WebException` handling. 

As per: http://msdn.microsoft.com/en-us/library/system.net.httpwebresponse.getresponsestream.aspx

> You must call either the Stream.Close or the HttpWebResponse.Close method to close the stream and release the connection for reuse. It is not necessary to call both Stream.Close and HttpWebResponse.Close, but doing so does not cause an error. Failure to close the stream will cause your application to run out of connections.

We rely on disposing the `stream` only but in this case we need to forcefully call dispose on `response` instead.
