### PR TITLE
Fix script representation for bulk updates

### DIFF
--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdate.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdate.cs
@@ -8,30 +8,40 @@ namespace Nest
 		where TDocument : class
 		where TPartialDocument : class
 	{
-		TDocument InferFrom { get; set; }
+		/// <summary>
+		/// Infers the id of the object to update from the provided <param name="object">object</param>. 
+		/// See <see cref="Doc"/> to apply a partial object merge.
+		/// </summary>
+		TDocument IdFrom { get; set; }
 
+		/// <summary>
+		/// A document to upsert when the specified document to be updated is not found
+		/// </summary>
 		TDocument Upsert { get; set; }
-		
+
+		/// <summary>
+		/// The partial update document to be merged on to the existing object.
+		/// </summary>
 		TPartialDocument Doc { get; set; }
-		
+
+		/// <summary>
+		/// Instead of sending a partial doc with <see cref="Doc"/> plus an upsert doc 
+		/// with <see cref="Upsert"/>, setting <see cref="DocAsUpsert"/> to <c>true</c> will 
+		/// use the contents of doc as the upsert value.
+		/// </summary>
 		bool? DocAsUpsert { get; set; }
-		
-		string Lang { get; set; }
-		
-		string Script { get; set; }
 
-		string ScriptId { get; set; }
-
-		string ScriptFile { get; set; }
-		
-		Dictionary<string, object> Params { get; set; }
+		/// <summary>
+		/// A script to specify the update.
+		/// </summary>
+		IScript Script { get; set; }
 	}
 
 	public class BulkUpdateOperation<TDocument, TPartialDocument> : BulkOperationBase, IBulkUpdateOperation<TDocument, TPartialDocument>
 		where TDocument : class
 		where TPartialDocument : class
 	{
-		
+
 		public BulkUpdateOperation(Id id) { this.Id = id; }
 
 		/// <summary>
@@ -39,22 +49,22 @@ namespace Nest
 		/// </summary>
 		/// <param name="idFrom">Use this document to infer the id from</param>
 		/// <param name="useIdFromAsUpsert">Use the document to infer on as the upsert document in this update operation</param>
-		public BulkUpdateOperation(TDocument idFrom, bool useIdFromAsUpsert = false) 
+		public BulkUpdateOperation(TDocument idFrom, bool useIdFromAsUpsert = false)
 		{
-			this.InferFrom = idFrom;
+			this.IdFrom = idFrom;
 			if (useIdFromAsUpsert)
 				this.Upsert = idFrom;
 		}
-		
+
 		/// <summary>
 		/// Create a new Bulk Operation
 		/// </summary>
 		/// <param name="idFrom">Use this document to infer the id from</param>
 		/// <param name="update">The partial update document (doc) to send as update</param>
 		/// <param name="useIdFromAsUpsert">Use the document to infer on as the upsert document in this update operation</param>
-		public BulkUpdateOperation(TDocument idFrom, TPartialDocument update, bool useIdFromAsUpsert = false) 
+		public BulkUpdateOperation(TDocument idFrom, TPartialDocument update, bool useIdFromAsUpsert = false)
 		{
-			this.InferFrom = idFrom;
+			this.IdFrom = idFrom;
 			if (useIdFromAsUpsert)
 				this.Upsert = idFrom;
 			this.Doc = update;
@@ -64,30 +74,45 @@ namespace Nest
 
 		protected override Type ClrType => typeof(TDocument);
 
-		protected override Id GetIdForOperation(Inferrer inferrer) => this.Id ?? new Id(new[] { this.InferFrom, this.Upsert }.FirstOrDefault(o=>o != null));
+		protected override Id GetIdForOperation(Inferrer inferrer) => 
+			this.Id ?? new Id(new[] { this.IdFrom, this.Upsert }.FirstOrDefault(o=>o != null));
 
-		protected override object GetBody() => 
+		protected override object GetBody() =>
 			new BulkUpdateBody<TDocument, TPartialDocument>
 		{
 			_PartialUpdate = this.Doc,
 			_Script = this.Script,
-			_ScriptId = this.ScriptId,
-			_ScriptFile = this.ScriptFile,
-			_Lang = this.Lang,
-			_Params = this.Params,
 			_Upsert = this.Upsert,
 			_DocAsUpsert = this.DocAsUpsert
 		};
 
-		public TDocument InferFrom { get; set; }
+		/// <summary>
+		/// Infers the id of the object to update from the provided <param name="object">object</param>. 
+		/// See <see cref="Doc"/> to apply a partial object merge.
+		/// </summary>
+		public TDocument IdFrom { get; set; }
+
+		/// <summary>
+		/// A document to upsert when the specified document to be updated is not found
+		/// </summary>
 		public TDocument Upsert { get; set; }
+
+		/// <summary>
+		/// The partial update document to be merged on to the existing object.
+		/// </summary>
 		public TPartialDocument Doc { get; set; }
+
+		/// <summary>
+		/// Instead of sending a partial doc with <see cref="Doc"/> plus an upsert doc 
+		/// with <see cref="Upsert"/>, setting <see cref="DocAsUpsert"/> to <c>true</c> will 
+		/// use the contents of doc as the upsert value.
+		/// </summary>
 		public bool? DocAsUpsert { get; set; }
-		public string Lang { get; set; }
-		public string Script { get; set; }
-		public string ScriptId { get; set; }
-		public string ScriptFile { get; set; }
-		public Dictionary<string, object> Params { get; set; }
+
+		/// <summary>
+		/// A script to specify the update.
+		/// </summary>
+		public IScript Script { get; set; }
 	}
 
 	public class BulkUpdateDescriptor<TDocument, TPartialDocument>
@@ -99,46 +124,31 @@ namespace Nest
 		protected override string BulkOperationType => "update";
 		protected override Type BulkOperationClrType => typeof(TDocument);
 
-		TDocument IBulkUpdateOperation<TDocument, TPartialDocument>.InferFrom { get; set; }
-
+		TDocument IBulkUpdateOperation<TDocument, TPartialDocument>.IdFrom { get; set; }
 		TDocument IBulkUpdateOperation<TDocument, TPartialDocument>.Upsert { get; set; }
-
 		TPartialDocument IBulkUpdateOperation<TDocument, TPartialDocument>.Doc { get; set; }
-
 		bool? IBulkUpdateOperation<TDocument, TPartialDocument>.DocAsUpsert { get; set; }
-
-		string IBulkUpdateOperation<TDocument, TPartialDocument>.Lang { get; set; }
-
-		string IBulkUpdateOperation<TDocument, TPartialDocument>.Script { get; set; }
-
-		string IBulkUpdateOperation<TDocument, TPartialDocument>.ScriptId { get; set; }
-
-		string IBulkUpdateOperation<TDocument, TPartialDocument>.ScriptFile { get; set; }
-
-		Dictionary<string, object> IBulkUpdateOperation<TDocument, TPartialDocument>.Params { get; set; }
+		IScript IBulkUpdateOperation<TDocument, TPartialDocument>.Script { get; set; }
 
 		protected override object GetBulkOperationBody() =>
 			new BulkUpdateBody<TDocument, TPartialDocument>
 			{
 				_PartialUpdate = Self.Doc,
 				_Script = Self.Script,
-				_ScriptId = Self.ScriptId,
-				_ScriptFile = Self.ScriptFile,
-				_Lang = Self.Lang,
-				_Params = Self.Params,
 				_Upsert = Self.Upsert,
 				_DocAsUpsert = Self.DocAsUpsert
 			};
 
-		protected override Id GetIdForOperation(Inferrer inferrer) => Self.Id ?? new Id(new[] { Self.InferFrom, Self.Upsert }.FirstOrDefault(o=>o != null));
+		protected override Id GetIdForOperation(Inferrer inferrer) => 
+			Self.Id ?? new Id(new[] { Self.IdFrom, Self.Upsert }.FirstOrDefault(o=>o != null));
 
 		/// <summary>
-		/// The object to update, if id is not manually set it will be inferred from the object.
-		/// Used ONLY to infer the ID see Document() to apply a partial object merge.
+		/// Infers the id of the object to update from the provided <param name="object">object</param>. 
+		/// See <see cref="Doc(TPartialDocument)"/> to apply a partial object merge.
 		/// </summary>
 		public BulkUpdateDescriptor<TDocument, TPartialDocument> IdFrom(TDocument @object, bool useAsUpsert = false)
 		{
-			Self.InferFrom = @object;
+			Self.IdFrom = @object;
 			return useAsUpsert ? this.Upsert(@object) : this;
 		}
 
@@ -152,19 +162,24 @@ namespace Nest
 		/// </summary>
 		public BulkUpdateDescriptor<TDocument, TPartialDocument> Doc(TPartialDocument @object) => Assign(a => a.Doc = @object);
 
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> DocAsUpsert(bool partialDocumentAsUpsert = true) => Assign(a => a.DocAsUpsert = partialDocumentAsUpsert);
+		/// <summary>
+		/// Instead of sending a partial doc with <see cref="Doc(TPartialDocument)"/> plus an upsert doc 
+		/// with <see cref="Upsert(TDocument)"/>, setting <see cref="DocAsUpsert"/> to <c>true</c> will 
+		/// use the contents of doc as the upsert value.
+		/// </summary>
+		public BulkUpdateDescriptor<TDocument, TPartialDocument> DocAsUpsert(bool partialDocumentAsUpsert = true) => 
+			Assign(a => a.DocAsUpsert = partialDocumentAsUpsert);
 
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> Lang(string lang) => Assign(a => a.Lang = lang);
+		/// <summary>
+		/// A script to specify the update.
+		/// </summary>
+		public BulkUpdateDescriptor<TDocument, TPartialDocument> Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
+			Assign(a => a.Script = scriptSelector?.Invoke(new ScriptDescriptor()));
 
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> Script(string script) => Assign(a => a.Script = script);
-
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> ScriptId(string scriptId) => Assign(a => a.ScriptId = scriptId);
-
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> ScriptFile(string scriptFile) => Assign(a => a.ScriptFile = scriptFile);
-
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> Params(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> paramDictionary) =>
-			Assign(a => a.Params = paramDictionary(new FluentDictionary<string, object>()));
-
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> RetriesOnConflict(int? retriesOnConflict) => Assign(a => a.RetriesOnConflict = retriesOnConflict);
+		/// <summary>
+		/// How many times an update should be retried in the case of a version conflict.
+		/// </summary>
+		public BulkUpdateDescriptor<TDocument, TPartialDocument> RetriesOnConflict(int? retriesOnConflict) => 
+			Assign(a => a.RetriesOnConflict = retriesOnConflict);
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
@@ -3,33 +3,20 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	internal class BulkUpdateBody<TDocument, TPartialUpdate> 
+	internal class BulkUpdateBody<TDocument, TPartialUpdate>
 		where TDocument : class
 		where TPartialUpdate : class
 	{
-		[JsonProperty(PropertyName = "doc")]
+		[JsonProperty("doc")]
 		internal TPartialUpdate _PartialUpdate { get; set; }
 
-		[JsonProperty(PropertyName = "upsert")]
+		[JsonProperty("upsert")]
 		internal TDocument _Upsert { get; set; }
 
-		[JsonProperty(PropertyName = "doc_as_upsert")]
+		[JsonProperty("doc_as_upsert")]
 		public bool? _DocAsUpsert { get; set; }
 
-		[JsonProperty(PropertyName = "script")]
-		internal string _Script { get; set; }
-
-		[JsonProperty("script_id")]
-		internal string _ScriptId { get; set; }
-		
-		[JsonProperty("script_file")]
-		internal string _ScriptFile { get; set; }
-
-		[JsonProperty(PropertyName = "params")]
-		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter))]
-		internal Dictionary<string, object> _Params { get; set; }
-		
-		[JsonProperty(PropertyName = "lang")]
-		public string _Lang { get; set; }
+		[JsonProperty("script")]
+		internal IScript _Script { get; set; }
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/IBulkOperation.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/IBulkOperation.cs
@@ -11,34 +11,34 @@ namespace Nest
 		string Operation { get; }
 		Type ClrType { get; }
 
