### PR TITLE
fix #2311 null GetResponseStream() on HttpWebException

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Text;
@@ -51,7 +52,7 @@ namespace Elasticsearch.Net
 				request.Headers.Add("Content-Encoding", "gzip");
 			}
 			if (!requestData.RunAs.IsNullOrEmpty())
-				request.Headers.Add("es-security-runas-user", requestData.RunAs);
+				request.Headers.Add("es-shield-runas-user", requestData.RunAs);
 
 			if (requestData.Headers != null && requestData.Headers.HasKeys())
 				request.Headers.Add(requestData.Headers);
@@ -142,6 +143,9 @@ namespace Elasticsearch.Net
 				var response = (HttpWebResponse)request.GetResponse();
 				builder.StatusCode = (int)response.StatusCode;
 				builder.Stream = response.GetResponseStream();
+				// https://github.com/elastic/elasticsearch-net/issues/2311
+				// if stream is null call dispose on response instead.
+				if (builder.Stream == null || builder.Stream == Stream.Null) response.Dispose();
 			}
 			catch (WebException e)
 			{
@@ -179,6 +183,9 @@ namespace Elasticsearch.Net
 				var response = (HttpWebResponse)(await request.GetResponseAsync().ConfigureAwait(false));
 				builder.StatusCode = (int)response.StatusCode;
 				builder.Stream = response.GetResponseStream();
+				// https://github.com/elastic/elasticsearch-net/issues/2311
+				// if stream is null call dispose on response instead.
+				if (builder.Stream == null || builder.Stream == Stream.Null) response.Dispose();
 			}
 			catch (WebException e)
 			{
@@ -197,6 +204,9 @@ namespace Elasticsearch.Net
 			{
 				builder.StatusCode = (int)response.StatusCode;
 				builder.Stream = response.GetResponseStream();
+				// https://github.com/elastic/elasticsearch-net/issues/2311
+				// if stream is null call dispose on response instead.
+				if (builder.Stream == null || builder.Stream == Stream.Null) response.Dispose();
 			}
 		}
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -21,7 +21,7 @@ namespace Elasticsearch.Net
 		public AuditEvent OnFailureAuditEvent => this.MadeItToResponse ? AuditEvent.BadResponse : AuditEvent.BadRequest;
 		public PipelineFailure OnFailurePipelineFailure => this.MadeItToResponse ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;
 
