### PR TITLE
Backport of the superuseful BulkAll to 2.x

### DIFF
--- a/src/Nest/Document/Multiple/Bulk/ElasticClient-Bulk.cs
+++ b/src/Nest/Document/Multiple/Bulk/ElasticClient-Bulk.cs
@@ -39,7 +39,7 @@ namespace Nest
 			// selector should not be nullable, but we can't change it for backwards compatibility reasons
 			if (selector == null)
 				throw new ArgumentNullException(nameof(selector));
-            return this.Bulk(selector.InvokeOrDefault(new BulkDescriptor()));
+			return this.Bulk(selector.InvokeOrDefault(new BulkDescriptor()));
 		}
 
 		/// <inheritdoc/>

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public class BulkAllObservable<T> : IDisposable, IObservable<IBulkAllResponse> where T : class
+	{
+		private readonly IBulkAllRequest<T> _partionedBulkRequest;
+		private readonly IConnectionSettingsValues _connectionSettings;
+		private readonly IElasticClient _client;
+		private readonly TimeSpan _backOffTime;
+		private readonly int _backOffRetries;
+		private readonly int _bulkSize;
+		private readonly int _maxDegreeOfParallelism;
+		private Action _incrementFailed = () => { };
+		private Action _incrementRetries = () => { };
+
+		private readonly CancellationToken _cancelToken;
+		private readonly CancellationToken _compositeCancelToken;
+		private readonly CancellationTokenSource _compositeCancelTokenSource;
+
+		private Func<IBulkResponse, bool> HandleErrors { get; set; }
+
+		public BulkAllObservable(
+			IElasticClient client,
+			IConnectionSettingsValues connectionSettings,
+			IBulkAllRequest<T> partionedBulkRequest,
+			CancellationToken cancellationToken = default(CancellationToken)
+			)
+		{
+			this._client = client;
+			this._connectionSettings = connectionSettings;
+			this._partionedBulkRequest = partionedBulkRequest;
+			this._backOffRetries = this._partionedBulkRequest.BackOffRetries.GetValueOrDefault(0);
+			this._backOffTime = (this._partionedBulkRequest?.BackOffTime?.ToTimeSpan() ?? TimeSpan.FromMinutes(1));
+			this._bulkSize = this._partionedBulkRequest.Size ?? 1000;
+			this._maxDegreeOfParallelism = this._partionedBulkRequest.MaxDegreeOfParallelism.HasValue
+				? this._partionedBulkRequest.MaxDegreeOfParallelism.Value
+				: 20;
+			this._cancelToken = cancellationToken;
+			this._compositeCancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(this._cancelToken);
+			this._compositeCancelToken = this._compositeCancelTokenSource.Token;
+		}
+
+		public IDisposable Subscribe(BulkAllObserver observer)
+		{
+			_incrementFailed = observer.IncrementTotalNumberOfFailedBuffers;
+			_incrementRetries = observer.IncrementTotalNumberOfRetries;
+			return this.Subscribe((IObserver<IBulkAllResponse>)observer);
+		}
+
+		public IDisposable Subscribe(IObserver<IBulkAllResponse> observer)
+		{
+			observer.ThrowIfNull(nameof(observer));
+			try
+			{
+				this.BulkAll(observer);
+			}
+			catch (Exception e)
+			{
+				observer.OnError(e);
+			}
+			return this;
+		}
+
+		private ElasticsearchClientException Throw(string message, IApiCallDetails details) =>
+			new ElasticsearchClientException(PipelineFailure.BadResponse, message, details);
+
+		private void BulkAll(IObserver<IBulkAllResponse> observer)
+		{
+			var documents = this._partionedBulkRequest.Documents;
+			var partioned = new PartitionHelper<T>(documents, this._bulkSize, this._maxDegreeOfParallelism);
+			partioned.ForEachAsync(
+				(buffer, page) => this.BulkAsync(buffer, page, 0),
+				(buffer, response) => observer.OnNext(response),
+				t => OnCompleted(t, observer)
+			);
+		}
+
+		private void OnCompleted(Task task, IObserver<IBulkAllResponse> observer)
+		{
+			switch (task.Status)
+			{
+				case System.Threading.Tasks.TaskStatus.RanToCompletion:
+					if (this._partionedBulkRequest.RefreshOnCompleted)
+					{
+						var refresh = this._client.Refresh(this._partionedBulkRequest.Index);
+						if (!refresh.IsValid) throw Throw($"Refreshing after all documents have indexed failed", refresh.ApiCall);
+					}
+					observer.OnCompleted();
+					break;
+				case System.Threading.Tasks.TaskStatus.Faulted:
+					observer.OnError(task.Exception.InnerException);
+					break;
+				case System.Threading.Tasks.TaskStatus.Canceled:
+					observer.OnError(new TaskCanceledException(task));
+					break;
+			}
+		}
+
+		private async Task<IBulkAllResponse> BulkAsync(IList<T> buffer, long page, int backOffRetries)
+		{
+			this._compositeCancelToken.ThrowIfCancellationRequested();
+
+			var r = this._partionedBulkRequest;
+			var response = await this._client.BulkAsync(s =>
+			{
+				s.Index(r.Index).Type(r.Type);
+				if (r.BufferToBulk != null) r.BufferToBulk(s, buffer);
+				else s.IndexMany(buffer);
+				if (r.Refresh.HasValue) s.Refresh(r.Refresh.Value);
+				if (!string.IsNullOrEmpty(r.Routing)) s.Routing(r.Routing);
+				if (r.Consistency.HasValue) s.Consistency(r.Consistency.Value);
+
+
+				return s;
+			});
+
+			this._compositeCancelToken.ThrowIfCancellationRequested();
+			if (!response.IsValid && backOffRetries < this._backOffRetries)
+			{
+				this._incrementRetries();
+				//wait before or after fishing out retriable docs?
+				await Task.Delay(this._backOffTime, this._compositeCancelToken).ConfigureAwait(false);
+				var retryDocuments = response.Items.Zip(buffer, (i, d) => new { i, d })
+					.Where(x => x.i.Status == 429)
+					.Select(x => x.d)
+					.ToList();
+
+				return await this.BulkAsync(retryDocuments, page, ++backOffRetries);
+			}
+			else if (!response.IsValid)
+			{
+				this._incrementFailed();
+				throw Throw($"Bulk indexing failed and after retrying {backOffRetries} times", response.ApiCall);
+			}
+			return new BulkAllResponse { Retries = backOffRetries, Page = page };
+		}
+
+		private sealed class PartitionHelper<TDocument> : IEnumerable<IList<TDocument>>
+		{
+			readonly IEnumerable<TDocument> _items;
+			readonly int _partitionSize;
+			readonly int _semaphoreSize;
+			bool _hasMoreItems;
+
+			internal PartitionHelper(IEnumerable<TDocument> i, int ps, int semaphoreSize)
+			{
+				_items = i;
+				_semaphoreSize = semaphoreSize;
+				_partitionSize = ps;
+			}
+
+			IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+			public IEnumerator<IList<TDocument>> GetEnumerator()
+			{
+				using (var enumerator = _items.GetEnumerator())
+				{
+					_hasMoreItems = enumerator.MoveNext();
+					while (_hasMoreItems)
+						yield return GetNextBatch(enumerator).ToList();
+				}
+			}
+
+			IEnumerable<TDocument> GetNextBatch(IEnumerator<TDocument> enumerator)
+			{
+				for (int i = 0; i < _partitionSize; ++i)
+				{
+					yield return enumerator.Current;
+					_hasMoreItems = enumerator.MoveNext();
+					if (!_hasMoreItems) yield break;
+				}
+			}
+
+			public Task ForEachAsync<TResult>(
+				Func<IList<TDocument>, long, Task<TResult>> taskSelector,
+				Action<IList<TDocument>, TResult> resultProcessor,
+				Action<Task> done
+			)
+			{
+				var semaphore = new SemaphoreSlim(initialCount: _semaphoreSize, maxCount: _semaphoreSize);
+				long page = 0;
+				return Task.WhenAll(
+						from item in this
+						select ProcessAsync(item, taskSelector, resultProcessor, semaphore, page++)
+					).ContinueWith(done);
+			}
+
+			private async Task ProcessAsync<TSource, TResult>(
+				TSource item,
+				Func<TSource, long, Task<TResult>> taskSelector,
+				Action<TSource, TResult> resultProcessor,
+				SemaphoreSlim semaphoreSlim,
+				long page)
+			{
+				if (semaphoreSlim != null) await semaphoreSlim.WaitAsync();
+				try
+				{
+					var result = await taskSelector(item, page);
+					resultProcessor(item, result);
+				}
+				catch
+				{
+					throw;
+				}
+				finally { if (semaphoreSlim != null) semaphoreSlim.Release(); }
+			}
+		}
+
+		public bool IsDisposed { get; private set; }
+		public void Dispose()
+		{
+			this.IsDisposed = true;
+			this._compositeCancelTokenSource?.Cancel();
+		}
+	}
+}

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -119,7 +119,7 @@ namespace Nest
 
 
 				return s;
