### PR TITLE
Adds test collections filtering

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -26,6 +26,7 @@ SET APIKEY=
 SET APIKEYPROVIDED="<empty>"
 SET FEED="elasticsearch-net"
 SET NEST_INTEGRATION_CLUSTER=
+SET NEST_TEST_FILTER=
 
 IF /I "%1"=="skiptests" (
 	set SKIPTESTS="1"
@@ -48,6 +49,7 @@ IF /I "%1"=="release" (
 IF /I "%1%"=="integrate" (
 	IF NOT [%2]==[] (set ESVERSIONS="%2")
 	IF NOT [%3]==[] (set NEST_INTEGRATION_CLUSTER="%3")
+	IF NOT [%4]==[] (set NEST_TEST_FILTER="%4")
 )
 
 IF /I "%1%"=="canary" (
@@ -61,5 +63,5 @@ IF /I "%1%"=="canary" (
 	IF /I "%2"=="skiptests" (set SKIPTESTS=1)
 )
 
-ECHO starting build using target=%TARGET% version=%VERSION% esversions=%ESVERSIONS% skiptests=%SKIPTESTS% apiKey=%APIKEYPROVIDED% feed=%FEED% escluster=%NEST_INTEGRATION_CLUSTER%
-"packages\build\FAKE\tools\Fake.exe" "build\\scripts\\Targets.fsx" "target=%TARGET%" "version=%VERSION%" "esversions=%ESVERSIONS%" "skiptests=%SKIPTESTS%" "apiKey=%APIKEY%" "feed=%FEED%" "escluster=%NEST_INTEGRATION_CLUSTER%"
+ECHO starting build using target=%TARGET% version=%VERSION% esversions=%ESVERSIONS% skiptests=%SKIPTESTS% apiKey=%APIKEYPROVIDED% feed=%FEED% escluster=%NEST_INTEGRATION_CLUSTER% testfilter=%NEST_TEST_FILTER%
+"packages\build\FAKE\tools\Fake.exe" "build\\scripts\\Targets.fsx" "target=%TARGET%" "version=%VERSION%" "esversions=%ESVERSIONS%" "skiptests=%SKIPTESTS%" "apiKey=%APIKEY%" "feed=%FEED%" "escluster=%NEST_INTEGRATION_CLUSTER%" "testfilter=%NEST_TEST_FILTER%"

--- a/build/scripts/Building.fsx
+++ b/build/scripts/Building.fsx
@@ -38,15 +38,12 @@ type Build() =
             link DotNetFramework.NetStandard1_3
         )
         
-    static let compile target = 
-        compileDesktop target
+    static member Compile() = 
+        //let target = if runningRelease then "Rebuild" else "Build"
+        compileDesktop "Rebuild"
         //we only need this output when doing a release otherwise depend on test to validate the build
         if runningRelease then compileCore()
         if not isMono && runningRelease then gitLink()
-
-    static member QuickCompile() = compile "Build"
-
-    static member Compile() = compile "Rebuild"
 
     static member Clean() =
         CleanDir Paths.BuildOutput

--- a/build/scripts/Targets.fsx
+++ b/build/scripts/Targets.fsx
@@ -32,16 +32,12 @@ Target "Test"  <| fun _ -> Tests.RunUnitTests()
 Target "InheritDoc"  <| fun _ -> InheritDoc.patchInheritDocs()
 
 Target "TestForever"  <| fun _ -> Tests.RunUnitTestsForever()
-    
-Target "QuickTest"  <| fun _ -> Tests.RunUnitTests()
 
-Target "Integrate"  <| fun _ -> Tests.RunIntegrationTests() (getBuildParamOrDefault "esversions" "") (getBuildParamOrDefault "escluster" "")
+Target "Integrate"  <| fun _ -> Tests.RunIntegrationTests (getBuildParamOrDefault "esversions" "") (getBuildParamOrDefault "escluster" "") (getBuildParamOrDefault "testfilter" "")
 
 Target "Profile" <| fun _ -> Profiler.Run()
 
 Target "Benchmark" <| fun _ -> Benchmarker.Run()
-
-Target "QuickCompile"  <| fun _ -> Build.QuickCompile()
 
 Target "Version" <| fun _ -> 
     Versioning.PatchAssemblyInfos()
@@ -81,9 +77,6 @@ Target "Canary" <| fun _ ->
 "Version"
   ==> "Release"
   ==> "Canary"
-
-"QuickCompile"
-  ==> "QuickTest"
 
 "BuildApp"
   ==> "Integrate"

--- a/build/scripts/Testing.fsx
+++ b/build/scripts/Testing.fsx
@@ -37,7 +37,7 @@ module Tests =
         testProjectJson "all"
 
 
-    let RunIntegrationTests() commaSeparatedEsVersions clusterFilter =
+    let RunIntegrationTests commaSeparatedEsVersions clusterFilter testFilter =
         let esVersions = 
             match commaSeparatedEsVersions with
             | "" -> failwith "when running integrate you have to pass a comma separated list of elasticsearch versions to test"
@@ -46,4 +46,5 @@ module Tests =
         for esVersion in esVersions do
             setProcessEnvironVar "NEST_INTEGRATION_CLUSTER" clusterFilter
             setProcessEnvironVar "NEST_INTEGRATION_VERSION" esVersion
+            setProcessEnvironVar "NEST_TEST_FILTER" testFilter
             testDesktopClr "all"

--- a/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
@@ -14,6 +14,7 @@ namespace Tests.Framework.Configuration
 		public override ElasticsearchVersion ElasticsearchVersion { get; protected set; } = new ElasticsearchVersion("5.0.0");
 		public override TestMode Mode { get; protected set; } = TestMode.Unit;
 		public override string ClusterFilter { get; protected set; }
+		public override string TestFilter { get; protected set; }
 
 		public EnvironmentConfiguration()
 		{
@@ -24,6 +25,7 @@ namespace Tests.Framework.Configuration
 
 			this.ElasticsearchVersion = new ElasticsearchVersion(string.IsNullOrWhiteSpace(version) ? "5.0.0" : version);
 			this.ClusterFilter = Environment.GetEnvironmentVariable("NEST_INTEGRATION_CLUSTER");
+			this.TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
 		}
 	}
 }