-		public Node Node { get; internal set; }
+		public Node Node { get; set; }
 		public TimeSpan RequestTimeout { get; }
 		public TimeSpan PingTimeout { get; }
 		public int KeepAliveTime { get; }

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -121,20 +121,20 @@ namespace Elasticsearch.Net
 		public void FirstPoolUsage(SemaphoreSlim semaphore)
 		{
 			if (!this.FirstPoolUsageNeedsSniffing) return;
-            if (!semaphore.Wait(this._settings.RequestTimeout))
-            {
-                if (this.FirstPoolUsageNeedsSniffing)
-                    throw new PipelineException(PipelineFailure.CouldNotStartSniffOnStartup, null);
-                return;
-            }
+			if (!semaphore.Wait(this._settings.RequestTimeout))
+			{
+				if (this.FirstPoolUsageNeedsSniffing)
+					throw new PipelineException(PipelineFailure.CouldNotStartSniffOnStartup, null);
+				return;
+			}
 
-            if (!this.FirstPoolUsageNeedsSniffing)
-            {
-                semaphore.Release();
-                return;
-            }
+			if (!this.FirstPoolUsageNeedsSniffing)
+			{
+				semaphore.Release();
+				return;
+			}
 
-            try
+			try
 			{
 				using (this.Audit(SniffOnStartup))
 				{
@@ -152,18 +152,18 @@ namespace Elasticsearch.Net
 		{
 			if (!this.FirstPoolUsageNeedsSniffing) return;
 			var success = await semaphore.WaitAsync(this._settings.RequestTimeout, cancellationToken).ConfigureAwait(false);
-            if (!success)
-            {
-                if(this.FirstPoolUsageNeedsSniffing)
-                    throw new PipelineException(PipelineFailure.CouldNotStartSniffOnStartup, null);
-                return;
-            }
+			if (!success)
+			{
+				if(this.FirstPoolUsageNeedsSniffing)
+					throw new PipelineException(PipelineFailure.CouldNotStartSniffOnStartup, null);
+				return;
+			}
 
 			if (!this.FirstPoolUsageNeedsSniffing)
-            {
-                semaphore.Release();
-                return;
-            }
+			{
+				semaphore.Release();
+				return;
+			}
 			try
 			{
 				using (this.Audit(SniffOnStartup))

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -56,6 +56,8 @@ namespace Elasticsearch.Net
 			return response;
 		}
 
+		private static IDisposable EmptyDisposable = new MemoryStream();
+
 		private void SetBody(ElasticsearchResponse<TReturn> response, Stream stream)
 		{
 			byte[] bytes = null;
@@ -66,7 +68,8 @@ namespace Elasticsearch.Net
 				bytes = this.SwapStreams(ref stream, ref inMemoryStream);
 			}
 
-			using (stream)
+			var needsDispose = typeof(TReturn) != typeof(Stream);
+			using (needsDispose ? stream : EmptyDisposable)
 			{
 				if (response.Success)
 				{
@@ -97,7 +100,8 @@ namespace Elasticsearch.Net
 				bytes = this.SwapStreams(ref stream, ref inMemoryStream);
 			}
 
-			using (stream)
+			var needsDispose = typeof(TReturn) != typeof(Stream);
+			using (needsDispose ? stream : EmptyDisposable)
 			{
 				if (response.Success)
 				{

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -66,21 +66,24 @@ namespace Elasticsearch.Net
 				bytes = this.SwapStreams(ref stream, ref inMemoryStream);
 			}
 
-			if (response.Success)
+			using (stream)
 			{
-				if (!SetSpecialTypes(stream, response, bytes))
+				if (response.Success)
 				{
-					if (this._requestData.CustomConverter != null) response.Body = this._requestData.CustomConverter(response, stream) as TReturn;
-					else response.Body = this._requestData.ConnectionSettings.Serializer.Deserialize<TReturn>(stream);
+					if (!SetSpecialTypes(stream, response, bytes))
+					{
+						if (this._requestData.CustomConverter != null) response.Body = this._requestData.CustomConverter(response, stream) as TReturn;
+						else response.Body = this._requestData.ConnectionSettings.Serializer.Deserialize<TReturn>(stream);
+					}
 				}
-			}
-			else if (response.HttpStatusCode != null)
-			{
-				ServerError serverError;
-				if (ServerError.TryCreate(stream, out serverError))
-					response.ServerError = serverError;
-				if (this._requestData.ConnectionSettings.DisableDirectStreaming)
-					response.ResponseBodyInBytes = bytes;
+				else if (response.HttpStatusCode != null)
+				{
+					ServerError serverError;
+					if (ServerError.TryCreate(stream, out serverError))
+						response.ServerError = serverError;
+					if (this._requestData.ConnectionSettings.DisableDirectStreaming)
+						response.ResponseBodyInBytes = bytes;
+				}
 			}
 		}
 
@@ -94,19 +97,22 @@ namespace Elasticsearch.Net
 				bytes = this.SwapStreams(ref stream, ref inMemoryStream);
 			}
 
-			if (response.Success)
+			using (stream)
 			{
-				if (!SetSpecialTypes(stream, response, bytes))
+				if (response.Success)
 				{
-					if (this._requestData.CustomConverter != null) response.Body = this._requestData.CustomConverter(response, stream) as TReturn;
-					else response.Body = await this._requestData.ConnectionSettings.Serializer.DeserializeAsync<TReturn>(stream, this._cancellationToken).ConfigureAwait(false);
+					if (!SetSpecialTypes(stream, response, bytes))
+					{
+						if (this._requestData.CustomConverter != null) response.Body = this._requestData.CustomConverter(response, stream) as TReturn;
+						else response.Body = await this._requestData.ConnectionSettings.Serializer.DeserializeAsync<TReturn>(stream, this._cancellationToken).ConfigureAwait(false);
+					}
 				}
-			}
-			else if (response.HttpStatusCode != null)
-			{
-				response.ServerError = await ServerError.TryCreateAsync(stream, this._cancellationToken).ConfigureAwait(false);
-				if (this._requestData.ConnectionSettings.DisableDirectStreaming)
-					response.ResponseBodyInBytes = bytes;
+				else if (response.HttpStatusCode != null)
+				{
+					response.ServerError = await ServerError.TryCreateAsync(stream, this._cancellationToken).ConfigureAwait(false);
+					if (this._requestData.ConnectionSettings.DisableDirectStreaming)
+						response.ResponseBodyInBytes = bytes;
+				}
 			}
 		}
 
@@ -137,15 +143,15 @@ namespace Elasticsearch.Net
 			var setSpecial = true;
 			if (this._requestData.ConnectionSettings.DisableDirectStreaming)
 				cs.ResponseBodyInBytes = bytes;
-		    var returnType = typeof (TReturn);
+			var returnType = typeof(TReturn);
 			if (returnType == typeof(string))
 				this.SetStringResult(cs as ElasticsearchResponse<string>, bytes);
 			else if (returnType == typeof(byte[]))
 				this.SetByteResult(cs as ElasticsearchResponse<byte[]>, bytes);
 			else if (returnType == typeof(VoidResponse))
 				this.SetVoidResult(cs as ElasticsearchResponse<VoidResponse>, responseStream);
-            else if (returnType == typeof(Stream))
-                this.SetStreamResult(cs as ElasticsearchResponse<Stream>, responseStream);
+			else if (returnType == typeof(Stream))
+				this.SetStreamResult(cs as ElasticsearchResponse<Stream>, responseStream);
 			else
 				setSpecial = false;
 			return setSpecial;

--- a/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/RequestPipelines.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/RequestPipelines.doc.cs
@@ -92,67 +92,67 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 			sniffingPipeline.FirstPoolUsageNeedsSniffing.Should().BeFalse();
 		}
 
-        /**==== Wait for first Sniff
-         * 
-         * All threads wait for the sniff on startup to finish, waiting the request timeout period. A
-         * https://msdn.microsoft.com/en-us/library/system.threading.semaphoreslim(v=vs.110).aspx[`SemaphoreSlim`] 
-         * is used to block threads until the sniff finishes and waiting threads release the `SemaphoreSlim` appropriately.
-         */
-        [U]
-	    public void FirstUsageCheckConcurrentThreads()
-	    {
-	        var response = new
-	        {
-	            cluster_name = "elasticsearch",
-	            nodes = new
-	            {
-	                node1 = new
-	                {
-	                    name = "Node Name 1",
-	                    transport_address = "127.0.0.1:9300",
-	                    host = "127.0.0.1",
-	                    ip = "127.0.01",
-	                    version = "5.0.0-alpha3",
-	                    build = "e455fd0",
-	                    http_address = "127.0.0.1:9200",
-	                    settings = new JObject
-	                    {
-	                        {"client.type", "node"},
-	                        {"cluster.name", "elasticsearch"},
-	                        {"config.ignore_system_properties", "true"},
-	                        {"name", "Node Name 1"},
-	                        {"path.home", "c:\\elasticsearch\\elasticsearch"},
-	                        {"path.logs", "c:/ elasticsearch/logs"}
-	                    }
-	                }
-	            }
-	        };
+		/**==== Wait for first Sniff
+		 *
+		 * All threads wait for the sniff on startup to finish, waiting the request timeout period. A
+		 * https://msdn.microsoft.com/en-us/library/system.threading.semaphoreslim(v=vs.110).aspx[`SemaphoreSlim`]
+		 * is used to block threads until the sniff finishes and waiting threads release the `SemaphoreSlim` appropriately.
+		 */
+		[U]
+		public void FirstUsageCheckConcurrentThreads()
+		{
+			var response = new
+			{
+				cluster_name = "elasticsearch",
+				nodes = new
+				{
+					node1 = new
+					{
+						name = "Node Name 1",
+						transport_address = "127.0.0.1:9300",
+						host = "127.0.0.1",
+						ip = "127.0.01",
+						version = "5.0.0-alpha3",
+						build = "e455fd0",
+						http_address = "127.0.0.1:9200",
+						settings = new JObject
+						{
+							{"client.type", "node"},
+							{"cluster.name", "elasticsearch"},
+							{"config.ignore_system_properties", "true"},
+							{"name", "Node Name 1"},
+							{"path.home", "c:\\elasticsearch\\elasticsearch"},
+							{"path.logs", "c:/ elasticsearch/logs"}
+						}
+					}
+				}
+			};
 
-	        var responseBody = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response));
+			var responseBody = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response));
 
