### PR TITLE
Assert all collections on Response types are read only

### DIFF
--- a/src/Elasticsearch.Net/Responses/ServerError.cs
+++ b/src/Elasticsearch.Net/Responses/ServerError.cs
@@ -82,7 +82,7 @@ namespace Elasticsearch.Net
 		public string ResourceId { get; set; }
 		public string ResourceType { get; set; }
 		public string Type { get; set; }
-		public List<RootCause> RootCause { get; set; }
+		public IReadOnlyCollection<RootCause> RootCause { get; set; }
 		public CausedBy CausedBy { get; set; }
 
 		internal static Error Create(IDictionary<string, object> dict, IJsonSerializerStrategy strategy)
@@ -99,7 +99,7 @@ namespace Elasticsearch.Net
 
 			var os = rootCause as object[];
 			if (os == null) return error;
-			error.RootCause = os.Select(o => (RootCause)strategy.DeserializeObject(o, typeof(RootCause))).ToList();
+			error.RootCause = os.Select(o => (RootCause)strategy.DeserializeObject(o, typeof(RootCause))).ToList().AsReadOnly();
 			return error;
 		}
 

--- a/src/Elasticsearch.Net/Serialization/SimpleJson.cs
+++ b/src/Elasticsearch.Net/Serialization/SimpleJson.cs
@@ -32,7 +32,7 @@
 //#define SIMPLE_JSON_DATACONTRACT
 
 // NOTE: uncomment the following line to enable IReadOnlyCollection<T> and IReadOnlyList<T> support.
-//#define SIMPLE_JSON_READONLY_COLLECTIONS
+#define SIMPLE_JSON_READONLY_COLLECTIONS
 
 // NOTE: uncomment the following line to disable linq expressions/compiled lambda (better performance) instead of method.invoke().
 // define if you are using .net framework <= 3.0 or < WP7.5
@@ -81,12 +81,12 @@ namespace Elasticsearch.Net
 		class JsonArray : List<object>
 	{
 		/// <summary>
-		/// Initializes a new instance of the <see cref="JsonArray"/> class. 
+		/// Initializes a new instance of the <see cref="JsonArray"/> class.
 		/// </summary>
 		public JsonArray() { }
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="JsonArray"/> class. 
+		/// Initializes a new instance of the <see cref="JsonArray"/> class.
 		/// </summary>
 		/// <param name="capacity">The capacity of the json array.</param>
 		public JsonArray(int capacity) : base(capacity) { }
@@ -480,7 +480,7 @@ namespace Elasticsearch.Net
 	/// <summary>
 	/// This class encodes and decodes JSON strings.
 	/// Spec. details, see http://www.json.org/
-	/// 
+	///
 	/// JSON uses Arrays and Objects. These correspond here to the datatypes JsonArray(IList&lt;object>) and JsonObject(IDictionary&lt;string,object>).
 	/// All numbers are parsed to doubles.
 	/// </summary>
@@ -1176,7 +1176,7 @@ namespace Elasticsearch.Net
 
 #endif
 	}
-    
+
 	[GeneratedCode("simple-json", "1.0.0")]
 #if SIMPLE_JSON_INTERNAL
 	internal
@@ -1289,7 +1289,7 @@ namespace Elasticsearch.Net
 
 			if (value == null)
 				return null;
-            
+
 			object obj = null;
 
 			if (str != null)
@@ -1327,7 +1327,7 @@ namespace Elasticsearch.Net
 			}
 			else if (value is bool)
 				return value;
-            
+
 			bool valueIsLong = value is long;
 			bool valueIsDouble = value is double;
 			if ((valueIsLong && type == typeof(long)) || (valueIsDouble && type == typeof(double)))

--- a/src/Nest/Cluster/ClusterReroute/ClusterRerouteState.cs
+++ b/src/Nest/Cluster/ClusterReroute/ClusterRerouteState.cs
@@ -17,7 +17,7 @@ namespace Nest
 
 		[JsonProperty("nodes")]
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, NodeState>))]
-		public Dictionary<string, NodeState> Nodes { get; internal set; }
+		public IReadOnlyDictionary<string, NodeState> Nodes { get; internal set; }
 
 		[JsonProperty("routing_table")]
 		public RoutingTableState RoutingTable { get; internal set; }

--- a/src/Nest/Cluster/ClusterState/IndexRoutingTable.cs
+++ b/src/Nest/Cluster/ClusterState/IndexRoutingTable.cs
@@ -7,6 +7,6 @@ namespace Nest
 	{
 		[JsonProperty("shards")]
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, List<RoutingShard>>))]
-		public Dictionary<string, List<RoutingShard>> Shards { get; internal set; }
+		public IReadOnlyDictionary<string, List<RoutingShard>> Shards { get; internal set; }
 	}
 }

--- a/src/Nest/Cluster/ClusterState/MetadataState.cs
+++ b/src/Nest/Cluster/ClusterState/MetadataState.cs
@@ -9,13 +9,13 @@ namespace Nest
 	{
 		[JsonProperty("templates")]
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, TemplateMapping>))]
-		public IDictionary<string, TemplateMapping> Templates { get; internal set; }
+		public IReadOnlyDictionary<string, TemplateMapping> Templates { get; internal set; }
 
 		[JsonProperty("cluster_uuid")]
 		public string ClusterUUID { get; internal set; }
 
 		[JsonProperty("indices")]
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, MetadataIndexState>))]
-		public Dictionary<string, MetadataIndexState> Indices { get; internal set; }
+		public IReadOnlyDictionary<string, MetadataIndexState> Indices { get; internal set; }
 	}
 }

