### PR TITLE
Small Performance Improvements

### DIFF
--- a/src/Elasticsearch.Net/Serialization/ElasticsearchDefaultSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/ElasticsearchDefaultSerializer.cs
@@ -8,8 +8,10 @@ namespace Elasticsearch.Net
 {
 	public class ElasticsearchDefaultSerializer : IElasticsearchSerializer
 	{
-		public static readonly ElasticsearchDefaultSerializer Instance = new ElasticsearchDefaultSerializer();
 		private static readonly ElasticsearchNetJsonStrategy Strategy = new ElasticsearchNetJsonStrategy();
+		private const int BufferSize = 81920;
+
+		public static readonly ElasticsearchDefaultSerializer Instance = new ElasticsearchDefaultSerializer();
 
 		public T Deserialize<T>(Stream stream)
 		{
@@ -34,7 +36,7 @@ namespace Elasticsearch.Net
 			using (var ms = new MemoryStream())
 			using (stream)
 			{
-				await stream.CopyToAsync(ms, 8096, cancellationToken).ConfigureAwait(false);
+				await stream.CopyToAsync(ms, BufferSize, cancellationToken).ConfigureAwait(false);
 				var buffer = ms.ToArray();
 				if (buffer.Length <= 1)
 					return default(T);

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -10,13 +10,13 @@ namespace Elasticsearch.Net
 	public class ResponseBuilder<TReturn>
 		where TReturn : class
 	{
-		public const int BufferSize = 8096;
+		private const int BufferSize = 81920;
 
 		public Exception Exception { get; set; }
 		public int? StatusCode { get; set; }
 		public Stream Stream { get; set; }
 
-		private RequestData _requestData;
+		private readonly RequestData _requestData;
 
 		public ResponseBuilder(RequestData requestData)
 		{

--- a/src/Elasticsearch.Net/Transport/PostData.cs
+++ b/src/Elasticsearch.Net/Transport/PostData.cs
@@ -24,6 +24,10 @@ namespace Elasticsearch.Net
 
 	public class PostData<T> : IPostData<T>
 	{
+		private const int BufferSize = 81920;
+		private const string NewLineString = "\n";
+		private static readonly byte[] NewLineByteArray = { (byte)'\n' };
+
 		private readonly string _literalString;
 		private readonly IEnumerable<string> _enumurabeOfStrings;
 		private readonly IEnumerable<object> _enumerableOfObject;
@@ -67,14 +71,14 @@ namespace Elasticsearch.Net
 			MemoryStream ms = null; Stream stream = null;
 			switch (Type)
 			{
-				case PostType.ByteArray: 
+				case PostType.ByteArray:
 					ms = new MemoryStream(WrittenBytes);
 					break;
 				case PostType.LiteralString:
 					ms = !string.IsNullOrEmpty(_literalString) ? new MemoryStream(_literalString?.Utf8Bytes()) : null;
 					break;
-				case PostType.EnumerableOfString: 
-					ms = _enumurabeOfStrings.HasAny() ? new MemoryStream((string.Join("\n", _enumurabeOfStrings) + "\n").Utf8Bytes()) : null;
+				case PostType.EnumerableOfString:
+					ms = _enumurabeOfStrings.HasAny() ? new MemoryStream((string.Join(NewLineString, _enumurabeOfStrings) + NewLineString).Utf8Bytes()) : null;
 					break;
 				case PostType.EnumerableOfObject:
 					if (!_enumerableOfObject.HasAny()) return;
@@ -88,10 +92,10 @@ namespace Elasticsearch.Net
 					foreach (var o in _enumerableOfObject)
 					{
 						settings.Serializer.Serialize(o, stream, SerializationFormatting.None);
-						stream.Write(new byte[] { (byte)'\n' }, 0, 1);
+						stream.Write(NewLineByteArray, 0, 1);
 					}
 					break;
-				case PostType.Serializable: 
+				case PostType.Serializable:
 					stream = writableStream;
 					if (settings.DisableDirectStreaming)
 					{
@@ -104,7 +108,7 @@ namespace Elasticsearch.Net
 			if (ms != null)
 			{
 				ms.Position = 0;
-				ms.CopyTo(writableStream, 8096);
+				ms.CopyTo(writableStream, BufferSize);
 			}
 			if (this.Type != 0)
 				this.WrittenBytes = ms?.ToArray();
@@ -116,14 +120,14 @@ namespace Elasticsearch.Net
 			MemoryStream ms = null; Stream stream = null;
 			switch (Type)
 			{
-				case PostType.ByteArray: 
+				case PostType.ByteArray:
 					ms = new MemoryStream(WrittenBytes);
 					break;
-				case PostType.LiteralString: 
+				case PostType.LiteralString:
 					ms = !string.IsNullOrEmpty(_literalString) ? new MemoryStream(_literalString.Utf8Bytes()) : null;
 					break;
-				case PostType.EnumerableOfString: 
-					ms = _enumurabeOfStrings.HasAny() ? new MemoryStream((string.Join("\n", _enumurabeOfStrings) + "\n").Utf8Bytes()) : null;
+				case PostType.EnumerableOfString:
+					ms = _enumurabeOfStrings.HasAny() ? new MemoryStream((string.Join(NewLineString, _enumurabeOfStrings) + NewLineString).Utf8Bytes()) : null;
 					break;
 				case PostType.EnumerableOfObject:
 					if (!_enumerableOfObject.HasAny()) return;
@@ -136,10 +140,10 @@ namespace Elasticsearch.Net
 					foreach (var o in _enumerableOfObject)
 					{
 						settings.Serializer.Serialize(o, stream, SerializationFormatting.None);
-						await stream.WriteAsync(new byte[] { (byte)'\n' }, 0, 1, cancellationToken).ConfigureAwait(false);
+						await stream.WriteAsync(NewLineByteArray, 0, 1, cancellationToken).ConfigureAwait(false);
 					}
 					break;
-				case PostType.Serializable: 
+				case PostType.Serializable:
 					stream = writableStream;
 					if (settings.DisableDirectStreaming)
 					{
@@ -152,7 +156,7 @@ namespace Elasticsearch.Net
 			if (ms != null)
 			{
 				ms.Position = 0;
-				await ms.CopyToAsync(writableStream, 8096, cancellationToken).ConfigureAwait(false);
+				await ms.CopyToAsync(writableStream, BufferSize, cancellationToken).ConfigureAwait(false);
 			}
 			if (this.Type != 0)
 				this.WrittenBytes = ms?.ToArray();

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
@@ -11,24 +11,40 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// A JSON serializer that uses Json.NET for serialization
+	/// </summary>
 	public class JsonNetSerializer : IElasticsearchSerializer
 	{
 		private static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
 
+		private JsonSerializer _defaultSerializer;
+		private JsonSerializer _indentedSerializer;
 
 		protected IConnectionSettingsValues Settings { get; }
+
+		/// <summary>
+		/// Resolves JsonContracts for types
+		/// </summary>
 		protected ElasticContractResolver ContractResolver { get; }
 
-		//todo this internal smells
+		//TODO this internal smells
 		internal JsonSerializer Serializer => _defaultSerializer;
 
-		private Dictionary<SerializationFormatting, JsonSerializer> _defaultSerializers;
-		private JsonSerializer _defaultSerializer;
+		/// <summary>
+		/// The size of the buffer to use when writing the serialized request
+		/// to the request stream
+		/// </summary>
+		// Performance tests as part of https://github.com/elastic/elasticsearch-net/issues/1899 indicate this 
+		// to be a good compromise buffer size for performance throughput and bytes allocated.
+		protected virtual int BufferSize => 1024;
 
 		[Obsolete("Use the connection settings constructor that takes an ISerializerFactory")]
 		protected virtual void ModifyJsonSerializerSettings(JsonSerializerSettings settings) { }
 
 		protected virtual IList<Func<Type, JsonConverter>> ContractConverters => null;
+
+		protected readonly ConcurrentDictionary<int, IPropertyMapping> Properties = new ConcurrentDictionary<int, IPropertyMapping>();
 
 		public JsonNetSerializer(IConnectionSettingsValues settings, Action<JsonSerializerSettings, IConnectionSettingsValues> settingsModifier) : this(settings, null, settingsModifier) { }
 
@@ -48,14 +64,14 @@ namespace Nest
 			// ReSharper disable once VirtualMemberCallInContructor
 			this.ContractResolver = new ElasticContractResolver(this.Settings, this.ContractConverters) { PiggyBackState = piggyBackState };
 
-			OverwriteDefaultSerializers(settingsModifier ?? ((s, csv) => { }));
+			OverwriteDefaultSerializers(settingsModifier ?? ((s, csv) => {}));
 		}
 
 		/// <summary>
-		/// If you subclass JsonNetSerializer and want to apply state passed in the constructor call this to
-		/// overwrite the DefaultSerializers's JsonSerializerSettings and/or connectionsettings.
+		/// If you subclass JsonNetSerializer and want to apply state passed in the constructor, call this to
+		/// overwrite the DefaultSerializers's JsonSerializerSettings and/or connectionSettings.
 		/// </summary>
-		/// <param name="settingsModifier"></param>
+		/// <param name="settingsModifier">a delegate used to modify json serializer and connection settings</param>
 		protected void OverwriteDefaultSerializers(Action<JsonSerializerSettings, IConnectionSettingsValues> settingsModifier)
 		{
 			settingsModifier.ThrowIfNull(nameof(settingsModifier));
@@ -65,20 +81,16 @@ namespace Nest
 			settingsModifier(indented, this.Settings);
 
 			this._defaultSerializer = JsonSerializer.Create(collapsed);
-			var indentedSerializer = JsonSerializer.Create(indented);
-			this._defaultSerializers = new Dictionary<SerializationFormatting, JsonSerializer>
-			{
-				{ SerializationFormatting.None, this._defaultSerializer },
-				{ SerializationFormatting.Indented, indentedSerializer }
-			};
-
+			this._indentedSerializer = JsonSerializer.Create(indented);
 		}
-
 
 		public virtual void Serialize(object data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.Indented)
 		{
-			var serializer = _defaultSerializers[formatting];
-			using (var writer = new StreamWriter(writableStream, ExpectedEncoding, 8096, leaveOpen: true))
+			var serializer = formatting == SerializationFormatting.Indented
+				? _indentedSerializer
+				: _defaultSerializer;
+
+			using (var writer = new StreamWriter(writableStream, ExpectedEncoding, BufferSize, leaveOpen: true))
 			using (var jsonWriter = new JsonTextWriter(writer))
 			{
 				serializer.Serialize(jsonWriter, data);
@@ -87,18 +99,16 @@ namespace Nest
 			}
 		}
 
-		protected readonly ConcurrentDictionary<int, IPropertyMapping> Properties = new ConcurrentDictionary<int, IPropertyMapping>();
-
 		public virtual IPropertyMapping CreatePropertyMapping(MemberInfo memberInfo)
 		{
 			IPropertyMapping mapping;
 			if (Properties.TryGetValue(memberInfo.GetHashCode(), out mapping)) return mapping;
-			mapping =  PropertyMappingFromAtrributes(memberInfo);
+			mapping =  PropertyMappingFromAttributes(memberInfo);
 			this.Properties.TryAdd(memberInfo.GetHashCode(), mapping);
 			return mapping;
 		}
 
-		private static IPropertyMapping PropertyMappingFromAtrributes(MemberInfo memberInfo)
+		private static IPropertyMapping PropertyMappingFromAttributes(MemberInfo memberInfo)
 		{
 			var jsonProperty = memberInfo.GetCustomAttribute<JsonPropertyAttribute>(true);
 			var ignoreProperty = memberInfo.GetCustomAttribute<JsonIgnoreAttribute>(true);

--- a/src/Nest/Document/Multiple/Bulk/BulkRequestJsonConverter.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequestJsonConverter.cs
@@ -15,8 +15,7 @@ namespace Nest
 			var bulk = value as IBulkRequest;
 			var settings = serializer?.GetConnectionSettings();
 			var elasticsearchSerializer = settings?.Serializer;
-			if (elasticsearchSerializer == null
-				|| bulk?.Operations == null) return ;
+			if (elasticsearchSerializer == null|| bulk?.Operations == null) return ;
 
 			foreach(var op in bulk.Operations)
 			{
@@ -26,12 +25,12 @@ namespace Nest
 				if (op.Type.EqualsMarker(bulk.Type)) op.Type = null;
 				op.Id = op.GetIdForOperation(settings.Inferrer);
 
-				var opJson = elasticsearchSerializer.SerializeToBytes(op, SerializationFormatting.None);
-				writer.WriteRaw($"{{\"{op.Operation}\":" + opJson.Utf8String() + "}\n");
+				var opJson = elasticsearchSerializer.SerializeToString(op, SerializationFormatting.None);
+				writer.WriteRaw($"{{\"{op.Operation}\":" + opJson + "}\n");
 				var body = op.GetBody();
 				if (body == null) continue;
-				var bodyJson = elasticsearchSerializer.SerializeToBytes(body, SerializationFormatting.None);
-				writer.WriteRaw(bodyJson.Utf8String() + "\n");
+				var bodyJson = elasticsearchSerializer.SerializeToString(body, SerializationFormatting.None);
+				writer.WriteRaw(bodyJson + "\n");
 			}
 		}
 

--- a/src/Nest/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemJsonConverter.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemJsonConverter.cs
@@ -5,7 +5,9 @@ namespace Nest
 {
 	internal class BulkResponseItemJsonConverter : JsonConverter
 	{
-		
+		public override bool CanWrite => false;
+		public override bool CanRead => true;
+
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
 			throw new NotSupportedException();
@@ -18,36 +20,32 @@ namespace Nest
 			if (reader.TokenType != JsonToken.PropertyName)
 				return null;
 
-			var key = reader.Value as string;
+			var key = (string)reader.Value;
 			reader.Read();
 			switch (key)
 			{
 				case "delete":
 					var deleteItem = new BulkDeleteResponseItem();
 					serializer.Populate(reader, deleteItem);
-					if (deleteItem != null)
-						deleteItem.Operation = key;
+					deleteItem.Operation = key;
 					reader.Read();
 					return deleteItem;
 				case "update":
 					var updateItem = new BulkUpdateResponseItem();
 					serializer.Populate(reader, updateItem);
-					if (updateItem != null)
-						updateItem.Operation = key;
+					updateItem.Operation = key;
 					reader.Read();
 					return updateItem;
 				case "index":
 					var indexItem = new BulkIndexResponseItem();
 					serializer.Populate(reader, indexItem);
-					if (indexItem != null)
-						indexItem.Operation = key;
+					indexItem.Operation = key;
 					reader.Read();
 					return indexItem;
 				case "create":
 					var createItem = new BulkCreateResponseItem();
 					serializer.Populate(reader, createItem);
-					if (createItem != null)
-						createItem.Operation = key;
+					createItem.Operation = key;
 					reader.Read();
 					return createItem;
 			}


### PR DESCRIPTION
Use the default buffer size when copying from one stream to another

Switch between default serializer and indented serializer with conditional ternary rather than allocating a dictionary

Introduce BufferSize property with a default size of 1024 to use when writing json to the request stream. Performance tests as part of #1899 indicate this to be a good compromise buffer size for performance throughput and bytes allocated.