-	        var inMemoryConnection = new WaitingInMemoryConnection(
-                TimeSpan.FromSeconds(1), 
-                responseBody);
+			var inMemoryConnection = new WaitingInMemoryConnection(
+				TimeSpan.FromSeconds(1),
+				responseBody);
 
-	        var sniffingPipeline = CreatePipeline(
-                uris => new SniffingConnectionPool(uris), 
-                connection: inMemoryConnection, 
-                settingsSelector: s => s.RequestTimeout(TimeSpan.FromSeconds(2)));
-       
-            var semaphoreSlim = new SemaphoreSlim(1, 1);
+			var sniffingPipeline = CreatePipeline(
+				uris => new SniffingConnectionPool(uris),
+				connection: inMemoryConnection,
+				settingsSelector: s => s.RequestTimeout(TimeSpan.FromSeconds(2)));
 
-            /**
-             * start three tasks that will initiate a sniff on startup. The first task will successfully
-             * sniff on startup with the remaining two waiting tasks exiting without exception and releasing
-             * the `SemaphoreSlim`.
-             */
-            var task1 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
-            var task2 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
-            var task3 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
+			var semaphoreSlim = new SemaphoreSlim(1, 1);
 
-	        var exception = Record.Exception(() => System.Threading.Tasks.Task.WaitAll(task1, task2, task3));
-	        exception.Should().BeNull();
-	    }
+			/**
+			 * start three tasks that will initiate a sniff on startup. The first task will successfully
+			 * sniff on startup with the remaining two waiting tasks exiting without exception and releasing
+			 * the `SemaphoreSlim`.
+			 */
+			var task1 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
+			var task2 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
+			var task3 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
+
+			var exception = Record.Exception(() => System.Threading.Tasks.Task.WaitAll(task1, task2, task3));
+			exception.Should().BeNull();
+		}
 
 		/**==== Sniffing on Connection Failure */
 		[U]