--- a/src/Nest/Cluster/ClusterState/RoutingNodesState.cs
+++ b/src/Nest/Cluster/ClusterState/RoutingNodesState.cs
@@ -8,9 +8,9 @@ namespace Nest
 	public class RoutingNodesState
 	{
 		[JsonProperty("unassigned")]
-		public List<RoutingShard> Unassigned { get; internal set; }
+		public IReadOnlyCollection<RoutingShard> Unassigned { get; internal set; }
 
 		[JsonProperty("nodes")]
-		public Dictionary<string, List<RoutingShard>> Nodes { get; internal set; }
+		public IReadOnlyDictionary<string, List<RoutingShard>> Nodes { get; internal set; }
 	}
 }

--- a/src/Nest/Cluster/ClusterState/RoutingTableState.cs
+++ b/src/Nest/Cluster/ClusterState/RoutingTableState.cs
@@ -9,6 +9,6 @@ namespace Nest
 	{
 		[JsonProperty("indices")]
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, IndexRoutingTable>))]
-		public Dictionary<string, IndexRoutingTable> Indices { get; internal set; }
+		public IReadOnlyDictionary<string, IndexRoutingTable> Indices { get; internal set; } = EmptyReadOnly<string, IndexRoutingTable>.Dictionary;
 	}
 }

--- a/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
+++ b/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
@@ -10,7 +10,7 @@ namespace Nest
 		public ClusterNodeCount Count { get; internal set; }
 
 		[JsonProperty("versions")]
-		public List<string> Versions { get; internal set; }
+		public IReadOnlyCollection<string> Versions { get; internal set; }
 
 		[JsonProperty("os")]
 		public ClusterOperatingSystemStats OperatingSystem { get; internal set; }
@@ -25,7 +25,7 @@ namespace Nest
 		public ClusterFileSystem FileSystem { get; internal set; }
 
 		[JsonProperty("plugins")]
-		public List<PluginStats> Plugins { get; internal set; }
+		public IReadOnlyCollection<PluginStats> Plugins { get; internal set; }
 	}
 
 	[JsonObject]
@@ -55,7 +55,7 @@ namespace Nest
 		public long MaxUptimeInMilliseconds { get; internal set; }
 
 		[JsonProperty("versions")]
-		public List<ClusterJvmVersion> Versions { get; internal set; }
+		public IReadOnlyCollection<ClusterJvmVersion> Versions { get; internal set; }
 
 		[JsonProperty("mem")]
 		public ClusterJvmMemory Memory { get; internal set; }
@@ -139,7 +139,7 @@ namespace Nest
 		public int AllocatedProcessors { get; internal set; }
 
 		[JsonProperty("names")]
-		public List<ClusterOperatingSystemName> Names { get; internal set; }
+		public IReadOnlyCollection<ClusterOperatingSystemName> Names { get; internal set; }
 	}
 
 	[JsonObject]

--- a/src/Nest/CommonOptions/Stats/IndexingStats.cs
+++ b/src/Nest/CommonOptions/Stats/IndexingStats.cs
@@ -44,6 +44,6 @@ namespace Nest
 
 		[JsonProperty("types")]
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, IndexingStats>))]
-		public Dictionary<string, IndexingStats> Types { get; set; }
+		public IReadOnlyDictionary<string, IndexingStats> Types { get; set; }
 	}
 }

--- a/src/Nest/Modules/SnapshotAndRestore/Snapshot/Snapshot.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Snapshot/Snapshot.cs
@@ -11,23 +11,23 @@ namespace Nest
 		public string Name { get; internal set;  }
 
 		[JsonProperty("indices")]
-		public IEnumerable<IndexName> Indices { get; internal set; }
+		public IReadOnlyCollection<IndexName> Indices { get; internal set; }
 
 		[JsonProperty("state")]
 		public string State { get; internal set; }
 
 		[JsonProperty("start_time")]
 		public DateTime StartTime { get; internal set;  }
-		
+
 		[JsonProperty("start_time_in_millis")]
 		public long StartTimeInMilliseconds { get; internal set;  }
-		
+
 		[JsonProperty("end_time")]
 		public DateTime EndTime { get; internal set;  }
-		
+
 		[JsonProperty("end_time_in_millis")]
 		public long EndTimeInMilliseconds { get; internal set;  }
-		
+
 		[JsonProperty("duration_in_millis")]
 		public long DurationInMilliseconds { get; internal set;  }
 
@@ -35,22 +35,6 @@ namespace Nest
 		public ShardsMetaData Shards { get; internal set; }
 
 		[JsonProperty("failures")]
-		public IEnumerable<SnapshotShardFailure> ShardFailures { get; internal set; }
-
-		/// <summary>
-		/// Contains the reason for each shard failure.
-		/// </summary>
-		/// For 2.0, remove this and rename ShardFailures => Failures
-		[JsonIgnore]
-		public IEnumerable<string> Failures
-		{
-			get
-			{
-				if (this.ShardFailures != null) 
-					return this.ShardFailures.Select(f => f.Reason);
-				return new List<string>();
-			}
-		}
-		
+		public IReadOnlyCollection<SnapshotShardFailure> Failures { get; internal set; }
 	}
 }

--- a/src/Nest/XPack/License/PostLicense/LicenseAcknowledgement.cs
+++ b/src/Nest/XPack/License/PostLicense/LicenseAcknowledgement.cs
@@ -1,4 +1,6 @@
-﻿namespace Nest
+﻿using System.Collections.Generic;
+
+namespace Nest
 {
 	/// <summary>
 	/// If the license is valid but is older or has less capabilities this will list out the reasons why a resubmission with acknowledge=true is required
@@ -6,6 +8,6 @@
 	public class LicenseAcknowledgement
 	{
 		public string Message { get; set; }
-		public string[] License { get; set; }
+		public IReadOnlyCollection<string> License { get; set; }
 	}
 }

--- a/src/Nest/XPack/Security/Authenticate/AuthenticateResponse.cs
+++ b/src/Nest/XPack/Security/Authenticate/AuthenticateResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -11,7 +9,7 @@ namespace Nest
 		string Username { get; }
 
 		[JsonProperty("roles")]
-		IEnumerable<string> Roles { get; }
+		IReadOnlyCollection<string> Roles { get; }
 
 		[JsonProperty("full_name")]
 		string FullName { get; }
