### PR TITLE
ScrollAll()

### DIFF
--- a/src/Elasticsearch.Net/Extensions/Extensions.cs
+++ b/src/Elasticsearch.Net/Extensions/Extensions.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
 using System.Text;
 
 namespace Elasticsearch.Net
@@ -122,5 +119,6 @@ namespace Elasticsearch.Net
 
 			return factor.ToString("0.##", CultureInfo.InvariantCulture) + interval;
 		}
+
 	}
 }

--- a/src/Nest/Document/Multiple/Reindex/ReindexResponse.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexResponse.cs
@@ -20,7 +20,7 @@ namespace Nest
 		/// <summary>
 		/// The no of scroll this result represents
 		/// </summary>
-		int Scroll { get; }
+		long Scroll { get; }
 
 		/// <summary>
 		/// Whether both the scroll and reindex result are valid
@@ -37,7 +37,7 @@ namespace Nest
 		public IBulkResponse BulkResponse { get; internal set; }
 		public ISearchResponse<T> SearchResponse { get; internal set; }
 
-		public int Scroll { get; internal set; }
+		public long Scroll { get; internal set; }
 
 		public bool IsValid =>
 			this.BulkResponse != null && this.BulkResponse.IsValid

--- a/src/Nest/Document/Multiple/ScrollAll/ElasticClient-ScrollAll.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ElasticClient-ScrollAll.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		IObservable<IScrollAllResponse<T>> ScrollAll<T>(Time scrollTime, int numberOfSlices, Func<ScrollAllDescriptor<T>, IScrollAllRequest> selector = null, CancellationToken cancellationToken = default(CancellationToken))
+			where T : class;
+
+		IObservable<IScrollAllResponse<T>> ScrollAll<T>(IScrollAllRequest request, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+	}
+
+	public partial class ElasticClient
+	{
+		public IObservable<IScrollAllResponse<T>> ScrollAll<T>(Time scrollTime, int numberOfSlices, Func<ScrollAllDescriptor<T>, IScrollAllRequest> selector = null, CancellationToken cancellationToken = default(CancellationToken))
+			where T : class =>
+			this.ScrollAll<T>(selector.InvokeOrDefault(new ScrollAllDescriptor<T>(scrollTime, numberOfSlices)), cancellationToken);
+
+		public IObservable<IScrollAllResponse<T>> ScrollAll<T>(IScrollAllRequest request, CancellationToken cancellationToken = default(CancellationToken))
+			where T : class =>
+			new ScrollAllObservable<T>(this, ConnectionSettings, request, cancellationToken);
+	}
+}

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Elasticsearch.Net;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Nest
+{
+	public class ScrollAllObservable<T> : IDisposable, IObservable<IScrollAllResponse<T>> where T : class
+	{
+		private readonly IScrollAllRequest _scrollAllRequest;
+		private readonly ISearchRequest _searchRequest;
+		private readonly IConnectionSettingsValues _connectionSettings;
+		private readonly IElasticClient _client;
+		private static IList<ISort> DocOrderSort = new ReadOnlyCollection<ISort>(new List<ISort> { new SortField { Field = "_doc" } });
+
+		private readonly CancellationToken _compositeCancelToken;
+		private readonly CancellationTokenSource _compositeCancelTokenSource;
+
+		public ScrollAllObservable(
+			IElasticClient client, 
+			IConnectionSettingsValues connectionSettings, 
+			IScrollAllRequest scrollAllRequest,
+			CancellationToken cancellationToken = default(CancellationToken)
+			)
+		{
+			this._connectionSettings = connectionSettings;
+			this._scrollAllRequest = scrollAllRequest;
+			this._searchRequest = scrollAllRequest?.Search ?? new SearchRequest<T>();
+			this._searchRequest.Sort = DocOrderSort;
+			this._searchRequest.RequestParameters.Scroll(this._scrollAllRequest.ScrollTime.ToTimeSpan());
+			this._client = client;
+			this._compositeCancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			this._compositeCancelToken = this._compositeCancelTokenSource.Token;
+		}
+
+		public IDisposable Subscribe(IObserver<IScrollAllResponse<T>> observer)
+		{
+			observer.ThrowIfNull(nameof(observer));
+			try
+			{
+				this.ScrollAll(observer);
+			}
+			catch (Exception e)
+			{
+				observer.OnError(e);
+			}
+			return this;
+		}
+
+		private void ScrollAll(IObserver<IScrollAllResponse<T>> observer)
+		{
+			var slices = this._scrollAllRequest.Slices;
+			var maxSlicesAtOnce = this._scrollAllRequest.MaxDegreeOfParallelism ?? this._scrollAllRequest.Slices;
+
+			Enumerable.Range(0, slices).ForEachAsync<int, bool>(
+				(slice, l) => this.ScrollSliceAsync(observer, slice),
+				(slice, r) => { },
+				t => OnCompleted(t, observer),
+				maxSlicesAtOnce
+			);
+		}
+
+		private async Task<bool> ScrollSliceAsync(IObserver<IScrollAllResponse<T>> observer, int slice)
+		{
+			var searchResult = await this.InitiateSearchAsync(slice).ConfigureAwait(false);
+			await this.ScrollToCompletionAsync(slice, observer, searchResult).ConfigureAwait(false);
+			return true;
+		}
+
+		private ElasticsearchClientException Throw(string message, IApiCallDetails details) =>
+			new ElasticsearchClientException(PipelineFailure.BadResponse, message, details);
+
+		private void ThrowOnBadSearchResult(ISearchResponse<T> result, int slice, int page)
+		{
+			if (result == null || !result.IsValid)
+			{
+				var path = result?.ApiCall.Uri.PathAndQuery ?? "(unknown)";
+				throw Throw($"scrolling search on {path} with slice {slice} was not valid on scroll iteration {page}", result?.ApiCall);
+			}
+			this._compositeCancelToken.ThrowIfCancellationRequested();
+		}
+
+		private async Task ScrollToCompletionAsync(int slice, IObserver<IScrollAllResponse<T>> observer, ISearchResponse<T> searchResult)
+		{
+			var page = 0;
+			ThrowOnBadSearchResult(searchResult, slice, page);
+			var scroll = this._scrollAllRequest.ScrollTime;
+			while (searchResult.IsValid && searchResult.Documents.HasAny())
+			{
+				observer.OnNext(new ScrollAllResponse<T>()
+				{
+					Slice = slice,
+					SearchResponse = searchResult,
+					Scroll = page
+				});
+				page++;
+				var request = new ScrollRequest(searchResult.ScrollId, scroll);
+				searchResult = await this._client.ScrollAsync<T>(request, this._compositeCancelToken).ConfigureAwait(false);
+				ThrowOnBadSearchResult(searchResult, slice, page);
+			}
+		}
+
+		private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+		private async Task<ISearchResponse<T>> InitiateSearchAsync(int slice)
+		{
+			//since we are mutating the searchRequests .Slice it can not be shared across threads for the initial searches
+			//so these happen serially
+			await _lock.WaitAsync(_compositeCancelToken).ConfigureAwait(false);
+			try
+			{
+				this._searchRequest.Slice = new SlicedScroll
+				{
+					Id = slice,
+					Max = this._scrollAllRequest.Slices,
+					Field = this._scrollAllRequest.RoutingField
+				};
+				var response = await this._client.SearchAsync<T>(this._searchRequest, this._compositeCancelToken).ConfigureAwait(false);
+				if (response.Total <= 0)
+					throw Throw($"ScrollAll query against {response.ApiCall.Uri.PathAndQuery} doesn't contain any documents.", response.ApiCall);
+				return response;
+			}
+			finally { _lock.Release(); }
+		}
+
+		private static void OnCompleted(Task task, IObserver<IScrollAllResponse<T>> observer)
+		{
+			switch (task.Status)
+			{
+				case System.Threading.Tasks.TaskStatus.RanToCompletion:
+					observer.OnCompleted();
+					break;
+				case System.Threading.Tasks.TaskStatus.Faulted:
+					observer.OnError(task.Exception.InnerException);
+					break;
+				case System.Threading.Tasks.TaskStatus.Canceled:
+					observer.OnError(new TaskCanceledException(task));
+					break;
+			}
+		}
+
+		public bool IsDisposed { get; private set; }
+		public void Dispose()
+		{
+			this.IsDisposed = true;
+			this._compositeCancelTokenSource?.Cancel();
+		}
+	}
+}

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
@@ -29,7 +29,8 @@ namespace Nest
 			this._connectionSettings = connectionSettings;
 			this._scrollAllRequest = scrollAllRequest;
 			this._searchRequest = scrollAllRequest?.Search ?? new SearchRequest<T>();