--- a/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.ConnectionPooling.Exceptions
+{
+	public class ResponseBuilderDisposeTests
+	{
+		private IConnectionSettingsValues _settings = TestClient.CreateSettings(forceInMemory: true);
+		private IConnectionSettingsValues _settingsDisableDirectStream =
+			TestClient.CreateSettings(modifySettings: s=>s.DisableDirectStreaming(), forceInMemory: true);
+
+		private class TrackDisposeStream : MemoryStream
+		{
+			public bool IsDisposed { get; private set; }
+			protected override void Dispose(bool disposing)
+			{
+				this.IsDisposed = true;
+				base.Dispose(disposing);
+			}
+		}
+
+		private class TrackMemoryStreamFactory : IMemoryStreamFactory
+		{
+			public IList<TrackDisposeStream> Created { get; } = new List<TrackDisposeStream>();
+
+			public MemoryStream Create()
+			{
+				var stream = new TrackDisposeStream();
+				this.Created.Add(stream);
+				return stream;
+			}
+		}
+
+		[U] public async Task ResponseWithHttpStatusCode() => await ResponseBuilderAssert(false, r => r.StatusCode = 1);
+
+		[U] public async Task ResponseBuilderWithNoHttpStatusCode() => await ResponseBuilderAssert(false);
+
+		[U] public async Task ResponseWithHttpStatusCodeDisableDirectStreaming() =>
+			await ResponseBuilderAssert(true, r => r.StatusCode = 1);
+
+		[U] public async Task ResponseBuilderWithNoHttpStatusCodeDisableDirectStreaming() =>
+			await ResponseBuilderAssert(true);
+
+		private async Task ResponseBuilderAssert(bool disableDirectStreaming, Action<ResponseBuilder<RootNodeInfoResponse>> mutate = null)
+		{
+			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
+			var memoryStreamFactory = new TrackMemoryStreamFactory();
+			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, memoryStreamFactory)
+			{
+				Node = new Node(new Uri("http://localhost:9200"))
+			};
+
+			var responseBuilder = new ResponseBuilder<RootNodeInfoResponse>(requestData)
+			{
+			};
+			mutate?.Invoke(responseBuilder);
+
+			var stream = new TrackDisposeStream();
+			responseBuilder.Stream = stream;
+
+			var response = responseBuilder.ToResponse();
+			memoryStreamFactory.Created.Count().Should().Be(disableDirectStreaming ? 1 : 0);
+			if (disableDirectStreaming)
+			{
+				var memoryStream = memoryStreamFactory.Created[0];
+				memoryStream.IsDisposed.Should().BeTrue();
+			}
+			stream.IsDisposed.Should().BeTrue();
+
+
+			stream = new TrackDisposeStream();
+			responseBuilder.Stream = stream;
+			response = await responseBuilder.ToResponseAsync();
+			memoryStreamFactory.Created.Count().Should().Be(disableDirectStreaming ? 2 : 0);
+			if (disableDirectStreaming)
+			{
+				var memoryStream = memoryStreamFactory.Created[1];
+				memoryStream.IsDisposed.Should().BeTrue();
+			}
+			stream.IsDisposed.Should().BeTrue();
+		}
+
+	}
+
+
+}

