### PR TITLE
Add Script and DotExpander Processors

### DIFF
--- a/src/Elasticsearch.Net/Extensions/Extensions.cs
+++ b/src/Elasticsearch.Net/Extensions/Extensions.cs
@@ -4,7 +4,9 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+#if DOTNETCORE
 using System.Reflection;
+#endif
 
 namespace Elasticsearch.Net
 {

--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/EnumMemberValueCasingJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/EnumMemberValueCasingJsonConverter.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+#if DOTNETCORE
+using System.Reflection;
+#endif
+
+namespace Nest
+{
+	/// <summary>
+	/// A Json converter that can serialize enums to strings where the string values
+	/// are specified using <see cref="EnumMemberAttribute.Value"/> and where values
+	/// differ in casing.
+	/// </summary>
+	/// <remarks>
+	/// See https://github.com/JamesNK/Newtonsoft.Json/issues/1067
+	/// </remarks>
+	/// <typeparam name="TEnum">the type of enum</typeparam>
+	internal class EnumMemberValueCasingJsonConverter<TEnum> : JsonConverter where TEnum : struct
+	{
+		private static readonly Dictionary<TEnum, string> EnumToString;
+		private static readonly Dictionary<string, TEnum> StringToEnum;
+
+		static EnumMemberValueCasingJsonConverter()
+		{
+			var enumType = typeof(TEnum);
+
+			if (!enumType.IsEnumType())
+				throw new InvalidOperationException($"{nameof(TEnum)} must be an enum.");
+
+			var enums = Enum.GetValues(enumType).Cast<TEnum>().ToList();
+			EnumToString = new Dictionary<TEnum, string>(enums.Count);
+			StringToEnum = new Dictionary<string, TEnum>(enums.Count, StringComparer.Ordinal);
+
+			foreach (var e in enums)
+			{
+#if DOTNETCORE
+				var field = enumType.GetTypeInfo().GetDeclaredField(e.ToString());
+#else
+				var field = enumType.GetField(e.ToString());
+#endif
+				var enumMemberValue = field.GetCustomAttributes(typeof(EnumMemberAttribute), true)
+					.Cast<EnumMemberAttribute>()
+					.Select(a => a.Value)
+					.SingleOrDefault() ?? field.Name;
+
+				TEnum first;
+				if (StringToEnum.TryGetValue(enumMemberValue, out first))
+					throw new InvalidOperationException($"Enum name '{enumMemberValue}' already exists on enum '{enumType.Name}'.");
+
+				var enumValue = (TEnum)Enum.Parse(enumType, field.Name);
+
+				EnumToString.Add(enumValue, enumMemberValue);
+				StringToEnum.Add(enumMemberValue, enumValue);
+			}
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var enumValue = (TEnum)value;
+			string stringValue;
+			if (!EnumToString.TryGetValue(enumValue, out stringValue))
+				throw new InvalidOperationException($"'{value}' is not a valid value for '{typeof(TEnum).Name}'");
+
+			writer.WriteValue(stringValue);
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var value = (string)reader.Value;
+
+			if (value == null)
+				return default(TEnum);
+
+			TEnum enumValue;
+			if (StringToEnum.TryGetValue(value, out enumValue))
+				return enumValue;
+
+			return Enum.TryParse(value, true, out enumValue) ? enumValue : default(TEnum);
+		}
+
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType == typeof(TEnum);
+		}
+	}
+}

