### PR TITLE
Adding a new field to deserialize took as long, and marking the old o…

### DIFF
--- a/src/Nest/Document/Multiple/Bulk/BulkResponse.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkResponse.cs
@@ -2,12 +2,16 @@
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
+using System;
 
 namespace Nest
 {
 	public interface IBulkResponse : IResponse
 	{
+		[Obsolete(@"Took field is an Int but the value in the response can exced the max value for Int.
+					If you use this field instead of TookAsLong the value can wrap around if it is too big.")]
 		int Took { get; }
+		long TookAsLong { get; }
 		bool Errors { get; }
 		IEnumerable<BulkResponseItemBase> Items { get; }
 		IEnumerable<BulkResponseItemBase> ItemsWithErrors { get; }
@@ -26,7 +30,21 @@ namespace Nest
 		}
 
 		[JsonProperty("took")]
-		public int Took { get; internal set; }
+		public long TookAsLong { get;  internal set;}
+
+		[Obsolete(@"Took field is an Int but the value in the response can exced the max value for Int.
+					If you use this field instead of TookAsLong the value can wrap around if it is too big.")]
+		public int Took
+		{
+			get
+			{
+				return unchecked((int)TookAsLong);
+			}
+			internal set
+			{
+				TookAsLong = value;
+			}
+		}
 
 		[JsonProperty("errors")]
 		public bool Errors { get; internal set; }

--- a/src/Nest/Document/Single/TermVectors/TermVectorsResponse.cs
+++ b/src/Nest/Document/Single/TermVectors/TermVectorsResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using System;
 
 namespace Nest
 {
@@ -10,7 +11,10 @@ namespace Nest
 		string Id { get; }
 		long Version { get; }
 		bool Found { get; }
+		[Obsolete(@"Took field is an Int but the value in the response can exced the max value for Int.
+					If you use this field instead of TookAsLong the value can wrap around if it is too big.")]
 		int Took { get; }
+		long TookAsLong { get; }
 		IDictionary<string, TermVector> TermVectors { get; }
 	}
 
@@ -33,7 +37,21 @@ namespace Nest
 		public bool Found { get; internal set; }
 
 		[JsonProperty(PropertyName = "took")]
-		public int Took { get; internal set; }
+		public long TookAsLong { get; internal set; }
+
+		[Obsolete(@"Took field is an Int but the value in the response can exced the max value for Int.
+					If you use this field instead of TookAsLong the value can wrap around if it is too big.")]
+		public int Took
+		{
+			get
+			{
+				return unchecked((int)TookAsLong);
+			}
+			internal set
+			{
+				TookAsLong = value;
+			}
+		}
 
 		[JsonProperty("term_vectors")]
 		public IDictionary<string, TermVector> TermVectors { get; internal set; } =  new Dictionary<string, TermVector>();

--- a/src/Nest/Search/Percolator/Percolate/PercolateResponse.cs
+++ b/src/Nest/Search/Percolator/Percolate/PercolateResponse.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
+using System;
 
 namespace Nest
 {
 	public interface IPercolateCountResponse : IResponse
 	{
+		[Obsolete(@"Took field is an Int but the value in the response can exced the max value for Int.
+					If you use this field instead of TookAsLong the value can wrap around if it is too big.")]
 		int Took { get; }
+		long TookAsLong { get; }
 		long Total { get; }
 	}
 
@@ -18,15 +22,29 @@ namespace Nest
 	[JsonObject]
 	public class PercolateCountResponse : ResponseBase, IPercolateCountResponse
 	{
-		[JsonProperty(PropertyName = "took")]
-		public int Took { get; internal set; }
+		[JsonProperty("took")]
+		public long TookAsLong { get; internal set; }
+
+		[Obsolete(@"Took field is an Int but the value in the response can exced the max value for Int.
+					If you use this field instead of TookAsLong the value can wrap around if it is too big.")]
+		public int Took
+		{
+			get
+			{
+				return unchecked((int)TookAsLong);
+			}
+			internal set
+			{
+				TookAsLong = value;
+			}
+		}
 
 		[JsonProperty(PropertyName = "total")]
 		public long Total { get; internal set; }
-		
+
 		[JsonProperty(PropertyName = "_shards")]
 		public ShardsMetaData Shards { get; internal set; }
-		
+
 		/// <summary>
 		/// The individual error for separate requests on the _mpercolate API
 		/// </summary>

--- a/src/Nest/Search/Search/SearchResponse.cs
+++ b/src/Nest/Search/Search/SearchResponse.cs
@@ -14,7 +14,11 @@ namespace Nest
 		Profile Profile { get; }
 		AggregationsHelper Aggs { get; }
 		IDictionary<string, Suggest[]> Suggest { get; }
+
+		[Obsolete(@"Took field is an Int but the value in the response can exced the max value for Int.
+					If you use this field instead of TookAsLong the value can wrap around if it is too big.")]
 		int Took { get; }
+		long TookAsLong { get; }
 		bool TimedOut { get; }
 		bool TerminatedEarly { get; }
 		string ScrollId { get; }
@@ -64,8 +68,22 @@ namespace Nest
 		[JsonProperty(PropertyName = "suggest")]
 		public IDictionary<string, Suggest[]> Suggest { get; internal set; }
 
-		[JsonProperty(PropertyName = "took")]
-		public int Took { get; internal set; }
+		[JsonProperty("took")]
+		public long TookAsLong { get; internal set; }
+
+		[Obsolete(@"Took field is an Int but the value in the response can exced the max value for Int.
+					If you use this field instead of TookAsLong the value can wrap around if it is too big.")]
+		public int Took
+		{
+			get
+			{
+				return unchecked((int)TookAsLong);
+			}
+			internal set
+			{
+				TookAsLong = value;
+			}
+		}
 
 		[JsonProperty("timed_out")]
 		public bool TimedOut { get; internal set; }


### PR DESCRIPTION
…ne as obsolete.

This is the second part of the changes discussed on #2317 (or at least a first try). 

Two things:
- I´m not very happy with the 'TookAsLong' name, but cannot find a better one, so suggestion are much appreciated.
- As the Took field is now marked as obsolete in those responses, there are some warnings in the tests. I have to use the new field, right?

/cc @gmarz 