@@ -28,13 +26,12 @@ namespace Nest
 	{
 		public string Username { get; internal set; }
 
-		public IEnumerable<string> Roles { get; internal set;  }
+		public IReadOnlyCollection<string> Roles { get; internal set; } = EmptyReadOnly<string>.Collection;
 
 		public string FullName { get; internal set;  }
 
 		public string Email { get; internal set;  }
 
 		public IReadOnlyDictionary<string, object> Metadata { get; internal set; } = EmptyReadOnly<string, object>.Dictionary;
-
 	}
 }

--- a/src/Nest/XPack/Watcher/AcknowledgeWatch/AcknowledgeWatchResponse.cs
+++ b/src/Nest/XPack/Watcher/AcknowledgeWatch/AcknowledgeWatchResponse.cs
@@ -33,7 +33,7 @@ namespace Nest
 		public DateTimeOffset? LastMetCondition { get; set; }
 
 		[JsonProperty("actions")]
-		public Dictionary<string, ActionStatus> Actions { get; set; }
+		public IReadOnlyDictionary<string, ActionStatus> Actions { get; set; }
 	}
 
 	public class ActionStatus

--- a/src/Nest/XPack/Watcher/ActivateWatch/ActivateWatchResponse.cs
+++ b/src/Nest/XPack/Watcher/ActivateWatch/ActivateWatchResponse.cs
@@ -21,6 +21,6 @@ namespace Nest
 		public ActivationState State { get; internal set; }
 
 		[JsonProperty("actions")]
-		public Dictionary<string, ActionStatus> Actions { get; set; }
+		public IReadOnlyDictionary<string, ActionStatus> Actions { get; set; }
 	}
 }

--- a/src/Nest/XPack/Watcher/ExecuteWatch/ExecuteWatchResponse.cs
+++ b/src/Nest/XPack/Watcher/ExecuteWatch/ExecuteWatchResponse.cs
@@ -49,7 +49,7 @@ namespace Nest
 		public Id WatchId { get; set; }
 
 		[JsonProperty("messages")]
-		public IEnumerable<string> Messages { get; set; }
+		public IReadOnlyCollection<string> Messages { get; set; }
 
 		[JsonProperty("state")]
 		public ActionExecutionState? State { get; set; }
@@ -64,7 +64,7 @@ namespace Nest
 		public InputContainer Input { get; set; }
 
 		[JsonProperty("metadata")]
-		public IDictionary<string, object> Metadata { get; set; }
+		public IReadOnlyDictionary<string, object> Metadata { get; set; }
 
 		[JsonProperty("result")]
 		public ExecutionResult Result { get; set; }
@@ -98,7 +98,7 @@ namespace Nest
 		public ExecutionResultCondition Condition { get; set; }
 
 		[JsonProperty("actions")]
-		public List<ExecutionResultAction> Actions { get; set; }
+		public IReadOnlyCollection<ExecutionResultAction> Actions { get; set; }
 	}
 
 	[JsonObject]
@@ -111,7 +111,7 @@ namespace Nest
 		public Status Status { get; set; }
 
 		[JsonProperty("payload")]
-		public Dictionary<string, object> Payload { get; set; }
+		public IReadOnlyDictionary<string, object> Payload { get; set; }
 	}
 
 	[JsonObject]

--- a/src/Nest/XPack/Watcher/Watch.cs
+++ b/src/Nest/XPack/Watcher/Watch.cs
@@ -7,7 +7,7 @@ namespace Nest
 	public class Watch
 	{
 		[JsonProperty("meta")]
-		public IDictionary<string, object> Meta { get; internal set; }
+		public IReadOnlyDictionary<string, object> Meta { get; internal set; }
 
 		[JsonProperty("input")]
 		public IInputContainer Input { get; internal set; }
@@ -23,7 +23,7 @@ namespace Nest
 
 		[JsonProperty("actions")]
 		[JsonConverter(typeof(ActionsJsonConverter))]
-		public IDictionary<string, IAction> Actions { get; internal set; }
+		public Actions Actions { get; internal set; }
 
 		[JsonProperty("status")]
 		public WatchStatus Status { get; internal set; }

--- a/src/Nest/XPack/Watcher/WatcherStats/WatcherStatsResponse.cs
+++ b/src/Nest/XPack/Watcher/WatcherStats/WatcherStatsResponse.cs
@@ -19,10 +19,10 @@ namespace Nest
 		ExecutionThreadPool ExecutionThreadPool { get; }
 
 		[JsonProperty("current_watches")]
-		IEnumerable<WatchRecordStats> CurrentWatches { get; }
+		IReadOnlyCollection<WatchRecordStats> CurrentWatches { get; }
 
 		[JsonProperty("queued_watches")]
-		IEnumerable<WatchRecordQueuedStats> QueuedWatches { get; }
+		IReadOnlyCollection<WatchRecordQueuedStats> QueuedWatches { get; }
 
 		[JsonProperty("manually_stopped")]
 		bool ManuallyStopped { get; }
@@ -52,9 +52,9 @@ namespace Nest
 
 		public ExecutionThreadPool ExecutionThreadPool { get; internal set; }
 
-		public IEnumerable<WatchRecordStats> CurrentWatches { get; internal set; }
+		public IReadOnlyCollection<WatchRecordStats> CurrentWatches { get; internal set; }
 
-		public IEnumerable<WatchRecordQueuedStats> QueuedWatches { get; internal set; }
+		public IReadOnlyCollection<WatchRecordQueuedStats> QueuedWatches { get; internal set; }
 
 		public bool ManuallyStopped { get; internal set; }
 	}

