### PR TITLE
Set ApiCall details on TermVectorResponses on MultiTermVectorsResponse

### DIFF
--- a/src/Nest/CommonAbstractions/Response/ResponseBase.cs
+++ b/src/Nest/CommonAbstractions/Response/ResponseBase.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using Elasticsearch.Net;
 using Newtonsoft.Json;

--- a/src/Nest/Document/Multiple/MultiTermVectors/MultiTermVectorsResponse.cs
+++ b/src/Nest/Document/Multiple/MultiTermVectors/MultiTermVectorsResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -11,8 +12,6 @@ namespace Nest
 	[JsonObject]
 	public class MultiTermVectorsResponse : ResponseBase, IMultiTermVectorsResponse
 	{
-		// TODO For 3.0 we should create a separate term vector object rather than using TermVectorsResponse
-		// since it contains general response data that isn't relevant (i.e. ApiCall, StatusCode, etc...)
 		[JsonProperty("docs")]
 		public IEnumerable<TermVectorsResponse> Documents { get; internal set; } = new List<TermVectorsResponse>();
 	}

--- a/src/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsApiTests.cs
+++ b/src/Tests/Document/Multiple/MultiTermVectors/MultiTermVectorsApiTests.cs
@@ -55,6 +55,8 @@ namespace Tests.Document.Multiple.MultiTermVectors
 		{
 			response.ShouldBeValid();
 			response.Documents.Should().NotBeEmpty().And.HaveCount(2).And.OnlyContain(d => d.Found);
+			response.Documents.All(r => r.IsValid).Should().BeTrue();
+
 			var termvectorDoc = response.Documents.FirstOrDefault(d => d.TermVectors.Count > 0);
 
 			termvectorDoc.Should().NotBeNull();


### PR DESCRIPTION
Add a specific deserialization override to set ApiCallDetails on each TermVectorResponse in MultiTermVectorsResponse.Documents.

Closes #2142