--- a/src/Nest/CommonOptions/TimeUnit/TimeUnit.cs
+++ b/src/Nest/CommonOptions/TimeUnit/TimeUnit.cs
@@ -1,23 +1,25 @@
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Nest
 {
+	[JsonConverter(typeof(EnumMemberValueCasingJsonConverter<TimeUnit>))]
 	public enum TimeUnit
 	{
 		[EnumMember(Value = "ms")]
-		Millisecond, 
+		Millisecond,
 		[EnumMember(Value = "s")]
-		Second, 
+		Second,
 		[EnumMember(Value = "m")]
-		Minute, 
+		Minute,
 		[EnumMember(Value = "h")]
-		Hour, 
+		Hour,
 		[EnumMember(Value = "d")]
 		Day,
 		[EnumMember(Value = "w")]
-		Week, 
+		Week,
 		[EnumMember(Value = "M")]
-		Month, 
+		Month,
 		[EnumMember(Value = "y")]
 		Year
 	}

--- a/src/Nest/Ingest/PipelineJsonConverter.cs
+++ b/src/Nest/Ingest/PipelineJsonConverter.cs
@@ -17,8 +17,7 @@ namespace Nest
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var root = JObject.Load(reader);
-			var pipeline = new Pipeline();
-			pipeline.Description = root["description"]?.ToString();
+			var pipeline = new Pipeline { Description = root["description"]?.ToString() };
 			if (root["processors"] != null)
 				pipeline.Processors = GetProcessors(root["processors"], serializer);
 			if (root["on_failure"] != null)
@@ -49,6 +48,9 @@ namespace Nest
 					case "date_index_name":
 						processors.Add(jsonProcessor.ToObject<DateIndexNameProcessor>(serializer));
 						break;
+					case "dot_expander":
+						processors.Add(jsonProcessor.ToObject<DotExpanderProcessor>(serializer));
+						break;
 					case "fail":
 						processors.Add(jsonProcessor.ToObject<FailProcessor>(serializer));
 						break;
@@ -75,6 +77,9 @@ namespace Nest
 						break;
 					case "rename":
 						processors.Add(jsonProcessor.ToObject<RenameProcessor>(serializer));
+						break;
+					case "script":
+						processors.Add(jsonProcessor.ToObject<ScriptProcessor>(serializer));
 						break;
 					case "set":
 						processors.Add(jsonProcessor.ToObject<SetProcessor>(serializer));

--- a/src/Nest/Ingest/Processors/AttachmentProcessor.cs
+++ b/src/Nest/Ingest/Processors/AttachmentProcessor.cs
@@ -5,6 +5,14 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// The ingest attachment plugin lets Elasticsearch extract file attachments in common formats
+	/// (such as PPT, XLS, and PDF) by using the Apache text extraction library Tika.
+	/// You can use the ingest attachment plugin as a replacement for the mapper attachment plugin.
+	/// </summary>
+	/// <remarks>
+	/// Requires the Ingest Attachment Processor Plugin to be installed on the cluster.
+	/// </remarks>
 	[JsonObject(MemberSerialization.OptIn)]
 	[JsonConverter(typeof(ProcessorJsonConverter<AttachmentProcessor>))]
 	public interface IAttachmentProcessor : IProcessor
@@ -36,22 +44,52 @@ namespace Nest
 		long? IndexedCharacters { get; set; }
 	}
 
+	/// <summary>
+	/// The ingest attachment plugin lets Elasticsearch extract file attachments in common formats
+	/// (such as PPT, XLS, and PDF) by using the Apache text extraction library Tika.
+	/// You can use the ingest attachment plugin as a replacement for the mapper attachment plugin.
+	/// </summary>
+	/// <remarks>
+	/// Requires the Ingest Attachment Processor Plugin to be installed on the cluster.
+	/// </remarks>
 	public class AttachmentProcessor : ProcessorBase, IAttachmentProcessor
 	{
 		protected override string Name => "attachment";
 
+		/// <summary>
+		/// The field to get the base64 encoded field from
+		/// </summary>
 		public Field Field { get; set; }
 
+		/// <summary>
+		/// The field that will hold the attachment information
+		/// </summary>
 		public Field TargetField { get; set; }
 
+		/// <summary>
+		/// Properties to select to be stored. Can be content, title, name, author,
+		/// keywords, date, content_type, content_length, language. Defaults to all
+		/// </summary>
 		public IEnumerable<string> Properties { get; set; }
 
+		/// <summary>
+		/// The number of chars being used for extraction to prevent huge fields. Use -1 for no limit.
+		/// Defaults to 100000.
+		/// </summary>
 		public long? IndexedCharacters { get; set; }
 	}
 
+	/// <summary>
+	/// The ingest attachment plugin lets Elasticsearch extract file attachments in common formats
+	/// (such as PPT, XLS, and PDF) by using the Apache text extraction library Tika.
+	/// You can use the ingest attachment plugin as a replacement for the mapper attachment plugin.
+	/// </summary>
+	/// <remarks>
+	/// Requires the Ingest Attachment Processor Plugin to be installed on the cluster.
+	/// </remarks>
 	public class AttachmentProcessorDescriptor<T>