-			});
+			}).ConfigureAwait(false);
 
 			this._compositeCancelToken.ThrowIfCancellationRequested();
 			if (!response.IsValid && backOffRetries < this._backOffRetries)
@@ -132,7 +132,7 @@ namespace Nest
 					.Select(x => x.d)
 					.ToList();
 
-				return await this.BulkAsync(retryDocuments, page, ++backOffRetries);
+				return await this.BulkAsync(retryDocuments, page, ++backOffRetries).ConfigureAwait(false);
 			}
 			else if (!response.IsValid)
 			{
@@ -198,10 +198,10 @@ namespace Nest
 				SemaphoreSlim semaphoreSlim,
 				long page)
 			{
-				if (semaphoreSlim != null) await semaphoreSlim.WaitAsync();
+				if (semaphoreSlim != null) await semaphoreSlim.WaitAsync().ConfigureAwait(false);
 				try
 				{
-					var result = await taskSelector(item, page);
+					var result = await taskSelector(item, page).ConfigureAwait(false);
 					resultProcessor(item, result);
 				}
 				catch

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObserver.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObserver.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading;
+
+namespace Nest
+{
+	public class BulkAllObserver : CoordinatedRequestObserverBase<IBulkAllResponse>
+	{
+		private long _totalNumberOfFailedBuffers;
+		private long _totalNumberOfRetries;
+
+		public long TotalNumberOfRetries => _totalNumberOfRetries;
+		public long TotalNumberOfFailedBuffers => _totalNumberOfFailedBuffers;
+
+		internal void IncrementTotalNumberOfRetries() => Interlocked.Increment(ref _totalNumberOfRetries);
+		internal void IncrementTotalNumberOfFailedBuffers() => Interlocked.Increment(ref _totalNumberOfFailedBuffers);
+
+		public BulkAllObserver(
+			Action<IBulkAllResponse> onNext = null,
+			Action<Exception> onError = null,
+			Action onCompleted = null
+			)
+			: base(onNext, onError, onCompleted)
+		{
+		}
+
+	}
+}

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllRequest.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllRequest.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public interface IBulkAllRequest<T> where T : class
+	{
+		/// <summary> In case of a 429 (too busy) how long should we wait before retrying</summary>
+		Time BackOffTime { get; set; }
+
+		/// <summary> In case of a 429 (too busy) how many times should we automatically back off before failing</summary>
+		int? BackOffRetries { get; set; }
+
+		/// <summary> The number of documents to send per bulk</summary>
+		int? Size { get; set; }
+
+		///<summary>
+		/// The documents to send to elasticsearch, try to keep the IEnumerable lazy.
+		/// The bulk observable will ToList() each partitioned page in a lazy fashion, to keep memory consumption to a minimum.
+		/// It makes no sense to set this to an list of 1 million records because all of those million records need to be in memory
+		/// Make use of c#'s lazy generator!
+		///</summary>
+		IEnumerable<T> Documents { get; }
+
+		///<summary>The maximum number of bulk operations we want to have in flight at a time</summary>
+		int? MaxDegreeOfParallelism { get; set; }
+
+		///<summary>Default index for items which don't provide one</summary>
+		IndexName Index { get; set; }
+
+		///<summary>Default document type for items which don't provide one</summary>
+		TypeName Type { get; set; }
+
+		///<summary>Explicit write consistency setting for the operation</summary>
+		Consistency? Consistency { get; set; }
+
+		///<summary>Refresh the index after performing each operation (elasticsearch will refresh locally)</summary>
+		bool? Refresh { get; set; }
+
+		///<summary>Refresh the index after performing ALL the bulk operations (NOTE this is an additional request)</summary>
+		bool RefreshOnCompleted { get; set; }
+
+		///<summary>Specific per bulk operation routing value</summary>
+		string Routing { get; set; }
+
+		///<summary>Explicit per operation timeout</summary>
+		Time Timeout { get; set; }
+
+		///<summary>The pipeline id to preprocess all the incoming documents with</summary>
+		string Pipeline { get; set; }
+
+		/// <summary>
+		/// By default the bulkall helper simply calls <see cref="BulkDescriptor.IndexMany"/> on the buffer.
+		/// There might be case where you'd like more control over this. By setting this callback you are in complete control
+		/// of describing how the buffer should be translated to a bulk operation. Maybe you want to enforce all documents are newly created using
+		/// <see cref="BulkDescriptor.CreateMany"/> or maybe a piece of metadata on <typeparamref name="T"/> controls where you need to call
+		/// <see cref="BulkDescriptor.Update{T, TPartialDocument}(Func{BulkUpdateDescriptor{T, TPartialDocument}, IBulkUpdateOperation{T, TPartialDocument}})"/>
+		/// or <see cref="BulkDescriptor.Index{T}(Func{BulkIndexDescriptor{T}, IIndexOperation{T}})"/>
+		/// </summary>
+		Action<BulkDescriptor, IList<T>> BufferToBulk { get; set; }
+	}
+
+	public class BulkAllRequest<T>  : IBulkAllRequest<T>
+		where T : class
+	{
+		/// <inheritdoc />
+		public Time BackOffTime { get; set; }
+		/// <inheritdoc />
+		public int? Size { get; set; }
+		/// <inheritdoc />
+		public int? MaxDegreeOfParallelism { get; set; }
+		/// <inheritdoc />
+		public int? BackOffRetries { get; set; }
+		/// <inheritdoc />
+		public IEnumerable<T> Documents { get; private set; }
+
+		/// <inheritdoc />
+		public IndexName Index { get; set; }
+		/// <inheritdoc />
+		public TypeName Type { get; set; }
+		/// <inheritdoc />
+		public Consistency? Consistency { get; set; }
+		/// <inheritdoc />
+		public bool? Refresh { get; set; }
+		/// <inheritdoc />
+		public bool RefreshOnCompleted { get; set; }
+		/// <inheritdoc />
+		public string Routing { get; set; }
+		/// <inheritdoc />
+		public Time Timeout { get; set; }
+		/// <inheritdoc />
+		public string Pipeline { get; set; }
+		/// <inheritdoc />
+		public Action<BulkDescriptor, IList<T>> BufferToBulk { get; set; }
+
+		public BulkAllRequest(IEnumerable<T> documents)
+		{
+			this.Documents = documents;
+			this.Index = typeof(T);
+			this.Type = typeof(T);
+		}
+	}
+
+	public class BulkAllDescriptor<T> : DescriptorBase<BulkAllDescriptor<T>, IBulkAllRequest<T>>, IBulkAllRequest<T>
+		where T : class
+	{
+		private readonly IEnumerable<T> _documents;
+
+		Time IBulkAllRequest<T>.BackOffTime { get; set; }
+		int? IBulkAllRequest<T>.Size { get; set; }
+		int? IBulkAllRequest<T>.BackOffRetries { get; set; }
+		int? IBulkAllRequest<T>.MaxDegreeOfParallelism { get; set; }
+		IEnumerable<T> IBulkAllRequest<T>.Documents => this._documents;
+
+		IndexName IBulkAllRequest<T>.Index { get; set; }
+		TypeName IBulkAllRequest<T>.Type { get; set; }
+		Consistency? IBulkAllRequest<T>.Consistency { get; set; }
+		bool? IBulkAllRequest<T>.Refresh { get; set; }
+		bool IBulkAllRequest<T>.RefreshOnCompleted { get; set; }
+		string IBulkAllRequest<T>.Routing { get; set; }
+		Time IBulkAllRequest<T>.Timeout { get; set; }
+		string IBulkAllRequest<T>.Pipeline { get; set; }
+		Action<BulkDescriptor, IList<T>>  IBulkAllRequest<T>.BufferToBulk { get; set; }
+
+		public BulkAllDescriptor(IEnumerable<T> documents)
+		{
+			this._documents = documents;
+			((IBulkAllRequest<T>)this).Index = typeof(T);
+			((IBulkAllRequest<T>)this).Type = typeof(T);
+		}
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> MaxDegreeOfParallelism(int? parallism) =>
+			Assign(a => a.MaxDegreeOfParallelism = parallism);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Size(int? size) => Assign(a => a.Size = size);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> BackOffRetries(int? backoffs) =>
+			Assign(a => a.BackOffRetries = backoffs);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> BackOffTime(Time time) => Assign(a => a.BackOffTime = time);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Index(IndexName index) => Assign(a => a.Index = index);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Index<TOther>() where TOther : class => Assign(a => a.Index = typeof(TOther));
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Type(TypeName type) => Assign(a => a.Type = type);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Type<TOther>() where TOther : class => Assign(a => a.Type = typeof(TOther));
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> RefreshOnCompleted(bool refresh = true) => Assign(p => p.RefreshOnCompleted = refresh);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Refresh(bool refresh = true) => Assign(p => p.Refresh = refresh);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Routing(string routing) => Assign(p => p.Routing = routing);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Timeout(Time timeout) => Assign(p => p.Timeout = timeout);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> Pipeline(string pipeline) => Assign(p => p.Pipeline = pipeline);
+
+		/// <inheritdoc />
+		public BulkAllDescriptor<T> BufferToBulk(Action<BulkDescriptor, IList<T>> modifier) => Assign(p => p.BufferToBulk = modifier);
+
+	}
+}

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllResponse.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllResponse.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	///
+	/// </summary>
+	public interface IBulkAllResponse
+    {
+        /// <summary>This is the Nth buffer.</summary>
+		long Page { get; }
+
+        /// <summary>The number of back off retries were needed to store this document.</summary>
+		int Retries { get; }
+    }
+
+    /// <summary>
+    /// POCO representing the reindex response for a each step
+    /// </summary>
+    [JsonObject]
+	public class BulkAllResponse : IBulkAllResponse
+	{
+		/// <inheritdoc />
+		public long Page { get; internal set; }
+
+		/// <inheritdoc />
+		public int Retries { get; internal set; }
+
+		/// <inheritdoc />
+		public bool IsValid => true;
+	}
+}

