### PR TITLE
fix #2368 by fixing the underlying problem that scalars should be easier

### DIFF
--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -33,7 +33,7 @@ namespace Nest
 
 		public IProperty Binary(Func<BinaryPropertyDescriptor<T>, IBinaryProperty> selector) =>
 			selector?.Invoke(new BinaryPropertyDescriptor<T>());
-
+		/
 		public IProperty Attachment(Func<AttachmentPropertyDescriptor<T>, IAttachmentProperty> selector) =>
 			selector?.Invoke(new AttachmentPropertyDescriptor<T>());
 
@@ -69,154 +69,154 @@ namespace Nest
 
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public IProperty Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<int>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-				selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
+				selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
 		public IProperty Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<int?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
 
 		public IProperty Scalar(Expression<Func<T, float>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<float>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
 		public IProperty Scalar(Expression<Func<T, float?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<float?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
 
 		public IProperty Scalar(Expression<Func<T, sbyte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
 		public IProperty Scalar(Expression<Func<T, sbyte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<sbyte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<sbyte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
 
 		public IProperty Scalar(Expression<Func<T, short>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 		public IProperty Scalar(Expression<Func<T, short?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<short>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<short?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 
 		public IProperty Scalar(Expression<Func<T, byte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 		public IProperty Scalar(Expression<Func<T, byte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<byte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<byte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 
 		public IProperty Scalar(Expression<Func<T, long>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, long?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<long>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<long?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 
 		public IProperty Scalar(Expression<Func<T, uint>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, uint?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<uint>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<uint?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 
 		public IProperty Scalar(Expression<Func<T, TimeSpan>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, TimeSpan?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<TimeSpan>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<TimeSpan?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 
 		public IProperty Scalar(Expression<Func<T, decimal>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, decimal?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<decimal>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<decimal?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 
 		public IProperty Scalar(Expression<Func<T, ulong>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, ulong?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<ulong>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<ulong?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 
 		public IProperty Scalar(Expression<Func<T, double>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, double?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<double>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<double?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 
 		public IProperty Scalar(Expression<Func<T, DateTime>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, DateTime?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<DateTime>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<DateTime?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 
 		public IProperty Scalar(Expression<Func<T, DateTimeOffset>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, DateTimeOffset?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<DateTimeOffset>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 
 		public IProperty Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
-			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
-			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<bool>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
-			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<bool?>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
-			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
 
 		public IProperty Scalar(Expression<Func<T, char>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, char?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<char>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<char?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 
 		public IProperty Scalar(Expression<Func<T, Guid>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<Guid>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<Guid?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 
 
 		public IProperty Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
-			selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field));
 		public IProperty Scalar(Expression<Func<T, IEnumerable<string>>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
-			selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field));
+			selector.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field));
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
 	}
 }

--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Nest
@@ -66,106 +67,155 @@ namespace Nest
 		public IProperty Percolator(Func<PercolatorPropertyDescriptor<T>, IPercolatorProperty> selector) =>
 			selector?.Invoke(new PercolatorPropertyDescriptor<T>());
 
-
-
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public IProperty Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
-
+		public IProperty Scalar(Expression<Func<T, IEnumerable<int>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+				selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
 		public IProperty Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<int?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
 
 		public IProperty Scalar(Expression<Func<T, float>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
-
+		public IProperty Scalar(Expression<Func<T, IEnumerable<float>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
 		public IProperty Scalar(Expression<Func<T, float?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<float?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
 
 		public IProperty Scalar(Expression<Func<T, sbyte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
-
 		public IProperty Scalar(Expression<Func<T, sbyte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<sbyte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<sbyte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
 
 		public IProperty Scalar(Expression<Func<T, short>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
-
 		public IProperty Scalar(Expression<Func<T, short?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<short>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<short?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 
 		public IProperty Scalar(Expression<Func<T, byte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
-
 		public IProperty Scalar(Expression<Func<T, byte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<byte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<byte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
 
 		public IProperty Scalar(Expression<Func<T, long>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
-
 		public IProperty Scalar(Expression<Func<T, long?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<long>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<long?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 
 		public IProperty Scalar(Expression<Func<T, uint>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
-
 		public IProperty Scalar(Expression<Func<T, uint?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<uint>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<uint?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 
 		public IProperty Scalar(Expression<Func<T, TimeSpan>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
-
 		public IProperty Scalar(Expression<Func<T, TimeSpan?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<TimeSpan>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<TimeSpan?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
 
 		public IProperty Scalar(Expression<Func<T, decimal>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
-
 		public IProperty Scalar(Expression<Func<T, decimal?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<decimal>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<decimal?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 
 		public IProperty Scalar(Expression<Func<T, ulong>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
-
 		public IProperty Scalar(Expression<Func<T, ulong?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<ulong>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<ulong?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 
 		public IProperty Scalar(Expression<Func<T, double>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
-
 		public IProperty Scalar(Expression<Func<T, double?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<double>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<double?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
 
 		public IProperty Scalar(Expression<Func<T, DateTime>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
 			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
-
 		public IProperty Scalar(Expression<Func<T, DateTime?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<DateTime>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<DateTime?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
 			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 
 		public IProperty Scalar(Expression<Func<T, DateTimeOffset>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
 			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
-
 		public IProperty Scalar(Expression<Func<T, DateTimeOffset?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<DateTimeOffset>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
 			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 
 		public IProperty Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
 			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
-
 		public IProperty Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
+			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<bool>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
+			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<bool?>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
 			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
 
 		public IProperty Scalar(Expression<Func<T, char>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
-
 		public IProperty Scalar(Expression<Func<T, char?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<char>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<char?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
 
 		public IProperty Scalar(Expression<Func<T, Guid>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
-
 		public IProperty Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<Guid>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<Guid?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+
 
 		public IProperty Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
+			selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field));
+		public IProperty Scalar(Expression<Func<T, IEnumerable<string>>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
 			selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field));
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
 	}

--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq.Expressions;
 
 namespace Nest
 {
@@ -6,7 +7,6 @@ namespace Nest
 		DescriptorBase<SingleMappingDescriptor<T>, IPropertiesDescriptor<T, IProperty>>, IPropertiesDescriptor<T, IProperty>
 		where T : class
 	{
-
 		[Obsolete("Only valid for indices created before Elasticsearch 5.0 and will be removed in the next major version.  For newly created indices, use `text` or `keyword` instead.")]
 		public IProperty String(Func<StringPropertyDescriptor<T>, IStringProperty> selector) =>
 			selector?.Invoke(new StringPropertyDescriptor<T>());
@@ -17,6 +17,10 @@ namespace Nest
 		public IProperty Keyword(Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			selector?.Invoke(new KeywordPropertyDescriptor<T>());
 
+		/// <summary>
+		/// Number introduces a numeric mapping that defaults to `float` use .Type() to set the right type if needed or use
+		/// <see cref="Scalar"/> instead of <see cref="Number"/>
+		/// </summary>
 		public IProperty Number(Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.Invoke(new NumberPropertyDescriptor<T>());
 
@@ -61,5 +65,106 @@ namespace Nest
 
 		public IProperty Percolator(Func<PercolatorPropertyDescriptor<T>, IPercolatorProperty> selector) =>
 			selector?.Invoke(new PercolatorPropertyDescriptor<T>());
+
+
+
+		public IProperty Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
+
+		public IProperty Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
+
+		public IProperty Scalar(Expression<Func<T, float>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
+
+		public IProperty Scalar(Expression<Func<T, float?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float));
+
+		public IProperty Scalar(Expression<Func<T, sbyte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
+
+		public IProperty Scalar(Expression<Func<T, sbyte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte));
+
+		public IProperty Scalar(Expression<Func<T, short>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+
+		public IProperty Scalar(Expression<Func<T, short?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+
+		public IProperty Scalar(Expression<Func<T, byte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+
+		public IProperty Scalar(Expression<Func<T, byte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short));
+
+		public IProperty Scalar(Expression<Func<T, long>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+
+		public IProperty Scalar(Expression<Func<T, long?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+
+		public IProperty Scalar(Expression<Func<T, uint>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+
+		public IProperty Scalar(Expression<Func<T, uint?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+
+		public IProperty Scalar(Expression<Func<T, TimeSpan>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+
+		public IProperty Scalar(Expression<Func<T, TimeSpan?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long));
+
+		public IProperty Scalar(Expression<Func<T, decimal>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+
+		public IProperty Scalar(Expression<Func<T, decimal?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+
+		public IProperty Scalar(Expression<Func<T, ulong>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+
+		public IProperty Scalar(Expression<Func<T, ulong?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+
+		public IProperty Scalar(Expression<Func<T, double>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+
+		public IProperty Scalar(Expression<Func<T, double?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double));
+
+		public IProperty Scalar(Expression<Func<T, DateTime>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, DateTime?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, DateTimeOffset>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, DateTimeOffset?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
+			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
+			selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, char>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, char?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, Guid>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field));
+
+		public IProperty Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
+			selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field));
 	}
 }

--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -19,7 +19,7 @@ namespace Nest
 
 		/// <summary>
 		/// Number introduces a numeric mapping that defaults to `float` use .Type() to set the right type if needed or use
-		/// <see cref="Scalar"/> instead of <see cref="Number"/>
+		/// Scalar instead of <see cref="Number"/>
 		/// </summary>
 		public IProperty Number(Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.Invoke(new NumberPropertyDescriptor<T>());
@@ -68,6 +68,7 @@ namespace Nest
 
 
 
+#pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public IProperty Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));
 
@@ -166,5 +167,6 @@ namespace Nest
 
 		public IProperty Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
 			selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field));
+#pragma warning restore CS3001 // Argument type is not CLS-compliant
 	}
 }

--- a/src/Nest/Mapping/Types/Properties-Scalar.cs
+++ b/src/Nest/Mapping/Types/Properties-Scalar.cs
@@ -101,154 +101,154 @@ namespace Nest
 	{
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<int>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-				SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
+				SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<int?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, float>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<float>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, float?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<float?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, sbyte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, sbyte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<sbyte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<sbyte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, short>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, short?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<short>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<short?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, byte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, byte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<byte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<byte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, long>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, long?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<long>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<long?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, uint>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, uint?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<uint>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<uint?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, TimeSpan>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, TimeSpan?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<TimeSpan>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<TimeSpan?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, decimal>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, decimal?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<decimal>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<decimal?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, ulong>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, ulong?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<ulong>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<ulong?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, double>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, double?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<double>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<double?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+			SetProperty(selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTime>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTime?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<DateTime>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<DateTime?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTimeOffset>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTimeOffset?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<DateTimeOffset>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<bool>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<bool?>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, char>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, char?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<char>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<char?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, Guid>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<Guid>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<Guid?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<string>>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
-			SetProperty(selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field)));
+			SetProperty(selector.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field)));
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
 	}
 }

--- a/src/Nest/Mapping/Types/Properties-Scalar.cs
+++ b/src/Nest/Mapping/Types/Properties-Scalar.cs
@@ -12,70 +12,87 @@ namespace Nest
 	{
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		TReturnType Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<int>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<int?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, float>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, float?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<float>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<float?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, sbyte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, sbyte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<sbyte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<sbyte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, short>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, short?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<short>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<short?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, byte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, byte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<byte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<byte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, long>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, long?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<long>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<long?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, uint>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, uint?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<uint>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<uint?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, TimeSpan>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, TimeSpan?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<TimeSpan>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<TimeSpan?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, decimal>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, decimal?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<decimal>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<decimal?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, ulong>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, ulong?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<ulong>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<ulong?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, double>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, double?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<double>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<double?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, DateTime>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, DateTime?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<DateTime>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<DateTime?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, DateTimeOffset>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, DateTimeOffset?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<DateTimeOffset>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<bool>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<bool?>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, char>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, char?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<char>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<char?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, Guid>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
-
 		TReturnType Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<Guid>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<Guid?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector);
+		TReturnType Scalar(Expression<Func<T, IEnumerable<string>>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector);
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
 	}
 
@@ -85,103 +102,153 @@ namespace Nest
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
-
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<int>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+				SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<int?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, float>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
-
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<float>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, float?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<float?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, sbyte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, sbyte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<sbyte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<sbyte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, short>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, short?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<short>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<short?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, byte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, byte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<byte>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<byte?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, long>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, long?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<long>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<long?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, uint>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, uint?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<uint>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<uint?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, TimeSpan>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, TimeSpan?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<TimeSpan>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<TimeSpan?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, decimal>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, decimal?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<decimal>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<decimal?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, ulong>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, ulong?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<ulong>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<ulong?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, double>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, double?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<double>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<double?>>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTime>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTime?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<DateTime>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<DateTime?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTimeOffset>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTimeOffset?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<DateTimeOffset>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<bool>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<bool?>>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, char>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, char?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<char>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<char?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, Guid>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
-
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<Guid>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<Guid?>>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field)));
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, IEnumerable<string>>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field)));
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
-
 	}
 }

--- a/src/Nest/Mapping/Types/Properties-Scalar.cs
+++ b/src/Nest/Mapping/Types/Properties-Scalar.cs
@@ -10,6 +10,7 @@ namespace Nest
 		where T : class
 		where TReturnType : class
 	{
+#pragma warning disable CS3001 // Argument type is not CLS-compliant
 		TReturnType Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
@@ -75,11 +76,13 @@ namespace Nest
 		TReturnType Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
 
 		TReturnType Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector);
+#pragma warning restore CS3001 // Argument type is not CLS-compliant
 	}
 
 	public partial class PropertiesDescriptor<T> : IsADictionaryDescriptorBase<PropertiesDescriptor<T>, IProperties, PropertyName, IProperty>, IPropertiesDescriptor<T, PropertiesDescriptor<T>>
 		where T : class
 	{
+#pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
 
@@ -178,6 +181,7 @@ namespace Nest
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
 			SetProperty(selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field)));
+#pragma warning restore CS3001 // Argument type is not CLS-compliant
 
 	}
 }

--- a/src/Nest/Mapping/Types/Properties-Scalar.cs
+++ b/src/Nest/Mapping/Types/Properties-Scalar.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	public partial interface IPropertiesDescriptor<T, out TReturnType>
+		where T : class
+		where TReturnType : class
+	{
+		TReturnType Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, float>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, float?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, sbyte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, sbyte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, short>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, short?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, byte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, byte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, long>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, long?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, uint>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, uint?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, TimeSpan>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, TimeSpan?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, decimal>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, decimal?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, ulong>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, ulong?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, double>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, double?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, DateTime>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, DateTime?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, DateTimeOffset>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, DateTimeOffset?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, char>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, char?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, Guid>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+
+		TReturnType Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector);
+	}
+
+	public partial class PropertiesDescriptor<T> : IsADictionaryDescriptorBase<PropertiesDescriptor<T>, IProperties, PropertyName, IProperty>, IPropertiesDescriptor<T, PropertiesDescriptor<T>>
+		where T : class
+	{
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, int?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, float>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, float?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Float)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, sbyte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, sbyte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Byte)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, short>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, short?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, byte>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, byte?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Short)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, long>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, long?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, uint>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, uint?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, TimeSpan>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, TimeSpan?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Long)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, decimal>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, decimal?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, ulong>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, ulong?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, double>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, double?>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Double)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTime>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTime?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTimeOffset>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, DateTimeOffset?>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, char>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, char?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, Guid>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, Guid?>> field, Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new KeywordPropertyDescriptor<T>().Name(field)));
+
+		public PropertiesDescriptor<T> Scalar(Expression<Func<T, string>> field, Func<TextPropertyDescriptor<T>, ITextProperty> selector) =>
+			SetProperty(selector?.InvokeOrDefault(new TextPropertyDescriptor<T>().Name(field)));
+
+	}
+}

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -44,7 +44,7 @@ namespace Nest
 		TReturnType Keyword(Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
 		/// <summary>
 		/// Number introduces a numeric mapping that defaults to `float` use .Type() to set the right type if needed or use
-		/// <see cref="Scalar"/> instead of <see cref="Number"/>
+		/// Scalar instead of <see cref="Number"/>
 		/// </summary>
 		TReturnType Number(Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 		TReturnType TokenCount(Func<TokenCountPropertyDescriptor<T>, ITokenCountProperty> selector);
@@ -80,7 +80,7 @@ namespace Nest
 
 		/// <summary>
 		/// Number introduces a numeric mapping that defaults to `float` use .Type() to set the right type if needed or use
-		/// <see cref="Scalar"/> instead of <see cref="Number"/>
+		/// Scalar instead of <see cref="Number"/>
 		/// </summary>
 		public PropertiesDescriptor<T> Number(Func<NumberPropertyDescriptor<T>, INumberProperty> selector) => SetProperty(selector);
 

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -33,7 +33,7 @@ namespace Nest
 		public void Add(Expression<Func<T, object>> name, IProperty property) => this.BackingDictionary.Add(name, property);
 	}
 
-	public interface IPropertiesDescriptor<T, out TReturnType>
+	public partial interface IPropertiesDescriptor<T, out TReturnType>
 		where T : class
 		where TReturnType : class
 	{
@@ -42,6 +42,10 @@ namespace Nest
 		TReturnType String(Func<StringPropertyDescriptor<T>, IStringProperty> selector);
 		TReturnType Text(Func<TextPropertyDescriptor<T>, ITextProperty> selector);
 		TReturnType Keyword(Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector);
+		/// <summary>
+		/// Number introduces a numeric mapping that defaults to `float` use .Type() to set the right type if needed or use
+		/// <see cref="Scalar"/> instead of <see cref="Number"/>
+		/// </summary>
 		TReturnType Number(Func<NumberPropertyDescriptor<T>, INumberProperty> selector);
 		TReturnType TokenCount(Func<TokenCountPropertyDescriptor<T>, ITokenCountProperty> selector);
 		TReturnType Date(Func<DatePropertyDescriptor<T>, IDateProperty> selector);
@@ -60,7 +64,7 @@ namespace Nest
 		TReturnType Percolator(Func<PercolatorPropertyDescriptor<T>, IPercolatorProperty> selector);
 	}
 
-	public class PropertiesDescriptor<T> : IsADictionaryDescriptorBase<PropertiesDescriptor<T>, IProperties, PropertyName, IProperty>, IPropertiesDescriptor<T, PropertiesDescriptor<T>>
+	public partial class PropertiesDescriptor<T> : IsADictionaryDescriptorBase<PropertiesDescriptor<T>, IProperties, PropertyName, IProperty>, IPropertiesDescriptor<T, PropertiesDescriptor<T>>
 		where T : class
 	{
 		public PropertiesDescriptor() : base(new Properties<T>()) { }
@@ -74,6 +78,10 @@ namespace Nest
 
 		public PropertiesDescriptor<T> Keyword(Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) => SetProperty(selector);
 
+		/// <summary>
+		/// Number introduces a numeric mapping that defaults to `float` use .Type() to set the right type if needed or use
+		/// <see cref="Scalar"/> instead of <see cref="Number"/>
+		/// </summary>
 		public PropertiesDescriptor<T> Number(Func<NumberPropertyDescriptor<T>, INumberProperty> selector) => SetProperty(selector);
 
 		public PropertiesDescriptor<T> TokenCount(Func<TokenCountPropertyDescriptor<T>, ITokenCountProperty> selector) => SetProperty(selector);

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -884,6 +884,7 @@
     <Compile Include="Mapping\Types\Geo\GeoShape\GeoShapeProperty.cs" />
     <Compile Include="Mapping\Types\Geo\GeoShape\GeoStrategy.cs" />
     <Compile Include="Mapping\Types\Geo\GeoShape\GeoTree.cs" />
+    <Compile Include="Mapping\Types\Properties-Scalar.cs" />
     <Compile Include="Mapping\Types\Properties.cs" />
     <Compile Include="Mapping\Types\PropertiesJsonConverter.cs" />
     <Compile Include="Mapping\Types\PropertyBase.cs" />

--- a/src/Tests/IndexModules/UsageTestBase.cs
+++ b/src/Tests/IndexModules/UsageTestBase.cs
@@ -12,13 +12,17 @@ namespace Tests.Framework
 		protected abstract TInitializer Initializer { get; }
 		protected abstract Func<TDescriptor, TInterface> Fluent { get; }
 
+		protected virtual bool TestObjectInitializer => true;
+
 		protected UsageTestBase()
 		{
 			this.FluentInstance = this.Fluent(new TDescriptor());
 		}
 
-		[U] protected void SerializesInitializer() =>
-			this.AssertSerializesAndRoundTrips<TInterface>(this.Initializer);
+		[U] protected void SerializesInitializer()
+		{
+			if (this.TestObjectInitializer) this.AssertSerializesAndRoundTrips<TInterface>(this.Initializer);
+		}
 
 		[U] protected void SerializesFluent() =>
 			this.AssertSerializesAndRoundTrips(this.FluentInstance);

--- a/src/Tests/Mapping/Scalar/ScalarUsageTests.cs
+++ b/src/Tests/Mapping/Scalar/ScalarUsageTests.cs
@@ -1,0 +1,150 @@
+﻿using Nest;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.Mapping.Scalar
+{
+	public class ScalarUsageTests : UsageTestBase<ITypeMapping, TypeMappingDescriptor<ScalarUsageTests.ScalarPoco>, TypeMapping>
+	{
+		protected override bool SupportsDeserialization => false;
+		protected override bool TestObjectInitializer => false;
+
+		public class ScalarPoco
+		{
+			public int Int { get; set; }
+			public int? IntNullable { get; set; }
+
+			public float Float { get; set; }
+			public float? FloatNullable { get; set; }
+
+			public double Double { get; set; }
+			public double? DoubleNullable { get; set; }
+
+			public sbyte SByte { get; set; }
+			public sbyte? SByteNullable { get; set; }
+
+			public short Short { get; set; }
+			public short? ShortNullable { get; set; }
+
+			public byte Byte { get; set; }
+			public byte? ByteNullable { get; set; }
+
+			public long Long { get; set; }
+			public long? LongNullable { get; set; }
+
+			public uint Uint { get; set; }
+			public uint? UintNullable { get; set; }
+
+			public TimeSpan TimeSpan { get; set; }
+			public TimeSpan? TimeSpanNullable { get; set; }
+
+			public decimal Decimal { get; set; }
+			public decimal? DecimalNullable { get; set; }
+
+			public ulong Ulong { get; set; }
+			public ulong? UlongNullable { get; set; }
+
+			public DateTime DateTime { get; set; }
+			public DateTime? DateTimeNullable { get; set; }
+
+			public DateTimeOffset DateTimeOffset { get; set; }
+			public DateTimeOffset? DateTimeOffsetNullable { get; set; }
+
+			public bool Bool { get; set; }
+			public bool? BoolNullable { get; set; }
+
+			public char Char { get; set; }
+			public char? CharNullable { get; set; }
+
+			public Guid Guid { get; set; }
+			public Guid? GuidNullable { get; set; }
+
+			public string String { get; set; }
+
+		}
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				@bool = new { type = "boolean" },
+				boolNullable = new { type = "boolean" },
+				@byte = new { type = "short" },
+				byteNullable = new { type = "short" },
+				@char = new { type = "keyword" },
+				charNullable = new { type = "keyword" },
+				dateTime = new { type = "date" },
+				dateTimeNullable = new { type = "date" },
+				dateTimeOffset = new { type = "date" },
+				dateTimeOffsetNullable = new { type = "date" },
+				@decimal = new { type = "double" },
+				decimalNullable = new { type = "double" },
+				@double = new { type = "double" },
+				doubleNullable = new { type = "double" },
+				@float = new { type = "float" },
+				floatNullable = new { type = "float" },
+				guid = new { type = "keyword" },
+				guidNullable = new { type = "keyword" },
+				@int = new { type = "integer" },
+				intNullable = new { type = "integer" },
+				@long = new { type = "long" },
+				longNullable = new { type = "long" },
+				sByte = new { type = "byte" },
+				sByteNullable = new { type = "byte" },
+				@short = new { type = "short" },
+				shortNullable = new { type = "short" },
+				@string = new { type = "text" },
+				timeSpan = new { type = "long" },
+				timeSpanNullable = new { type = "long" },
+				@uint = new { type = "long" },
+				uintNullable = new { type = "long" },
+				@ulong = new { type = "double" },
+				ulongNullable = new { type = "double" }
+			}
+		};
+
+		protected override Func<TypeMappingDescriptor<ScalarPoco>, ITypeMapping> Fluent => f => f
+			.Properties(ps => ps
+				.Scalar(p => p.Int, m => m)
+				.Scalar(p => p.IntNullable, m => m)
+				.Scalar(p => p.Float, m => m)
+				.Scalar(p => p.FloatNullable, m => m)
+				.Scalar(p => p.Double, m => m)
+				.Scalar(p => p.DoubleNullable, m => m)
+				.Scalar(p => p.SByte, m => m)
+				.Scalar(p => p.SByteNullable, m => m)
+				.Scalar(p => p.Short, m => m)
+				.Scalar(p => p.ShortNullable, m => m)
+				.Scalar(p => p.Byte, m => m)
+				.Scalar(p => p.ByteNullable, m => m)
+				.Scalar(p => p.Long, m => m)
+				.Scalar(p => p.LongNullable, m => m)
+				.Scalar(p => p.Uint, m => m)
+				.Scalar(p => p.UintNullable, m => m)
+				.Scalar(p => p.TimeSpan, m => m)
+				.Scalar(p => p.TimeSpanNullable, m => m)
+				.Scalar(p => p.Decimal, m => m)
+				.Scalar(p => p.DecimalNullable, m => m)
+				.Scalar(p => p.Ulong, m => m)
+				.Scalar(p => p.UlongNullable, m => m)
+				.Scalar(p => p.DateTime, m => m)
+				.Scalar(p => p.DateTimeNullable, m => m)
+				.Scalar(p => p.DateTimeOffset, m => m)
+				.Scalar(p => p.DateTimeOffsetNullable, m => m)
+				.Scalar(p => p.Bool, m => m)
+				.Scalar(p => p.BoolNullable, m => m)
+				.Scalar(p => p.Char, m => m)
+				.Scalar(p => p.CharNullable, m => m)
+				.Scalar(p => p.Guid, m => m)
+				.Scalar(p => p.GuidNullable, m => m)
+				.Scalar(p => p.String, m => m)
+			);
+
+		protected override TypeMapping Initializer => null;
+	}
+}

--- a/src/Tests/Mapping/Scalar/ScalarUsageTests.cs
+++ b/src/Tests/Mapping/Scalar/ScalarUsageTests.cs
@@ -17,54 +17,87 @@ namespace Tests.Mapping.Scalar
 		public class ScalarPoco
 		{
 			public int Int { get; set; }
+			public IEnumerable<int> Ints { get; set; }
 			public int? IntNullable { get; set; }
+			public IEnumerable<int?> IntNullables { get; set; }
 
 			public float Float { get; set; }
+			public IEnumerable<float> Floats { get; set; }
 			public float? FloatNullable { get; set; }
+			public IEnumerable<float?> FloatNullables { get; set; }
 
 			public double Double { get; set; }
+			public IEnumerable<double> Doubles { get; set; }
 			public double? DoubleNullable { get; set; }
+			public IEnumerable<double?> DoubleNullables { get; set; }
 
 			public sbyte SByte { get; set; }
+			public IEnumerable<sbyte> SBytes { get; set; }
 			public sbyte? SByteNullable { get; set; }
+			public IEnumerable<sbyte?> SByteNullables { get; set; }
 
 			public short Short { get; set; }
+			public IEnumerable<short> Shorts { get; set; }
 			public short? ShortNullable { get; set; }
+			public IEnumerable<short?> ShortNullables { get; set; }
 
 			public byte Byte { get; set; }
+			public IEnumerable<byte> Bytes { get; set; }
 			public byte? ByteNullable { get; set; }
+			public IEnumerable<byte?> ByteNullables { get; set; }
 
 			public long Long { get; set; }
+			public IEnumerable<long> Longs { get; set; }
 			public long? LongNullable { get; set; }
+			public IEnumerable<long?> LongNullables { get; set; }
 
 			public uint Uint { get; set; }
+			public IEnumerable<uint> Uints { get; set; }
 			public uint? UintNullable { get; set; }
+			public IEnumerable<uint?> UintNullables { get; set; }
 
 			public TimeSpan TimeSpan { get; set; }
+			public IEnumerable<TimeSpan> TimeSpans { get; set; }
 			public TimeSpan? TimeSpanNullable { get; set; }
+			public IEnumerable<TimeSpan?> TimeSpanNullables { get; set; }
 
 			public decimal Decimal { get; set; }
+			public IEnumerable<decimal> Decimals {get;set; }
 			public decimal? DecimalNullable { get; set; }
+			public IEnumerable<decimal?> DecimalNullables { get; set; }
 
 			public ulong Ulong { get; set; }
+			public IEnumerable<ulong> Ulongs { get; set; }
 			public ulong? UlongNullable { get; set; }
+			public IEnumerable<ulong?> UlongNullables { get; set; }
 
 			public DateTime DateTime { get; set; }
+			public IEnumerable<DateTime> DateTimes { get; set; }
 			public DateTime? DateTimeNullable { get; set; }
+			public IEnumerable<DateTime?> DateTimeNullables { get; set; }
 
 			public DateTimeOffset DateTimeOffset { get; set; }
+			public IEnumerable<DateTimeOffset> DateTimeOffsets { get; set; }
 			public DateTimeOffset? DateTimeOffsetNullable { get; set; }
+			public IEnumerable<DateTimeOffset?> DateTimeOffsetNullables { get; set; }
 
 			public bool Bool { get; set; }
+			public IEnumerable<bool> Bools { get; set; }
 			public bool? BoolNullable { get; set; }
+			public IEnumerable<bool?> BoolNullables { get; set; }
 
 			public char Char { get; set; }
+			public IEnumerable<char> Chars { get; set; }
 			public char? CharNullable { get; set; }
+			public IEnumerable<char?> CharNullables { get; set; }
 
 			public Guid Guid { get; set; }
+			public IEnumerable<Guid> Guids { get; set; }
 			public Guid? GuidNullable { get; set; }
+			public IEnumerable<Guid?> GuidNullables { get; set; }
 
 			public string String { get; set; }
+			public IEnumerable<string> Strings { get; set; }
 		}
 
 		protected override object ExpectJson => new
@@ -72,76 +105,142 @@ namespace Tests.Mapping.Scalar
 			properties = new
 			{
 				@bool = new { type = "boolean" },
+				bools = new { type = "boolean" },
 				boolNullable = new { type = "boolean" },
+				boolNullables = new { type = "boolean" },
 				@byte = new { type = "short" },
+				bytes = new { type = "short" },
 				byteNullable = new { type = "short" },
+				byteNullables = new { type = "short" },
 				@char = new { type = "keyword" },
+				chars = new { type = "keyword" },
 				charNullable = new { type = "keyword" },
+				charNullables = new { type = "keyword" },
 				dateTime = new { type = "date" },
+				dateTimes = new { type = "date" },
 				dateTimeNullable = new { type = "date" },
+				dateTimeNullables = new { type = "date" },
 				dateTimeOffset = new { type = "date" },
+				dateTimeOffsets = new { type = "date" },
 				dateTimeOffsetNullable = new { type = "date" },
+				dateTimeOffsetNullables = new { type = "date" },
 				@decimal = new { type = "double" },
+				decimals = new { type = "double" },
 				decimalNullable = new { type = "double" },
+				decimalNullables = new { type = "double" },
 				@double = new { type = "double" },
+				doubles = new { type = "double" },
 				doubleNullable = new { type = "double" },
+				doubleNullables = new { type = "double" },
 				@float = new { type = "float" },
+				floats = new { type = "float" },
 				floatNullable = new { type = "float" },
+				floatNullables = new { type = "float" },
 				guid = new { type = "keyword" },
+				guids = new { type = "keyword" },
 				guidNullable = new { type = "keyword" },
+				guidNullables = new { type = "keyword" },
 				@int = new { type = "integer" },
+				ints = new { type = "integer" },
 				intNullable = new { type = "integer" },
+				intNullables = new { type = "integer" },
 				@long = new { type = "long" },
+				longs = new { type = "long" },
 				longNullable = new { type = "long" },
+				longNullables = new { type = "long" },
 				sByte = new { type = "byte" },
+				sBytes = new { type = "byte" },
 				sByteNullable = new { type = "byte" },
+				sByteNullables = new { type = "byte" },
 				@short = new { type = "short" },
+				shorts = new { type = "short" },
 				shortNullable = new { type = "short" },
-				@string = new { type = "text" },
+				shortNullables = new { type = "short" },
 				timeSpan = new { type = "long" },
+				timeSpans = new { type = "long" },
 				timeSpanNullable = new { type = "long" },
+				timeSpanNullables = new { type = "long" },
 				@uint = new { type = "long" },
+				uints = new { type = "long" },
 				uintNullable = new { type = "long" },
+				uintNullables = new { type = "long" },
 				@ulong = new { type = "double" },
-				ulongNullable = new { type = "double" }
+				ulongs = new { type = "double" },
+				ulongNullable = new { type = "double" },
+				ulongNullables = new { type = "double" },
+				@string = new { type = "text" },
+				strings = new { type = "text" }
 			}
 		};
 
 		protected override Func<TypeMappingDescriptor<ScalarPoco>, ITypeMapping> Fluent => f => f
 			.Properties(ps => ps
 				.Scalar(p => p.Int, m => m)
+				.Scalar(p => p.Ints, m => m)
 				.Scalar(p => p.IntNullable, m => m)
+				.Scalar(p => p.IntNullables, m => m)
 				.Scalar(p => p.Float, m => m)
+				.Scalar(p => p.Floats, m => m)
 				.Scalar(p => p.FloatNullable, m => m)
+				.Scalar(p => p.FloatNullables, m => m)
 				.Scalar(p => p.Double, m => m)
+				.Scalar(p => p.Doubles, m => m)
 				.Scalar(p => p.DoubleNullable, m => m)
+				.Scalar(p => p.DoubleNullables, m => m)
 				.Scalar(p => p.SByte, m => m)
+				.Scalar(p => p.SBytes, m => m)
 				.Scalar(p => p.SByteNullable, m => m)
+				.Scalar(p => p.SByteNullables, m => m)
 				.Scalar(p => p.Short, m => m)
+				.Scalar(p => p.Shorts, m => m)
 				.Scalar(p => p.ShortNullable, m => m)
+				.Scalar(p => p.ShortNullables, m => m)
 				.Scalar(p => p.Byte, m => m)
+				.Scalar(p => p.Bytes, m => m)
 				.Scalar(p => p.ByteNullable, m => m)
+				.Scalar(p => p.ByteNullables, m => m)
 				.Scalar(p => p.Long, m => m)
+				.Scalar(p => p.Longs, m => m)
 				.Scalar(p => p.LongNullable, m => m)
+				.Scalar(p => p.LongNullables, m => m)
 				.Scalar(p => p.Uint, m => m)
+				.Scalar(p => p.Uints, m => m)
 				.Scalar(p => p.UintNullable, m => m)
+				.Scalar(p => p.UintNullables, m => m)
 				.Scalar(p => p.TimeSpan, m => m)
+				.Scalar(p => p.TimeSpans, m => m)
 				.Scalar(p => p.TimeSpanNullable, m => m)
+				.Scalar(p => p.TimeSpanNullables, m => m)
 				.Scalar(p => p.Decimal, m => m)
+				.Scalar(p => p.Decimals, m => m)
 				.Scalar(p => p.DecimalNullable, m => m)
+				.Scalar(p => p.DecimalNullables, m => m)
 				.Scalar(p => p.Ulong, m => m)
+				.Scalar(p => p.Ulongs, m => m)
 				.Scalar(p => p.UlongNullable, m => m)
+				.Scalar(p => p.UlongNullables, m => m)
 				.Scalar(p => p.DateTime, m => m)
+				.Scalar(p => p.DateTimes, m => m)
 				.Scalar(p => p.DateTimeNullable, m => m)
+				.Scalar(p => p.DateTimeNullables, m => m)
 				.Scalar(p => p.DateTimeOffset, m => m)
+				.Scalar(p => p.DateTimeOffsets, m => m)
 				.Scalar(p => p.DateTimeOffsetNullable, m => m)
+				.Scalar(p => p.DateTimeOffsetNullables, m => m)
 				.Scalar(p => p.Bool, m => m)
+				.Scalar(p => p.Bools, m => m)
 				.Scalar(p => p.BoolNullable, m => m)
+				.Scalar(p => p.BoolNullables, m => m)
 				.Scalar(p => p.Char, m => m)
+				.Scalar(p => p.Chars, m => m)
 				.Scalar(p => p.CharNullable, m => m)
+				.Scalar(p => p.CharNullables, m => m)
 				.Scalar(p => p.Guid, m => m)
+				.Scalar(p => p.Guids, m => m)
 				.Scalar(p => p.GuidNullable, m => m)
+				.Scalar(p => p.GuidNullables, m => m)
 				.Scalar(p => p.String, m => m)
+				.Scalar(p => p.Strings, m => m)
 			);
 
 		protected override TypeMapping Initializer => null;

--- a/src/Tests/Mapping/Scalar/ScalarUsageTests.cs
+++ b/src/Tests/Mapping/Scalar/ScalarUsageTests.cs
@@ -65,7 +65,6 @@ namespace Tests.Mapping.Scalar
 			public Guid? GuidNullable { get; set; }
 
 			public string String { get; set; }
-
 		}
 
 		protected override object ExpectJson => new

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -348,6 +348,7 @@
     <Compile Include=".\Indices\StatusManagement\Upgrade\UpgradeApiTests.cs" />
     <Compile Include=".\Indices\StatusManagement\Upgrade\UpgradeUrlTests.cs" />
     <Compile Include=".\Mapping\Metafields\MetafieldsMappingApiTestsBase.cs" />
+    <Compile Include="Mapping\Scalar\ScalarUsageTests.cs" />
     <Compile Include="Ingest\ProcessorSerializationTests.cs" />
     <Compile Include="Mapping\Types\Complex\Nested\NestedAttributeTests.cs" />
     <Compile Include="Mapping\Types\Complex\Object\ObjectAttributeTests.cs" />

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: u
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.0.0-beta1


### PR DESCRIPTION
... to map inside the fluent properties descriptor


```csharp
.Properties(ps => ps
 	.Scalar(p => p.Int, m => m)
 	.Scalar(p => p.IntNullable, m => m)
 	.Scalar(p => p.Float, m => m)
 	.Scalar(p => p.FloatNullable, m => m)
 	.Scalar(p => p.Char, m => m)
 	.Scalar(p => p.CharNullable, m => m)
 	.Scalar(p => p.Guid, m => m)
///snip 	
	.Scalar(p => p.String, m => m)
 );
```

