### PR TITLE
Fix dictionary serialization

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/VerbatimDictionaryKeysConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/VerbatimDictionaryKeysConverter.cs
@@ -12,9 +12,9 @@ namespace Nest
 	/// JSON converter for IDictionary that ignores the contract resolver (e.g. CamelCaseFieldNamesContractResolver)
 	/// when converting dictionary keys to property names.
 	/// </summary>
-	internal class VerbatimDictionaryKeysJsonConverter<TKey, TValue> : JsonConverter
+	internal class VerbatimDictionaryKeysJsonConverter : JsonConverter
 	{
-		public override bool CanConvert(Type t) => typeof (IDictionary<TKey, TValue>).IsAssignableFrom(t);
+		public override bool CanConvert(Type t) => typeof(IDictionary).IsAssignableFrom(t);
 
 		public override bool CanRead => false;
 
@@ -25,32 +25,127 @@ namespace Nest
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
-			var dictionary = value as IDictionary<TKey, TValue>;
-			if (dictionary == null) return;
+			var dictionary = (IDictionary)value;
+			if (dictionary == null)
+			{
+				writer.WriteNull();
+				return;
+			}
 
 			var settings = serializer.GetConnectionSettings();
-			var seenEntries = new Dictionary<string, TValue>(dictionary.Count);
-			var keyIsString = typeof(TKey) == typeof(string);
-			var keyIsField = typeof(TKey) == typeof(Field);
-			var keyIsPropertyName = typeof(TKey) == typeof(PropertyName);
-			var keyIsIndexName = typeof(TKey) == typeof(IndexName);
-			var keyIsTypeName = typeof(TKey) == typeof(TypeName);
+			var seenEntries = new Dictionary<string, object>(dictionary.Count);
 
-			foreach (var entry in dictionary)
+			Field fieldName;
+			PropertyName propertyName;
+			IndexName indexName;
+			TypeName typeName;
+
+			foreach (DictionaryEntry entry in dictionary)
 			{
 				if (entry.Value == null && serializer.NullValueHandling == NullValueHandling.Ignore)
 					continue;
 				string key;
-				if (keyIsString)
+				if (settings == null)
+					key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
+				else if (AsType(entry.Key, out fieldName))
+				{
+					key = settings.Inferrer.Field(fieldName);
+				}
+				else if (AsType(entry.Key, out propertyName))
+				{
+					if (propertyName?.Property != null)
+					{
+						IPropertyMapping mapping;
+						if (settings.PropertyMappings.TryGetValue(propertyName.Property, out mapping) && mapping.Ignore)
+						{
+							continue;
+						}
+					}
+
+					key = settings.Inferrer.PropertyName(propertyName);
+				}
+				else if (AsType(entry.Key, out indexName))
+				{
+					key = settings.Inferrer.IndexName(indexName);
+				}
+				else if (AsType(entry.Key, out typeName))
+				{
+					key = settings.Inferrer.TypeName(typeName);
+				}
+				else
+					key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
+
+				if (key != null)
+					seenEntries[key] = entry.Value;
+			}
+
+			writer.WriteStartObject();
+			foreach (var entry in seenEntries)
+			{
+				writer.WritePropertyName(entry.Key);
+				serializer.Serialize(writer, entry.Value);
+			}
+			writer.WriteEndObject();
+		}
+
+		private static bool AsType<T>(object value, out T convertedValue) where T : class
+		{
+			convertedValue = value as T;
+			return convertedValue != null;
+		}
+	}
+
+	/// <summary>
+	/// JSON converter for IDictionary&lt;TKey,TValue&gt; and IReadOnlyDictionary&lt;TKey,TValue&gt;
+	/// that ignores the contract resolver (e.g. CamelCaseFieldNamesContractResolver)
+	/// when converting dictionary keys to property names.
+	/// </summary>
+	internal class VerbatimDictionaryKeysJsonConverter<TKey, TValue> : JsonConverter
+	{
+		private readonly bool _keyIsString = typeof(TKey) == typeof(string);
+		private readonly bool _keyIsField = typeof(TKey) == typeof(Field);
+		private readonly bool _keyIsPropertyName = typeof(TKey) == typeof(PropertyName);
+		private readonly bool _keyIsIndexName = typeof(TKey) == typeof(IndexName);
+		private readonly bool _keyIsTypeName = typeof(TKey) == typeof(TypeName);
+
+		public override bool CanConvert(Type t) =>
+			typeof(IDictionary<TKey, TValue>).IsAssignableFrom(t) ||
+			typeof(IReadOnlyDictionary<TKey, TValue>).IsAssignableFrom(t);
+
+		public override bool CanRead => false;
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			throw new NotSupportedException();
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var enumerable = (IEnumerable<KeyValuePair<TKey, TValue>>)value;
+			if (enumerable == null)
+			{
+				writer.WriteNull();
+				return;
+			}
+
+			var settings = serializer.GetConnectionSettings();
+			var seenEntries = new Dictionary<string, TValue>(enumerable.Count());
+
+			foreach (var entry in enumerable)
+			{
+				if (entry.Value == null && serializer.NullValueHandling == NullValueHandling.Ignore)
+					continue;
+				string key;
+				if (_keyIsString)
 					key = entry.Key?.ToString();
 				else if (settings == null)
 					key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
-				else if (keyIsField)
+				else if (_keyIsField)
 				{
 					var fieldName = entry.Key as Field;
 					key = settings.Inferrer.Field(fieldName);
 				}
-				else if (keyIsPropertyName)
+				else if (_keyIsPropertyName)
 				{
 					var propertyName = entry.Key as PropertyName;
 					if (propertyName?.Property != null)
@@ -64,12 +159,12 @@ namespace Nest
 
 					key = settings.Inferrer.PropertyName(propertyName);
 				}
-				else if (keyIsIndexName)
+				else if (_keyIsIndexName)
 				{
 					var indexName = entry.Key as IndexName;
 					key = settings.Inferrer.IndexName(indexName);
 				}
-				else if (keyIsTypeName)
+				else if (_keyIsTypeName)
 				{
 					var typeName = entry.Key as TypeName;
 					key = settings.Inferrer.TypeName(typeName);

--- a/src/Nest/CrossPlatform/TypeExtensions.cs
+++ b/src/Nest/CrossPlatform/TypeExtensions.cs
@@ -13,8 +13,33 @@ namespace Nest
 #if DOTNETCORE
 			return type.GetTypeInfo().IsGenericType;
 #else
-		return type.IsGenericType;
+			return type.IsGenericType;
 #endif
+		}
+
+		internal static bool IsGenericDictionary(this Type type)
+		{
+			return type.GetInterfaces().Any(t =>
+				t.IsGeneric() && (
+				t.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+				t.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)));
+		}
+
+		internal static bool TryGetGenericDictionaryArguments(this Type type, out Type[] genericArguments)
+		{
+			var genericDictionary = type.GetInterfaces().FirstOrDefault(t =>
+				t.IsGeneric() && (
+				t.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+				t.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)));
+
+			if (genericDictionary == null)
+			{
+				genericArguments = new Type[0];
+				return false;
+			}
+
+			genericArguments = genericDictionary.GetGenericArguments();
+			return true;
 		}
 
 		internal static bool IsValue(this Type type)