-			this._searchRequest.Sort = DocOrderSort;
+			if (this._searchRequest.Sort == null)
+				this._searchRequest.Sort = DocOrderSort;
 			this._searchRequest.RequestParameters.Scroll(this._scrollAllRequest.ScrollTime.ToTimeSpan());
 			this._client = client;
 			this._compositeCancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObserver.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObserver.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Nest
+{
+	public class ScrollAllObserver<T> : CoordinatedRequestObserverBase<IScrollAllResponse<T>> where T : class
+	{
+		public ScrollAllObserver(
+			Action<IScrollAllResponse<T>> onNext = null,
+			Action<Exception> onError = null,
+			System.Action onCompleted = null)
+			: base(onNext, onError, onCompleted) { }
+
+	}
+}

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllRequest.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllRequest.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace Nest
+{
+	public interface IScrollAllRequest
+	{
+		/// <summary>
+		/// The ammount of time to keep the scroll alive on the server
+		/// </summary>
+		Time ScrollTime { get; set; }
+		/// <summary>
+		/// An optional search request that describes the search we want to scroll over.
+		/// Defaults to matchall on the index and type of T in the <see cref="ScrollAllObserver{T}"/>.
+		/// Note: both scroll and slice information WILL be overriden.
+		/// </summary>
+		ISearchRequest Search { get; set; }
+		/// <summary>
+		/// The maximum number of slices to partition the scroll over
+		/// </summary>
+		int Slices { get; set; }
+		/// <summary>
+		/// The maximum degree of parallelism we should drain the sliced scroll, defaults to the value of <see cref="Slices"/>
+		/// </summary>
+		int? MaxDegreeOfParallelism { get; set; }
+		/// <summary>
+		/// Set a different routing field, has to have doc_values enabled
+		/// </summary>
+		Field RoutingField { get; set; }
+	}
+
+	public class ScrollAllRequest : IScrollAllRequest
+	{
+		int IScrollAllRequest.Slices { get; set; }
+		Time IScrollAllRequest.ScrollTime { get; set; }
+
+		/// <inheritdoc/>
+		public ISearchRequest Search { get; set; }
+
+		/// <inheritdoc/>
+		public Field RoutingField { get; set; }
+		/// <inheritdoc/>
+		public int? MaxDegreeOfParallelism { get; set; }
+
+		public ScrollAllRequest(Time scrollTime, int numberOfSlices)
+		{
+			var i = ((IScrollAllRequest)this);
+			i.ScrollTime = scrollTime;
+			i.Slices = numberOfSlices;
+		}
+		public ScrollAllRequest(Time scrollTime, int numberOfSlices, Field routingField) : this(scrollTime, numberOfSlices)
+		{
+			((IScrollAllRequest)this).RoutingField = routingField;
+		}
+	}
+
+	public class ScrollAllDescriptor<T> : DescriptorBase<ScrollAllDescriptor<T>, IScrollAllRequest>, IScrollAllRequest where T : class
+	{
+		ISearchRequest IScrollAllRequest.Search { get; set; }
+		int IScrollAllRequest.Slices { get; set; }
+		Field IScrollAllRequest.RoutingField { get; set; }
+		Time IScrollAllRequest.ScrollTime { get; set; }
+		int? IScrollAllRequest.MaxDegreeOfParallelism { get; set; }
+
+		public ScrollAllDescriptor(Time scrollTime, int numberOfSlices)
+		{
+			Assign(a =>
+			{
+				a.ScrollTime = scrollTime;
+				a.Slices = numberOfSlices;
+			});
+		}
+
+		/// <inheritdoc/>
+		public ScrollAllDescriptor<T> MaxDegreeOfParallelism(int maxDegreeOfParallelism) =>
+			Assign(a => a.MaxDegreeOfParallelism = maxDegreeOfParallelism);
+
+		/// <inheritdoc/>
+		public ScrollAllDescriptor<T> RoutingField(Field field) => Assign(a => a.RoutingField = field);
+
+		/// <inheritdoc/>
+		public ScrollAllDescriptor<T> RoutingField(Expression<Func<T, object>> objectPath) =>
+			Assign(a => a.RoutingField = objectPath);
+
+		/// <inheritdoc/>
+		public ScrollAllDescriptor<T> Search(Func<SearchDescriptor<T>, ISearchRequest> selector) =>
+			Assign(a => a.Search = selector?.Invoke(new SearchDescriptor<T>()));
+
+	}
+}

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllRequest.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllRequest.cs
@@ -50,7 +50,7 @@ namespace Nest
 		}
 		public ScrollAllRequest(Time scrollTime, int numberOfSlices, Field routingField) : this(scrollTime, numberOfSlices)
 		{
-			((IScrollAllRequest)this).RoutingField = routingField;
+			this.RoutingField = routingField;
 		}
 	}
 

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllResponse.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllResponse.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary> A response returned for each scroll in ScrollAll() </summary>
+	public interface IScrollAllResponse<T> where T : class
+	{
+		/// <summary>
+		/// The scroll result
+		/// </summary>
+		ISearchResponse<T> SearchResponse { get; }
+
+		/// <summary>
+		/// The nth scroll this response represents
+		/// </summary>
+		long Scroll { get; }
+
+		/// <summary>
+		/// The nth slice this response belongs to
+		/// </summary>
+		int Slice { get; }
+	}
+
+	/// <summary> A response returned for each scroll in ScrollAll() </summary>
+	[JsonObject]
+	public class ScrollAllResponse<T> : IScrollAllResponse<T> where T : class
+	{
+		public ISearchResponse<T> SearchResponse { get; internal set; }
+		public long Scroll { get; internal set; }
+		public int Slice { get; internal set; }
+
+		public bool IsValid => this.SearchResponse != null && this.SearchResponse.IsValid;
+	}
+}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -565,6 +565,11 @@
     <Compile Include="Document\Multiple\ReindexRethrottle\ReindexNode.cs" />
     <Compile Include="Document\Multiple\ReindexRethrottle\ReindexRethrottleResponse.cs" />
     <Compile Include="Document\Multiple\Retries.cs" />