--- a/src/Tests/Framework/Configuration/ITestConfiguration.cs
+++ b/src/Tests/Framework/Configuration/ITestConfiguration.cs
@@ -12,6 +12,7 @@ namespace Tests.Framework.Configuration
 		TestMode Mode { get; }
 		ElasticsearchVersion ElasticsearchVersion { get; }
 		string ClusterFilter { get; }
+		string TestFilter { get; }
 		bool ForceReseed { get; }
 		bool TestAgainstAlreadyRunningElasticsearch { get; }
 

--- a/src/Tests/Framework/Configuration/NodeConfiguration.cs
+++ b/src/Tests/Framework/Configuration/NodeConfiguration.cs
@@ -14,6 +14,7 @@ namespace Tests.Framework.Integration
 		public bool RunIntegrationTests { get; }
 		public bool RunUnitTests { get; }
 		public string ClusterFilter { get; }
+		public string TestFilter { get; }
 
 		public string TypeOfCluster { get; set; }
 		public ElasticsearchPlugin[] RequiredPlugins { get; set; } = { };
@@ -29,6 +30,7 @@ namespace Tests.Framework.Integration
 			this.RunIntegrationTests = configuration.RunIntegrationTests;
 			this.RunUnitTests = configuration.RunUnitTests;
 			this.ClusterFilter = configuration.ClusterFilter;
+			this.TestFilter = configuration.TestFilter;
 		}
 	}
 }

--- a/src/Tests/Framework/Configuration/TestConfigurationBase.cs
+++ b/src/Tests/Framework/Configuration/TestConfigurationBase.cs
@@ -14,6 +14,7 @@ namespace Tests.Framework.Configuration
 		public abstract bool ForceReseed { get; protected set; }
 		public abstract TestMode Mode { get; protected set; }
 		public abstract string ClusterFilter { get; protected set; }
+		public abstract string TestFilter { get; protected set; }
 
 		public virtual bool RunIntegrationTests => Mode == TestMode.Mixed || Mode == TestMode.Integration;
 		public virtual bool RunUnitTests => Mode == TestMode.Mixed || Mode == TestMode.Unit;

--- a/src/Tests/Framework/Configuration/YamlConfiguration.cs
+++ b/src/Tests/Framework/Configuration/YamlConfiguration.cs
@@ -12,13 +12,14 @@ namespace Tests.Framework.Configuration
 		public override bool ForceReseed { get; protected set; } = true;
 		public override TestMode Mode { get; protected set; } = TestMode.Unit;
 		public override string ClusterFilter { get; protected set; }
+		public override string TestFilter { get; protected set; }
 
 		public YamlConfiguration(string configurationFile)
 		{
 			if (!File.Exists(configurationFile)) return;
 
 			var config = File.ReadAllLines(configurationFile)
-				.Where(l=>!l.Trim().StartsWith("#"))
+				.Where(l=>!l.Trim().StartsWith("#") && !string.IsNullOrWhiteSpace(l))
 				.ToDictionary(ConfigName, ConfigValue);
 
 			this.Mode = GetTestMode(config["mode"]);
@@ -26,6 +27,7 @@ namespace Tests.Framework.Configuration
 			this.ForceReseed = bool.Parse(config["force_reseed"]);
 			this.TestAgainstAlreadyRunningElasticsearch = bool.Parse(config["test_against_already_running_elasticsearch"]);
 			this.ClusterFilter = config.ContainsKey("cluster_filter") ? config["cluster_filter"] : null;
+			this.TestFilter = config.ContainsKey("test_filter") ? config["test_filter"] : null;
 		}
 
 		private static string ConfigName(string configLine) => Parse(configLine, 0);

