### PR TITLE
Adding support for local metadata on properties.

### DIFF
--- a/src/Nest/Mapping/AttributeBased/ElasticsearchPropertyAttributeBase.cs
+++ b/src/Nest/Mapping/AttributeBased/ElasticsearchPropertyAttributeBase.cs
@@ -32,8 +32,8 @@ namespace Nest
 		public static ElasticsearchPropertyAttributeBase From(MemberInfo memberInfo)
 		{
 			return memberInfo.GetCustomAttribute<ElasticsearchPropertyAttributeBase>(true);
-		}
+	}
 
-	    IDictionary<string, object> IPropertyWithLocalMetadata.LocalMetadata { get; set; }
+		IDictionary<string, object> IPropertyWithLocalMetadata.LocalMetadata { get; set; }
 	}
 }

--- a/src/Nest/Mapping/AttributeBased/ElasticsearchPropertyAttributeBase.cs
+++ b/src/Nest/Mapping/AttributeBased/ElasticsearchPropertyAttributeBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Elasticsearch.Net;
@@ -32,5 +33,7 @@ namespace Nest
 		{
 			return memberInfo.GetCustomAttribute<ElasticsearchPropertyAttributeBase>(true);
 		}
+
+	    IDictionary<string, object> IPropertyWithLocalMetadata.LocalMetadata { get; set; }
 	}
 }

--- a/src/Nest/Mapping/TypeMapping.cs
+++ b/src/Nest/Mapping/TypeMapping.cs
@@ -157,11 +157,11 @@ namespace Nest
 		/// <inheritdoc/>
 		public TypeMappingDescriptor<T> SizeField(Func<SizeFieldDescriptor, ISizeField> sizeFieldSelector) => Assign(a => a.SizeField = sizeFieldSelector?.Invoke(new SizeFieldDescriptor()));
 
-        /// <inheritdoc/>
-        public TypeMappingDescriptor<T> SourceField(Func<SourceFieldDescriptor, ISourceField> sourceFieldSelector) => Assign(a => a.SourceField = sourceFieldSelector?.Invoke(new SourceFieldDescriptor()));
+		/// <inheritdoc/>
+		public TypeMappingDescriptor<T> SourceField(Func<SourceFieldDescriptor, ISourceField> sourceFieldSelector) => Assign(a => a.SourceField = sourceFieldSelector?.Invoke(new SourceFieldDescriptor()));
 
-        /// <inheritdoc/>
-        public TypeMappingDescriptor<T> DisableSizeField(bool disabled = true) => Assign(a => a.SizeField = new SizeField { Enabled = !disabled });
+		/// <inheritdoc/>
+		public TypeMappingDescriptor<T> DisableSizeField(bool disabled = true) => Assign(a => a.SizeField = new SizeField { Enabled = !disabled });
 
 		/// <inheritdoc/>
 		public TypeMappingDescriptor<T> DisableIndexField(bool disabled = true) => Assign(a => a.IndexField = new IndexField { Enabled = !disabled });

--- a/src/Nest/Mapping/Types/PropertyBase.cs
+++ b/src/Nest/Mapping/Types/PropertyBase.cs
@@ -13,19 +13,19 @@ namespace Nest
 		[JsonProperty("type")]
 		TypeName Type { get; set; }
 
-        /// <summary>
-        /// Local property metadata that will NOT be stored in Elasticsearch with the mappings
-        /// </summary>
-        [JsonIgnore]
-        IDictionary<string, object> LocalMetadata { get; set; }
-    }
+		/// <summary>
+		/// Local property metadata that will NOT be stored in Elasticsearch with the mappings
+		/// </summary>
+		[JsonIgnore]
+		IDictionary<string, object> LocalMetadata { get; set; }
+	}
 
-    public interface IPropertyWithClrOrigin
+	public interface IPropertyWithClrOrigin
 	{
 		PropertyInfo ClrOrigin { get; set; }
 	}
 