-: ProcessorDescriptorBase<AttachmentProcessorDescriptor<T>, IAttachmentProcessor>, IAttachmentProcessor
-where T : class
+		: ProcessorDescriptorBase<AttachmentProcessorDescriptor<T>, IAttachmentProcessor>, IAttachmentProcessor
+		where T : class
 	{
 		protected override string Name => "attachment";
 
@@ -60,20 +98,44 @@ where T : class
 		IEnumerable<string> IAttachmentProcessor.Properties { get; set; }
 		long? IAttachmentProcessor.IndexedCharacters { get; set; }
 
+		/// <summary>
+		/// The field to get the base64 encoded field from
+		/// </summary>
 		public AttachmentProcessorDescriptor<T> Field(Field field) => Assign(a => a.Field = field);
 
+		/// <summary>
+		/// The field to get the base64 encoded field from
+		/// </summary>
 		public AttachmentProcessorDescriptor<T> Field(Expression<Func<T, object>> objectPath) =>
 			Assign(a => a.Field = objectPath);
 
+		/// <summary>
+		/// The field that will hold the attachment information
+		/// </summary>
 		public AttachmentProcessorDescriptor<T> TargetField(Field field) => Assign(a => a.TargetField = field);
 
+		/// <summary>
+		/// The field that will hold the attachment information
+		/// </summary>
 		public AttachmentProcessorDescriptor<T> TargetField(Expression<Func<T, object>> objectPath) =>
 			Assign(a => a.TargetField = objectPath);
 
+		/// <summary>
+		/// The number of chars being used for extraction to prevent huge fields. Use -1 for no limit.
+		/// Defaults to 100000.
+		/// </summary>
 		public AttachmentProcessorDescriptor<T> IndexedCharacters(long indexedCharacters) => Assign(a => a.IndexedCharacters = indexedCharacters);
 
+		/// <summary>
+		/// Properties to select to be stored. Can be content, title, name, author,
+		/// keywords, date, content_type, content_length, language. Defaults to all
+		/// </summary>
 		public AttachmentProcessorDescriptor<T> Properties(IEnumerable<string> properties) => Assign(a => a.Properties = properties);
 
+		/// <summary>
+		/// Properties to select to be stored. Can be content, title, name, author,
+		/// keywords, date, content_type, content_length, language. Defaults to all
+		/// </summary>
 		public AttachmentProcessorDescriptor<T> Properties(params string[] properties) => Assign(a => a.Properties = properties);
 	}
 }

--- a/src/Nest/Ingest/Processors/DateIndexNameProcessor.cs
+++ b/src/Nest/Ingest/Processors/DateIndexNameProcessor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
@@ -70,18 +69,46 @@ namespace Nest
 	{
 		protected override string Name => "date_index_name";
 
+		/// <summary>
+		/// The field to get the date or timestamp from.
+		/// </summary>
 		public Field Field { get; set; }
 
+		/// <summary>
+		/// A prefix of the index name to be prepended before the printed date.
+		/// </summary>
 		public string IndexNamePrefix { get; set; }
 
+		/// <summary>
+		/// How to round the date when formatting the date into the index name.
+		/// </summary>
 		public DateRounding DateRounding { get; set; }
 
+		/// <summary>
+		/// An array of the expected date formats for parsing
+		/// dates / timestamps in the document being preprocessed.
+		/// Default is yyyy-MM-dd’T'HH:mm:ss.SSSZ
+		/// </summary>
 		public IEnumerable<string> DateFormats { get; set; }
 
+		/// <summary>
+		/// The timezone to use when parsing the date and when date
+		/// math index supports resolves expressions into concrete
+		/// index names.
+		/// </summary>
 		public string TimeZone { get; set; }
 
+		/// <summary>
+		/// The locale to use when parsing the date from the document
+		/// being preprocessed, relevant when parsing month names or
+		/// week days.
+		/// </summary>
 		public string Locale { get; set; }
 
+		/// <summary>
+		/// The format to be used when printing the parsed date into
+		/// the index name.
+		/// </summary>
 		public string IndexNameFormat { get; set; }
 	}
 
@@ -99,34 +126,70 @@ namespace Nest
 		string IDateIndexNameProcessor.Locale { get; set; }
 		string IDateIndexNameProcessor.IndexNameFormat { get; set; }
 
+		/// <summary>
+		/// The field to get the date or timestamp from.
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> Field(Field field) => Assign(a => a.Field = field);
 
+		/// <summary>
+		/// The field to get the date or timestamp from.
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> Field(Expression<Func<T, object>> objectPath) =>
 			Assign(a => a.Field = objectPath);
 
+		/// <summary>
+		/// A prefix of the index name to be prepended before the printed date.
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> IndexNamePrefix(string indexNamePrefix) =>
 			Assign(a => a.IndexNamePrefix = indexNamePrefix);
 
