### PR TITLE
Add SniffResponseTesting to expose SniffResponse.AddressRe for unit t…

### DIFF
--- a/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
+++ b/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
@@ -5,12 +5,12 @@ using System.Text.RegularExpressions;
 
 namespace Elasticsearch.Net
 {
-	internal class SniffResponse
+	public class SniffResponse
 	{
-		internal static Regex AddressRe { get; } = new Regex(@"^((?<fqdn>[^/]+)/)?(?<ip>[^:]+|\[[\da-fA-F:\.]+\]):(?<port>\d+)$");
+		public static Regex AddressRegex { get; } = new Regex(@"^((?<fqdn>[^/]+)/)?(?<ip>[^:]+|\[[\da-fA-F:\.]+\]):(?<port>\d+)$");
 
 		public string cluster_name { get; set; }
-		public Dictionary<string, NodeInfo> nodes { get; set; }
+		internal Dictionary<string, NodeInfo> nodes { get; set; }
 
 		public IEnumerable<Node> ToNodes(bool forceHttp = false)
 		{
@@ -30,7 +30,7 @@ namespace Elasticsearch.Net
 		{
 			if (boundAddress.IsNullOrEmpty()) return null;
 			var suffix = forceHttp ? "s" : string.Empty;
-			var match = AddressRe.Match(boundAddress);
+			var match = AddressRegex.Match(boundAddress);
 			if (!match.Success) throw new Exception($"Can not parse bound_address: {boundAddress} to Uri");
 
 			var fqdn = match.Groups["fqdn"].Value?.Trim();
@@ -70,16 +70,5 @@ namespace Elasticsearch.Net
 	internal class NodeInfoHttp
 	{
 		public IList<string> bound_address { get; set; }
-	}
-
-	/// <summary>
-	/// Exposes <see cref="SniffResponse.AddressRe"/> - for unit testing purposes only
-	/// </summary>
-	public static class SniffResponseTesting
-	{
-		public static Regex AddressRe
-		{
-			get { return SniffResponse.AddressRe; }
-		}
 	}
 }

--- a/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
+++ b/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
@@ -7,8 +7,7 @@ namespace Elasticsearch.Net
 {
 	internal class SniffResponse
 	{
-
-		private static Regex AddressRe { get; } = new Regex(@"^((?<fqdn>[^/]+)/)?(?<ip>[^:]+):(?<port>\d+)$");
+		internal static Regex AddressRe { get; } = new Regex(@"^((?<fqdn>[^/]+)/)?(?<ip>[^:]+|\[[\da-fA-F:\.]+\]):(?<port>\d+)$");
 
 		public string cluster_name { get; set; }
 		public Dictionary<string, NodeInfo> nodes { get; set; }
@@ -71,5 +70,16 @@ namespace Elasticsearch.Net
 	internal class NodeInfoHttp
 	{
 		public IList<string> bound_address { get; set; }
+	}
+
+	/// <summary>
+	/// Exposes <see cref="SniffResponse.AddressRe"/> - for unit testing purposes only
+	/// </summary>
+	public static class SniffResponseTesting
+	{
+		public static Regex AddressRe
+		{
+			get { return SniffResponse.AddressRe; }
+		}
 	}
 }

--- a/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
+++ b/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
@@ -7,6 +7,11 @@ namespace Elasticsearch.Net
 {
 	public class SniffResponse
 	{
+		//internal ctor  - so that only Elasticsearch.Net can instantiate it
+		internal SniffResponse()
+		{
+		}
+
 		public static Regex AddressRegex { get; } = new Regex(@"^((?<fqdn>[^/]+)/)?(?<ip>[^:]+|\[[\da-fA-F:\.]+\]):(?<port>\d+)$");
 
 		public string cluster_name { get; set; }

--- a/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs
@@ -28,7 +28,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 				var ip = testcases[i, 1];
 				var port = testcases[i, 2];
 
-				var match = Elasticsearch.Net.SniffResponseTesting.AddressRe.Match(address);
+				var match = Elasticsearch.Net.SniffResponse.AddressRegex.Match(address);
 
 				match.Success.Should().BeTrue();
 

--- a/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs
@@ -1,0 +1,40 @@
+﻿using FluentAssertions;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
+{
+	public class AddressParsing
+	{
+		[U]
+		public void IsMatched()
+		{
+			//based on examples from http://www.ietf.org/rfc/rfc2732.txt
+			var testcases = new[,]
+			{
+				{"[::1]:9200", "[::1]", "9200"},
+				{"192.168.2.1:231", "192.168.2.1", "231"},
+				{"[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80", "[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", "80"},
+				{"[1080:0:0:0:8:800:200C:417A]:1234", "[1080:0:0:0:8:800:200C:417A]", "1234"},
+				{"[3ffe:2a00:100:7031::1]:1", "[3ffe:2a00:100:7031::1]", "1"},
+				{"[1080::8:800:200C:417A]:123", "[1080::8:800:200C:417A]", "123"},
+				{"[::192.9.5.5]:12", "[::192.9.5.5]", "12"},
+				{"[::FFFF:129.144.52.38]:80", "[::FFFF:129.144.52.38]", "80"},
+				{"[2010:836B:4179::836B:4179]:34533", "[2010:836B:4179::836B:4179]", "34533"}
+			};
+
+			for (var i = 0; i < testcases.GetLength(0); i++)
+			{
+				var address = testcases[i, 0];
+				var ip = testcases[i, 1];
+				var port = testcases[i, 2];
+
+				var match = Elasticsearch.Net.SniffResponseTesting.AddressRe.Match(address);
+
+				match.Success.Should().BeTrue();
+
+				match.Groups["ip"].Value.ShouldBeEquivalentTo(ip);
+				match.Groups["port"].Value.ShouldBeEquivalentTo(port);
+			}
+		}
+	}
+}

--- a/src/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
@@ -53,7 +53,7 @@ namespace Tests.Framework
 						this._cluster.SniffingRules,
 						requestData.RequestTimeout,
 						(r) => this.UpdateCluster(r.NewClusterState),
-						(r) => SniffResponse.Create(this._cluster.Nodes, this._cluster.SniffShouldReturnFqnd)
+						(r) => MockResponses.SniffResponse.Create(this._cluster.Nodes, this._cluster.SniffShouldReturnFqnd)
 					);
 				}
 				if (IsPingRequest(requestData))

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Cat\CatThreadPool\CatThreadpoolApiTests.cs" />
     <Compile Include="Cat\CatThreadPool\CatThreadPoolUrlTests.cs" />
     <Compile Include="ClientConcepts\ConnectionPooling\Dispose\ResponseBuilderDisposeTests.cs" />
+    <Compile Include="ClientConcepts\ConnectionPooling\Sniffing\AddressParsing.doc.cs" />
     <Compile Include="Cluster\TaskManagement\GetTask\GetTaskApiTests.cs" />
     <Compile Include="Cluster\TaskManagement\GetTask\GetTaskUrlTests.cs" />
     <Compile Include="Document\Multiple\Bulk\BulkResponseParsingTests.cs" />


### PR DESCRIPTION
Added SniffResponseTesting just to expose SniffResponse.AddressRe so we don't have to adjust the visibility of SniffResponse.

Also looked at adding InternalsVisibleTo for the Test project to Elasticsearch.Net, but the strong name / signing prevented this.
fixes #2350 

CLA signing is in progress