--- a/src/Tests/Cluster/ClusterState/ClusterStatsApiTests.cs
+++ b/src/Tests/Cluster/ClusterState/ClusterStatsApiTests.cs
@@ -40,7 +40,7 @@ namespace Tests.Cluster.ClusterState
 
 		private void Assert(IReadOnlyDictionary<string, NodeState> nodes, string master)
 		{
-			nodes.Should().NotBeEmpty().And.Contain(kv=>kv.Key == master);
+			nodes.Should().NotBeEmpty().And.ContainKey(master);
 			var node = nodes[master];
 			node.Name.Should().NotBeNullOrWhiteSpace();
 			node.TransportAddress.Should().NotBeNullOrWhiteSpace();

--- a/src/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelApiTests.cs
+++ b/src/Tests/Cluster/TaskManagement/TasksCancel/TasksCancelApiTests.cs
@@ -71,7 +71,7 @@ namespace Tests.Cluster.TaskManagement.TasksCancel
 			response.NodeFailures.Should().BeNullOrEmpty();
 			response.Nodes.Should().NotBeEmpty();
 			var tasks = response.Nodes.First().Value.Tasks;
-			tasks.Should().NotBeEmpty().And.Contain(kv=> kv.Key == this.TaskId);
+			tasks.Should().NotBeEmpty().And.ContainKey(this.TaskId);
 		}
 	}
 }