-    public abstract class PropertyBase : IProperty, IPropertyWithClrOrigin
+	public abstract class PropertyBase : IProperty, IPropertyWithClrOrigin
 	{
 		protected PropertyBase(TypeName typeName)
 		{
@@ -36,9 +36,9 @@ namespace Nest
 		public virtual TypeName Type { get; set; }
 		PropertyInfo IPropertyWithClrOrigin.ClrOrigin { get; set; }
 
-        /// <summary>
-        /// Local property metadata that will NOT be stored in Elasticsearch with the mappings
-        /// </summary>
-        public IDictionary<string, object> LocalMetadata { get; set; }
-    }
+		/// <summary>
+		/// Local property metadata that will NOT be stored in Elasticsearch with the mappings
+		/// </summary>
+		public IDictionary<string, object> LocalMetadata { get; set; }
+	}
 }

--- a/src/Nest/Mapping/Types/PropertyBase.cs
+++ b/src/Nest/Mapping/Types/PropertyBase.cs
@@ -1,24 +1,30 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using Newtonsoft.Json;
 
 namespace Nest
 {
 	[JsonObject(MemberSerialization.OptIn)]
 	[ContractJsonConverter(typeof(PropertyJsonConverter))]
-	public interface IProperty : IFieldMapping
+	public interface IProperty : IFieldMapping, IPropertyWithLocalMetadata
 	{
 		PropertyName Name { get; set; }
 
 		[JsonProperty("type")]
 		TypeName Type { get; set; }
-	}
+    }
 
-	public interface IPropertyWithClrOrigin
+    public interface IPropertyWithClrOrigin
 	{
 		PropertyInfo ClrOrigin { get; set; }
 	}
 
-	public abstract class PropertyBase : IProperty, IPropertyWithClrOrigin
+    public interface IPropertyWithLocalMetadata {
+        [JsonIgnore]
+        IDictionary<string, object> LocalMetadata { get; set; }
+    }
+
+    public abstract class PropertyBase : IProperty, IPropertyWithClrOrigin
 	{
 		protected PropertyBase(TypeName typeName)
 		{
@@ -28,5 +34,6 @@ namespace Nest
 		public PropertyName Name { get; set; }
 		public virtual TypeName Type { get; set; }
 		PropertyInfo IPropertyWithClrOrigin.ClrOrigin { get; set; }
-	}
+        IDictionary<string, object> IPropertyWithLocalMetadata.LocalMetadata { get; set; }
+    }
 }

--- a/src/Nest/Mapping/Types/PropertyBase.cs
+++ b/src/Nest/Mapping/Types/PropertyBase.cs
@@ -6,23 +6,24 @@ namespace Nest
 {
 	[JsonObject(MemberSerialization.OptIn)]
 	[ContractJsonConverter(typeof(PropertyJsonConverter))]
-	public interface IProperty : IFieldMapping, IPropertyWithLocalMetadata
+	public interface IProperty : IFieldMapping
 	{
 		PropertyName Name { get; set; }
 
 		[JsonProperty("type")]
 		TypeName Type { get; set; }
+
+        /// <summary>
+        /// Local property metadata that will NOT be stored in Elasticsearch with the mappings
+        /// </summary>
+        [JsonIgnore]
+        IDictionary<string, object> LocalMetadata { get; set; }
     }
 
     public interface IPropertyWithClrOrigin
 	{
 		PropertyInfo ClrOrigin { get; set; }
 	}
-
-    public interface IPropertyWithLocalMetadata {
-        [JsonIgnore]
-        IDictionary<string, object> LocalMetadata { get; set; }
-    }
 
     public abstract class PropertyBase : IProperty, IPropertyWithClrOrigin
 	{
@@ -34,6 +35,10 @@ namespace Nest
 		public PropertyName Name { get; set; }
 		public virtual TypeName Type { get; set; }
 		PropertyInfo IPropertyWithClrOrigin.ClrOrigin { get; set; }
-        IDictionary<string, object> IPropertyWithLocalMetadata.LocalMetadata { get; set; }
+
+        /// <summary>
+        /// Local property metadata that will NOT be stored in Elasticsearch with the mappings
+        /// </summary>
+        public IDictionary<string, object> LocalMetadata { get; set; }
     }
 }

--- a/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
+++ b/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
@@ -19,9 +19,9 @@ namespace Nest
 
 		public TDescriptor Name(Expression<Func<T, object>> objectPath) => Assign(a => a.Name = objectPath);
 
