### PR TITLE
Add specific TermVectors type for MultiTermVectors

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/ReadOnlyCollectionJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/ReadOnlyCollectionJsonConverter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// Json converter that deserializes into an <see cref="ReadOnlyCollection{TInterface}"/> or <see cref="IReadOnlyCollection{TInterface}"/>
+	/// where <typeparamref name="TInterface"/> does not have a custom deserializer and should be deserialized
+	/// into concrete types of <typeparamref name="TDocument"/>
+	/// </summary>
+	/// <remarks>
+	/// <typeparamref name="TInterface"/> may not have a deserializer for valid reasons, for example, an interface may be implemented by two
+	/// concrete types that need to be deserialized. In this case, a deserializer would not know which concrete type to deserialize to in
+	/// a given context.
+	/// </remarks>
+	/// <typeparam name="TDocument">The concrete type to deserialize</typeparam>
+	/// <typeparam name="TInterface">The interface for the deserialized readonly collection</typeparam>
+	internal class ReadOnlyCollectionJsonConverter<TDocument, TInterface> : JsonConverter
+		where TDocument : TInterface
+		where TInterface : class
+	{
+		public override bool CanWrite => false;
+		public override bool CanRead => true;
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			throw new NotSupportedException();
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType != JsonToken.StartArray)
+				return EmptyReadOnly<TInterface>.Collection;
+
+			var list = new List<TInterface>();
+			reader.Read();
+			while (reader.TokenType != JsonToken.EndArray)
+			{
+				var item = serializer.Deserialize<TDocument>(reader);
+				list.Add(item);
+				reader.Read();
+			}
+
+			return new ReadOnlyCollection<TInterface>(list);
+		}
+
+		public override bool CanConvert(Type objectType) => true;
+	}
+}

--- a/src/Nest/Document/Multiple/MultiTermVectors/MultiTermVectorsResponse.cs
+++ b/src/Nest/Document/Multiple/MultiTermVectors/MultiTermVectorsResponse.cs
@@ -5,13 +5,14 @@ namespace Nest
 {
 	public interface IMultiTermVectorsResponse : IResponse
 	{
-		IReadOnlyCollection<TermVectorsResponse> Documents { get; }
+		IReadOnlyCollection<ITermVectors> Documents { get; }
 	}
 
 	[JsonObject]
 	public class MultiTermVectorsResponse : ResponseBase, IMultiTermVectorsResponse
 	{
 		[JsonProperty("docs")]
-		public IReadOnlyCollection<TermVectorsResponse> Documents { get; internal set; } = EmptyReadOnly<TermVectorsResponse>.Collection;
+		[JsonConverter(typeof(ReadOnlyCollectionJsonConverter<TermVectorsResult, ITermVectors>))]
+		public IReadOnlyCollection<ITermVectors> Documents { get; internal set; } = EmptyReadOnly<ITermVectors>.Collection;
 	}
 }

--- a/src/Nest/Document/Single/TermVectors/TermVectors.cs
+++ b/src/Nest/Document/Single/TermVectors/TermVectors.cs
@@ -3,12 +3,18 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	public interface ITermVectorsResponse : IResponse, ITermVectors
+	public interface ITermVectors
 	{
+		string Index { get; }
+		string Type { get; }
+		string Id { get; }
+		long Version { get; }
+		bool Found { get; }
+		long Took { get; }
+		IReadOnlyDictionary<string, TermVector> TermVectors { get; }
 	}
 
-	[JsonObject]
-	public class TermVectorsResponse : ResponseBase, ITermVectorsResponse
+	public class TermVectorsResult : ITermVectors
 	{
 		[JsonProperty("_index")]
 		public string Index { get; internal set; }

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -471,6 +471,7 @@
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\JsonConverterBase.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\KeyValueJsonConverter.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\ReadAsTypeJsonConverter.cs" />
+    <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\ReadOnlyCollectionJsonConverter.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\ReserializeJsonConverter.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\ServerErrorJsonConverter.cs" />
     <Compile Include="CommonAbstractions\SerializationBehavior\GenericJsonConverters\ReadSingleOrEnumerableJsonConverter.cs" />
@@ -610,6 +611,7 @@
     <Compile Include="Document\Single\Source\SourceRequest.cs" />
     <Compile Include="Document\Single\TermVectors\ElasticClient-TermVectors.cs" />
     <Compile Include="Document\Single\TermVectors\FieldStatistics.cs" />
+    <Compile Include="Document\Single\TermVectors\TermVectors.cs" />
     <Compile Include="Document\Single\TermVectors\TermVector.cs" />
     <Compile Include="Document\Single\TermVectors\TermVectorFilter.cs" />
     <Compile Include="Document\Single\TermVectors\TermVectorsRequest.cs" />

--- a/src/Tests/Document/Single/TermVectors/TermVectorsApiTests.cs
+++ b/src/Tests/Document/Single/TermVectors/TermVectorsApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Elasticsearch.Net;
+using FluentAssertions;
 using Nest;
 using Tests.Framework;
 using Tests.Framework.Integration;
@@ -70,5 +71,24 @@ namespace Tests.Document.Single.TermVectors
 				MaximumWordLength = 200
 			}
 		};
+
+		protected override void ExpectResponse(ITermVectorsResponse response)
+		{
+			response.ShouldBeValid();
+
+			response.TermVectors.Should().NotBeEmpty();
+			response.Found.Should().BeTrue();
+			response.Version.Should().Be(1);
+			response.Id.Should().NotBeNullOrEmpty();
+			response.Index.Should().NotBeNullOrEmpty();
+			response.Type.Should().NotBeNullOrEmpty();
+
+			foreach (var termVector in response.TermVectors)
+			{
+				termVector.Key.Should().NotBeNullOrEmpty();
+				termVector.Value.FieldStatistics.Should().NotBeNull();
+				termVector.Value.Terms.Should().NotBeEmpty();
+			}
+		}
 	}
 }


### PR DESCRIPTION
In NEST 2.x, MultiTermVectorsResponse reuses TermVectorsResponse as the type in the collection, but this exposes other properties inherited from IResponse. Introduce a specific type for this that does not inherit from IResponse.