--- a/src/Tests/CodeStandards/Responses.doc.cs
+++ b/src/Tests/CodeStandards/Responses.doc.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.CodeStandards
+{
+	public class Responses
+	{
+		/**
+		* Every collection property on a Response type should be either IReadOnlyCollection or IReadOnlyDictionary
+		*/
+		[U]
+		public void ResponsePropertyCollectionsShouldBeReadOnly()
+		{
+			var exceptions = new HashSet<PropertyInfo>
+			{
+				typeof(ITypeMapping).GetProperty(nameof(ITypeMapping.DynamicDateFormats)),
+				typeof(ITypeMapping).GetProperty(nameof(ITypeMapping.Meta)),
+				typeof(TypeMapping).GetProperty(nameof(TypeMapping.DynamicDateFormats)),
+				typeof(TypeMapping).GetProperty(nameof(TypeMapping.Meta)),
+#pragma warning disable 618
+				typeof(IMultiPercolateResponse).GetProperty(nameof(IMultiPercolateResponse.Responses)),
+#pragma warning restore 618
+				typeof(IBulkResponse).GetProperty(nameof(IBulkResponse.ItemsWithErrors)),
+				typeof(IMultiSearchResponse).GetProperty(nameof(IMultiSearchResponse.AllResponses)),
+			};
+
+			var responseInterfaceTypes = from t in typeof(IResponse).Assembly().Types()
+							    where t.IsInterface() && typeof(IResponse).IsAssignableFrom(t)
+							    select t;
+
+			var ruleBreakers = new List<string>();
+			var seenTypes = new HashSet<Type>();
+			foreach (var responseType in responseInterfaceTypes)
+			{
+				FindPropertiesBreakingRule(responseType, exceptions, seenTypes, ruleBreakers);
+			}
+
+			ruleBreakers.Should().BeEmpty();
+		}
+
+		private static void FindPropertiesBreakingRule(Type type, HashSet<PropertyInfo> exceptions, HashSet<Type> seenTypes, List<string> ruleBreakers)
+		{
+			if (seenTypes.Add(type))
+			{
+				var properties = type.GetProperties();
+				foreach (var propertyInfo in properties)
+				{
+					if (exceptions.Contains(propertyInfo))
+						continue;
+
+					if (typeof(IDictionary).IsAssignableFrom(propertyInfo.PropertyType) ||
+						typeof(ICollection).IsAssignableFrom(propertyInfo.PropertyType))
+					{
+						ruleBreakers.Add($"{type.FullName}.{propertyInfo.Name} is of type {propertyInfo.PropertyType.Name}");
+					}
+					else if (propertyInfo.PropertyType.IsGenericType())
+					{
+						var genericTypeDefinition = propertyInfo.PropertyType.GetGenericTypeDefinition();
+						if (genericTypeDefinition == typeof(IDictionary<,>) ||
+						    genericTypeDefinition == typeof(Dictionary<,>) ||
+						    genericTypeDefinition == typeof(IEnumerable<>) ||
+							genericTypeDefinition == typeof(IList<>) ||
+							genericTypeDefinition == typeof(ICollection<>))
+						{
+							ruleBreakers.Add($"{type.FullName}.{propertyInfo.Name} is of type {propertyInfo.PropertyType.Name}");
+						}
+					}
+					else if (propertyInfo.PropertyType.IsClass() && (propertyInfo.PropertyType.Namespace.StartsWith("Nest") ||
+					                                                 propertyInfo.PropertyType.Namespace.StartsWith("Elasticsearch.Net")))
+					{
+						FindPropertiesBreakingRule(propertyInfo.PropertyType, exceptions, seenTypes, ruleBreakers);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsApiTests.cs
+++ b/src/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsApiTests.cs
@@ -62,7 +62,7 @@ namespace Tests.Document.Multiple.MultiTermVectors
 			termvectorDoc.Type.Should().NotBeNull();
 			termvectorDoc.Id.Should().NotBeNull();
 
-			termvectorDoc.TermVectors.Should().NotBeEmpty().And.Contain(kv=> kv.Key == "firstName");
+			termvectorDoc.TermVectors.Should().NotBeEmpty().And.ContainKey("firstName");
 			var vectors = termvectorDoc.TermVectors["firstName"];
 			vectors.Terms.Should().NotBeEmpty();
 			foreach (var vectorTerm in vectors.Terms)

--- a/src/Tests/Framework/Extensions/ReadOnlyDictionaryAssertions.cs
+++ b/src/Tests/Framework/Extensions/ReadOnlyDictionaryAssertions.cs
@@ -1,0 +1,987 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using FluentAssertions.Common;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using Tests.Framework.Extensions;
+
+namespace FluentAssertions
+{
+	public static class ShouldExtensions
+	{
+		public static ReadOnlyDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> actualValue)
+		{
+			return new ReadOnlyDictionaryAssertions<TKey, TValue>(actualValue);
+		}
+
+		public static GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this Dictionary<TKey, TValue> actualValue)
+		{
+			return new GenericDictionaryAssertions<TKey, TValue>(actualValue);
+		}
+	}
+}
+
+namespace Tests.Framework.Extensions
+{
+	public class WhichValueConstraint<TKey, TValue> : AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>
+	{
+		/// <summary>Gets the value of the object referred to by the key.</summary>
+		public TValue WhichValue { get; private set; }
+
+		public WhichValueConstraint(ReadOnlyDictionaryAssertions<TKey, TValue> parentConstraint, TValue value)
+		  : base(parentConstraint)
+		{
+			this.WhichValue = value;
+		}
+	}
+
+	/// <summary>
+	/// Contains a number of methods to assert that an <see cref="IDictionary{TKey,TValue}"/> is in the expected state.
+	/// </summary>
+	[DebuggerNonUserCode]
+	public class ReadOnlyDictionaryAssertions<TKey, TValue> :
+		ReferenceTypeAssertions<IReadOnlyDictionary<TKey, TValue>, ReadOnlyDictionaryAssertions<TKey, TValue>>
+	{
+		public ReadOnlyDictionaryAssertions(IReadOnlyDictionary<TKey, TValue> dictionary)
+		{
+			if (dictionary != null)
+			{
+				Subject = dictionary;
+			}
+		}
+
+		#region HaveCount
+
+		/// <summary>
+		/// Asserts that the number of items in the dictionary matches the supplied <paramref name="expected" /> amount.
+		/// </summary>
+		/// <param name="expected">The expected number of items.</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> HaveCount(int expected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {0} item(s){reason}, but found {1}.", expected, Subject);
+			}
+
+			int actualCount = Subject.Count;
+
+			Execute.Assertion
+				.ForCondition((actualCount == expected))
+				.BecauseOf(because, becauseArgs)
+				.FailWith("Expected {context:dictionary} {0} to have {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		/// <summary>
+		/// Asserts that the number of items in the dictionary matches a condition stated by a predicate.
+		/// </summary>
+		/// <param name="countPredicate">The predicate which must be satisfied by the amount of items.</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> HaveCount(Expression<Func<int, bool>> countPredicate,
+			string because = "", params object[] becauseArgs)
+		{
+			if (countPredicate == null)
+			{
+				throw new NullReferenceException("Cannot compare dictionary count against a <null> predicate.");
+			}
+
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to have {0} items{reason}, but found {1}.", countPredicate.Body, Subject);
+			}
+
+			Func<int, bool> compiledPredicate = countPredicate.Compile();
+
+			int actualCount = Subject.Count;
+
+			if (!compiledPredicate(actualCount))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} {0} to have a count {1}{reason}, but count is {2}.",
+						Subject, countPredicate.Body, actualCount);
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		#endregion
+
+		#region BeEmpty
+
+		/// <summary>
+		/// Asserts that the dictionary does not contain any items.
+		/// </summary>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to be empty{reason}, but found {0}.", Subject);
+			}
+
+			Execute.Assertion
+				.ForCondition(!Subject.Any())
+				.BecauseOf(because, becauseArgs)
+				.FailWith("Expected {context:dictionary} to not have any items{reason}, but found {0}.", Subject.Count);
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary contains at least 1 item.
+		/// </summary>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "",
+			params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} not to be empty{reason}, but found {0}.", Subject);
+			}
+
+			Execute.Assertion
+				.ForCondition(Subject.Any())
+				.BecauseOf(because, becauseArgs)
+				.FailWith("Expected one or more items{reason}, but found none.");
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		#endregion
+
+		#region Equal
+
+		/// <summary>
+		/// Asserts that the current dictionary contains all the same key-value pairs as the
+		/// specified <paramref name="expected"/> dictionary. Keys and values are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected dictionary</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> Equal(IReadOnlyDictionary<TKey, TValue> expected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found {1}.", expected, Subject);
+			}
+
+			if (expected == null)
+			{
+				throw new ArgumentNullException("expected", "Cannot compare dictionary with <null>.");
+			}
+
+			IEnumerable<TKey> missingKeys = expected.Keys.Except(Subject.Keys);
+			IEnumerable<TKey> additionalKeys = Subject.Keys.Except(expected.Keys);
+
+			if (missingKeys.Any())
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but could not find keys {1}.", expected,
+						missingKeys);
+			}
+
+			if (additionalKeys.Any())
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found additional keys {1}.", expected,
+						additionalKeys);
+			}
+
+			foreach (var key in expected.Keys)
+			{
+				Execute.Assertion
+					.ForCondition(Subject[key].IsSameOrEqualTo(expected[key]))
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but {1} differs at key {2}.",
+					expected, Subject, key);
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		/// <summary>
+		/// Asserts the current dictionary not to contain all the same key-value pairs as the
+		/// specified <paramref name="unexpected"/> dictionary. Keys and values are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="unexpected">The unexpected dictionary</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotEqual(IReadOnlyDictionary<TKey, TValue> unexpected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected dictionaries not to be equal{reason}, but found {0}.", Subject);
+			}
+
+			if (unexpected == null)
+			{
+				throw new ArgumentNullException("unexpected", "Cannot compare dictionary with <null>.");
+			}
+
+			IEnumerable<TKey> missingKeys = unexpected.Keys.Except(Subject.Keys);
+			IEnumerable<TKey> additionalKeys = Subject.Keys.Except(unexpected.Keys);
+
+			bool foundDifference = missingKeys.Any()
+				|| additionalKeys.Any()
+					|| (Subject.Keys.Any(key => !Subject[key].IsSameOrEqualTo(unexpected[key])));
+
+			if (!foundDifference)
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Did not expect dictionaries {0} and {1} to be equal{reason}.", unexpected, Subject);
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		#endregion
+
+		#region ContainKey
+
+		/// <summary>
+		/// Asserts that the dictionary contains the specified key. Keys are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected key</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public WhichValueConstraint<TKey, TValue> ContainKey(TKey expected,
+			string because = "", params object[] becauseArgs)
+		{
+			AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> andConstraint = ContainKeys(new[] { expected }, because, becauseArgs);
+
+			return new WhichValueConstraint<TKey, TValue>(andConstraint.And, Subject[expected]);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary contains all of the specified keys. Keys are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected keys</param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected)
+		{
+			return ContainKeys(expected, String.Empty);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary contains all of the specified keys. Keys are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected keys</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> ContainKeys(IEnumerable<TKey> expected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (expected == null)
+			{
+				throw new NullReferenceException("Cannot verify key containment against a <null> collection of keys");
+			}
+
+			TKey[] expectedKeys = expected.ToArray();
+
+			if (!expectedKeys.Any())
+			{
+				throw new ArgumentException("Cannot verify key containment against an empty sequence");
+			}
+
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", expected, Subject);
+			}
+
+			var missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
+
+			if (missingKeys.Any())
+			{
+				if (expectedKeys.Count() > 1)
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}, but could not find {2}.", Subject,
+							expected, missingKeys);
+				}
+				else
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
+							expected.Cast<object>().First());
+				}
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		#endregion
+
+		#region NotContainKey
+
+		/// <summary>
+		/// Asserts that the current dictionary does not contain the specified <paramref name="unexpected" /> key.
+		/// Keys are compared using their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="unexpected">The unexpected key</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} not to contain key {0}{reason}, but found {1}.", unexpected, Subject);
+			}
+
+			if (Subject.ContainsKey(unexpected))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("{context:Dictionary} {0} should not contain key {1}{reason}, but found it anyhow.", Subject, unexpected);
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary does not contain any of the specified keys. Keys are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="unexpected">The unexpected keys</param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected)
+		{
+			return NotContainKeys(unexpected, String.Empty);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary does not contain any of the specified keys. Keys are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="unexpected">The unexpected keys</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContainKeys(IEnumerable<TKey> unexpected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (unexpected == null)
+			{
+				throw new NullReferenceException("Cannot verify key containment against a <null> collection of keys");
+			}
+
+			TKey[] unexpectedKeys = unexpected.ToArray();
+
+			if (!unexpectedKeys.Any())
+			{
+				throw new ArgumentException("Cannot verify key containment against an empty sequence");
+			}
+
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", unexpected, Subject);
+			}
+
+			var foundKeys = unexpectedKeys.Intersect(Subject.Keys);
+
+			if (foundKeys.Any())
+			{
+				if (unexpectedKeys.Count() > 1)
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}, but found {2}.", Subject,
+							unexpected, foundKeys);
+				}
+				else
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to not contain key {1}{reason}.", Subject,
+							unexpected.Cast<object>().First());
+				}
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		#endregion
+
+		#region ContainValue
+
+		/// <summary>
+		/// Asserts that the dictionary contains the specified value. Values are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndWhichConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected,
+			string because = "", params object[] becauseArgs)
+		{
+			AndWhichConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> innerConstraint =
+					ContainValuesAndWhich(new[] { expected }, because, becauseArgs);
+
+			return
+				new AndWhichConstraint
+					<ReadOnlyDictionaryAssertions<TKey, TValue>, TValue>(
+					innerConstraint.And, innerConstraint.Which);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary contains all of the specified values. Values are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected values</param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected)
+		{
+			return ContainValues(expected, String.Empty);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary contains all of the specified values. Values are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected values</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> ContainValues(IEnumerable<TValue> expected,
+			string because = "", params object[] becauseArgs)
+		{
+			return ContainValuesAndWhich(expected, because, becauseArgs);
+		}
+
+		private AndWhichConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected, string because = "",
+			params object[] becauseArgs)
+		{
+			if (expected == null)
+			{
+				throw new NullReferenceException("Cannot verify value containment against a <null> collection of values");
+			}
+
+			TValue[] expectedValues = expected.ToArray();
+
+			if (!expectedValues.Any())
+			{
+				throw new ArgumentException("Cannot verify value containment with an empty sequence");
+			}
+
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to contain value {0}{reason}, but found {1}.", expected, Subject);
+			}
+
+			var missingValues = expectedValues.Except(Subject.Values);
+			if (missingValues.Any())
+			{
+				if (expectedValues.Length > 1)
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to contain value {1}{reason}, but could not find {2}.", Subject,
+							expected, missingValues);
+				}
+				else
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to contain value {1}{reason}.", Subject,
+							expected.Cast<object>().First());
+				}
+			}
+
+			return
+				new AndWhichConstraint
+					<ReadOnlyDictionaryAssertions<TKey, TValue>,
+						IEnumerable<TValue>>(this,
+							RepetitionPreservingIntersect(Subject.Values, expectedValues));
+		}
+
+		/// <summary>
+		/// Returns an enumerable consisting of all items in the first collection also appearing in the second.
+		/// </summary>
+		/// <remarks>Enumerable.Intersect is not suitable because it drops any repeated elements.</remarks>
+		private IEnumerable<TValue> RepetitionPreservingIntersect(
+			IEnumerable<TValue> first, IEnumerable<TValue> second)
+		{
+			var secondSet = new HashSet<TValue>(second);
+			return first.Where(secondSet.Contains);
+		}
+
+		#endregion
+
+		#region NotContainValue
+
+		/// <summary>
+		/// Asserts that the current dictionary does not contain the specified <paramref name="unexpected" /> value.
+		/// Values are compared using their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="unexpected">The unexpected value</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} not to contain value {0}{reason}, but found {1}.", unexpected, Subject);
+			}
+
+			if (Subject.Values.Contains(unexpected))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("{context:Dictionary} {0} should not contain value {1}{reason}, but found it anyhow.", Subject, unexpected);
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary does not contain any of the specified values. Values are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="unexpected">The unexpected values</param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected)
+		{
+			return NotContainValues(unexpected, String.Empty);
+		}
+
+		/// <summary>
+		/// Asserts that the dictionary does not contain any of the specified values. Values are compared using
+		/// their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="unexpected">The unexpected values</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContainValues(IEnumerable<TValue> unexpected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (unexpected == null)
+			{
+				throw new NullReferenceException("Cannot verify value containment against a <null> collection of values");
+			}
+
+			var unexpectedValues = unexpected.ToArray();
+
+			if (!unexpectedValues.Any())
+			{
+				throw new ArgumentException("Cannot verify value containment with an empty sequence");
+			}
+
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to not contain value {0}{reason}, but found {1}.", unexpected, Subject);
+			}
+
+			var foundValues = unexpectedValues.Intersect(Subject.Values);
+			if (foundValues.Any())
+			{
+				if (unexpectedValues.Length > 1)
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to not contain value {1}{reason}, but found {2}.", Subject,
+							unexpected, foundValues);
+				}
+				else
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to not contain value {1}{reason}.", Subject,
+							unexpected.Cast<object>().First());
+				}
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		#endregion
+
+		#region Contain
+
+		/// <summary>
+		/// Asserts that the current dictionary contains the specified <paramref name="expected"/>.
+		/// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected key/value pairs.</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> Contain(IEnumerable<KeyValuePair<TKey, TValue>> expected,
+			string because = "", params object[] becauseArgs)
+		{
+			if (expected == null)
+			{
+				throw new ArgumentNullException("expected", "Cannot compare dictionary with <null>.");
+			}
+
+			KeyValuePair<TKey, TValue>[] expectedKeyValuePairs = expected.ToArray();
+
+			if (!expectedKeyValuePairs.Any())
+			{
+				throw new ArgumentException("Cannot verify key containment against an empty collection of key/value pairs");
+			}
+
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but dictionary is {1}.", expected, Subject);
+			}
+
+			var expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
+			var missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
+
+			if (missingKeys.Any())
+			{
+				if (expectedKeyValuePairs.Count() > 1)
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to contain key(s) {1}{reason}, but could not find keys {2}.", Subject,
+							expectedKeys, missingKeys);
+				}
+				else
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} {0} to contain key {1}{reason}.", Subject,
+							expectedKeys.Cast<object>().First());
+				}
+			}
+
+			KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+
+			if (keyValuePairsNotSameOrEqualInSubject.Any())
+			{
+				if (keyValuePairsNotSameOrEqualInSubject.Count() > 1)
+				{
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} to contain {0}{reason}, but {context:dictionary} differs at keys {1}.",
+							expectedKeyValuePairs, keyValuePairsNotSameOrEqualInSubject.Select(keyValuePair => keyValuePair.Key));
+				}
+				else
+				{
+					var expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject.First();
+					TValue actual = Subject[expectedKeyValuePair.Key];
+
+					Execute.Assertion
+						.BecauseOf(because, becauseArgs)
+						.FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", expectedKeyValuePair.Value, expectedKeyValuePair.Key, actual);
+				}
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		/// <summary>
+		/// Asserts that the current dictionary contains the specified <paramref name="expected"/>.
+		/// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="expected">The expected <see cref="KeyValuePair{TKey,TValue}"/></param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> Contain(KeyValuePair<TKey, TValue> expected,
+			string because = "", params object[] becauseArgs)
+		{
+			return Contain(expected.Key, expected.Value, because, becauseArgs);
+		}
+
+		/// <summary>
+		/// Asserts that the current dictionary contains the specified <paramref name="value" /> for the supplied <paramref
+		/// name="key" />. Values are compared using their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="key">The key for which to validate the value</param>
+		/// <param name="value">The value to validate</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value,
+			string because = "", params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but dictionary is {2}.", value, key,
+						Subject);
+			}
+
+			if (Subject.ContainsKey(key))
+			{
+				TValue actual = Subject[key];
+
+				Execute.Assertion
+					.ForCondition(actual.IsSameOrEqualTo(value))
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", value, key, actual);
+			}
+			else
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but the key was not found.", value,
+						key);
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		#endregion
+
+		#region NotContain
+
+		/// <summary>
+		/// Asserts that the current dictionary does not contain the specified <paramref name="items"/>.
+		/// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="items">The unexpected key/value pairs</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContain(IEnumerable<KeyValuePair<TKey, TValue>> items,
+			string because = "", params object[] becauseArgs)
+		{
+			if (items == null)
+			{
+				throw new ArgumentNullException("items", "Cannot compare dictionary with <null>.");
+			}
+
+			KeyValuePair<TKey, TValue>[] keyValuePairs = items.ToArray();
+
+			if (!keyValuePairs.Any())
+			{
+				throw new ArgumentException("Cannot verify key containment against an empty collection of key/value pairs");
+			}
+
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is {1}.", items, Subject);
+			}
+
+			var keyValuePairsFound = keyValuePairs.Where(keyValuePair => Subject.ContainsKey(keyValuePair.Key)).ToArray();
+
+			if (keyValuePairsFound.Any())
+			{
+				var keyValuePairsSameOrEqualInSubject = keyValuePairsFound.Where(keyValuePair => Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+
+				if (keyValuePairsSameOrEqualInSubject.Any())
+				{
+					if (keyValuePairsSameOrEqualInSubject.Count() > 1)
+					{
+						Execute.Assertion
+							.BecauseOf(because, becauseArgs)
+							.FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but found them anyhow.", keyValuePairs);
+					}
+					else
+					{
+						var keyValuePair = keyValuePairsSameOrEqualInSubject.First();
+
+						Execute.Assertion
+							.BecauseOf(because, becauseArgs)
+							.FailWith("Expected {context:dictionary} to not contain value {0} at key {1}{reason}, but found it anyhow.", keyValuePair.Value, keyValuePair.Key);
+					}
+				}
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		/// <summary>
+		/// Asserts that the current dictionary does not contain the specified <paramref name="item"/>.
+		/// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="item">The unexpected <see cref="KeyValuePair{TKey,TValue}"/></param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContain(KeyValuePair<TKey, TValue> item,
+			string because = "", params object[] becauseArgs)
+		{
+			return NotContain(item.Key, item.Value, because, becauseArgs);
+		}
+
+		/// <summary>
+		/// Asserts that the current dictionary does not contain the specified <paramref name="value" /> for the
+		/// supplied <paramref name="key" />. Values are compared using their <see cref="object.Equals(object)" /> implementation.
+		/// </summary>
+		/// <param name="key">The key for which to validate the value</param>
+		/// <param name="value">The value to validate</param>
+		/// <param name="because">
+		/// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+		/// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+		/// </param>
+		/// <param name="becauseArgs">
+		/// Zero or more objects to format using the placeholders in <see cref="because" />.
+		/// </param>
+		public AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value,
+			string because = "", params object[] becauseArgs)
+		{
+			if (ReferenceEquals(Subject, null))
+			{
+				Execute.Assertion
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but dictionary is {2}.", value,
+						key, Subject);
+			}
+
+			if (Subject.ContainsKey(key))
+			{
+				TValue actual = Subject[key];
+
+				Execute.Assertion
+					.ForCondition(!actual.IsSameOrEqualTo(value))
+					.BecauseOf(because, becauseArgs)
+					.FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.", value, key);
+			}
+
+			return new AndConstraint<ReadOnlyDictionaryAssertions<TKey, TValue>>(this);
+		}
+
+		#endregion
+
+		/// <summary>
+		/// Returns the type of the subject the assertion applies on.
+		/// </summary>
+		protected override string Context
+		{
+			get { return "dictionary"; }
+		}
+	}
+}