+		/// <summary>
+		/// How to round the date when formatting the date into the index name.
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> DateRounding(DateRounding dateRounding) =>
 			Assign(a => a.DateRounding = dateRounding);
 
+		/// <summary>
+		/// An array of the expected date formats for parsing
+		/// dates / timestamps in the document being preprocessed.
+		/// Default is yyyy-MM-dd’T'HH:mm:ss.SSSZ
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> DateFormats(IEnumerable<string> dateFormats) =>
 			Assign(a => a.DateFormats = dateFormats);
 
+		/// <summary>
+		/// An array of the expected date formats for parsing
+		/// dates / timestamps in the document being preprocessed.
+		/// Default is yyyy-MM-dd’T'HH:mm:ss.SSSZ
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> DateFormats(params string[] dateFormats) =>
 			Assign(a => a.DateFormats = dateFormats);
 
+		/// <summary>
+		/// The timezone to use when parsing the date and when date
+		/// math index supports resolves expressions into concrete
+		/// index names.
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> TimeZone(string timeZone) =>
 			Assign(a => a.TimeZone = timeZone);
 
+		/// <summary>
+		/// The locale to use when parsing the date from the document
+		/// being preprocessed, relevant when parsing month names or
+		/// week days.
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> Locale(string locale) =>
 			Assign(a => a.Locale = locale);
 
+		/// <summary>
+		/// The format to be used when printing the parsed date into
+		/// the index name.
+		/// </summary>
 		public DateIndexNameProcessorDescriptor<T> IndexNameFormat(string indexNameFormat) =>
 			Assign(a => a.IndexNameFormat = indexNameFormat);
 	}
 
-	[JsonConverter(typeof(StringEnumConverter))]
+	[JsonConverter(typeof(EnumMemberValueCasingJsonConverter<DateRounding>))]
 	public enum DateRounding
 	{
 		[EnumMember(Value = "s")]

--- a/src/Nest/Ingest/Processors/DotExpanderProcessor.cs
+++ b/src/Nest/Ingest/Processors/DotExpanderProcessor.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// Expands a field with dots into an object field.
+	/// This processor allows fields with dots in the name to be accessible by other processors in the pipeline.
+	/// Otherwise these fields can’t be accessed by any processor.
+	/// </summary>
+	[JsonObject(MemberSerialization.OptIn)]
+	[JsonConverter(typeof(ProcessorJsonConverter<DotExpanderProcessor>))]
+	public interface IDotExpanderProcessor : IProcessor
+	{
+		/// <summary>
+		/// The field to expand into an object field
+		/// </summary>
+		[JsonProperty("field")]
+		Field Field { get; set; }
+
+		/// <summary>
+		/// The field that contains the field to expand.
+		/// Only required if the field to expand is part another object field,
+		/// because the field option can only understand leaf fields.
+		/// </summary>
+		[JsonProperty("path")]
+		string Path { get; set; }
+	}
+
+	/// <summary>
+	/// Expands a field with dots into an object field.
+	/// This processor allows fields with dots in the name to be accessible by other processors in the pipeline.
+	/// Otherwise these fields can’t be accessed by any processor.
+	/// </summary>
+	public class DotExpanderProcessor : ProcessorBase, IDotExpanderProcessor
+	{
+		protected override string Name => "dot_expander";
+
+		/// <summary>
+		/// The field to expand into an object field
+		/// </summary>
+		[JsonProperty("field")]
+		public Field Field { get; set; }
+
+		/// <summary>
+		/// The field that contains the field to expand.
+		/// Only required if the field to expand is part another object field,
+		/// because the field option can only understand leaf fields.
+		/// </summary>
+		[JsonProperty("path")]
+		public string Path { get; set; }
+	}
+
+	/// <summary>
+	/// Expands a field with dots into an object field.
+	/// This processor allows fields with dots in the name to be accessible by other processors in the pipeline.
+	/// Otherwise these fields can’t be accessed by any processor.
+	/// </summary>
+	public class DotExpanderProcessorDescriptor<T>
+		: ProcessorDescriptorBase<DotExpanderProcessorDescriptor<T>, IDotExpanderProcessor>, IDotExpanderProcessor
+		where T : class
+	{
+		protected override string Name => "dot_expander";
+
+		Field IDotExpanderProcessor.Field { get; set; }
+		string IDotExpanderProcessor.Path { get; set; }
+
+		/// <summary>
+		/// The field to expand into an object field
+		/// </summary>
+		public DotExpanderProcessorDescriptor<T> Field(Field field) => Assign(a => a.Field = field);
+
+		/// <summary>
+		/// The field to expand into an object field
+		/// </summary>
+		public DotExpanderProcessorDescriptor<T> Field(Expression<Func<T, object>> objectPath) =>
+			Assign(a => a.Field = objectPath);
+
+		/// <summary>
+		/// The field that contains the field to expand.
+		/// Only required if the field to expand is part another object field,
+		/// because the field option can only understand leaf fields.
+		/// </summary>
+		public DotExpanderProcessorDescriptor<T> Path(string path) => Assign(a => a.Path = path);
+	}
+}