-        /// <summary>
-        /// Local property metadata that will NOT be stored in Elasticsearch with the mappings
-        /// </summary>
-	    public IDictionary<string, object> LocalMetadata { get; set; }
+		/// <summary>
+		/// Local property metadata that will NOT be stored in Elasticsearch with the mappings
+		/// </summary>
+		public IDictionary<string, object> LocalMetadata { get; set; }
 	}
 }

--- a/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
+++ b/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
@@ -19,6 +19,9 @@ namespace Nest
 
 		public TDescriptor Name(Expression<Func<T, object>> objectPath) => Assign(a => a.Name = objectPath);
 
-	    IDictionary<string, object>  IPropertyWithLocalMetadata.LocalMetadata { get; set; }
+        /// <summary>
+        /// Local property metadata that will NOT be stored in Elasticsearch with the mappings
+        /// </summary>
+	    public IDictionary<string, object> LocalMetadata { get; set; }
 	}
 }

--- a/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
+++ b/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Nest
@@ -17,5 +18,7 @@ namespace Nest
 		public TDescriptor Name(PropertyName name) => Assign(a => a.Name = name);
 
 		public TDescriptor Name(Expression<Func<T, object>> objectPath) => Assign(a => a.Name = objectPath);
+
+	    IDictionary<string, object>  IPropertyWithLocalMetadata.LocalMetadata { get; set; }
 	}
 }

--- a/src/Nest/Mapping/Visitor/IMappingVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IMappingVisitor.cs
@@ -5,64 +5,64 @@ namespace Nest
 	public interface IMappingVisitor
 	{
 		int Depth { get; set; }
-		void Visit(TypeMapping mapping);
+		void Visit(ITypeMapping mapping);
 #pragma warning disable 618
-		void Visit(StringProperty property);
+		void Visit(IStringProperty property);
 #pragma warning restore 618
-		void Visit(TextProperty property);
-		void Visit(KeywordProperty property);
-		void Visit(DateProperty property);
-		void Visit(BooleanProperty property);
-		void Visit(BinaryProperty property);
-		void Visit(ObjectProperty property);
-		void Visit(NestedProperty property);
-		void Visit(IpProperty property);
-		void Visit(GeoPointProperty property);
-		void Visit(GeoShapeProperty property);
-		void Visit(AttachmentProperty property);
-		void Visit(NumberProperty property);
-		void Visit(CompletionProperty property);
-		void Visit(Murmur3HashProperty property);
-		void Visit(TokenCountProperty property);
+		void Visit(ITextProperty property);
+		void Visit(IKeywordProperty property);
+		void Visit(IDateProperty property);
+		void Visit(IBooleanProperty property);
+		void Visit(IBinaryProperty property);
+		void Visit(IObjectProperty property);
+		void Visit(INestedProperty property);
+		void Visit(IIpProperty property);
+		void Visit(IGeoPointProperty property);
+		void Visit(IGeoShapeProperty property);
+		void Visit(IAttachmentProperty property);
+		void Visit(INumberProperty property);
+		void Visit(ICompletionProperty property);
+		void Visit(IMurmur3HashProperty property);
+		void Visit(ITokenCountProperty property);
 	}
 
 	public class NoopMappingVisitor : IMappingVisitor
 	{
 		public virtual int Depth { get; set; }
 
-		public virtual void Visit(TypeMapping mapping) { }
+		public virtual void Visit(ITypeMapping mapping) { }
 
 #pragma warning disable 618
-		public virtual void Visit(StringProperty property ) { }
+		public virtual void Visit(IStringProperty property ) { }
 #pragma warning restore 618
-		public virtual void Visit(TextProperty property) { }
+		public virtual void Visit(ITextProperty property) { }
 
-		public virtual void Visit(KeywordProperty property) { }
+		public virtual void Visit(IKeywordProperty property) { }
 
-		public virtual void Visit(DateProperty property) { }
+		public virtual void Visit(IDateProperty property) { }
 
-		public virtual void Visit(BooleanProperty property) { }
+		public virtual void Visit(IBooleanProperty property) { }
 
-		public virtual void Visit(BinaryProperty property) { }
+		public virtual void Visit(IBinaryProperty property) { }
 
-		public virtual void Visit(NumberProperty property) { }
+		public virtual void Visit(INumberProperty property) { }
 
-		public virtual void Visit(ObjectProperty property) { }
+		public virtual void Visit(IObjectProperty property) { }
 
-		public virtual void Visit(NestedProperty property) { }
+		public virtual void Visit(INestedProperty property) { }
 
-		public virtual void Visit(IpProperty property) { }
+		public virtual void Visit(IIpProperty property) { }
 
-		public virtual void Visit(GeoPointProperty property) { }
+		public virtual void Visit(IGeoPointProperty property) { }
 
-		public virtual void Visit(GeoShapeProperty property) { }
+		public virtual void Visit(IGeoShapeProperty property) { }
 
-		public virtual void Visit(AttachmentProperty property) { }
+		public virtual void Visit(IAttachmentProperty property) { }
 
-		public virtual void Visit(CompletionProperty property) { }
+		public virtual void Visit(ICompletionProperty property) { }
 
-		public virtual void Visit(Murmur3HashProperty property) { }
+		public virtual void Visit(IMurmur3HashProperty property) { }
 
-		public virtual void Visit(TokenCountProperty property) { }
+		public virtual void Visit(ITokenCountProperty property) { }
 	}
 }