--- a/src/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
+++ b/src/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
@@ -72,7 +72,7 @@ namespace Tests.Indices.IndexManagement.CreateIndex
 			var indexSettings = this.Client.GetIndexSettings(g => g.Index(CallIsolatedValue));
 
 			indexSettings.IsValid.Should().BeTrue();
-			indexSettings.Indices.Should().NotBeEmpty().And.Contain(kv=> kv.Key == CallIsolatedValue);
+			indexSettings.Indices.Should().NotBeEmpty().And.ContainKey(CallIsolatedValue);
 
 			var settings = indexSettings.Indices[CallIsolatedValue];
 

--- a/src/Tests/Indices/Monitoring/IndicesShardStores/IndicesShardStoresApiTests.cs
+++ b/src/Tests/Indices/Monitoring/IndicesShardStores/IndicesShardStoresApiTests.cs
@@ -57,7 +57,7 @@ namespace Tests.Indices.Monitoring.IndicesShardStores
 			r.Indices.Should().NotBeEmpty();
 			var indicesShardStore = r.Indices[IndexWithUnassignedShards];
 			indicesShardStore.Should().NotBeNull();
-			indicesShardStore.Shards.Should().NotBeEmpty().And.Contain(kv=> kv.Key == "0");
+			indicesShardStore.Shards.Should().NotBeEmpty().And.ContainKey("0");
 			var shardStoreWrapper = indicesShardStore.Shards["0"];
 			shardStoreWrapper.Stores.Should().NotBeNullOrEmpty();
 