--- a/src/Nest/Ingest/Processors/GeoIpProcessor.cs
+++ b/src/Nest/Ingest/Processors/GeoIpProcessor.cs
@@ -5,6 +5,15 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// The GeoIP processor adds information about the geographical location of IP addresses,
+	/// based on data from the Maxmind databases.
+	/// This processor adds this information by default under the geoip field.
+	/// The geoip processor can resolve both IPv4 and IPv6 addresses.
+	/// </summary>
+	/// <remarks>
+	/// Requires the Ingest Geoip Processor Plugin to be installed on the cluster.
+	/// </remarks>
 	[JsonObject(MemberSerialization.OptIn)]
 	[JsonConverter(typeof(ProcessorJsonConverter<GeoIpProcessor>))]
 	public interface IGeoIpProcessor : IProcessor
@@ -22,6 +31,15 @@ namespace Nest
 		IEnumerable<string> Properties { get; set; }
 	}
 
+	/// <summary>
+	/// The GeoIP processor adds information about the geographical location of IP addresses,
+	/// based on data from the Maxmind databases.
+	/// This processor adds this information by default under the geoip field.
+	/// The geoip processor can resolve both IPv4 and IPv6 addresses.
+	/// </summary>
+	/// <remarks>
+	/// Requires the Ingest Geoip Processor Plugin to be installed on the cluster.
+	/// </remarks>
 	public class GeoIpProcessor : ProcessorBase, IGeoIpProcessor
 	{
 		protected override string Name => "geoip";
@@ -35,6 +53,15 @@ namespace Nest
 		public IEnumerable<string> Properties { get; set; }
 	}
 
+	/// <summary>
+	/// The GeoIP processor adds information about the geographical location of IP addresses,
+	/// based on data from the Maxmind databases.
+	/// This processor adds this information by default under the geoip field.
+	/// The geoip processor can resolve both IPv4 and IPv6 addresses.
+	/// </summary>
+	/// <remarks>
+	/// Requires the Ingest Geoip Processor Plugin to be installed on the cluster.
+	/// </remarks>
 	public class GeoIpProcessorDescriptor<T>
 	: ProcessorDescriptorBase<GeoIpProcessorDescriptor<T>, IGeoIpProcessor>, IGeoIpProcessor
 	where T : class