--- a/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
@@ -39,17 +39,17 @@ namespace Tests.ClientConcepts.ConnectionPooling.Exceptions
 			}
 		}
 
-		[U] public async Task ResponseWithHttpStatusCode() => await ResponseBuilderAssert(false, r => r.StatusCode = 1);
+		[U] public async Task ResponseWithHttpStatusCode() => await AssertRegularResponse(false, r => r.StatusCode = 1);
 
-		[U] public async Task ResponseBuilderWithNoHttpStatusCode() => await ResponseBuilderAssert(false);
+		[U] public async Task ResponseBuilderWithNoHttpStatusCode() => await AssertRegularResponse(false);
 
 		[U] public async Task ResponseWithHttpStatusCodeDisableDirectStreaming() =>
-			await ResponseBuilderAssert(true, r => r.StatusCode = 1);
+			await AssertRegularResponse(true, r => r.StatusCode = 1);
 
 		[U] public async Task ResponseBuilderWithNoHttpStatusCodeDisableDirectStreaming() =>
-			await ResponseBuilderAssert(true);
+			await AssertRegularResponse(true);
 
-		private async Task ResponseBuilderAssert(bool disableDirectStreaming, Action<ResponseBuilder<RootNodeInfoResponse>> mutate = null)
+		private async Task AssertRegularResponse(bool disableDirectStreaming, Action<ResponseBuilder<RootNodeInfoResponse>> mutate = null)
 		{
 			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
 			var memoryStreamFactory = new TrackMemoryStreamFactory();
@@ -86,6 +86,46 @@ namespace Tests.ClientConcepts.ConnectionPooling.Exceptions
 				memoryStream.IsDisposed.Should().BeTrue();
 			}
 			stream.IsDisposed.Should().BeTrue();
+		}
+
+		[U] public async Task StreamResponseWithHttpStatusCode() => await AssertStreamResponse(false, r => r.StatusCode = 200);
+
+		[U] public async Task StreamResponseBuilderWithNoHttpStatusCode() => await AssertStreamResponse(false);
+
+		[U] public async Task StreamResponseWithHttpStatusCodeDisableDirectStreaming() =>
+			await AssertStreamResponse(true, r => r.StatusCode = 1);
+
+		[U] public async Task StreamResponseBuilderWithNoHttpStatusCodeDisableDirectStreaming() =>
+			await AssertStreamResponse(true);
+
+		private async Task AssertStreamResponse(bool disableDirectStreaming, Action<ResponseBuilder<Stream>> mutate = null)
+		{
+			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
+			var memoryStreamFactory = new TrackMemoryStreamFactory();
+
+			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, (IRequestParameters)null, memoryStreamFactory)
+			{
+				Node = new Node(new Uri("http://localhost:9200"))
+			};
+
+			var responseBuilder = new ResponseBuilder<Stream>(requestData)
+			{
+			};
+			mutate?.Invoke(responseBuilder);
+
+			var stream = new TrackDisposeStream();
+			responseBuilder.Stream = stream;
+
+			var response = responseBuilder.ToResponse();
+			memoryStreamFactory.Created.Count().Should().Be(disableDirectStreaming ? 1 : 0);
+			stream.IsDisposed.Should().Be(disableDirectStreaming ? true : false);
+
+
+			stream = new TrackDisposeStream();
+			responseBuilder.Stream = stream;
+			response = await responseBuilder.ToResponseAsync();
+			memoryStreamFactory.Created.Count().Should().Be(disableDirectStreaming ? 2 : 0);
+			stream.IsDisposed.Should().Be(disableDirectStreaming ? true : false);
 		}
 
 	}

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -67,8 +67,11 @@ namespace Tests.Framework
 				.IndexName("queries")
 				.TypeName(PercolatorType)
 			)
