### PR TITLE
fix #2220 allow more control in BulkAll 

### DIFF
--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -108,12 +108,15 @@ namespace Nest
 			var r = this._partionedBulkRequest;
 			var response = await this._client.BulkAsync(s =>
 			{
-				s.IndexMany(buffer);
 				s.Index(r.Index).Type(r.Type);
+				if (r.BufferToBulk != null) r.BufferToBulk(s, buffer);
+				else s.IndexMany(buffer);
 				if (!string.IsNullOrEmpty(r.Pipeline)) s.Pipeline(r.Pipeline);
 				if (r.Refresh.HasValue) s.Refresh(r.Refresh.Value);
 				if (!string.IsNullOrEmpty(r.Routing)) s.Routing(r.Routing);
 				if (r.WaitForActiveShards.HasValue) s.WaitForActiveShards(r.WaitForActiveShards.ToString());
+
+
 				return s;
 			}, this._compositeCancelToken).ConfigureAwait(false);
 

--- a/src/Tests/Document/Multiple/BulkAll/BulkAllApiTests.cs
+++ b/src/Tests/Document/Multiple/BulkAll/BulkAllApiTests.cs
@@ -33,7 +33,8 @@ namespace Tests.Document.Multiple.BulkAll
 			this._client = cluster.Client;
 		}
 
-		[I] public void ReturnsExpectedResponse()
+		[I]
+		public void ReturnsExpectedResponse()
 		{
 			var index = CreateIndexName();
 			var handle = new ManualResetEvent(false);
@@ -71,7 +72,8 @@ namespace Tests.Document.Multiple.BulkAll
 			bulkObserver.TotalNumberOfRetries.Should().Be(0);
 		}
 
-		[I] public void DisposingObservableCancelsBulkAll()
+		[I]
+		public void DisposingObservableCancelsBulkAll()
 		{
 			var index = CreateIndexName();
 			var handle = new ManualResetEvent(false);
@@ -113,7 +115,8 @@ namespace Tests.Document.Multiple.BulkAll
 			bulkObserver.TotalNumberOfRetries.Should().Be(0);
 		}
 
-		[I] public void CancelBulkAll()
+		[I]
+		public void CancelBulkAll()
 		{
 			var index = CreateIndexName();
 			var handle = new ManualResetEvent(false);
@@ -157,7 +160,8 @@ namespace Tests.Document.Multiple.BulkAll
 			bulkObserver.TotalNumberOfRetries.Should().Be(0);
 		}
 
-		[I] public async Task AwaitBulkAll()
+		[I]
+		public async Task AwaitBulkAll()
 		{
 			var index = CreateIndexName();
 			var handle = new ManualResetEvent(false);
@@ -176,11 +180,12 @@ namespace Tests.Document.Multiple.BulkAll
 				.Size(size)
 				.RefreshOnCompleted()
 				.Index(index)
+				.BufferToBulk((r, buffer) => r.IndexMany(buffer))
 			, tokenSource.Token);
 
 
 			await observableBulk
-				.ForEachAsync(x=> Interlocked.Increment(ref seenPages), tokenSource.Token);
+				.ForEachAsync(x => Interlocked.Increment(ref seenPages), tokenSource.Token);
 
 			seenPages.Should().Be(pages);
 			var count = this._client.Count<SmallObject>(f => f.Index(index));


### PR DESCRIPTION
how the buffer of `IList<T>` buffer is tranlated into a single bulk request, rather then always simply calling `IndexMany` on it.

This allows you to do use e.g the `IndexMany(buffer, perDocumentOpSelector)` overload or manually looping over the buffer and doing a `Create/Update/Index`