### PR TITLE
Fix RequestData hashcode and equality for .NET core HttpConnection

### DIFF
--- a/src/Elasticsearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
+++ b/src/Elasticsearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Elasticsearch.Net
+﻿namespace Elasticsearch.Net
 {
 	public class BasicAuthenticationCredentials
 	{

--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -31,30 +31,32 @@ namespace Elasticsearch.Net
 	public class HttpConnection : IConnection
 	{
 		private readonly object _lock = new object();
+
 		private readonly ConcurrentDictionary<int, HttpClient> _clients = new ConcurrentDictionary<int, HttpClient>();
 
 		private HttpClient GetClient(RequestData requestData)
 		{
-			var hashCode = requestData.GetHashCode();
+			var key = GetClientKey(requestData);
 			HttpClient client;
-			if (this._clients.TryGetValue(hashCode, out client)) return client;
-			lock (_lock)
+			if (!this._clients.TryGetValue(key, out client))
 			{
-				if (this._clients.TryGetValue(hashCode, out client)) return client;
-
-				var handler = CreateHttpClientHandler(requestData);
-
-				client = new HttpClient(handler, false)
+				lock (_lock)
 				{
-					Timeout = requestData.RequestTimeout
-				};
+					client = this._clients.GetOrAdd(key, h =>
+					{
+						var handler = CreateHttpClientHandler(requestData);
+						var httpClient = new HttpClient(handler, false)
+						{
+							Timeout = requestData.RequestTimeout
+						};
 
-				client.DefaultRequestHeaders.ExpectContinue = false;
-
-				this._clients.TryAdd(hashCode, client);
-				return client;
+						httpClient.DefaultRequestHeaders.ExpectContinue = false;
+						return httpClient;
+					});
+				}
 			}
 
+			return client;
 		}
 
 		public virtual ElasticsearchResponse<TReturn> Request<TReturn>(RequestData requestData) where TReturn : class
@@ -189,7 +191,6 @@ namespace Elasticsearch.Net
 			}
 		}
 
-
 		private static System.Net.Http.HttpMethod ConvertHttpMethod(HttpMethod httpMethod)
 		{
 			switch (httpMethod)
@@ -201,6 +202,20 @@ namespace Elasticsearch.Net
 				case HttpMethod.HEAD: return System.Net.Http.HttpMethod.Head;
 				default:
 					throw new ArgumentException("Invalid value for HttpMethod", nameof(httpMethod));
+			}
+		}
+
+		private static int GetClientKey(RequestData requestData)
+		{
+			unchecked
+			{
+				var hashCode = requestData.RequestTimeout.GetHashCode();
+				hashCode = (hashCode * 397) ^ requestData.HttpCompression.GetHashCode();
+				hashCode = (hashCode * 397) ^ (requestData.ProxyAddress?.GetHashCode() ?? 0);
+				hashCode = (hashCode * 397) ^ (requestData.ProxyUsername?.GetHashCode() ?? 0);
+				hashCode = (hashCode * 397) ^ (requestData.ProxyPassword?.GetHashCode() ?? 0);
+				hashCode = (hashCode * 397) ^ requestData.DisableAutomaticProxyDetection.GetHashCode();
+				return hashCode;
 			}
 		}
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -112,55 +112,5 @@ namespace Elasticsearch.Net
 				path += "&" + queryString.Substring(1, queryString.Length - 1);
 			return path;
 		}
-
-
-		protected bool Equals(RequestData other) =>
-			RequestTimeout.Equals(other.RequestTimeout)
-			&& PingTimeout.Equals(other.PingTimeout)
-			&& KeepAliveTime == other.KeepAliveTime
-			&& KeepAliveInterval == other.KeepAliveInterval
-			&& Pipelined == other.Pipelined
-			&& HttpCompression == other.HttpCompression
-			&& Equals(Headers, other.Headers)
-			&& string.Equals(RunAs, other.RunAs)
-			&& string.Equals(ProxyAddress, other.ProxyAddress)
-			&& string.Equals(ProxyUsername, other.ProxyUsername)
-			&& string.Equals(ProxyPassword, other.ProxyPassword)
-			&& DisableAutomaticProxyDetection == other.DisableAutomaticProxyDetection
-			&& Equals(BasicAuthorizationCredentials, other.BasicAuthorizationCredentials)
-			&& Equals(ConnectionSettings, other.ConnectionSettings)
-			&& Equals(MemoryStreamFactory, other.MemoryStreamFactory);
-
-		public override bool Equals(object obj)
-		{
-			if (ReferenceEquals(null, obj)) return false;
-			if (ReferenceEquals(this, obj)) return true;
-			if (obj.GetType() != this.GetType()) return false;
-			return Equals((RequestData) obj);
-		}
-
-		public override int GetHashCode()
-		{
-			unchecked
-			{
-				var hashCode = RequestTimeout.GetHashCode();
-				hashCode = (hashCode*397) ^ PingTimeout.GetHashCode();
-				hashCode = (hashCode*397) ^ KeepAliveTime;
-				hashCode = (hashCode*397) ^ KeepAliveInterval;
-				hashCode = (hashCode*397) ^ (RunAs?.GetHashCode() ?? 0);
-				hashCode = (hashCode*397) ^ Pipelined.GetHashCode();
-				hashCode = (hashCode*397) ^ HttpCompression.GetHashCode();
-				hashCode = (hashCode*397) ^ (Headers?.GetHashCode() ?? 0);
-				hashCode = (hashCode*397) ^ (ProxyAddress?.GetHashCode() ?? 0);
-				hashCode = (hashCode*397) ^ (ProxyUsername?.GetHashCode() ?? 0);
-				hashCode = (hashCode*397) ^ (ProxyPassword?.GetHashCode() ?? 0);
-				hashCode = (hashCode*397) ^ DisableAutomaticProxyDetection.GetHashCode();
-				hashCode = (hashCode*397) ^ (BasicAuthorizationCredentials?.GetHashCode() ?? 0);
-				hashCode = (hashCode*397) ^ (ConnectionSettings?.GetHashCode() ?? 0);
-				hashCode = (hashCode*397) ^ (MemoryStreamFactory?.GetHashCode() ?? 0);
-				return hashCode;
-			}
-		}
-
 	}
 }


### PR DESCRIPTION
RequestData's GetHashCode implementation uses instances of types that will return different values per instance (Headers, BasicAuthenticationCredentials). GetHashCode and Equals only need to reference properties that are unchanging per HttpClient instance, which are:

RequestTimeout
HttpCompression
ProxyAddress
ProxyUsername
ProxyPassword
DisableAutomaticProxyDetection

All other properties are set per request.

Fixes #2417