### PR TITLE
fix #2164 you can now skip the create index step if you use our Reind…

### DIFF
--- a/src/Nest/Document/Multiple/Reindex/ReindexRequest.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexRequest.cs
@@ -6,86 +6,104 @@ namespace Nest
 	{
 		IndexName To { get; set; }
 		IndexName From { get; set; }
-		Types Type { get; set; }
-		Time Scroll { get; set; }
-		int? Size { get; set; }
-
-		QueryContainer Query { get; set; }
-
-		ICreateIndexRequest CreateIndexRequest { get; set; }
-
-		IPutMappingRequest PutMappingRequest { get; set; }
-	}
-
-	public class ReindexRequest : IReindexRequest
-	{
-		public IndexName To { get; set; }
-		public IndexName From { get; set; }
-		public Types Type { get; set; }
-		public Time Scroll { get; set; }
-		public int? Size { get; set; }
-		public QueryContainer Query { get; set; }
-		public ICreateIndexRequest CreateIndexRequest { get; set; }
-		public IPutMappingRequest PutMappingRequest { get; set; }
-		public ReindexRequest(IndexName from, IndexName to, Types type)
-		{
-			this.To = to;
-			this.From = from;
-			this.Type = type;
-		}
-	}
-
-	public class ReindexDescriptor<T> : DescriptorBase<ReindexDescriptor<T>, IReindexRequest>, IReindexRequest where T : class
-	{
-		IndexName IReindexRequest.To { get; set; }
-		IndexName IReindexRequest.From { get; set; }
-		Types IReindexRequest.Type { get; set; }
-		Time IReindexRequest.Scroll { get; set; }
-		int? IReindexRequest.Size { get; set; }
-		QueryContainer IReindexRequest.Query { get; set; }
-		ICreateIndexRequest IReindexRequest.CreateIndexRequest { get; set; }
-		IPutMappingRequest IReindexRequest.PutMappingRequest { get; set; }
-
-		public ReindexDescriptor(IndexName from, IndexName to)
-		{
-			Assign(a => a.From = from)
-			.Assign(a => a.To = to)
-			.Assign(a => a.Type = typeof(T));
-		}
-
+		Types Types { get; set; }
 		/// <summary>
-		/// A search request can be scrolled by specifying the scroll parameter. The scroll parameter is a time value parameter (for example: scroll=5m), indicating for how long the nodes that participate in the search will maintain relevant resources in order to continue and support it. This is very similar in its idea to opening a cursor against a database.
+		/// A search request can be scrolled by specifying the scroll parameter. The scroll parameter is a time value
+		/// parameter (for example: scroll=5m), indicating for how long the nodes that participate in the search
+		/// will maintain relevant resources in order to continue and support it. This is very similar in its idea to opening a cursor against a database.
 		/// </summary>
-		/// <param name="scrollTime">The scroll parameter is a time value parameter (for example: scroll=5m)</param>
-		/// <returns></returns>
-		public ReindexDescriptor<T> Scroll(Time scrollTime) => Assign(a => a.Scroll = scrollTime);
+		Time Scroll { get; set; }
 
 		/// <summary>
 		/// The number of hits to return. Defaults to 100. When using scroll search type,
 		/// size is actually multiplied by the number of shards!
 		/// </summary>
-		public ReindexDescriptor<T> Size(int? size) => Assign(a => a.Size = size);
-
-		/// <summary>
-		/// The number of hits to return. Defaults to 100.
-		/// </summary>
-		public ReindexDescriptor<T> Take(int? take) => Assign(a => a.Size = take);
+		int? Size { get; set; }
 
 		/// <summary>
 		/// A query to optionally limit the documents to use for the reindex operation.
 		/// </summary>
+		QueryContainer Query { get; set; }
+
+		/// <summary>
+		/// Do not send a create index call on <see cref="To"/>, assume the index has been created outside of the reindex.
+		/// </summary>
+		bool OmitIndexCreation { get; set; }
+
+		/// <summary>
+		/// Describe how the newly created index should be created. Remember you can also register Index Templates for more dynamic usecases.
+		/// </summary>
+		ICreateIndexRequest CreateIndexRequest { get; set; }
+	}
+
+	public class ReindexRequest : IReindexRequest
+	{
+		/// <inheritdoc/>
+		public bool OmitCreateIndex { get; set; }
+		/// <inheritdoc/>
+		public IndexName To { get; set; }
+		/// <inheritdoc/>
+		public IndexName From { get; set; }
+		/// <inheritdoc/>
+		public Types Types { get; set; }
+		/// <inheritdoc/>
+		public Time Scroll { get; set; }
+		/// <inheritdoc/>
+		public int? Size { get; set; }
+		/// <inheritdoc/>
+		public QueryContainer Query { get; set; }
+		/// <inheritdoc/>
+		public ICreateIndexRequest CreateIndexRequest { get; set; }
+
+		public ReindexRequest(IndexName from, IndexName to, Types types)
+		{
+			this.To = to;
+			this.From = from;
+			this.Types = types;
+		}
+	}
+
+	public class ReindexDescriptor<T> : DescriptorBase<ReindexDescriptor<T>, IReindexRequest>, IReindexRequest where T : class
+	{
+		bool IReindexRequest.OmitIndexCreation { get; set; }
+		IndexName IReindexRequest.To { get; set; }
+		IndexName IReindexRequest.From { get; set; }
+		Types IReindexRequest.Types { get; set; }
+		Time IReindexRequest.Scroll { get; set; }
+		int? IReindexRequest.Size { get; set; }
+		QueryContainer IReindexRequest.Query { get; set; }
+		ICreateIndexRequest IReindexRequest.CreateIndexRequest { get; set; }
+
+		public ReindexDescriptor(IndexName from, IndexName to)
+		{
+			Assign(a => a.From = from)
+			.Assign(a => a.To = to)
+			.Assign(a => a.Types = typeof(T));
+		}
+
+		/// <inheritdoc/>
+		public ReindexDescriptor<T> Scroll(Time scrollTime) => Assign(a => a.Scroll = scrollTime);
+
+		/// <inheritdoc/>
+		public ReindexDescriptor<T> Size(int? size) => Assign(a => a.Size = size);
+
+		/// <inheritdoc/>
+		public ReindexDescriptor<T> Take(int? take) => Assign(a => a.Size = take);
+
+		/// <inheritdoc/>
+		public ReindexDescriptor<T> OmitIndexCreation(bool omit = true) => Assign(a => a.OmitIndexCreation = true);
+
+		/// <inheritdoc/>
 		public ReindexDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> querySelector) =>
 			Assign(a => a.Query = querySelector?.Invoke(new QueryContainerDescriptor<T>()));
 
-		/// <summary>
-		/// A query to optionally limit the documents to use for the reindex operation.
-		/// </summary>
+		/// <inheritdoc/>
 		public ReindexDescriptor<T> Query(QueryContainer query) => Assign(a => a.Query = query);
 
 		/// <summary>
 		/// Specify the document types to reindex. By default, will be <typeparamref name="T"/>
 		/// </summary>
-		public ReindexDescriptor<T> Type(Types type) => Assign(a => a.Type = type);
+		public ReindexDescriptor<T> Type(Types type) => Assign(a => a.Types = type);
 
 		/// <summary>
 		/// Reindex all document types.


### PR DESCRIPTION
…ex() helper, also made sure we use a _doc sort on the scroll