### PR TITLE
Infer index from generic type parameter T in Suggest<T>

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Domain/CsharpMethod.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/CsharpMethod.cs
@@ -76,24 +76,24 @@ namespace ApiGenerator.Domain
 			var m = this.RequestType;
 			foreach (var url in this.Url.Paths)
 			{
-				var cp = this.Url.Parts
+				var urlRouteParameters = this.Url.Parts
 					.Where(p => !ApiUrl.BlackListRouteValues.Contains(p.Key))
 					.Where(p => url.Contains($"{{{p.Value.Name}}}"))
 					.OrderBy(kv => url.IndexOf($"{{{kv.Value.Name}}}", StringComparison.Ordinal));
-				var par = string.Join(", ", cp.Select(p => $"{ClrParamType(p.Value.ClrTypeName)} {p.Key}"));
+				var par = string.Join(", ", urlRouteParameters.Select(p => $"{ClrParamType(p.Value.ClrTypeName)} {p.Key}"));
 				var routing = string.Empty;
 
 				//Routes that take {indices}/{types} and both are optional
 				//we rather not generate a parameterless constructor and force folks to call Indices.All
-				if (!cp.Any() && IndicesAndTypes)
+				if (!urlRouteParameters.Any() && IndicesAndTypes)
 				{
 					ParameterlessIndicesTypesConstructor(ctors, m);
 					continue;
 				}
 
-				if (cp.Any())
+				if (urlRouteParameters.Any())
 				{
-					routing = "r=>r." + string.Join(".", cp
+					routing = "r=>r." + string.Join(".", urlRouteParameters
 						.Select(p => new
 						{
 							route = p.Key,
@@ -109,17 +109,24 @@ namespace ApiGenerator.Domain
 				}
 
 				var doc = $@"/// <summary>{url}</summary>";
-				if (cp.Any())
+				if (urlRouteParameters.Any())
 				{
-					doc += "\r\n" + string.Join("\t\t\r\n", cp.Select(p => $"///<param name=\"{p.Key}\">{(p.Value.Required ? "this parameter is required" : "Optional, accepts null")}</param>"));
+					doc += "\r\n" + string.Join("\t\t\r\n", urlRouteParameters.Select(p => $"///<param name=\"{p.Key}\">{(p.Value.Required ? "this parameter is required" : "Optional, accepts null")}</param>"));
 				}
 				var generated = $"public {m}({par}) : base({routing}){{}}";
 
 				// special case SearchRequest<T> to pass the type of T as the type, when only the index is specified.
-				if (m == "SearchRequest" && cp.Count() == 1 && !string.IsNullOrEmpty(this.RequestTypeGeneric))
+				if (m == "SearchRequest" && urlRouteParameters.Count() == 1 && !string.IsNullOrEmpty(this.RequestTypeGeneric))
 				{
 					var generic = this.RequestTypeGeneric.Replace("<", "").Replace(">", "");
-					generated = $"public {m}({par}) : this({cp.First().Key}, typeof({generic})){{}}";
+					generated = $"public {m}({par}) : this({urlRouteParameters.First().Key}, typeof({generic})){{}}";
+				}
+
+				if ((m == "SuggestRequest") && string.IsNullOrEmpty(par) && !string.IsNullOrEmpty(this.RequestTypeGeneric))
+				{
+					var generic = this.RequestTypeGeneric.Replace("<", "").Replace(">", "");
+					doc = AppendToSummary(doc, ". Will infer the index from the generic type");
+					generated = $"public {m}({par}) : this(typeof({generic})){{}}";
 				}
 
 				var c = new Constructor { Generated = generated, Description = doc };
@@ -159,21 +166,21 @@ namespace ApiGenerator.Domain
 			var m = this.DescriptorType;
 			foreach (var url in this.Url.Paths)
 			{
-				var cp = this.Url.Parts
+				var requiredUrlRouteParameters = this.Url.Parts
 					.Where(p => !ApiUrl.BlackListRouteValues.Contains(p.Key))
 					.Where(p => p.Value.Required)
 					.Where(p => url.Contains($"{{{p.Value.Name}}}"))
 					.OrderBy(kv => url.IndexOf($"{{{kv.Value.Name}}}", StringComparison.Ordinal));
-				var par = string.Join(", ", cp.Select(p => $"{ClrParamType(p.Value.ClrTypeName)} {p.Key}"));
+				var par = string.Join(", ", requiredUrlRouteParameters.Select(p => $"{ClrParamType(p.Value.ClrTypeName)} {p.Key}"));
 				var routing = string.Empty;
 				//Routes that take {indices}/{types} and both are optional
-				if (!cp.Any() && IndicesAndTypes)
+				if (!requiredUrlRouteParameters.Any() && IndicesAndTypes)
 				{
 					AddParameterlessIndicesTypesConstructor(ctors, m);
 					continue;
 				}
-				if (cp.Any())
-					routing = "r=>r." + string.Join(".", cp
+				if (requiredUrlRouteParameters.Any())
+					routing = "r=>r." + string.Join(".", requiredUrlRouteParameters
 						.Select(p => new
 						{
 							route = p.Key,
@@ -187,18 +194,26 @@ namespace ApiGenerator.Domain
 						.Select(p => $"{p.call}(\"{p.route}\", {p.v})")
 					);
 				var doc = $@"/// <summary>{url}</summary>";
-				if (cp.Any())
+				if (requiredUrlRouteParameters.Any())
 				{
-					doc += "\r\n" + string.Join("\t\t\r\n", cp.Select(p => $"///<param name=\"{p.Key}\"> this parameter is required</param>"));
+					doc += "\r\n" + string.Join("\t\t\r\n", requiredUrlRouteParameters.Select(p => $"///<param name=\"{p.Key}\"> this parameter is required</param>"));
 				}
 
 				var generated = $"public {m}({par}) : base({routing}){{}}";
 
 				// Add typeof(T) as the default type when only index specified
-				if ((m == "UpdateByQueryDescriptor") && cp.Count() == 1 && !string.IsNullOrEmpty(this.RequestTypeGeneric))
+				if ((m == "UpdateByQueryDescriptor") && requiredUrlRouteParameters.Count() == 1 && !string.IsNullOrEmpty(this.RequestTypeGeneric))
 				{
 					var generic = this.RequestTypeGeneric.Replace("<", "").Replace(">", "");
 					generated = $"public {m}({par}) : base({routing}.Required(\"type\", (Types)typeof({generic}))){{}}";
+				}
+
+				// Add typeof(T) as the default index to use for Suggest
+				if ((m == "SuggestDescriptor") && !string.IsNullOrEmpty(this.RequestTypeGeneric))
+				{
+					var generic = this.RequestTypeGeneric.Replace("<", "").Replace(">", "");
+					doc = AppendToSummary(doc, ". Will infer the index from the generic type");
+					generated = $"public {m}({par}) : base(r => r.Required(\"index\", (Indices)typeof({generic}))){{}}";
 				}
 
 				var c = new Constructor { Generated = generated, Description = doc };
@@ -288,6 +303,13 @@ namespace ApiGenerator.Domain
 			return setters;
 		}
 
+		private string AppendToSummary(string doc, string toAppend)
+		{
+			return Regex.Replace(
+						doc,
+						@"^(\/\/\/ <summary>)(.*?)(<\/summary>)(.*)",
+						"$1$2" + toAppend + "$3$4");
+		}
 
 		private bool IsPartless => this.Url.Parts == null || !this.Url.Parts.Any();
 		private bool IsScroll => this.Url.Parts.All(p => p.Key == "scroll_id");

--- a/src/Nest/Search/Search/ElasticClient-Search.cs
+++ b/src/Nest/Search/Search/ElasticClient-Search.cs
@@ -11,7 +11,7 @@ namespace Nest
 		/// The search API allows to execute a search query and get back search hits that match the query.
 		/// <para> </para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-search.html
 		/// </summary>
-		/// <typeparam name="T">The type used to infer the index and typename as well describe the query strongly typed</typeparam>
+		/// <typeparam name="T">The type used to infer the index and type name as well describe the query strongly typed</typeparam>
 		/// <param name="selector">A descriptor that describes the parameters for the search operation</param>
 		ISearchResponse<T> Search<T>(Func<SearchDescriptor<T>, ISearchRequest> selector = null) where T : class;
 
@@ -29,7 +29,7 @@ namespace Nest
 			where TResult : class;
 
 		/// <inheritdoc/>
-		/// <typeparam name="T">The type used to infer the index and typename as well describe the query strongly typed</typeparam>
+		/// <typeparam name="T">The type used to infer the index and type name as well describe the query strongly typed</typeparam>
 		/// <param name="selector">A descriptor that describes the parameters for the search operation</param>
 		Task<ISearchResponse<T>> SearchAsync<T>(Func<SearchDescriptor<T>, ISearchRequest> selector = null) where T : class;
 
@@ -61,7 +61,7 @@ namespace Nest
 			this.Search<TResult>(selector.InvokeOrDefault(new SearchDescriptor<T>()));
 
 		/// <inheritdoc/>
-		public ISearchResponse<T> Search<T>(ISearchRequest request) where T : class => 
+		public ISearchResponse<T> Search<T>(ISearchRequest request) where T : class =>
 			this.Search<T, T>(request);
 
 		/// <inheritdoc/>
@@ -77,7 +77,7 @@ namespace Nest
 
 		/// <inheritdoc/>
 		public Task<ISearchResponse<T>> SearchAsync<T>(Func<SearchDescriptor<T>, ISearchRequest> selector = null)
-			where T : class => 
+			where T : class =>
 			this.SearchAsync<T, T>(selector);
 
 		/// <inheritdoc/>
@@ -87,7 +87,7 @@ namespace Nest
 			this.SearchAsync<TResult>(selector.InvokeOrDefault(new SearchDescriptor<T>()));
 
 		/// <inheritdoc/>
-		public Task<ISearchResponse<T>> SearchAsync<T>(ISearchRequest request) where T : class => 
+		public Task<ISearchResponse<T>> SearchAsync<T>(ISearchRequest request) where T : class =>
 			this.SearchAsync<T, T>(request);
 
 		/// <inheritdoc/>

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -177,7 +177,7 @@ namespace Nest
 	}
 
 	/// <summary>
-	/// A descriptor wich describes a search operation for _search and _msearch
+	/// A descriptor which describes a search operation for _search and _msearch
 	/// </summary>
 	public partial class SearchDescriptor<T> where T : class
 	{

--- a/src/Nest/Search/Suggesters/Suggest/ElasticClient-Suggest.cs
+++ b/src/Nest/Search/Suggesters/Suggest/ElasticClient-Suggest.cs
@@ -7,7 +7,7 @@ namespace Nest
 	public partial interface IElasticClient
 	{
 		/// <summary>
-		/// The suggest feature suggests similar looking terms based on a provided text by using a suggester. 
+		/// The suggest feature suggests similar looking terms based on a provided text by using a suggester.
 		/// <para> </para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-suggesters.html
 		/// </summary>
 		/// <typeparam name="T">The type used to strongly type parts of the suggest operation</typeparam>
@@ -24,8 +24,6 @@ namespace Nest
 		Task<ISuggestResponse> SuggestAsync(ISuggestRequest request);
 	}
 
-	//TODO limit scope of fluent to IndexName of T
-
 	public partial class ElasticClient
 	{
 		/// <inheritdoc/>
@@ -33,18 +31,18 @@ namespace Nest
 			this.Suggest(selector?.Invoke(new SuggestDescriptor<T>()));
 
 		/// <inheritdoc/>
-		public ISuggestResponse Suggest(ISuggestRequest request) => 
+		public ISuggestResponse Suggest(ISuggestRequest request) =>
 			this.Dispatcher.Dispatch<ISuggestRequest, SuggestRequestParameters, SuggestResponse>(
 				request,
 				this.LowLevelDispatch.SuggestDispatch<SuggestResponse>
 			);
 
 		/// <inheritdoc/>
-		public Task<ISuggestResponse> SuggestAsync<T>(Func<SuggestDescriptor<T>, ISuggestRequest> selector) where T : class => 
+		public Task<ISuggestResponse> SuggestAsync<T>(Func<SuggestDescriptor<T>, ISuggestRequest> selector) where T : class =>
 			this.SuggestAsync(selector?.Invoke(new SuggestDescriptor<T>()));
 
 		/// <inheritdoc/>
-		public Task<ISuggestResponse> SuggestAsync(ISuggestRequest request) => 
+		public Task<ISuggestResponse> SuggestAsync(ISuggestRequest request) =>
 			this.Dispatcher.DispatchAsync<ISuggestRequest, SuggestRequestParameters, SuggestResponse, ISuggestResponse>(
 				request,
 				this.LowLevelDispatch.SuggestDispatchAsync<SuggestResponse>

--- a/src/Nest/Search/Suggesters/Suggest/SuggestRequest.cs
+++ b/src/Nest/Search/Suggesters/Suggest/SuggestRequest.cs
@@ -5,13 +5,21 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonConverter(typeof(SuggestRequestJsonConverter))]
-	public partial interface ISuggestRequest 
+	public partial interface ISuggestRequest
 	{
 		string GlobalText { get; set; }
 		ISuggestContainer Suggest { get; set; }
 	}
 
-	public partial class SuggestRequest 
+	public partial class SuggestRequest
+	{
+		public string GlobalText { get; set; }
+		public ISuggestContainer Suggest { get; set; }
+	}
+
+	public partial interface ISuggestRequest<T> : ISearchRequest { }
+
+	public partial class SuggestRequest<T>
 	{
 		public string GlobalText { get; set; }
 		public ISuggestContainer Suggest { get; set; }
@@ -29,25 +37,25 @@ namespace Nest
 		public SuggestDescriptor<T> GlobalText(string globalText) => Assign(a => a.GlobalText = globalText);
 
 		/// <summary>
-		/// The term suggester suggests terms based on edit distance. The provided suggest text is analyzed before terms are suggested. 
+		/// The term suggester suggests terms based on edit distance. The provided suggest text is analyzed before terms are suggested.
 		/// The suggested terms are provided per analyzed suggest text token. The term suggester doesn’t take the query into account that is part of request.
 		/// </summary>
 		public SuggestDescriptor<T> Term(string name, Func<TermSuggesterDescriptor<T>, ITermSuggester> suggest) =>
-			AssignToBucket(name, suggest?.Invoke(new TermSuggesterDescriptor<T>()), (b, s) => b.Term = s);  
+			AssignToBucket(name, suggest?.Invoke(new TermSuggesterDescriptor<T>()), (b, s) => b.Term = s);
 
 		/// <summary>
-		/// The phrase suggester adds additional logic on top of the term suggester to select entire corrected phrases 
-		/// instead of individual tokens weighted based on ngram-langugage models. 
+		/// The phrase suggester adds additional logic on top of the term suggester to select entire corrected phrases
+		/// instead of individual tokens weighted based on ngram-langugage models.
 		/// </summary>
 		public SuggestDescriptor<T> Phrase(string name, Func<PhraseSuggesterDescriptor<T>, IPhraseSuggester> suggest) =>
-			AssignToBucket(name, suggest?.Invoke(new PhraseSuggesterDescriptor<T>()), (b, s) => b.Phrase = s);  
+			AssignToBucket(name, suggest?.Invoke(new PhraseSuggesterDescriptor<T>()), (b, s) => b.Phrase = s);
 
 		/// <summary>
-		/// The completion suggester is a so-called prefix suggester. 
+		/// The completion suggester is a so-called prefix suggester.
 		/// It does not do spell correction like the term or phrase suggesters but allows basic auto-complete functionality.
 		/// </summary>
 		public SuggestDescriptor<T> Completion(string name, Func<CompletionSuggesterDescriptor<T>, ICompletionSuggester> suggest) =>
-			AssignToBucket(name, suggest?.Invoke(new CompletionSuggesterDescriptor<T>()), (b, s) => b.Completion = s);  
+			AssignToBucket(name, suggest?.Invoke(new CompletionSuggesterDescriptor<T>()), (b, s) => b.Completion = s);
 
 		private SuggestDescriptor<T> AssignToBucket<TSuggester>(string name, TSuggester suggester, Action<SuggestBucket, TSuggester> assign)
 			where TSuggester : ISuggester

--- a/src/Nest/_Generated/_Descriptors.generated.cs
+++ b/src/Nest/_Generated/_Descriptors.generated.cs
@@ -4329,8 +4329,8 @@ namespace Nest
 	public partial class SuggestDescriptor<T>  : RequestDescriptorBase<SuggestDescriptor<T>,SuggestRequestParameters, ISuggestRequest>, ISuggestRequest
 	{ 
 		Indices ISuggestRequest.Index => Self.RouteValues.Get<Indices>("index");
-			/// <summary>/_suggest</summary>
-		public SuggestDescriptor() : base(){}
+			/// <summary>/_suggest. Will infer the index from the generic type</summary>
+		public SuggestDescriptor() : base(r => r.Required("index", (Indices)typeof(T))){}
 		
 
 			///<summary>A comma-separated list of index names to restrict the operation; use the special string `_all` or Indices.All to perform the operation on all indices</summary>

--- a/src/Nest/_Generated/_Requests.generated.cs
+++ b/src/Nest/_Generated/_Requests.generated.cs
@@ -5210,6 +5210,42 @@ namespace Nest
 		Indices Index { get; }
 	 } 
 	///<summary>Request parameters for Suggest <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-suggesters.html</pre></summary>
+	public partial class SuggestRequest<T>  : PlainRequestBase<SuggestRequestParameters>, ISuggestRequest
+	{
+		protected ISuggestRequest Self => this;
+		Indices ISuggestRequest.Index => Self.RouteValues.Get<Indices>("index");
+			/// <summary>/_suggest. Will infer the index from the generic type</summary>
+		public SuggestRequest() : this(typeof(T)){}
+		
+
+		/// <summary>/{index}/_suggest</summary>
+///<param name="index">Optional, accepts null</param>
+		public SuggestRequest(Indices index) : base(r=>r.Optional("index", index)){}
+		
+
+			///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
+		public bool IgnoreUnavailable { get { return Q<bool>("ignore_unavailable"); } set { Q("ignore_unavailable", value); } }
+		
+		///<summary>Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)</summary>
+		public bool AllowNoIndices { get { return Q<bool>("allow_no_indices"); } set { Q("allow_no_indices", value); } }
+		
+		///<summary>Whether to expand wildcard expression to concrete indices that are open, closed or both.</summary>
+		public ExpandWildcards ExpandWildcards { get { return Q<ExpandWildcards>("expand_wildcards"); } set { Q("expand_wildcards", value); } }
+		
+		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
+		public string Preference { get { return Q<string>("preference"); } set { Q("preference", value); } }
+		
+		///<summary>Specific routing value</summary>
+		public string Routing { get { return Q<string>("routing"); } set { Q("routing", value); } }
+		
+		///<summary>The URL-encoded request definition</summary>
+		public string Source { get { return Q<string>("source"); } set { Q("source", value); } }
+		
+		///<summary>Comma separated list of filters used to reduce the response returned by Elasticsearch</summary>
+		public string FilterPath { get { return Q<string>("filter_path"); } set { Q("filter_path", value); } }
+		
+		}
+	///<summary>Request parameters for Suggest <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-suggesters.html</pre></summary>
 	public partial class SuggestRequest  : PlainRequestBase<SuggestRequestParameters>, ISuggestRequest
 	{
 		protected ISuggestRequest Self => this;

--- a/src/Tests/Search/Suggesters/SuggestApiTests.cs
+++ b/src/Tests/Search/Suggesters/SuggestApiTests.cs
@@ -16,7 +16,7 @@ namespace Tests.Search.Suggesters
 
 	*/
 	public class SuggestApiTests
-		: ApiIntegrationTestBase<ReadOnlyCluster, ISuggestResponse, ISuggestRequest, SuggestDescriptor<Project>, SuggestRequest>
+		: ApiIntegrationTestBase<ReadOnlyCluster, ISuggestResponse, ISuggestRequest, SuggestDescriptor<Project>, SuggestRequest<Project>>
 	{
 		public SuggestApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
@@ -30,7 +30,7 @@ namespace Tests.Search.Suggesters
 		protected override int ExpectStatusCode => 200;
 		protected override bool ExpectIsValid => true;
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
-		protected override string UrlPath => "/_suggest";
+		protected override string UrlPath => "/project/_suggest";
 		protected override bool SupportsDeserialization => false;
 
 		protected override object ExpectJson =>
@@ -144,8 +144,8 @@ namespace Tests.Search.Suggesters
 					.RealWordErrorLikelihood(0.5)
 				);
 
-		protected override SuggestRequest Initializer =>
-			new SuggestRequest
+		protected override SuggestRequest<Project> Initializer =>
+			new SuggestRequest<Project>
 			{
 				Suggest = new SuggestContainer
 				{

--- a/src/Tests/Search/Suggesters/SuggestUrlTests.cs
+++ b/src/Tests/Search/Suggesters/SuggestUrlTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+using static Tests.Framework.UrlTester;
+
+namespace Tests.Search.Suggesters
+{
+	public class SuggestUrlTests
+	{
+		[U]
+		public async Task Urls()
+		{
+			await POST("/project/_suggest")
+					.Fluent(c => c.Suggest<Project>(s => s))
+					.Request(c => c.Suggest(new SuggestRequest<Project>()))
+					.FluentAsync(c => c.SuggestAsync<Project>(s => s))
+					.RequestAsync(c => c.SuggestAsync(new SuggestRequest<Project>()))
+				;
+
+			await POST("/_suggest")
+					.Fluent(c => c.Suggest<Project>(s => s.AllIndices()))
+					.Request(c => c.Suggest(new SuggestRequest<Project>(Nest.Indices.All)))
+					.FluentAsync(c => c.SuggestAsync<Project>(s => s.AllIndices()))
+					.RequestAsync(c => c.SuggestAsync(new SuggestRequest<Project>(Nest.Indices.All)))
+				;
+
+			// Non-generic Object Initializer syntax
+			await POST("/_suggest")
+					.Request(c => c.Suggest(new SuggestRequest()))
+					.RequestAsync(c => c.SuggestAsync(new SuggestRequest()))
+				;
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -604,6 +604,7 @@
     <Compile Include="Search\Hits\HitsSerializationTests.cs" />
     <Compile Include="Search\Search\Rescoring\RescoreUsageTests.cs" />
     <Compile Include="Search\Search\InvalidSearchApiTests.cs" />
+    <Compile Include="Search\Suggesters\SuggestUrlTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsApiTests.cs" />
     <Compile Include="XPack\Security\ClearCachedRealms\ClearCachedRealmsUrlTests.cs" />
     <Compile Include="XPack\Security\Role\ClearCachedRoles\ClearCachedRolesApiTests.cs" />


### PR DESCRIPTION
In NEST 1.x, the index is inferred from T but this behaviour changed in 2.x such that the index was not inferred from T and always had to be explicitly specified. This commit reverts the behaviour to that of 1.x such that index is inferred from T again, and introduces a SuggestRequest<T> with a parameterless ctor that also infers the index from T.

Closes #2335