### PR TITLE
Fix #2319 caching of constant Field expressions

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -38,7 +38,7 @@ namespace Nest
 				var comparisonValue = value.ComparisonValueFromExpression(out type);
 				_type = type;
 				SetComparisonValue(comparisonValue);
-				CacheableExpression = !new HasConstantExpressionVisitor(value).Found;
+				CacheableExpression = !new HasVariableExpressionVisitor(value).Found;
 			}
 		}
 

--- a/src/Nest/CommonAbstractions/Infer/Field/FieldExpressionVisitor.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/FieldExpressionVisitor.cs
@@ -12,18 +12,24 @@ using System.Threading.Tasks;
 
 namespace Nest
 {
-	internal class HasConstantExpressionVisitor : ExpressionVisitor
+	internal class HasVariableExpressionVisitor : ExpressionVisitor
 	{
-		public bool Found { get; private set; }
+		private bool _found;
+		public bool Found
+		{
+			get { return _found; }
+			// This is only set to true once to prevent clobbering from subsequent node visits
+			private set { if (!_found) _found = value; }
+		}
 
-		public HasConstantExpressionVisitor(Expression e)
+		public HasVariableExpressionVisitor(Expression e)
 		{
 			this.Visit(e);
 		}
 
 		public override Expression Visit(Expression node)
 		{
-			if (!Found)
+			if (!this.Found)
 				return base.Visit(node);
 			return node;
 		}
@@ -35,7 +41,6 @@ namespace Nest
 				var lastArg = node.Arguments.Last();
 				var constantExpression = lastArg as ConstantExpression;
 				this.Found = constantExpression == null;
-				return node;
 			}
 			else if (node.Method.Name == "get_Item" && node.Arguments.Any())
 			{
@@ -50,15 +55,8 @@ namespace Nest
 				var lastArg = node.Arguments.Last();
 				var constantExpression = lastArg as ConstantExpression;
 				this.Found = constantExpression == null;
-				return node;
 			}
 			return base.VisitMethodCall(node);
-		}
-
-		protected override Expression VisitConstant(ConstantExpression node)
-		{
-			this.Found = true;
-			return node;
 		}
 	}
 

--- a/src/Nest/CommonAbstractions/Infer/PropertyName/PropertyName.cs
+++ b/src/Nest/CommonAbstractions/Infer/PropertyName/PropertyName.cs
@@ -35,7 +35,7 @@ namespace Nest
 			return new PropertyName
 			{
 				Expression = expression,
-				CacheableExpression = !new HasConstantExpressionVisitor(expression).Found,
+				CacheableExpression = !new HasVariableExpressionVisitor(expression).Found,
 				_comparisonValue = expression.ComparisonValueFromExpression(out type),
 				_type = type
 			};

--- a/src/Tests/ClientConcepts/HighLevel/Caching/FieldResolverCacheTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Caching/FieldResolverCacheTests.cs
@@ -147,11 +147,11 @@ namespace Tests.ClientConcepts.HighLevel.Caching
 				var suffix = "raw";
 				var resolver = new TestableFieldResolver(new ConnectionSettings());
 				var resolved = resolver.Resolve(Field<Project>(p => p.Name.Suffix(suffix)));
-				resolved.Should().EndWith("raw");
+				resolved.Should().Be("name.raw");
 				resolver.CachedFields.Should().Be(0);
 				suffix = "foo";
 				resolved = resolver.Resolve(Field<Project>(p => p.Name.Suffix(suffix)));
-				resolved.Should().EndWith("foo");
+				resolved.Should().Be("name.foo");
 				resolver.CachedFields.Should().Be(0);
 			}
 
@@ -169,15 +169,75 @@ namespace Tests.ClientConcepts.HighLevel.Caching
 				resolved.Should().Contain(key);
 			}
 