--- a/src/Nest/Document/Multiple/BulkAll/ElasticClient-BulkAll.cs
+++ b/src/Nest/Document/Multiple/BulkAll/ElasticClient-BulkAll.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <summary>
+		/// Helper method you can pass an IEnumerable that we will be partionened and send as multiple bulks in parallel
+		/// </summary>
+		/// <param name="selector">the descriptor to describe the reindex operation</param>
+		/// <returns>An IObservable&lt;IBulkAllResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		BulkAllObservable<T> BulkAll<T>(
+			IEnumerable<T> documents,
+			Func<BulkAllDescriptor<T>, IBulkAllRequest<T>> selector,
+			CancellationToken cancellationToken = default(CancellationToken)
+			)
+			where T : class;
+
+		/// <summary>
+		/// Helper method that allows you to reindex from one index into another using SCAN and SCROLL.
+		/// </summary>
+		/// <param name="request">a request object to describe the reindex operation</param>
+		/// <returns>An IObservable&lt;IBulkAllResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		BulkAllObservable<T> BulkAll<T>(IBulkAllRequest<T> request, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+	}
+
+	public partial class ElasticClient
+	{
+		///<inheritdoc />
+		public BulkAllObservable<T>  BulkAll<T>(
+			IEnumerable<T> documents,
+			Func<BulkAllDescriptor<T>, IBulkAllRequest<T>> selector,
+			CancellationToken cancellationToken = default(CancellationToken)
+			)
+			where T : class =>
+			this.BulkAll<T>(selector.InvokeOrDefault(new BulkAllDescriptor<T>(documents)), cancellationToken);
+
+		///<inheritdoc />
+		public BulkAllObservable<T>  BulkAll<T>(IBulkAllRequest<T> request, CancellationToken cancellationToken = default(CancellationToken))
+			where T : class =>
+			new BulkAllObservable<T>(this, ConnectionSettings, request, cancellationToken);
+	}
+}