--- a/src/Nest/Mapping/Visitor/MappingWalker.cs
+++ b/src/Nest/Mapping/Visitor/MappingWalker.cs
@@ -23,7 +23,7 @@ namespace Nest
 			}
 		}
 
-		public void Accept(TypeMapping mapping)
+		public void Accept(ITypeMapping mapping)
 		{
 			if (mapping == null) return;
 			this._visitor.Visit(mapping);
@@ -41,20 +41,20 @@ namespace Nest
 				switch (type.Name)
 				{
 					case "text":
-						var t = field as TextProperty;
+						var t = field as ITextProperty;
 						if (t == null) continue;
 						this._visitor.Visit(t);
 						this.Accept(t.Fields);
 						break;
 					case "keyword":
-						var k = field as KeywordProperty;
+						var k = field as IKeywordProperty;
 						if (k == null) continue;
 						this._visitor.Visit(k);
 						this.Accept(k.Fields);
 						break;
 					case "string":
 #pragma warning disable 618
-						var s = field as StringProperty;
+						var s = field as IStringProperty;
 #pragma warning restore 618
 						if (s == null) continue;
 						this._visitor.Visit(s);
@@ -66,31 +66,31 @@ namespace Nest
 					case "short":
 					case "integer":
 					case "long":
-						var nu = field as NumberProperty;
+						var nu = field as INumberProperty;
 						if (nu == null) continue;
 						this._visitor.Visit(nu);
 						this.Accept(nu.Fields);
 						break;
 					case "date":
-						var d = field as DateProperty;
+						var d = field as IDateProperty;
 						if (d == null) continue;
 						this._visitor.Visit(d);
 						this.Accept(d.Fields);
 						break;
 					case "boolean":
-						var bo = field as BooleanProperty;
+						var bo = field as IBooleanProperty;
 						if (bo == null) continue;
 						this._visitor.Visit(bo);
 						this.Accept(bo.Fields);
 						break;
 					case "binary":
-						var bi = field as BinaryProperty;
+						var bi = field as IBinaryProperty;
 						if (bi == null) continue;
 						this._visitor.Visit(bi);
 						this.Accept(bi.Fields);
 						break;
 					case "object":
-						var o = field as ObjectProperty;
+						var o = field as IObjectProperty;
 						if (o == null) continue;
 						this._visitor.Visit(o);
 						this._visitor.Depth += 1;
@@ -98,7 +98,7 @@ namespace Nest
 						this._visitor.Depth -= 1;
 						break;
 					case "nested":
-						var n = field as NestedProperty;
+						var n = field as INestedProperty;
 						if (n == null) continue;
 						this._visitor.Visit(n);
 						this._visitor.Depth += 1;
@@ -106,43 +106,43 @@ namespace Nest
 						this._visitor.Depth -= 1;
 						break;
 					case "ip":
-						var i = field as IpProperty;
+						var i = field as IIpProperty;
 						if (i == null) continue;
 						this._visitor.Visit(i);
 						this.Accept(i.Fields);
 						break;
 					case "geo_point":
-						var gp = field as GeoPointProperty;
+						var gp = field as IGeoPointProperty;
 						if (gp == null) continue;
 						this._visitor.Visit(gp);
 						this.Accept(gp.Fields);
 						break;
 					case "geo_shape":
-						var gs = field as GeoShapeProperty;
+						var gs = field as IGeoShapeProperty;
 						if (gs == null) continue;
 						this._visitor.Visit(gs);
 						this.Accept(gs.Fields);
 						break;
 					case "attachment":
-						var a = field as AttachmentProperty;
+						var a = field as IAttachmentProperty;
 						if (a == null) continue;
 						this._visitor.Visit(a);
 						this.Accept(a.Fields);
 						break;
 					case "completion":
-						var c = field as CompletionProperty;
+						var c = field as ICompletionProperty;
 						if (c == null) continue;
 						this._visitor.Visit(c);
 						this.Accept(c.Fields);
 						break;
 					case "murmur3":
-						var mm = field as Murmur3HashProperty;
+						var mm = field as IMurmur3HashProperty;
 						if (mm == null) continue;
 						this._visitor.Visit(mm);
 						this.Accept(mm.Fields);
 						break;
 					case "token_count":
-						var tc = field as TokenCountProperty;
+						var tc = field as ITokenCountProperty;
 						if (tc == null) continue;
 						this._visitor.Visit(tc);
 						this.Accept(tc.Fields);

--- a/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -117,87 +117,87 @@ namespace Tests.Indices.MappingManagement.GetMapping
 		}
 
 #pragma warning disable 618
-		public void Visit(StringProperty mapping)
+		public void Visit(IStringProperty mapping)
 		{
 			Increment("string");
 		}
 #pragma warning restore 618
-		public void Visit(DateProperty mapping)
+		public void Visit(IDateProperty mapping)
 		{
 			Increment("date");
 		}
 
-		public void Visit(BinaryProperty mapping)
+		public void Visit(IBinaryProperty mapping)
 		{
 			Increment("binary");
 		}
 
-		public void Visit(NestedProperty mapping)
+		public void Visit(INestedProperty mapping)
 		{
 			Increment("nested");
 		}
 
-		public void Visit(GeoPointProperty mapping)
+		public void Visit(IGeoPointProperty mapping)
 		{
 			Increment("geo_point");
 		}
 
-		public void Visit(AttachmentProperty mapping)
+		public void Visit(IAttachmentProperty mapping)
 		{
 			Increment("attachment");
 		}
 
-		public void Visit(CompletionProperty mapping)
+		public void Visit(ICompletionProperty mapping)
 		{
 			Increment("completion");
 		}
 
-		public void Visit(TokenCountProperty mapping)
+		public void Visit(ITokenCountProperty mapping)
 		{
 			Increment("token_count");
 		}
 
-		public void Visit(Murmur3HashProperty mapping)
+		public void Visit(IMurmur3HashProperty mapping)
 		{
 			Increment("murmur3");
 		}
 
-		public void Visit(NumberProperty mapping)
+		public void Visit(INumberProperty mapping)
 		{
 			Increment("number");
 		}
 
-		public void Visit(GeoShapeProperty mapping)
+		public void Visit(IGeoShapeProperty mapping)
 		{
 			Increment("geo_shape");
 		}
 
-		public void Visit(IpProperty mapping)
+		public void Visit(IIpProperty mapping)
 		{
 			Increment("ip");
 		}
 
-		public void Visit(ObjectProperty mapping)
+		public void Visit(IObjectProperty mapping)
 		{
 			Increment("object");
 		}
 
-		public void Visit(BooleanProperty mapping)
+		public void Visit(IBooleanProperty mapping)
 		{
 			Increment("boolean");
 		}
 
-		public void Visit(TextProperty mapping)
+		public void Visit(ITextProperty mapping)
 		{
 			Increment("text");
 		}
 
-		public void Visit(KeywordProperty mapping)
+		public void Visit(IKeywordProperty mapping)
 		{
 			Increment("keyword");
 		}
 
-		public void Visit(TypeMapping mapping)
+		public void Visit(ITypeMapping mapping)
 		{
 			Increment("type");
 		}

--- a/src/Tests/Mapping/Metafields/LocalMetadataTests.cs
+++ b/src/Tests/Mapping/Metafields/LocalMetadataTests.cs
@@ -32,15 +32,15 @@ namespace Tests.Mapping.Metafields
         public static TDescriptor AddTestLocalMetadata<TDescriptor>(this TDescriptor descriptor)
                 where TDescriptor : IDescriptor
         {
-            var descriptorWithLocalMetadata = descriptor as IPropertyWithLocalMetadata;
+            var propertyDescriptor = descriptor as IProperty;
 
-            if (descriptorWithLocalMetadata == null)
+            if (propertyDescriptor == null)
                 return descriptor;
 
-            if (descriptorWithLocalMetadata.LocalMetadata == null)
-                descriptorWithLocalMetadata.LocalMetadata = new Dictionary<string, object>();
+            if (propertyDescriptor.LocalMetadata == null)
+                propertyDescriptor.LocalMetadata = new Dictionary<string, object>();
 
-            descriptorWithLocalMetadata.LocalMetadata.Add("Test", "TestValue");
+            propertyDescriptor.LocalMetadata.Add("Test", "TestValue");
 
             return descriptor;
         }
@@ -52,13 +52,12 @@ namespace Tests.Mapping.Metafields
 
         public override void Visit(ITextProperty property)
         {
-            var propertyWithLocalMetadata = property as IPropertyWithLocalMetadata;
-            propertyWithLocalMetadata.Should().NotBeNull();
-            propertyWithLocalMetadata.LocalMetadata.Should().NotBeNull();
+            property.Should().NotBeNull();
+            property.LocalMetadata.Should().NotBeNull();
 
-            MetadataCount += propertyWithLocalMetadata.LocalMetadata.Count;
+            MetadataCount += property.LocalMetadata.Count;
 
-            propertyWithLocalMetadata.LocalMetadata.Should().Contain("Test", "TestValue");
+            property.LocalMetadata.Should().Contain("Test", "TestValue");
         }
     }
 }

