### PR TITLE
fix #2448 favor publish_address in 5.x

### DIFF
--- a/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/RequestPipelines.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/RequestPipelines.doc.cs
@@ -78,7 +78,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 			var staticPipeline = CreatePipeline(uris => new StaticConnectionPool(uris));
 			var sniffingPipeline = CreatePipeline(uris => new SniffingConnectionPool(uris));
 
-			/** Here we have setup three pipelines using three different connection pools. Let's see how they behave
+			/** Here we have setup three pipelines using Three different connection pools. Let's see how they behave
 			* on first usage
 			*/
 			singleNodePipeline.FirstPoolUsageNeedsSniffing.Should().BeFalse();
@@ -146,11 +146,11 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 			 * sniff on startup with the remaining two waiting tasks exiting without exception and releasing
 			 * the `SemaphoreSlim`.
 			 */
-			var task1 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
-			var task2 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
-			var task3 = System.Threading.Tasks.Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
+			var task1 = Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
+			var task2 = Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
+			var task3 = Task.Run(() => sniffingPipeline.FirstPoolUsage(semaphoreSlim));
 
-			var exception = Record.Exception(() => System.Threading.Tasks.Task.WaitAll(task1, task2, task3));
+			var exception = Record.Exception(() => Task.WaitAll(task1, task2, task3));
 			exception.Should().BeNull();
 		}
 

--- a/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using Elasticsearch.Net;
+using FluentAssertions;
 using Tests.Framework;
 
 namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
@@ -28,7 +29,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 				var ip = testcases[i, 1];
 				var port = testcases[i, 2];
 
-				var match = Elasticsearch.Net.SniffResponse.AddressRegex.Match(address);
+				var match = SniffParser.AddressRegex.Match(address);
 
 				match.Success.Should().BeTrue();
 

--- a/src/Tests/Framework/VirtualClustering/MockResponses/SniffingResponse.cs
+++ b/src/Tests/Framework/VirtualClustering/MockResponses/SniffingResponse.cs
@@ -10,12 +10,12 @@ namespace Tests.Framework.MockResponses
 	{
 		private static string ClusterName => "elasticsearch-test-cluster";
 
-		public static byte[] Create(IEnumerable<Node> nodes, bool randomFqdn = false)
+		public static byte[] Create(IEnumerable<Node> nodes, string publishAddressOverride, bool randomFqdn = false)
 		{
 			var response = new
 			{
 				cluster_name = ClusterName,
-				nodes = SniffResponseNodes(nodes, randomFqdn)
+				nodes = SniffResponseNodes(nodes, publishAddressOverride, randomFqdn)
 			};
 			using (var ms = new MemoryStream())
 			{
@@ -23,17 +23,19 @@ namespace Tests.Framework.MockResponses
 				return ms.ToArray();
 			}
 		}
-		private static IDictionary<string, object> SniffResponseNodes(IEnumerable<Node> nodes, bool randomFqdn) =>
+		private static IDictionary<string, object> SniffResponseNodes(IEnumerable<Node> nodes, string publishAddressOverride, bool randomFqdn) =>
 			(from node in nodes
 			let id = string.IsNullOrEmpty(node.Id) ? Guid.NewGuid().ToString("N").Substring(0, 8) : node.Id
 			let name = string.IsNullOrEmpty(node.Name) ? Guid.NewGuid().ToString("N").Substring(0, 8) : node.Name
 			select new { id, name, node })
-			.ToDictionary(kv => kv.id, kv => CreateNodeResponse(kv.node, kv.name, randomFqdn));
+			.ToDictionary(kv => kv.id, kv => CreateNodeResponse(kv.node, kv.name, publishAddressOverride, randomFqdn));
 
 		private static Random Random = new Random(1337);
-		private static object CreateNodeResponse(Node node, string name, bool randomFqdn)
+		private static object CreateNodeResponse(Node node, string name, string publishAddressOverride, bool randomFqdn)
 		{
 			var fqdn = randomFqdn ? $"fqdn{node.Uri.Port}/" : "";
+			var publishAddress = !string.IsNullOrWhiteSpace(publishAddressOverride) ? publishAddressOverride : "127.0.0.1";
+			publishAddress += ":" + node.Uri.Port;
 
 			var nodeResponse = new
 			{
@@ -49,7 +51,8 @@ namespace Tests.Framework.MockResponses
 					bound_address = new []
 					{
 						$"{fqdn}127.0.0.1:{node.Uri.Port}"
-					}
+					},
+					publish_address = publishAddress
 				} : null,
 				settings = new Dictionary<string, object>
 				{

--- a/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
@@ -15,7 +15,10 @@ namespace Tests.Framework
 		public TestableDateTimeProvider DateTimeProvider { get; } = new TestableDateTimeProvider();
 
 		private bool _sniffReturnsFqdn = false;
-		public bool SniffShouldReturnFqnd => _sniffReturnsFqdn;
+		internal bool SniffShouldReturnFqnd => _sniffReturnsFqdn;
+
+		private string _publishAddress;
+		internal string PublishAddressOverride => _publishAddress;
 
 		public IReadOnlyList<Node> Nodes => _nodes;
 
@@ -27,6 +30,12 @@ namespace Tests.Framework
 		public VirtualCluster SniffShouldReturnFqdn()
 		{
 			_sniffReturnsFqdn = true;
+			return this;
+		}
+
+		public VirtualCluster PublishAddress(string publishHost)
+		{
+			_publishAddress = publishHost;
 			return this;
 		}
 

--- a/src/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
@@ -53,7 +53,7 @@ namespace Tests.Framework
 						this._cluster.SniffingRules,
 						requestData.RequestTimeout,
 						(r) => this.UpdateCluster(r.NewClusterState),
-						(r) => MockResponses.SniffResponse.Create(this._cluster.Nodes, this._cluster.SniffShouldReturnFqnd)
+						(r) => SniffResponse.Create(this._cluster.Nodes, this._cluster.PublishAddressOverride, this._cluster.SniffShouldReturnFqnd)
 					);
 				}
 				if (IsPingRequest(requestData))

--- a/src/Tests/Framework/VirtualClustering/WaitingInMemoryConnection.cs
+++ b/src/Tests/Framework/VirtualClustering/WaitingInMemoryConnection.cs
@@ -23,7 +23,7 @@ namespace Tests.Framework
 
         public override async Task<ElasticsearchResponse<TReturn>> RequestAsync<TReturn>(RequestData requestData, CancellationToken cancellationToken)
         {
-            await Task.Delay(_waitTime);
+            await Task.Delay(_waitTime, cancellationToken);
             return await base.RequestAsync<TReturn>(requestData, cancellationToken);
         }
     }


### PR DESCRIPTION
Now that 5.x no longer returns http_address we need to give precedence
to `publish_address` over `bound_address`