+			[U]
+			public void ExpressionWithDictionaryItemVariableExpressionAndVariableSuffix()
+			{
+				var resolver = new TestableFieldResolver(new ConnectionSettings());
+				var key = "key1";
+				var suffix = "x";
+				var resolved = resolver.Resolve(Field<Project>(p => p.Metadata[key].Suffix(suffix)));
+				resolver.CachedFields.Should().Be(0);
+				resolved.Should().Be($"metadata.{key}.x");
+				key = "key2";
+				suffix = "y";
+				resolved = resolver.Resolve(Field<Project>(p => p.Metadata[key].Suffix(suffix)));
+				resolver.CachedFields.Should().Be(0);
+				resolved.Should().Be($"metadata.{key}.y");
+			}
+
+			[U]
+			public void ExpressionWithDictionaryItemVariableExpressionAndEquivalentVariableSuffix()
+			{
+				var resolver = new TestableFieldResolver(new ConnectionSettings());
+				var key = "key1";
+				var suffix = "x";
+				var resolved = resolver.Resolve(Field<Project>(p => p.Metadata[key].Suffix(suffix)));
+				resolver.CachedFields.Should().Be(0);
+				resolved.Should().Be($"metadata.{key}.x");
+				key = "key2";
+				resolved = resolver.Resolve(Field<Project>(p => p.Metadata[key].Suffix(suffix)));
+				resolver.CachedFields.Should().Be(0);
+				resolved.Should().Be($"metadata.{key}.x");
+			}
+
+			[U]
+			public void ExpressionWithDictionaryItemVariableExpressionAndConstantSuffix()
+			{
+				var resolver = new TestableFieldResolver(new ConnectionSettings());
+				var key = "key1";
+				var resolved = resolver.Resolve(Field<Project>(p => p.Metadata[key].Suffix("x")));
+				resolver.CachedFields.Should().Be(0);
+				resolved.Should().Be($"metadata.{key}.x");
+				key = "key2";
+				resolved = resolver.Resolve(Field<Project>(p => p.Metadata[key].Suffix("y")));
+				resolver.CachedFields.Should().Be(0);
+				resolved.Should().Be($"metadata.{key}.y");
+			}
+
+			[U]
+			public void ExpressionWithDictionaryItemVariableExpressionAndEquivalentConstantSuffix()
+			{
+				var resolver = new TestableFieldResolver(new ConnectionSettings());
+				var key = "key1";
+				var resolved = resolver.Resolve(Field<Project>(p => p.Metadata[key].Suffix("x")));
+				resolver.CachedFields.Should().Be(0);
+				resolved.Should().Be($"metadata.{key}.x");
+				key = "key2";
+				resolved = resolver.Resolve(Field<Project>(p => p.Metadata[key].Suffix("x")));
+				resolver.CachedFields.Should().Be(0);
+				resolved.Should().Be($"metadata.{key}.x");
+			}
+
+
 			[U] public void ExpressionWithDictionaryItemConstantExpression()
 			{
 				var resolver = new TestableFieldResolver(new ConnectionSettings());
 				var resolved = resolver.Resolve(Field<Project>(p => p.Metadata["key1"]));
 				resolver.CachedFields.Should().Be(1);
-				resolved.Should().Contain("key1");
+				resolved.Should().Be("metadata.key1");
 				resolved = resolver.Resolve(Field<Project>(p => p.Metadata["key2"]));
 				resolver.CachedFields.Should().Be(2);
-				resolved.Should().Contain("key2");
+				resolved.Should().Be("metadata.key2");
 			}
 
 			[U] public void ExpressionWithDictionaryItemConstantExpressionAndVariableSuffix()
@@ -186,11 +246,23 @@ namespace Tests.ClientConcepts.HighLevel.Caching
 				var suffix = "x";
 				var resolved = resolver.Resolve(Field<Project>(p => p.Metadata["key1"].Suffix(suffix)));
 				resolver.CachedFields.Should().Be(0);
-				resolved.Should().Contain("key1").And.EndWith(".x");
+				resolved.Should().Be("metadata.key1.x");
 				suffix = "y";
 				resolved = resolver.Resolve(Field<Project>(p => p.Metadata["key2"].Suffix(suffix)));
 				resolver.CachedFields.Should().Be(0);
-				resolved.Should().Contain("key2").And.EndWith(".y");
+				resolved.Should().Be("metadata.key2.y");
+			}
+
+			[U]
+			public void ExpressionWithDictionaryItemConstantExpressionAndConstantSuffix()
+			{
+				var resolver = new TestableFieldResolver(new ConnectionSettings());
+				var resolved = resolver.Resolve(Field<Project>(p => p.Metadata["key1"].Suffix("x")));
+				resolver.CachedFields.Should().Be(1);
+				resolved.Should().Be("metadata.key1.x");
+				resolved = resolver.Resolve(Field<Project>(p => p.Metadata["key2"].Suffix("y")));
+				resolver.CachedFields.Should().Be(2);
+				resolved.Should().Be("metadata.key2.y");
 			}
 
 			[U]


### PR DESCRIPTION
We only cache Field expressions that do not contain variables.  For
instance:

```csharp
  Field<Project>(p => p.Name)
  Field<Project>(p => p.Name.Suffix("foo"))
  Field<Project>(p => p.Metadata["foo"])
```
are all cachable since they only contain constant expressions.

whereas

```csharp
  Field<Project>(p => p.Name.Suffix(myVariable))
  Field<Project>(p => p.Metadata[myVariable])
```
are not cachable since we can't evaluate the value of `myVariable` to be
used as a cache key.

However, there was a bug which this commit fixes where we would cache a
variable expression that ended with a constant.  For instance:

```csharp
  Field<Project>(p => p.Metadata[myVariable].Suffix("foo"))
```
This expression was incorrectly cached because HasConstantExpressionVisitor
only concerned itself with the last method call: `Suffix("foo")`.

With this change, `HasConstantExpressionVisitor` has been renamed to
`HasVariableExpressionVisitor` to better align with what it actually
does.  And now accounts for every node in the expression, ensuring that
we only cache expressions that contain only constants.