--- a/src/Nest/Ingest/Processors/ScriptProcessor.cs
+++ b/src/Nest/Ingest/Processors/ScriptProcessor.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// Allows inline, stored, and file scripts to be executed within ingest pipelines.
+	/// </summary>
+	[JsonObject(MemberSerialization.OptIn)]
+	[JsonConverter(typeof(ProcessorJsonConverter<ScriptProcessor>))]
+	public interface IScriptProcessor : IProcessor
+	{
+		/// <summary>
+		/// The scripting language. Defaults to painless
+		/// </summary>
+		[JsonProperty("lang")]
+		string Lang { get; set; }
+
+		/// <summary>
+		/// The script file to refer to
+		/// </summary>
+		[JsonProperty("file")]
+		string File { get; set; }
+
+		/// <summary>
+		/// The stored script id to refer to
+		/// </summary>
+		[JsonProperty("id")]
+		string Id { get; set; }
+
+		/// <summary>
+		/// An inline script to be executed
+		/// </summary>
+		[JsonProperty("inline")]
+		string Inline { get; set; }
+
+		/// <summary>
+		/// Parameters for the script
+		/// </summary>
+		[JsonProperty("params")]
+		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter))]
+		Dictionary<string, object> Params { get; set; }
+	}
+
+	/// <summary>
+	/// Allows inline, stored, and file scripts to be executed within ingest pipelines.
+	/// </summary>
+	public class ScriptProcessor : ProcessorBase, IScriptProcessor
+	{
+		protected override string Name => "script";
+
+		/// <summary>
+		/// The scripting language. Defaults to painless
+		/// </summary>
+		public string Lang { get; set; }
+
+		/// <summary>
+		/// The script file to refer to
+		/// </summary>
+		public string File { get; set; }
+
+		/// <summary>
+		/// The stored script id to refer to
+		/// </summary>
+		public string Id { get; set; }
+
+		/// <summary>
+		/// An inline script to be executed
+		/// </summary>
+		public string Inline { get; set; }
+
+		/// <summary>
+		/// Parameters for the script
+		/// </summary>
+		public Dictionary<string, object> Params { get; set; }
+	}
+
+	/// <summary>
+	/// Allows inline, stored, and file scripts to be executed within ingest pipelines.
+	/// </summary>
+	public class ScriptProcessorDescriptor
+		: ProcessorDescriptorBase<ScriptProcessorDescriptor, IScriptProcessor>, IScriptProcessor
+	{
+		protected override string Name => "script";
+
+		string IScriptProcessor.Lang { get; set; }
+		string IScriptProcessor.File{ get; set; }
+		string IScriptProcessor.Id{ get; set; }
+		string IScriptProcessor.Inline { get; set; }
+		Dictionary<string, object> IScriptProcessor.Params { get; set; }
+
+		/// <summary>
+		/// The scripting language. Defaults to painless
+		/// </summary>
+		public ScriptProcessorDescriptor Lang(string lang) => Assign(a => a.Lang = lang);
+
+		/// <summary>
+		/// The script file to refer to
+		/// </summary>
+		public ScriptProcessorDescriptor File(string file) => Assign(a => a.File = file);
+
+		/// <summary>
+		/// The stored script id to refer to
+		/// </summary>
+		public ScriptProcessorDescriptor Id(string id) => Assign(a => a.Id = id);
+
+		/// <summary>
+		/// An inline script to be executed
+		/// </summary>
+		public ScriptProcessorDescriptor Inline(string inline) => Assign(a => a.Inline = inline);
+
+		/// <summary>
+		/// Parameters for the script
+		/// </summary>
+		public ScriptProcessorDescriptor Params(Dictionary<string, object> scriptParams) => Assign(a => a.Params = scriptParams);
+
+		/// <summary>
+		/// Parameters for the script
+		/// </summary>
+		public ScriptProcessorDescriptor Params(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> paramsSelector) =>
+			Assign(a => a.Params = paramsSelector?.Invoke(new FluentDictionary<string, object>()));
+	}
+}

--- a/src/Nest/Ingest/ProcessorsDescriptor.cs
+++ b/src/Nest/Ingest/ProcessorsDescriptor.cs
@@ -8,31 +8,39 @@ namespace Nest
 		public ProcessorsDescriptor() : base(new List<IProcessor>()) { }
 
 		/// <summary>
-		/// The ingest attachment plugin lets Elasticsearch extract file attachments in common formats (such as PPT, XLS, and PDF)
-		/// by using the Apache text extraction library Tika. You can use the ingest attachment plugin as a replacement
-		/// for the mapper attachment plugin. The ingest-attachment plugin must be installed for this functionality.
+		/// The ingest attachment plugin lets Elasticsearch extract file attachments in common formats
+		/// (such as PPT, XLS, and PDF) by using the Apache text extraction library Tika.
+		/// You can use the ingest attachment plugin as a replacement for the mapper attachment plugin.
 		/// </summary>
+		/// <remarks>
+		/// Requires the Ingest Attachment Processor Plugin to be installed on the cluster.
+		/// </remarks>
 		public ProcessorsDescriptor Attachment<T>(Func<AttachmentProcessorDescriptor<T>, IAttachmentProcessor> selector) where T : class  =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new AttachmentProcessorDescriptor<T>())));
 
 		public ProcessorsDescriptor Append<T>(Func<AppendProcessorDescriptor<T>, IAppendProcessor> selector) where T : class  =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new AppendProcessorDescriptor<T>())));
 
-
 		public ProcessorsDescriptor Convert<T>(Func<ConvertProcessorDescriptor<T>, IConvertProcessor> selector) where T : class  =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new ConvertProcessorDescriptor<T>())));
-
 
 		public ProcessorsDescriptor Date<T>(Func<DateProcessorDescriptor<T>, IDateProcessor> selector) where T : class  =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new DateProcessorDescriptor<T>())));
 
 		/// <summary>