-		[JsonProperty(PropertyName = "_index")]
+		[JsonProperty("_index")]
 		IndexName Index { get; set; }
 
-		[JsonProperty(PropertyName = "_type")]
+		[JsonProperty("_type")]
 		TypeName Type { get; set; }
 
-		[JsonProperty(PropertyName = "_id")]
+		[JsonProperty("_id")]
 		Id Id { get; set; }
 
-		[JsonProperty(PropertyName = "_version")]
+		[JsonProperty("_version")]
 		long? Version { get; set; }
 
-		[JsonProperty(PropertyName = "_version_type")]
+		[JsonProperty("_version_type")]
 		[JsonConverter(typeof(StringEnumConverter))]
 		VersionType? VersionType { get; set; }
 
-		[JsonProperty(PropertyName = "_routing")]
+		[JsonProperty("_routing")]
 		string Routing { get; set; }
 
-		[JsonProperty(PropertyName = "_parent")]
+		[JsonProperty("_parent")]
 		Id Parent { get; set; }
 
 		[JsonProperty("_timestamp")]
-		[Obsolete("This feature is no longer supported on indices created in Elasticsearch 5.x and up")]
+		[Obsolete("This feature is no longer supported on indices created in Elasticsearch 5.0.0 and up")]
 		long? Timestamp { get; set; }
 
 		[JsonProperty("_ttl")]