+    <Compile Include="Document\Multiple\ScrollAll\ElasticClient-ScrollAll.cs" />
+    <Compile Include="Document\Multiple\ScrollAll\ScrollAllObservable.cs" />
+    <Compile Include="Document\Multiple\ScrollAll\ScrollAllObserver.cs" />
+    <Compile Include="Document\Multiple\ScrollAll\ScrollAllRequest.cs" />
+    <Compile Include="Document\Multiple\ScrollAll\ScrollAllResponse.cs" />
     <Compile Include="Document\Multiple\UpdateByQuery\UpdateByQueryRequest.cs" />
     <Compile Include="Document\Multiple\UpdateByQuery\UpdateByQueryResponse.cs" />
     <Compile Include="Document\Multiple\UpdateByQuery\ElasticClient-UpdateByQuery.cs" />

--- a/src/Nest/Search/Scroll/Scroll/SlicedScroll.cs
+++ b/src/Nest/Search/Scroll/Scroll/SlicedScroll.cs
@@ -23,7 +23,6 @@ namespace Nest
 
 	}
 
-
 	public class SlicedScrollDescriptor<T> : DescriptorBase<SlicedScrollDescriptor<T>, ISlicedScroll>, ISlicedScroll
 		where T : class
 	{

--- a/src/Tests/Document/Multiple/BulkAll/BulkAllApiTests.cs
+++ b/src/Tests/Document/Multiple/BulkAll/BulkAllApiTests.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -33,26 +36,66 @@ namespace Tests.Document.Multiple.BulkAll
 			this._client = cluster.Client;
 		}
 