-		/// The purpose of this processor is to point documents to the right time
-		/// based index based on a date or timestamp field in a document
+		/// Point documents to the right time-based index based on a date or timestamp field in a document
 		/// by using the date math index name support.
 		/// </summary>
 		public ProcessorsDescriptor DateIndexName<T>(Func<DateIndexNameProcessorDescriptor<T>, IDateIndexNameProcessor> selector) where T : class  =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new DateIndexNameProcessorDescriptor<T>())));
+
+		/// <summary>
+		/// Expands a field with dots into an object field.
+		/// This processor allows fields with dots in the name to be accessible by other processors in the pipeline.
+		/// Otherwise these fields can’t be accessed by any processor.
+		/// </summary>
+		public ProcessorsDescriptor DotExpander<T>(Func<DotExpanderProcessorDescriptor<T>, IDotExpanderProcessor> selector) where T : class  =>
+			Assign(a => a.AddIfNotNull(selector?.Invoke(new DotExpanderProcessorDescriptor<T>())));
 
 		public ProcessorsDescriptor Fail(Func<FailProcessorDescriptor, IFailProcessor> selector) =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new FailProcessorDescriptor())));
@@ -41,10 +49,14 @@ namespace Nest
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new ForeachProcessorDescriptor<T>())));
 
 		/// <summary>
-		/// The GeoIP processor adds information about the geographical location of IP addresses, based on data from the Maxmind databases.
-		/// This processor adds this information by default under the geoip field. The ingest-geoip plugin must be installed for this
-		/// functionality.
+		/// Adds information about the geographical location of IP addresses,
+		/// based on data from the Maxmind databases.
+		/// This processor adds this information by default under the geoip field.
+		/// The geoip processor can resolve both IPv4 and IPv6 addresses.
 		/// </summary>
+		/// <remarks>
+		/// Requires the Ingest Geoip Processor Plugin to be installed on the cluster.
+		/// </remarks>
 		public ProcessorsDescriptor GeoIp<T>(Func<GeoIpProcessorDescriptor<T>, IGeoIpProcessor> selector) where T : class  =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new GeoIpProcessorDescriptor<T>())));
 
@@ -68,6 +80,12 @@ namespace Nest
 
 		public ProcessorsDescriptor Rename<T>(Func<RenameProcessorDescriptor<T>, IRenameProcessor> selector) where T : class  =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new RenameProcessorDescriptor<T>())));
+
+		/// <summary>
+		/// Allows inline, stored, and file scripts to be executed within ingest pipelines.
+		/// </summary>
+		public ProcessorsDescriptor Script(Func<ScriptProcessor, IScriptProcessor> selector) =>
+			Assign(a => a.AddIfNotNull(selector?.Invoke(new ScriptProcessor())));
 
 		public ProcessorsDescriptor Set<T>(Func<SetProcessorDescriptor<T>, ISetProcessor> selector) where T : class  =>
 			Assign(a => a.AddIfNotNull(selector?.Invoke(new SetProcessorDescriptor<T>())));

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -464,6 +464,7 @@
     <Compile Include="CommonAbstractions\SerializationBehavior\ContractJsonConverterAttribute.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\ElasticContractResolver.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\CompositeJsonConverter.cs" />
+    <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\EnumMemberValueCasingJsonConverter.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\FromJson.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\JsonConverterBase.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\KeyValueJsonConverter.cs" />
@@ -788,9 +789,11 @@
     <Compile Include="Indices\StatusManagement\Upgrade\UpgradeStatus\UpgradeStatusRequest.cs" />
     <Compile Include="Indices\StatusManagement\Upgrade\UpgradeStatus\UpgradeStatusResponse.cs" />
     <Compile Include="Indices\StatusManagement\Upgrade\UpgradeStatus\UpgradeStatusResponseJsonConverter.cs" />
+    <Compile Include="Ingest\Processors\DotExpanderProcessor.cs" />
     <Compile Include="Ingest\Processors\GeoIpProcessor.cs" />
     <Compile Include="Ingest\Processors\AttachmentProcessor.cs" />
     <Compile Include="Ingest\Processors\DateIndexNameProcessor.cs" />
+    <Compile Include="Ingest\Processors\ScriptProcessor.cs" />
     <Compile Include="Ingest\Processors\SortProcessor.cs" />
     <Compile Include="Mapping\AttributeBased\ElasticsearchCorePropertyAttributeBase.cs" />
     <Compile Include="Ingest\DeletePipeline\DeletePipelineRequest.cs" />