-		[Obsolete("This feature is no longer supported on indices created in Elasticsearch 5.x and up")]
+		[Obsolete("This feature is no longer supported on indices created in Elasticsearch 5.0.0 and up")]
 		Time Ttl { get; set; }
 
 		[JsonProperty("_retry_on_conflict")]

--- a/src/Nest/QueryDsl/Specialized/Script/ScriptQueryConverter.cs
+++ b/src/Nest/QueryDsl/Specialized/Script/ScriptQueryConverter.cs
@@ -8,11 +8,6 @@ namespace Nest
 {
 	internal class ScriptQueryConverter : JsonConverter
 	{
-		private readonly VerbatimDictionaryKeysJsonConverter _dictionaryConverter =
-		new VerbatimDictionaryKeysJsonConverter();
-
-		private readonly PropertyJsonConverter _elasticTypeConverter = new PropertyJsonConverter();
-
 		public override bool CanRead => true;
 		public override bool CanWrite => true;
 		public override bool CanConvert(Type objectType) => true;
@@ -46,79 +41,6 @@ namespace Nest
 			var scriptProperty = properties.FirstOrDefault(p => p.Name == "script");
 			if (scriptProperty != null)
 				properties.AddRange(scriptProperty.Value.Value<JObject>().Properties());
-
-			foreach (var p in properties)
-			{
-				switch (p.Name)
-				{
-					case "_name":
-						r.Name = p.Value.Value<string>();
-						break;
-					case "boost":
-						r.Boost = p.Value.Value<double>();
-						break;
-					case "id":
-						r.Id = p.Value.Value<string>();
-						break;
-					case "file":
-						r.File = p.Value.Value<string>();
-						break;
-					case "inline":
-						r.Inline = p.Value.Value<string>();
-						break;
-					case "lang":
-						r.Lang = p.Value.Value<string>();
-						break;
-					case "params":
-						r.Params = p.Value.ToObject<Dictionary<string, object>>();
-						break;
-				}
-			}
-			return r;
-		}
-	}
-
-
-
-	internal class SimpleScriptQueryConverter : JsonConverter
-	{
-		private readonly VerbatimDictionaryKeysJsonConverter _dictionaryConverter =
-		new VerbatimDictionaryKeysJsonConverter();
-
-		private readonly PropertyJsonConverter _elasticTypeConverter = new PropertyJsonConverter();
-
-		public override bool CanRead => true;
-		public override bool CanWrite => true;
-		public override bool CanConvert(Type objectType) => true;
-
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-		{
-			var v = value as IScriptQuery;
-			if (v == null) return;
-
-			writer.WriteStartObject();
-			if (!v.Name.IsNullOrEmpty()) writer.WriteProperty(serializer, "_name", v.Name);
-			if (v.Boost != null) writer.WriteProperty(serializer, "boost", v.Boost);
-			//writer.WritePropertyName("script");
-			writer.WriteStartObject();
-			{
-				if (v.Id != null) writer.WriteProperty(serializer, "id", v.Id);
-				if (v.File != null) writer.WriteProperty(serializer, "file", v.File);
-				if (v.Inline != null) writer.WriteProperty(serializer, "inline", v.Inline);
-				if (v.Lang != null) writer.WriteProperty(serializer, "lang", v.Lang);
-				if (v.Params != null) writer.WriteProperty(serializer, "params", v.Params);
-			}
-			//writer.WriteEndObject();
-			writer.WriteEndObject();
-		}
-
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-		{
-			var r = new ScriptQuery();
-			JObject o = JObject.Load(reader);
-			var properties = o.Properties().ToListOrNullIfEmpty();
-			//var scriptProperty = properties.First(p=>p.Name == "script");
-			//properties.AddRange(scriptProperty.Value.Value<JObject>().Properties());
 
 			foreach (var p in properties)
 			{

--- a/src/Tests/Document/Multiple/Bulk/BulkApiTests.cs
+++ b/src/Tests/Document/Multiple/Bulk/BulkApiTests.cs
@@ -61,6 +61,13 @@ namespace Tests.Document.Multiple.Bulk
 			new Dictionary<string, object>{ { "delete", new { _type="project", _id = Project.Instance.Name + "1" } } },
 			new Dictionary<string, object>{ { "create", new { _type="project", _id = Project.Instance.Name + "2" } } },
 			Project.InstanceAnonymous,
+			new Dictionary<string, object>{ { "update", new { _type="project", _id = Project.Instance.Name + "2" } } },
+			new Dictionary<string, object>{ { "script", new
+			{
+				inline= "ctx._source.numberOfCommits = params.commits",
+				@params = new { commits = 30 },
+				lang = "painless"
+			} } },
 		};
 
 		protected override Func<BulkDescriptor, IBulkRequest> Fluent => d => d
@@ -70,8 +77,15 @@ namespace Tests.Document.Multiple.Bulk
 			.Update<Project, object>(b => b.Doc(new { leadDeveloper = new { firstName = "martijn" } }).Id(Project.Instance.Name))
 			.Create<Project>(b => b.Document(Project.Instance).Id(Project.Instance.Name + "1"))
 			.Delete<Project>(b=>b.Id(Project.Instance.Name + "1"))
-			.Create<Project>(b => b.Document(Project.Instance).Id(Project.Instance.Name + "2"));
-
+			.Create<Project>(b => b.Document(Project.Instance).Id(Project.Instance.Name + "2"))
+			.Update<Project>(b => b
+				.Id(Project.Instance.Name + "2")
+				.Script(s => s
+					.Inline("ctx._source.numberOfCommits = params.commits")
+					.Params(p => p.Add("commits", 30))
+					.Lang("painless")
+				)
+			);
 
 		protected override BulkRequest Initializer =>
 			new BulkRequest(CallIsolatedValue)
@@ -93,6 +107,14 @@ namespace Tests.Document.Multiple.Bulk
 					{
 						Id = Project.Instance.Name + "2",
 					},
+					new BulkUpdateOperation<Project, object>(Project.Instance.Name + "2")
+					{
+						Script = new InlineScript("ctx._source.numberOfCommits = params.commits")
+						{
+							Params = new Dictionary<string, object> { { "commits", 30 } },
+							Lang = "painless"
+						}
+					}
 				}
 			};
 
@@ -121,6 +143,7 @@ namespace Tests.Document.Multiple.Bulk
 
 			var project2 = this.Client.Source<Project>(Project.Instance.Name + "2", p => p.Index(CallIsolatedValue));
 			project2.Description.Should().Be("Default");
+			project2.NumberOfCommits.Should().Be(30);
 		}
 	}
 }


### PR DESCRIPTION
Parameters related to an update script should be serialized as properties of an object assigned to a script property.

Change the name of the `InferFrom` on bulk update operation to `IdFrom` to align naming with fluent method name and indicate that it sets the id.

Closes #2357