--- a/src/Tests/Framework/SerializationTests/DictionarySerializationTests.cs
+++ b/src/Tests/Framework/SerializationTests/DictionarySerializationTests.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Nest;
+using Newtonsoft.Json.Linq;
+
+namespace Tests.Framework
+{
+	public class IsADictionarySerializationTests : SerializationTestBase
+	{
+		// This doesn't technically support deserialization as the keys
+		// get camel cased on serialization and remain cased this way on deserialization,
+		// not matching the original key cased form
+		protected override bool SupportsDeserialization => false;
+
+		protected override object ExpectJson => new
+			{
+				key1 = "value1",
+				key2 = "value2",
+			};
+
+		// IIsADictionary implementations do not use the VerbatimDictionaryKeysConverter
+		// so keys are camel cased on serialization, in line with NEST conventions
+		[U]
+		public void CanSerializeIsADictionary()
+		{
+			var isADictionary = new MyIsADictionary(new Dictionary<object, object>
+			{
+				{ "Key1", "value1" },
+				{ "Key2", "value2" },
+			});
+
+			this.AssertSerializesAndRoundTrips(isADictionary);
+		}
+
+		private class MyIsADictionary : IsADictionaryBase<object, object>
+		{
+			public MyIsADictionary(IDictionary<object, object> backingDictionary) : base(backingDictionary) { }
+		}
+	}
+
+	public class DictionarySerializationTests : SerializationTestBase
+	{
+		protected override object ExpectJson => new JObject
+			{
+				{ "Key1", "value1" },
+				{ "Key2", "value2" },
+			};
+
+		[U]
+		public void CanSerializeCustomGenericDictionary()
+		{
+			var dictionary = new MyGenericDictionary
+			{
+				{ "Key1", "value1" },
+				{ "Key2", "value2" },
+			};
+
+			this.AssertSerializesAndRoundTrips(dictionary);
+		}
+
+		[U]
+		public void CanSerializeGenericDictionary()
+		{
+			var dictionary = new Dictionary<string,string>
+			{
+				{ "Key1", "value1" },
+				{ "Key2", "value2" },
+			};
+
+			this.AssertSerializesAndRoundTrips(dictionary);
+		}
+
+		[U]
+		public void CanSerializeGenericReadOnlyDictionary()
+		{
+			var dictionary = new ReadOnlyDictionary<string, string>(
+				new Dictionary<string, string>
+				{
+					{ "Key1", "value1" },
+					{ "Key2", "value2" },
+				});
+
+			this.AssertSerializesAndRoundTrips(dictionary);
+		}
+
+		[U]
+		public void CanSerializeCustomGenericIDictionary()
+		{
+			var dictionary = new MyGenericIDictionary
+			{
+				{ "Key1", "value1" },
+				{ "Key2", "value2" },
+			};
+
+			this.AssertSerializesAndRoundTrips(dictionary);
+		}
+
+		[U]
+		public void CanSerializeCustomGenericIReadOnlyDictionary()
+		{
+			var dictionary = new MyGenericIReadOnlyDictionary(new Dictionary<object, object>
+			{
+				{ "Key1", "value1" },
+				{ "Key2", "value2" },
+			});
+
+			this.AssertSerializesAndRoundTrips(dictionary);
+		}
+
+		[U]
+		public void CanSerializeCustomDictionary()
+		{
+			var hashTable = new MyDictionary
+			{
+				{ "Key1", "value1" },
+				{ "Key2", "value2" },
+			};
+
+			this.AssertSerializesAndRoundTrips(hashTable);
+		}
+
+		[U]
+		public void CanSerializeDictionary()
+		{
+			var hashTable = new Hashtable
+			{
+				{ "Key1", "value1" },
+				{ "Key2", "value2" },
+			};
+
+			this.AssertSerializesAndRoundTrips(hashTable);
+		}
+
+		private class MyDictionary : IDictionary
+		{
+			private readonly IDictionary _dictionary = new Hashtable();
+
+			public bool Contains(object key) => _dictionary.Contains(key);
+
+			public void Add(object key, object value) => _dictionary.Add(key, value);
+
+			public void Clear() => _dictionary.Clear();
+
+			public IDictionaryEnumerator GetEnumerator() => _dictionary.GetEnumerator();
+
+			public void Remove(object key) => _dictionary.Remove(key);
+
+			public object this[object key]
+			{
+				get { return _dictionary[key]; }
+				set { _dictionary[key] = value; }
+			}
+
+			public ICollection Keys => _dictionary.Keys;
+
+			public ICollection Values => _dictionary.Values;
+
+			public bool IsReadOnly => _dictionary.IsReadOnly;
+
+			public bool IsFixedSize => _dictionary.IsFixedSize;
+
+			IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_dictionary).GetEnumerator();
+
+			public void CopyTo(Array array, int index) => _dictionary.CopyTo(array, index);
+
+			public int Count => _dictionary.Count;
+
+			public object SyncRoot => _dictionary.SyncRoot;
+
+			public bool IsSynchronized => _dictionary.IsSynchronized;
+		}
+
+		private class MyGenericDictionary : Dictionary<string, string> {}
+
+		private class MyGenericIReadOnlyDictionary : IReadOnlyDictionary<object, object>
+		{
+			private readonly IDictionary<object, object> _backingDictionary;
+
+			public MyGenericIReadOnlyDictionary(IDictionary<object, object> dictionary)
+			{
+				_backingDictionary = dictionary ?? new Dictionary<object, object>();
+			}
+
+			public IEnumerator<KeyValuePair<object, object>> GetEnumerator() => _backingDictionary.GetEnumerator();
+
+			IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_backingDictionary).GetEnumerator();
+
+			public int Count => _backingDictionary.Count;
+
+			public bool ContainsKey(object key) => _backingDictionary.ContainsKey(key);
+
+			public bool TryGetValue(object key, out object value) => _backingDictionary.TryGetValue(key, out value);
+
+			public object this[object key] => _backingDictionary[key];
+
+			public IEnumerable<object> Keys => _backingDictionary.Keys;
+
+			public IEnumerable<object> Values => _backingDictionary.Values;
+		}
+
+		private class MyGenericIDictionary : IDictionary<object, object>
+		{
+			private readonly IDictionary<object, object> _backingDictionary = new Dictionary<object, object>();
+
+			public IEnumerator<KeyValuePair<object, object>> GetEnumerator() => _backingDictionary.GetEnumerator();
+
+			IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_backingDictionary).GetEnumerator();
+
+			public void Add(KeyValuePair<object, object> item) => _backingDictionary.Add(item);
+
+			public void Clear() => _backingDictionary.Clear();
+
+			public bool Contains(KeyValuePair<object, object> item) => _backingDictionary.Contains(item);
+
+			public void CopyTo(KeyValuePair<object, object>[] array, int arrayIndex) => _backingDictionary.CopyTo(array, arrayIndex);
+
+			public bool Remove(KeyValuePair<object, object> item) => _backingDictionary.Remove(item);
+
+			public int Count => _backingDictionary.Count;
+
+			public bool IsReadOnly => _backingDictionary.IsReadOnly;
+
+			public bool ContainsKey(object key) => _backingDictionary.ContainsKey(key);
+
+			public void Add(object key, object value) => _backingDictionary.Add(key, value);
+
+			public bool Remove(object key) => _backingDictionary.Remove(key);
+
+			public bool TryGetValue(object key, out object value) => _backingDictionary.TryGetValue(key, out value);
+
+			public object this[object key]
+			{
+				get { return _backingDictionary[key]; }
+				set { _backingDictionary[key] = value; }
+			}
+
+			public ICollection<object> Keys => _backingDictionary.Keys;
+
+			public ICollection<object> Values => _backingDictionary.Values;
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -242,6 +242,7 @@
     <Compile Include="Framework\Extensions\ShouldExtensions.cs" />
     <Compile Include="Framework\ManagedElasticsearch\FileSystem\INodeFileSystem.cs" />
     <Compile Include="Framework\MockData\GeoIp.cs" />
+    <Compile Include="Framework\SerializationTests\DictionarySerializationTests.cs" />
     <Compile Include="Framework\VirtualClustering\Audit\Auditor.cs" />
     <Compile Include="Framework\VirtualClustering\Audit\Audits.cs" />
     <Compile Include=".\Framework\Configuration\EnvironmentConfiguration.cs" />


### PR DESCRIPTION
Change in b062c5ec2b4ce49b1ecd5ba633199161e42e02d5 did not handle a number of dictionary cases including

- types that implement `IReadOnlyDictionary<TKey,TValue>`

    e.g. `public class MyReadOnlyDictionary<TKey,TValue> : IReadOnlyDictionary<TKey,TValue>`

- types that implement `IDictionary<TKey, TValue>`

    e.g. `public class MyDictionary<TKey,TValue> : IDictionary<TKey,TValue>`

- non-generic types that inherit a closed generic dictionary type

    e.g. `public class MyDictionary : Dictionary<string,object>`

- types that implement `IDictionary` that are not generic

    e.g. `public class MyNonGenericDictionary : IDictionary`

Include serialization tests for all the above cases and additionally, serialize `null` when the cast value in the json converter is null.

Fixes #2411