### PR TITLE
fix #2461 `&=` in the bool DSL is viral.

### DIFF
--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Dsl.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Dsl.cs
@@ -68,7 +68,7 @@ namespace Nest
 			if (!leftWritable && !rightWritable) return true;
 
 			queryContainer = leftWritable ? leftContainer : rightContainer;
-			return !leftWritable || !rightWritable;
+			return true;
 		}
 
 		public static QueryContainer operator !(QueryContainer queryContainer) => queryContainer == null || (!queryContainer.IsWritable)

--- a/src/Nest/QueryDsl/Abstractions/Query/BoolQueryOrExtensions.cs
+++ b/src/Nest/QueryDsl/Abstractions/Query/BoolQueryOrExtensions.cs
@@ -56,7 +56,8 @@ namespace Nest
 			boolQuery != null && boolQuery.IsWritable && !boolQuery.Locked && boolQuery.HasOnlyShouldClauses();
 
 		private static QueryContainer CreateShouldContainer(List<QueryContainer> shouldClauses) =>
-			new BoolQuery(createdByBoolDsl: true)
+			//new BoolQuery(createdByBoolDsl: true)
+			new BoolQuery()
 			{
 				Should = shouldClauses.ToListOrNullIfEmpty()
 			};

--- a/src/Nest/QueryDsl/Abstractions/Query/QueryBase.cs
+++ b/src/Nest/QueryDsl/Abstractions/Query/QueryBase.cs
@@ -82,14 +82,8 @@ namespace Nest
 			return anyEmpty;
 		}
 
-		public static implicit operator QueryContainer(QueryBase query)
-		{
-			if (query == null)
-				return null;
-			return new QueryContainer(query);
-
-
-		}
+		public static implicit operator QueryContainer(QueryBase query) =>
+			query == null ? null : new QueryContainer(query);
 
 		internal void WrapInContainer(IQueryContainer container)
 		{

--- a/src/Nest/QueryDsl/Abstractions/Query/QueryDescriptorBase.cs
+++ b/src/Nest/QueryDsl/Abstractions/Query/QueryDescriptorBase.cs
@@ -23,6 +23,6 @@ namespace Nest
 
 		public TDescriptor Strict(bool strict = true) => Assign(a => a.IsStrict = strict);
 
-		bool IQuery.IsWritable { get { return Self.IsVerbatim || !Self.Conditionless; } }
+		bool IQuery.IsWritable => Self.IsVerbatim || !Self.Conditionless;
 	}
 }

--- a/src/Nest/QueryDsl/Compound/Bool/BoolQuery.cs
+++ b/src/Nest/QueryDsl/Compound/Bool/BoolQuery.cs
@@ -51,15 +51,12 @@ namespace Nest
 		bool? DisableCoord { get; set; }
 
 		bool Locked { get; }
-		bool CreatedByBoolDsl { get; }
 	}
 
 	public class BoolQuery : QueryBase, IBoolQuery
 	{
 		internal static bool Locked(IBoolQuery q) => !q.Name.IsNullOrEmpty() || q.Boost.HasValue || q.DisableCoord.HasValue || q.MinimumShouldMatch != null;
 		bool IBoolQuery.Locked => BoolQuery.Locked(this);
-		private readonly bool _createdByBoolDsl;
-		bool IBoolQuery.CreatedByBoolDsl => _createdByBoolDsl;
 
 		private IList<QueryContainer> _must;
 		private IList<QueryContainer> _mustNot;
@@ -67,16 +64,6 @@ namespace Nest
 		private IList<QueryContainer> _filter;
 
 		public BoolQuery() { }
-
-		/// <summary>
-		/// Internal constructor which we use internally in the bool dsl so we know its safe to reuse a boolean query instance
-		/// </summary>
-		/// <param name="createdByBoolDsl">ignored</param>
-		internal BoolQuery(bool createdByBoolDsl)
-		{
-			this._createdByBoolDsl = true;
-		}
-
 
 		/// <summary>
 		/// The clause(s) that must appear in matching documents
@@ -137,7 +124,6 @@ namespace Nest
 		, IBoolQuery where T : class
 	{
 		bool IBoolQuery.Locked => BoolQuery.Locked(this);
-		bool IBoolQuery.CreatedByBoolDsl { get; } = false;
 
 		protected override bool Conditionless => BoolQuery.IsConditionless(this);
 		private IList<QueryContainer> _must;

--- a/src/Tests/QueryDsl/BoolDsl/BoolDsl.doc.cs
+++ b/src/Tests/QueryDsl/BoolDsl/BoolDsl.doc.cs
@@ -336,6 +336,33 @@ namespace Tests.QueryDsl.BoolDsl
 			nestedBool.Bool.Name.Should().Be(firstName);
 		}
 
+		//hide
+		[U] public void AndShouldNotBeViralAnyWayYouComposeIt()
+		{
+			QueryContainer andAssign = new TermQuery { Field = "a", Value = "a" };
+			andAssign &= new TermQuery { Field = "b", Value = "b" };
+
+			AssertAndIsNotViral(andAssign, "&=");
+
+			QueryContainer andOperator =
+				new TermQuery { Field = "a", Value = "a" } && new TermQuery { Field = "b", Value = "b" };
+
+			AssertAndIsNotViral(andOperator, "&&");
+		}
+
+		//hide
+		private static void AssertAndIsNotViral(QueryContainer query, string origin)
+		{
+			IQueryContainer original = query;
+			original.Bool.Must.Should().HaveCount(2, $"query composed using {origin} should have 2 must clauses before");
+			IQueryContainer result = query && new TermQuery { Field = "c", Value = "c" };
+			result.Bool.Must.Should().HaveCount(3, $"query composed using {origin} combined with && should have 3 must clauses");
+			original.Bool.Must.Should().HaveCount(2, $"query composed using {origin} should still have 2 must clauses after composition");
+		}
+
+
+
+
 		/** === Perfomance considerations
 		*
 		* If you have a requirement of combining many many queries using the bool dsl please take the following into account.
@@ -349,8 +376,10 @@ namespace Tests.QueryDsl.BoolDsl
 			var c = new QueryContainer();
 			var q = new TermQuery { Field = "x", Value = "x" };
 
-			for (var i=0;i<1000;i++)
+			for (var i = 0; i < 1000; i++)
+			{
 				c &= q;
+			}
 		}
 		/**
 		 *....

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,19 +1,12 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
-
+mode: m
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.0.2
-
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
 # cluster_filter:
-
-# test filter allows you to only run the integration tests matching the filter (using a simple contains)
-# cluster_filter:
-
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running
 force_reseed: true
-
 # do not spawn nodes as part of the test setup if we find a node is already running
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true


### PR DESCRIPTION
The performance and allocations fixes in #2235 also introduced virality
on the QueryContainer when using &= assignment. The composed result was
correct but the QueryContainer composed of `&=` would be left marked as
`CreatedByTheBoolDsl` which meant it was marked for reuse.

If you then later combined it with && (e.g `andAssignedQuery` && `newQuery`) the resulting
query would be correct but if you rely on `andAssignedQuery` not being
mutated you'd be in for a nasty suprise.

A QueryContainer composed with `&&` did not expose the same virality
problems.

This was due to a difference in how the `&` operator overload on `QueryContainer` and `QueryBase` behaved.

Removed the notion of trying to reuse all together since the big
performance gain from #2235 is that we can flatten many boolean should
queries using `&=` or `&&` or visa versa many boolean must queries with
`|=` or `||`.