+			//.EnableTcpKeepAlive(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2))
+			//.PrettyJson()
 			//TODO make this random
 			//.EnableHttpCompression()
+
 			.OnRequestDataCreated(data=> data.Headers.Add("TestMethod", ExpensiveTestNameForIntegrationTests()));
 
 		public static string PercolatorType => Configuration.ElasticsearchVersion <= new ElasticsearchVersion("5.0.0-alpha1") ? ".percolator" : "query";

--- a/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
@@ -84,11 +84,11 @@ namespace Tests.Framework
 			return new SealedVirtualCluster(this, new SniffingConnectionPool(nodes, randomize: false, dateTimeProvider: this.DateTimeProvider), this.DateTimeProvider);
 		}
 
-        public SealedVirtualCluster StickyConnectionPool(Func<IList<Node>, IEnumerable<Node>> seedNodesSelector = null)
-        {
-            var nodes = seedNodesSelector?.Invoke(this._nodes) ?? this._nodes;
-            return new SealedVirtualCluster(this, new StickyConnectionPool(nodes, dateTimeProvider: this.DateTimeProvider), this.DateTimeProvider);
-        }
-    }
+		public SealedVirtualCluster StickyConnectionPool(Func<IList<Node>, IEnumerable<Node>> seedNodesSelector = null)
+		{
+			var nodes = seedNodesSelector?.Invoke(this._nodes) ?? this._nodes;
+			return new SealedVirtualCluster(this, new StickyConnectionPool(nodes, dateTimeProvider: this.DateTimeProvider), this.DateTimeProvider);
+		}
+	}
 
 }

--- a/src/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
@@ -207,14 +207,17 @@ namespace Tests.Framework
 			if (rule?.ReturnResponse != null)
 				return rule.ReturnResponse;
 
+			if (DefaultResponseBytes != null) return DefaultResponseBytes;
 			var response = DefaultResponse;
 			using (var ms = new MemoryStream())
 			{
 				new ElasticsearchDefaultSerializer().Serialize(response, ms);
-				return ms.ToArray();
+				DefaultResponseBytes = ms.ToArray();
 			}
+			return DefaultResponseBytes;
 		}
 
+		private static byte[] DefaultResponseBytes;
 		private static object DefaultResponse
 		{
 			get

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Cat\CatTasks\CatTasksUrlTests.cs" />
     <Compile Include="Cat\CatThreadPool\CatThreadpoolApiTests.cs" />
     <Compile Include="Cat\CatThreadPool\CatThreadPoolUrlTests.cs" />
+    <Compile Include="ClientConcepts\ConnectionPooling\Dispose\ResponseBuilderDisposeTests.cs" />
     <Compile Include="Cluster\TaskManagement\GetTask\GetTaskApiTests.cs" />
     <Compile Include="Cluster\TaskManagement\GetTask\GetTaskUrlTests.cs" />
     <Compile Include="Document\Multiple\Bulk\BulkResponseParsingTests.cs" />

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,8 +1,8 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
+mode: u
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
-elasticsearch_version: latest
+elasticsearch_version: 5.0.0-beta1
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running
 force_reseed: true
 # do not spawn nodes as part of the test setup if we find a node is already running


### PR DESCRIPTION
Confirmed we do not handle the case where `response.GetResponseStream()` returns null in our `WebException` handling. 

As per: http://msdn.microsoft.com/en-us/library/system.net.httpwebresponse.getresponsestream.aspx

> You must call either the Stream.Close or the HttpWebResponse.Close method to close the stream and release the connection for reuse. It is not necessary to call both Stream.Close and HttpWebResponse.Close, but doing so does not cause an error. Failure to close the stream will cause your application to run out of connections.

We rely on disposing the `stream` only but in this case we need to forcefully call dispose on `response` instead.