--- a/src/Nest/Document/Multiple/Reindex/ReindexResponse.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexResponse.cs
@@ -2,10 +2,10 @@
 
 namespace Nest
 {
-    /// <summary>
-    /// The reindex response for a reindexing step
-    /// </summary>
-    public interface IReindexResponse<T> where T : class
+	/// <summary>
+	/// The reindex response for a reindexing step
+	/// </summary>
+	public interface IReindexResponse<T> where T : class
     {
         /// <summary>
         /// The bulk result indexing the search results into the new index.
@@ -39,7 +39,7 @@ namespace Nest
 
 		public int Scroll { get; internal set; }
 
-		public bool IsValid => 
+		public bool IsValid =>
 			this.BulkResponse != null && this.BulkResponse.IsValid
 			&& this.SearchResponse != null && this.SearchResponse.IsValid;
 	}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -467,6 +467,7 @@
     <Compile Include="CommonOptions\DateMath\DateMathExpression.cs" />
     <Compile Include="CommonOptions\DateMath\DateMathOperation.cs" />
     <Compile Include="CommonOptions\Failures\BulkError.cs" />
+    <Compile Include="Document\Multiple\BulkAll\BulkAllResponse.cs" />
     <Compile Include="Document\Multiple\BulkIndexByScrollFailure.cs" />
     <Compile Include="CommonOptions\Failures\ShardFailure.cs" />
     <Compile Include="CommonOptions\Failures\Throwable.cs" />
@@ -531,6 +532,10 @@
     <Compile Include="Document\Multiple\Bulk\ElasticClient-Bulk.cs" />
     <Compile Include="Document\Multiple\Bulk\ElasticClient-DeleteMany.cs" />
     <Compile Include="Document\Multiple\Bulk\ElasticClient-IndexMany.cs" />
+    <Compile Include="Document\Multiple\BulkAll\ElasticClient-BulkAll.cs" />
+    <Compile Include="Document\Multiple\BulkAll\BulkAllObservable.cs" />
+    <Compile Include="Document\Multiple\BulkAll\BulkAllRequest.cs" />
+    <Compile Include="Document\Multiple\BulkAll\BulkAllObserver.cs" />
     <Compile Include="Document\Multiple\ReindexOnServer\ReindexDestination.cs" />
     <Compile Include="Document\Multiple\ReindexOnServer\ReindexRouting.cs" />
     <Compile Include="Document\Multiple\ReindexOnServer\ReindexSource.cs" />

--- a/src/Tests/Document/Multiple/BulkAll/BulkAllApiTests.cs
+++ b/src/Tests/Document/Multiple/BulkAll/BulkAllApiTests.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Xunit;
+
+namespace Tests.Document.Multiple.BulkAll
+{
+	public class BulkAllApiTests : SerializationTestBase, IClusterFixture<IntrusiveOperationCluster>
+	{
+		private class SmallObject
+		{
+			public int Id { get; set; }
+		}
+
+		private readonly IElasticClient _client;
+
+		private static string CreateIndexName() => $"project-copy-{Guid.NewGuid().ToString("N").Substring(8)}";
+
+		private IEnumerable<SmallObject> CreateLazyStreamOfDocuments(int count)
+		{
+			for (var i = 0; i < count; i++)
+				yield return new SmallObject() { Id = i };
+		}
+
+		public BulkAllApiTests(IntrusiveOperationCluster cluster, EndpointUsage usage)
+		{
+			this._client = cluster.Client;
+		}
+
+		[I]
+		public void ReturnsExpectedResponse()
+		{
+			var index = CreateIndexName();
+			var handle = new ManualResetEvent(false);
+
+			var size = 1000;
+			var pages = 100;
+			var seenPages = 0;
+			var numberOfDocuments = size * pages;
+			var documents = this.CreateLazyStreamOfDocuments(numberOfDocuments);
+
+			//first we setup our cold observable
+			var observableBulk = this._client.BulkAll(documents, f => f
+				.MaxDegreeOfParallelism(8)
+				.BackOffTime(TimeSpan.FromSeconds(10))
+				.BackOffRetries(2)
+				.Size(size)
+				.RefreshOnCompleted()
+				.Index(index)
+			);
+			//we set up an observer
+			var bulkObserver = new BulkAllObserver(
+				onError: (e) => { throw e; },
+				onCompleted: () => handle.Set(),
+				onNext: (b) => Interlocked.Increment(ref seenPages)
+			);
+			//when we subscribe the observable becomes hot
+			observableBulk.Subscribe(bulkObserver);
+
+			handle.WaitOne(TimeSpan.FromMinutes(5));
+
+			seenPages.Should().Be(pages);
+			var count = this._client.Count<SmallObject>(f => f.Index(index));
+			count.Count.Should().Be(numberOfDocuments);
+			bulkObserver.TotalNumberOfFailedBuffers.Should().Be(0);
+			bulkObserver.TotalNumberOfRetries.Should().Be(0);
+		}
+
+		[I]
+		public void DisposingObservableCancelsBulkAll()
+		{
+			var index = CreateIndexName();
+			var handle = new ManualResetEvent(false);
+
+			var size = 1000;
+			var pages = 100;
+			var seenPages = 0;
+			var numberOfDocuments = size * pages;
+			var documents = this.CreateLazyStreamOfDocuments(numberOfDocuments);
+
+			//first we setup our cold observable
+			var observableBulk = this._client.BulkAll(documents, f => f
+				.MaxDegreeOfParallelism(8)
+				.BackOffTime(TimeSpan.FromSeconds(10))
+				.BackOffRetries(2)
+				.Size(size)
+				.RefreshOnCompleted()
+				.Index(index)
+			);
+			//we set up an observer
+			var bulkObserver = new BulkAllObserver(
+				onError: (e) => { throw e; },
+				onCompleted: () => handle.Set(),
+				onNext: (b) => Interlocked.Increment(ref seenPages)
+			);
+			//when we subscribe the observable becomes hot
+			observableBulk.Subscribe(bulkObserver);
+
+			//we wait N seconds to see some bulks
+			handle.WaitOne(TimeSpan.FromSeconds(3));
+			observableBulk.Dispose();
+			//we wait N seconds to give in flight request a chance to cancel
+			handle.WaitOne(TimeSpan.FromSeconds(3));
+
+			seenPages.Should().BeLessThan(pages).And.BeGreaterThan(0);
+			var count = this._client.Count<SmallObject>(f => f.Index(index));
+			count.Count.Should().BeLessThan(numberOfDocuments).And.BeGreaterThan(0);
+			bulkObserver.TotalNumberOfFailedBuffers.Should().Be(0);
+			bulkObserver.TotalNumberOfRetries.Should().Be(0);
+		}
+
+		[I]
+		public void CancelBulkAll()
+		{
+			var index = CreateIndexName();
+			var handle = new ManualResetEvent(false);
+
+			var size = 1000;
+			var pages = 100;
+			var seenPages = 0;
+			var numberOfDocuments = size * pages;
+			var documents = this.CreateLazyStreamOfDocuments(numberOfDocuments);
+
+			//first we setup our cold observable
+			var tokenSource = new CancellationTokenSource();
+			var observableBulk = this._client.BulkAll(documents, f => f
+				.MaxDegreeOfParallelism(8)
+				.BackOffTime(TimeSpan.FromSeconds(10))
+				.BackOffRetries(2)
+				.Size(size)
+				.RefreshOnCompleted()
+				.Index(index)
+			, tokenSource.Token);
+
+			//we set up an observer
+			var bulkObserver = new BulkAllObserver(
+				onError: (e) => { throw e; },
+				onCompleted: () => handle.Set(),
+				onNext: (b) => Interlocked.Increment(ref seenPages)
+			);
+			//when we subscribe the observable becomes hot
+			observableBulk.Subscribe(bulkObserver);
+
+			//we wait Nseconds to see some bulks
+			handle.WaitOne(TimeSpan.FromSeconds(3));
+			tokenSource.Cancel();
+			//we wait Nseconds to give in flight request a chance to cancel
+			handle.WaitOne(TimeSpan.FromSeconds(3));
+
+			seenPages.Should().BeLessThan(pages).And.BeGreaterThan(0);
+			var count = this._client.Count<SmallObject>(f => f.Index(index));
+			count.Count.Should().BeLessThan(numberOfDocuments).And.BeGreaterThan(0);
+			bulkObserver.TotalNumberOfFailedBuffers.Should().Be(0);
+			bulkObserver.TotalNumberOfRetries.Should().Be(0);
+		}
+
+		[I]
+		public async Task AwaitBulkAll()
+		{
+			var index = CreateIndexName();
+			var handle = new ManualResetEvent(false);
+
+			var size = 1000;
+			var pages = 10;
+			var seenPages = 0;
+			var numberOfDocuments = size * pages;
+			var documents = this.CreateLazyStreamOfDocuments(numberOfDocuments);
+
+			var tokenSource = new CancellationTokenSource();
+			var observableBulk = this._client.BulkAll(documents, f => f
+				.MaxDegreeOfParallelism(8)
+				.BackOffTime(TimeSpan.FromSeconds(10))
+				.BackOffRetries(2)
+				.Size(size)
+				.RefreshOnCompleted()
+				.Index(index)
+				.BufferToBulk((r, buffer) => r.IndexMany(buffer))
+			, tokenSource.Token);
+
+
+			await observableBulk
+				.ForEachAsync(x => Interlocked.Increment(ref seenPages), tokenSource.Token);
+
+			seenPages.Should().Be(pages);
+			var count = this._client.Count<SmallObject>(f => f.Index(index));
+			count.Count.Should().Be(numberOfDocuments);
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -237,6 +237,7 @@
     <Compile Include=".\Framework\Integration\Bootstrappers\Seeder.cs" />
     <Compile Include=".\Framework\Integration\Clusters\ClusterBase.cs" />
     <Compile Include="ClientConcepts\ConnectionPooling\Dispose\ResponseBuilderDisposeTests.cs" />
+    <Compile Include="Document\Multiple\BulkAll\BulkAllApiTests.cs" />
     <Compile Include="Document\Multiple\ReindexRethrottle\ReindexRethrottleApiTests.cs" />
     <Compile Include="Document\Multiple\ReindexRethrottle\ReindexRethrottleUrlTests.cs" />
     <Compile Include="Framework\Extensions\ShouldExtensions.cs" />


### PR DESCRIPTION
This backport includes:

https://github.com/elastic/elasticsearch-net/pull/2402

and @russcam's fixes:  

https://github.com/elastic/elasticsearch-net/commit/cf5b298e86368032f713fbe7d575de948e1e46ec
https://github.com/elastic/elasticsearch-net/commit/f1eabf4343c7e32aaa2995840dde8a1d1366ace7