-		[I]
-		public void ReturnsExpectedResponse()
+		[I] public async Task BulkAllAndScrollAll()
 		{
 			var index = CreateIndexName();
-			var handle = new ManualResetEvent(false);
 
-			var size = 1000;
-			var pages = 100;
-			var seenPages = 0;
-			var numberOfDocuments = size * pages;
+			const int size = 1000, pages = 100, numberOfDocuments = size * pages, numberOfShards = 10;
 			var documents = this.CreateLazyStreamOfDocuments(numberOfDocuments);
 
+			await this.CreateIndexAsync(index, numberOfShards);
+
+			this.BulkAll(index, documents, size, pages, numberOfDocuments);
+			this.ScrollAll(index, numberOfShards, numberOfDocuments);
+		}
+
+		private void ScrollAll(string index, int numberOfShards, int numberOfDocuments)
+		{
+			var handle = new ManualResetEvent(false);
+			var scrollObservable = this._client.ScrollAll<SmallObject>("1m", numberOfShards, s => s
+				.MaxDegreeOfParallelism(numberOfShards / 2)
+				.Search(search => search
+					.Index(index)
+					.AllTypes()
+					.MatchAll()
+				)
+			);
+
+			//we set up an observer
+			var seenDocuments = 0;
+			var seenSlices = new ConcurrentBag<int>();
+
+			//since we call allTypes search should be bounded to index.
+			var scrollObserver = new ScrollAllObserver<SmallObject>(
+				onError: (e) => { throw e; },
+				onCompleted: () => handle.Set(),
+				onNext: (b) =>
+				{
+					seenSlices.Add(b.Slice);
+					Interlocked.Add(ref seenDocuments, b.SearchResponse.Hits.Count);
+				}
+			);
+			//when we subscribe the observable becomes hot
+			scrollObservable.Subscribe(scrollObserver);
+			handle.WaitOne(TimeSpan.FromMinutes(5));
+			seenDocuments.Should().Be(numberOfDocuments);
+			var groups = seenSlices.GroupBy(s => s).ToList();
+			groups.Count().Should().Be(numberOfShards);
+			groups.Should().OnlyContain(g => g.Count() > 1);
+		}
+
+		private void BulkAll(string index, IEnumerable<SmallObject> documents, int size,  int pages, int numberOfDocuments)
+		{
+			var handle = new ManualResetEvent(false);
+			var seenPages = 0;
 			//first we setup our cold observable
 			var observableBulk = this._client.BulkAll(documents, f => f
-				.MaxDegreeOfParallelism(8)
-				.BackOffTime(TimeSpan.FromSeconds(10))
-				.BackOffRetries(2)
-				.Size(size)
-				.RefreshOnCompleted()
-				.Index(index)
+					.MaxDegreeOfParallelism(8)
+					.BackOffTime(TimeSpan.FromSeconds(10))
+					.BackOffRetries(2)
+					.Size(size)
+					.RefreshOnCompleted()
+					.Index(index)
 			);
 			//we set up an observer
 			var bulkObserver = new BulkAllObserver(
@@ -69,9 +112,20 @@ namespace Tests.Document.Multiple.BulkAll
 			var count = this._client.Count<SmallObject>(f => f.Index(index));
 			count.Count.Should().Be(numberOfDocuments);
 			bulkObserver.TotalNumberOfFailedBuffers.Should().Be(0);
-			bulkObserver.TotalNumberOfRetries.Should().Be(0);
 		}
 
+		private async Task CreateIndexAsync(string indexName, int numberOfShards)
+		{
+			var handle = new ManualResetEvent(false);
+			var result = await this._client.CreateIndexAsync(indexName, s => s
+					.Settings(settings => settings
+							.NumberOfShards(numberOfShards)
+							.NumberOfReplicas(0)
+					)
+			);
+			result.Should().NotBeNull();
+			result.IsValid.Should().BeTrue();
+		}
 		[I]
 		public void DisposingObservableCancelsBulkAll()
 		{
@@ -112,7 +166,6 @@ namespace Tests.Document.Multiple.BulkAll
 			var count = this._client.Count<SmallObject>(f => f.Index(index));
 			count.Count.Should().BeLessThan(numberOfDocuments).And.BeGreaterThan(0);
 			bulkObserver.TotalNumberOfFailedBuffers.Should().Be(0);
-			bulkObserver.TotalNumberOfRetries.Should().Be(0);
 		}
 
 		[I]

--- a/src/Tests/Framework/Configuration/YamlConfiguration.cs
+++ b/src/Tests/Framework/Configuration/YamlConfiguration.cs
@@ -25,7 +25,7 @@ namespace Tests.Framework.Configuration
 			this.ElasticsearchVersion = new ElasticsearchVersion(config["elasticsearch_version"]);
 			this.ForceReseed = bool.Parse(config["force_reseed"]);
 			this.TestAgainstAlreadyRunningElasticsearch = bool.Parse(config["test_against_already_running_elasticsearch"]);
-			this.ClusterFilter = config["cluster_filter"];
+			this.ClusterFilter = config.ContainsKey("cluster_filter") ? config["cluster_filter"] : null;
 		}
 
 		private static string ConfigName(string configLine) => Parse(configLine, 0);