--- a/src/Tests/Ingest/PipelineCrudTests.cs
+++ b/src/Tests/Ingest/PipelineCrudTests.cs
@@ -41,11 +41,11 @@ namespace Tests.Ingest
 			var processors = pipeline.Processors;
 			processors.Should().NotBeNull().And.HaveCount(2);
 
-			var uppercase = processors.Where(p => p.Name == "uppercase").FirstOrDefault() as UppercaseProcessor;
+			var uppercase = processors.FirstOrDefault(p => p.Name == "uppercase") as UppercaseProcessor;
 			uppercase.Should().NotBeNull();
 			uppercase.Field.Should().NotBeNull();
 
-			var set = processors.Where(p => p.Name == "set").FirstOrDefault() as SetProcessor;
+			var set = processors.FirstOrDefault(p => p.Name == "set") as SetProcessor;
 			set.Should().NotBeNull();
 			set.Field.Should().NotBeNull();
 			set.Value.Should().NotBeNull();
@@ -154,16 +154,16 @@ namespace Tests.Ingest
 			var processors = pipeline.Processors;
 			processors.Should().NotBeNull().And.HaveCount(3);
 
-			var uppercase = processors.Where(p => p.Name == "uppercase").FirstOrDefault() as UppercaseProcessor;
+			var uppercase = processors.FirstOrDefault(p => p.Name == "uppercase") as UppercaseProcessor;
 			uppercase.Should().NotBeNull();
 			uppercase.Field.Should().NotBeNull();
 
-			var set = processors.Where(p => p.Name == "set").FirstOrDefault() as SetProcessor;
+			var set = processors.FirstOrDefault(p => p.Name == "set") as SetProcessor;
 			set.Should().NotBeNull();
 			set.Field.Should().NotBeNull();
 			set.Value.Should().NotBeNull();
 
-			var rename = processors.Where(p => p.Name == "rename").FirstOrDefault() as RenameProcessor;
+			var rename = processors.FirstOrDefault(p => p.Name == "rename") as RenameProcessor;
 			rename.Should().NotBeNull();
 			rename.Field.Should().NotBeNull();
 			rename.TargetField.Should().NotBeNull();

--- a/src/Tests/Ingest/ProcessorSerializationTests.cs
+++ b/src/Tests/Ingest/ProcessorSerializationTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using System.Reflection;
+
+namespace Tests.Ingest
+{
+	public class ProcessorSerializationTests : SerializationTestBase
+	{
+		[U]
+		public void CanSerializeAndDeserializeAllProcessors()
+		{
+			var processorTypes =
+				from t in typeof(IProcessor).Assembly().Types()
+				where typeof(ProcessorBase).IsAssignableFrom(t) && !t.IsAbstract()
+				select t;
+
+			var processors = processorTypes
+				.Select(processorType => (IProcessor)Activator.CreateInstance(processorType))
+				.ToList();
+
+			var pipeline = new Pipeline { Processors = processors };
+			var deserializedPipeline = this.Deserialize<Pipeline>(this.Serialize(pipeline));
+
+			deserializedPipeline.Processors.Should().HaveCount(pipeline.Processors.Count());
+			deserializedPipeline.Processors.Select(p => p.Name).Distinct().Should().HaveCount(pipeline.Processors.Count());
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -349,6 +349,7 @@
     <Compile Include=".\Indices\StatusManagement\Upgrade\UpgradeApiTests.cs" />
     <Compile Include=".\Indices\StatusManagement\Upgrade\UpgradeUrlTests.cs" />
     <Compile Include=".\Mapping\Metafields\MetafieldsMappingApiTestsBase.cs" />
+    <Compile Include="Ingest\ProcessorSerializationTests.cs" />
     <Compile Include="Mapping\Types\Complex\Nested\NestedAttributeTests.cs" />
     <Compile Include="Mapping\Types\Complex\Object\ObjectAttributeTests.cs" />
     <Compile Include="Mapping\Types\Core\Binary\BinaryAttributeTests.cs" />


### PR DESCRIPTION
- Add serialization test to ensure that all processors can be serialized and deserialized with the correct processor names
- Json.Net cannot handle an enum that is serialized to string where the values come from EnumMemberAttribute values and differ only in casing. Opened an issue at https://github.com/JamesNK/Newtonsoft.Json/issues/1067. We have two enums, TimeUnit and DateRounding that both use M and m for Month and Minute, respectively. Implemented a generic json converter that is able to handle this case.

Closes #2334