--- a/src/Tests/Reproduce/GithubIssue2323.cs
+++ b/src/Tests/Reproduce/GithubIssue2323.cs
@@ -42,7 +42,7 @@ namespace Tests.Reproduce
 			innerHits.Should().NotBeNullOrEmpty();
 
 			var innerHit = innerHits.First();
-			innerHit.Should().Contain(k => k.Key == "tags");
+			innerHit.Should().ContainKey("tags");
 			var hitMetadata = innerHit["tags"].Hits.Hits.First();
 
 			hitMetadata.Nested.Should().NotBeNull();

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -222,6 +222,7 @@
     <Compile Include="ClientConcepts\ConnectionPooling\Sniffing\AddressParsing.doc.cs" />
     <Compile Include="Cluster\TaskManagement\GetTask\GetTaskApiTests.cs" />
     <Compile Include="Cluster\TaskManagement\GetTask\GetTaskUrlTests.cs" />
+    <Compile Include="CodeStandards\Responses.doc.cs" />
     <Compile Include="Document\Multiple\Bulk\BulkInvalidVersionApiTests.cs" />
     <Compile Include="Document\Multiple\Bulk\BulkResponseParsingTests.cs" />
     <Compile Include="Document\Multiple\MultiGet\GetManyApiTests.cs" />
