### PR TITLE
found one remaining instance where an readonly* initialized property …

### DIFF
--- a/src/Nest/Cluster/NodesHotThreads/NodesHotThreadsResponse.cs
+++ b/src/Nest/Cluster/NodesHotThreads/NodesHotThreadsResponse.cs
@@ -25,6 +25,6 @@ namespace Nest
 			this.HotThreads = threadInfo;
 		}
 
-		public IReadOnlyCollection<HotThreadInformation> HotThreads { get; } = EmptyReadOnly<HotThreadInformation>.Collection;
+		public IReadOnlyCollection<HotThreadInformation> HotThreads { get; internal set; } = EmptyReadOnly<HotThreadInformation>.Collection;
 	}
 }

--- a/src/Nest/Indices/IndexManagement/GetIndex/GetIndexResponse.cs
+++ b/src/Nest/Indices/IndexManagement/GetIndex/GetIndexResponse.cs
@@ -11,6 +11,6 @@ namespace Nest
 	[JsonConverter(typeof(DictionaryResponseJsonConverter<GetIndexResponse, string, IndexState>))]
 	public class GetIndexResponse : DictionaryResponseBase<string, IndexState>, IGetIndexResponse
 	{
-	    public IReadOnlyDictionary<string, IndexState> Indices => Self.BackingDictionary;
+		public IReadOnlyDictionary<string, IndexState> Indices => Self.BackingDictionary;
 	}
 }


### PR DESCRIPTION
…only has a getter, while this works and can also deserialize using black magic reflection an internal setter is nicer