--- a/src/Tests/Mapping/Metafields/LocalMetadataTests.cs
+++ b/src/Tests/Mapping/Metafields/LocalMetadataTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Nest;
+using Tests.Mapping.Types.Core.Text;
+using Xunit;
+
+namespace Tests.Mapping.Metafields
+{
+    public class LocalMetadataTests
+    {
+        [Fact]
+        public void CanAssignAndAccessLocalMetadata()
+        {
+            var descriptor = new TypeMappingDescriptor<TextTest>().Properties(p => p
+                .Text(t => t
+                    .Name(o => o.Full)
+                    .Norms()
+                    .AddTestLocalMetadata()
+                )) as ITypeMapping;
+
+            var visitor = new LocalMatadataVisitor();
+            var walker = new MappingWalker(visitor);
+            walker.Accept(descriptor.Properties);
+
+            visitor.MetadataCount.Should().Be(1);
+        }
+    }
+
+    public static class TestLocalMetadataMappingExtensions
+    {
+        public static TDescriptor AddTestLocalMetadata<TDescriptor>(this TDescriptor descriptor)
+                where TDescriptor : IDescriptor
+        {
+            var descriptorWithLocalMetadata = descriptor as IPropertyWithLocalMetadata;
+
+            if (descriptorWithLocalMetadata == null)
+                return descriptor;
+
+            if (descriptorWithLocalMetadata.LocalMetadata == null)
+                descriptorWithLocalMetadata.LocalMetadata = new Dictionary<string, object>();
+
+            descriptorWithLocalMetadata.LocalMetadata.Add("Test", "TestValue");
+
+            return descriptor;
+        }
+    }
+
+    public class LocalMatadataVisitor : NoopMappingVisitor
+    {
+        public int MetadataCount { get; set; }
+
+        public override void Visit(ITextProperty property)
+        {
+            var propertyWithLocalMetadata = property as IPropertyWithLocalMetadata;
+            propertyWithLocalMetadata.Should().NotBeNull();
+            propertyWithLocalMetadata.LocalMetadata.Should().NotBeNull();
+
+            MetadataCount += propertyWithLocalMetadata.LocalMetadata.Count;
+
+            propertyWithLocalMetadata.LocalMetadata.Should().Contain("Test", "TestValue");
+        }
+    }
+}