@@ -237,6 +238,7 @@
     <Compile Include="Framework\EndpointTests\TestState\AsyncLazy.cs" />
     <Compile Include="Framework\EndpointTests\Clusters\IntrusiveOperationCluster.cs" />
     <Compile Include="Framework\EndpointTests\Clusters\WritableCluster.cs" />
+    <Compile Include="Framework\Extensions\ReadOnlyDictionaryAssertions.cs" />
     <Compile Include="Framework\Extensions\ShouldExtensions.cs" />
     <Compile Include="Framework\ManagedElasticsearch\FileSystem\INodeFileSystem.cs" />
     <Compile Include="Framework\MockData\GeoIp.cs" />


### PR DESCRIPTION
Following on from merge of https://github.com/elastic/elasticsearch-net/pull/2399 into `master`.

- Reflection unit test traverses IResponse properties to check their types.
- Add Fluent Assertions for IReadOnlyDictionary<TKey, TValue>. See https://github.com/dennisdoomen/FluentAssertions/issues/357
- Update Watcher APIs to use readonly collections
- Use Actions for actions on Watch type
- Enable readonly collection deserialization in SimpleJson

Should we also assert that `IReadOnlyCollection<T>` and `IReadOnlyDictionary<TKey, TValue>` properties on responses are not `null` as a general rule?