### PR TITLE
Include ignore_above in string keyword mapping inference

### DIFF
--- a/src/Nest/Mapping/Types/Core/String/StringAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/String/StringAttribute.cs
@@ -32,6 +32,7 @@ namespace Nest
 		public TermVectorOption TermVector { get { return Self.TermVector.GetValueOrDefault(); } set { Self.TermVector = value; } }
 		public bool Norms { get { return Self.Norms.GetValueOrDefault(true); } set { Self.Norms = value; } }
 
+		[Obsolete("Only valid for indices created before Elasticsearch 5.0 and will be removed in the next major version.  For newly created indices, use Text or Keyword attribute instead.")]
 		public StringAttribute() : base("string") { }
 	}
 }

--- a/src/Nest/Mapping/Visitor/PropertyWalker.cs
+++ b/src/Nest/Mapping/Visitor/PropertyWalker.cs
@@ -91,7 +91,11 @@ namespace Nest
 				{
 					Fields = new Properties
 					{
-						{ "keyword", new KeywordProperty() }
+						{ "keyword", new KeywordProperty
+							{
+								IgnoreAbove = 256
+							}
+						}
 					}
 				};
 

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
@@ -171,7 +171,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 										{
 											keyword = new
 											{
-												type = "keyword"
+												type = "keyword",
+												ignore_above = 256
 											}
 										},
 										type = "text"
@@ -190,7 +191,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 										{
 											keyword = new
 											{
-												type = "keyword"
+												type = "keyword",
+												ignore_above = 256
 											}
 										},
 										type = "text"
@@ -208,7 +210,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 								{
 									keyword = new
 									{
-										type = "keyword"
+										type = "keyword",
+										ignore_above = 256
 									}
 								},
 								type = "text"
@@ -234,7 +237,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 								{
 									keyword = new
 									{
-										type = "keyword"
+										type = "keyword",
+										ignore_above = 256
 									}
 								},
 								type = "text"
@@ -253,7 +257,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 								{
 									keyword = new
 									{
-										type = "keyword"
+										type = "keyword",
+										ignore_above = 256
 									}
 								},
 								type = "text"
@@ -312,7 +317,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 								{
 									keyword = new
 									{
-										type = "keyword"
+										type = "keyword",
+										ignore_above = 256
 									}
 								}
 							},
@@ -426,7 +432,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 										{
 											keyword = new
 											{
-												type = "keyword"
+												type = "keyword",
+												ignore_above = 256
 											}
 										},
 										type = "text"
@@ -445,7 +452,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 										{
 											keyword = new
 											{
-												type = "keyword"
+												type = "keyword",
+												ignore_above = 256
 											}
 										},
 										type = "text"
@@ -498,7 +506,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 										{
 											keyword = new
 											{
-												type = "keyword"
+												type = "keyword",
+												ignore_above = 256
 											}
 										},
 										type = "text"
@@ -517,7 +526,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 										{
 											keyword = new
 											{
-												type = "keyword"
+												type = "keyword",
+												ignore_above = 256
 											}
 										},
 										type = "text"
@@ -657,7 +667,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 										{
 											keyword = new
 											{
-												type = "keyword"
+												type = "keyword",
+												ignore_above = 256
 											}
 										},
 										type = "text"
@@ -676,7 +687,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 										{
 											keyword = new
 											{
-												type = "keyword"
+												type = "keyword",
+												ignore_above = 256
 											}
 										},
 										type = "text"
@@ -780,7 +792,8 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 								{
 									keyword = new
 									{
-										type = "keyword"
+										type = "keyword",
+										ignore_above = 256
 									}
 								}
 							}

--- a/src/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
+++ b/src/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
@@ -37,7 +37,8 @@ namespace Tests.Indices.MappingManagement.PutMapping
 					{
 						keyword = new
 						{
-							type = "keyword"
+							type = "keyword",
+							ignore_above = 256
 						}
 					},
 					type = "text"
@@ -224,7 +225,11 @@ namespace Tests.Indices.MappingManagement.PutMapping
 						{
 							Fields = new Properties
 							{
-								{ "keyword", new KeywordProperty() }
+								{ "keyword", new KeywordProperty
+									{
+										IgnoreAbove = 256
+									}
+								}
 							}
 						}
 				},

--- a/src/Tests/Mapping/Types/Complex/Nested/NestedAttributeTests.cs
+++ b/src/Tests/Mapping/Types/Complex/Nested/NestedAttributeTests.cs
@@ -43,7 +43,8 @@ namespace Tests.Mapping.Types.Complex.Nested
 							{
 								keyword = new
 								{
-									type = "keyword"
+									type = "keyword",
+									ignore_above = 256
 								}
 							}
 						}
@@ -61,7 +62,8 @@ namespace Tests.Mapping.Types.Complex.Nested
 							{
 								keyword = new
 								{
-									type = "keyword"
+									type = "keyword",
+									ignore_above = 256
 								}
 							}
 						}

--- a/src/Tests/Mapping/Types/Complex/Object/ObjectAttributeTests.cs
+++ b/src/Tests/Mapping/Types/Complex/Object/ObjectAttributeTests.cs
@@ -39,7 +39,8 @@ namespace Tests.Mapping.Types.Complex.Object
 							{
 								keyword = new
 								{
-									type = "keyword"
+									type = "keyword",
+									ignore_above = 256
 								}
 							}
 						}
@@ -57,7 +58,8 @@ namespace Tests.Mapping.Types.Complex.Object
 							{
 								keyword = new
 								{
-									type = "keyword"
+									type = "keyword",
+									ignore_above = 256
 								}
 							}
 						}

--- a/src/Tests/Mapping/Types/Core/String/StringAttributeTests.cs
+++ b/src/Tests/Mapping/Types/Core/String/StringAttributeTests.cs
@@ -66,7 +66,8 @@ namespace Tests.Mapping.Types.Core.String
 					{
 						keyword = new
 						{
-							type = "keyword"
+							type = "keyword",
+							ignore_above = 256
 						}
 					}
 				},

--- a/src/Tests/Mapping/Types/Core/Text/TextAttributeTests.cs
+++ b/src/Tests/Mapping/Types/Core/Text/TextAttributeTests.cs
@@ -61,7 +61,8 @@ namespace Tests.Mapping.Types.Core.Text
 					{
 						keyword = new
 						{
-							type = "keyword"
+							type = "keyword",
+							ignore_above = 256
 						}
 					}
 				}

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: m
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.0.0


### PR DESCRIPTION
This aligns with the default inferred mapping for a string in Elasticsearch 5.0
Closes #2329