--- a/src/Tests/Mapping/Metafields/LocalMetadataTests.cs
+++ b/src/Tests/Mapping/Metafields/LocalMetadataTests.cs
@@ -8,56 +8,56 @@ using Xunit;
 namespace Tests.Mapping.Metafields
 {
     public class LocalMetadataTests
-    {
-        [Fact]
-        public void CanAssignAndAccessLocalMetadata()
-        {
-            var descriptor = new TypeMappingDescriptor<TextTest>().Properties(p => p
-                .Text(t => t
-                    .Name(o => o.Full)
-                    .Norms()
-                    .AddTestLocalMetadata()
-                )) as ITypeMapping;
+	{
+		[Fact]
+		public void CanAssignAndAccessLocalMetadata()
+		{
+			var descriptor = new TypeMappingDescriptor<TextTest>().Properties(p => p
+				.Text(t => t
+					.Name(o => o.Full)
+					.Norms()
+					.AddTestLocalMetadata()
+				)) as ITypeMapping;
 
-            var visitor = new LocalMatadataVisitor();
-            var walker = new MappingWalker(visitor);
-            walker.Accept(descriptor.Properties);
+			var visitor = new LocalMatadataVisitor();
+			var walker = new MappingWalker(visitor);
+			walker.Accept(descriptor.Properties);
 
-            visitor.MetadataCount.Should().Be(1);
-        }
-    }
+			visitor.MetadataCount.Should().Be(1);
+		}
+	}
 
-    public static class TestLocalMetadataMappingExtensions
-    {
-        public static TDescriptor AddTestLocalMetadata<TDescriptor>(this TDescriptor descriptor)
-                where TDescriptor : IDescriptor
-        {
-            var propertyDescriptor = descriptor as IProperty;
+	public static class TestLocalMetadataMappingExtensions
+	{
+		public static TDescriptor AddTestLocalMetadata<TDescriptor>(this TDescriptor descriptor)
+				where TDescriptor : IDescriptor
+		{
+			var propertyDescriptor = descriptor as IProperty;
 
-            if (propertyDescriptor == null)
-                return descriptor;
+			if (propertyDescriptor == null)
+				return descriptor;
 
-            if (propertyDescriptor.LocalMetadata == null)
-                propertyDescriptor.LocalMetadata = new Dictionary<string, object>();
+			if (propertyDescriptor.LocalMetadata == null)
+				propertyDescriptor.LocalMetadata = new Dictionary<string, object>();
 
-            propertyDescriptor.LocalMetadata.Add("Test", "TestValue");
+			propertyDescriptor.LocalMetadata.Add("Test", "TestValue");
 
-            return descriptor;
-        }
-    }
+			return descriptor;
+		}
+	}
 
-    public class LocalMatadataVisitor : NoopMappingVisitor
-    {
-        public int MetadataCount { get; set; }
+	public class LocalMatadataVisitor : NoopMappingVisitor
+	{
+		public int MetadataCount { get; set; }
 
-        public override void Visit(ITextProperty property)
-        {
-            property.Should().NotBeNull();
-            property.LocalMetadata.Should().NotBeNull();
+		public override void Visit(ITextProperty property)
+		{
+			property.Should().NotBeNull();
+			property.LocalMetadata.Should().NotBeNull();
 
-            MetadataCount += property.LocalMetadata.Count;
+			MetadataCount += property.LocalMetadata.Count;
 
-            property.LocalMetadata.Should().Contain("Test", "TestValue");
-        }
-    }
+			property.LocalMetadata.Should().Contain("Test", "TestValue");
+		}
+	}
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -391,6 +391,7 @@
     <Compile Include="Ingest\PutPipeline\PutPipelineUrlTests.cs" />
     <Compile Include="Ingest\SimulatePipeline\SimulatePipelineApiTests.cs" />
     <Compile Include="Ingest\SimulatePipeline\SimulatePipelineUrlTests.cs" />
+    <Compile Include="Mapping\Metafields\LocalMetadataTests.cs" />
     <Compile Include="Mapping\Types\Core\Keyword\KeywordMappingTests.cs" />
     <Compile Include="Mapping\Types\Core\Percolator\PercolatorMappingTests.cs" />
     <Compile Include="Mapping\Types\Core\Text\TextMappingTests.cs" />


### PR DESCRIPTION
Initial pull request for adding support for local metadata to properties. I had to change the IMappingVisitor to use the property interfaces since it was taking the concrete classes and the mapping descriptors would not work with this. That doesn't seem to break anything and seems to just make the visitor support more scenarios, but I also realize that it's a breaking change that you might not want to take on and we could easily create our own visitor.