--- a/src/Tests/Framework/XUnitPlumbing/IntegrationTestDiscoverer.cs
+++ b/src/Tests/Framework/XUnitPlumbing/IntegrationTestDiscoverer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Tests.Framework
@@ -15,8 +16,11 @@ namespace Tests.Framework
 		protected override bool SkipMethod(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
 		{
 			var classOfMethod = Type.GetType(testMethod.TestClass.Class.Name, true, true);
-			var method = classOfMethod.GetMethod(testMethod.Method.Name);
-			var collectionType = testMethod.TestClass?.TestCollection?.CollectionDefinition?.Name;
+			var method = classOfMethod.GetMethod(testMethod.Method.Name, BindingFlags.FlattenHierarchy | BindingFlags.NonPublic | BindingFlags.Public)
+				?? testMethod.Method.ToRuntimeMethod();
+
+			var collectionType = TestAssemblyRunner.GetClusterForCollection(testMethod.TestClass?.TestCollection);
+
 			return TypeSkipVersionAttributeSatisfies(classOfMethod) ||
 				   MethodSkipVersionAttributeSatisfies(method) ||
 				   RequiresPluginButRunningAgainstSnapshot(classOfMethod, collectionType);

--- a/src/Tests/Framework/XUnitPlumbing/NestTestDiscoverer.cs
+++ b/src/Tests/Framework/XUnitPlumbing/NestTestDiscoverer.cs
@@ -25,7 +25,7 @@ namespace Tests.Framework
 				? Enumerable.Empty<IXunitTestCase>()
 				: new[] { new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
 
-		protected static bool RequiresPluginButRunningAgainstSnapshot(Type classOfMethod, string collectionClass)
+		protected static bool RequiresPluginButRunningAgainstSnapshot(Type classOfMethod, Type collectionType)
 		{
 			Attribute[] classAttributes, collectionAttributes = { };
 #if !DOTNETCORE
@@ -33,13 +33,12 @@ namespace Tests.Framework
 #else
 			classAttributes =  classOfMethod.GetTypeInfo().GetCustomAttributes(typeof(RequiresPluginAttribute), true).ToArray();
 #endif
-			if (collectionClass != null)
+			if (collectionType != null)
 			{
-				var classOfCollection = Type.GetType(collectionClass, true, true);
 #if !DOTNETCORE
-				collectionAttributes = Attribute.GetCustomAttributes(classOfCollection, typeof(RequiresPluginAttribute), true);
+				collectionAttributes = Attribute.GetCustomAttributes(collectionType, typeof(RequiresPluginAttribute), true);
 #else
-				collectionAttributes =  classOfCollection.GetTypeInfo().GetCustomAttributes(typeof(RequiresPluginAttribute), true).ToArray();
+				collectionAttributes =  collectionType.GetTypeInfo().GetCustomAttributes(typeof(RequiresPluginAttribute), true).ToArray();
 #endif
 			}
 			if (!classAttributes.Concat(collectionAttributes).Any()) return false;

--- a/src/Tests/Framework/XUnitPlumbing/UnitTestDiscoverer.cs
+++ b/src/Tests/Framework/XUnitPlumbing/UnitTestDiscoverer.cs
@@ -1,4 +1,5 @@
 using System;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Tests.Framework
@@ -11,9 +12,9 @@ namespace Tests.Framework
 		protected override bool SkipMethod(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
 		{
 			var classOfMethod = Type.GetType(testMethod.TestClass.Class.Name, true, true);
-			var collectionType = testMethod.TestClass?.TestCollection?.CollectionDefinition?.Name;
 			//in mixed mode we do not want to run any api tests for plugins when running against a snapshot
 			//because the client is "hot"
+			var collectionType = TestAssemblyRunner.GetClusterForCollection(testMethod.TestClass?.TestCollection);
 			return TestClient.Configuration.RunIntegrationTests && RequiresPluginButRunningAgainstSnapshot(classOfMethod, collectionType);
 		}
 	}

--- a/src/Tests/Framework/Xunit/TestFramework.cs
+++ b/src/Tests/Framework/Xunit/TestFramework.cs
@@ -22,7 +22,11 @@ namespace Xunit
 			Console.WriteLine($" - {nameof(config.ForceReseed)}: {config.ForceReseed}");
 			Console.WriteLine($" - {nameof(config.Mode)}: {config.Mode.ToString()}");
 			if (config.Mode == TestMode.Integration)
+			{
 				Console.WriteLine($" - {nameof(config.ClusterFilter)}: {config.ClusterFilter}");
+				Console.WriteLine($" - {nameof(config.TestFilter)}: {config.TestFilter}");
+
+			}
 			Console.WriteLine($" - {nameof(config.RunIntegrationTests)}: {config.RunIntegrationTests}");
 			Console.WriteLine($" - {nameof(config.RunUnitTests)}: {config.RunUnitTests}");
 

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,12 +1,19 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: m
+mode: i
+
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.0.2
+
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
 # cluster_filter:
+
+# test filter allows you to only run the integration tests matching the filter (using a simple contains)
+# cluster_filter:
+
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running
 force_reseed: true
+
 # do not spawn nodes as part of the test setup if we find a node is already running
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true


### PR DESCRIPTION
> build integrate 5.0.0 readonly getindexapi

Also fixes SkipMethod being too greedy ReadOnly cluster was only
yielding 14 tests.