--- a/src/Tests/Search/Scroll/Scroll/SlicedScrollSearchApiTests.cs
+++ b/src/Tests/Search/Scroll/Scroll/SlicedScrollSearchApiTests.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 namespace Tests.Search.Scroll.Scroll
 {
-	public class SlicedScrollApiTests : ApiIntegrationTestBase<ReadOnlyCluster, ISearchResponse<Project>, IScrollRequest, ScrollDescriptor<Project>, ScrollRequest>
+	public class SlicedScrollSearchApiTests : ApiIntegrationTestBase<ReadOnlyCluster, ISearchResponse<Project>, IScrollRequest, ScrollDescriptor<Project>, ScrollRequest>
 	{
-		public SlicedScrollApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public SlicedScrollSearchApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		private string _scrollId = "default-for-unit-tests";
 

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -657,7 +657,7 @@
     <Compile Include="Reproduce\GithubIssue2173.cs" />
     <Compile Include="Search\Request\SlicedScrollSearchUsageTests.cs" />
     <Compile Include="Search\Request\SearchAfterUsageTests.cs" />
-    <Compile Include="Search\Scroll\Scroll\SlicedScrollApiTests.cs" />
+    <Compile Include="Search\Scroll\Scroll\SlicedScrollSearchApiTests.cs" />
     <Compile Include="Search\Search\Rescoring\RescoreUsageTests.cs" />
     <Compile Include="Search\Search\InvalidSearchApiTests.cs" />
     <Compile Include="Search\Suggesters\SuggestUrlTests.cs" />
@@ -759,7 +759,9 @@
     <Content Include="ClientConcepts\LowLevel\pipeline.xml" />
     <Content Include="QueryDsl\BoolDsl\hadouken-indentation.jpg" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Document\Multiple" />
+  </ItemGroup>
   <Import Project="..\outputpath.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Choose>

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -4,10 +4,9 @@ mode: m
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.0.2
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
-cluster_filter: 
+# cluster_filter:
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running
 force_reseed: true
 # do not spawn nodes as part of the test setup if we find a node is already running
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true
-


### PR DESCRIPTION
Exposes a sliced scroll behind an observable with an optional max degree
of parallelism

```csharp
var scrollObservable = this._client.ScrollAll<SmallObject>("1m", slices, s => s
	.MaxDegreeOfParallelism(slices/ 2)
	.Search(search => search
		.Index(index)
		.AllTypes()
		.MatchAll()
	)
);
```