### PR TITLE
Reindex now allows the target type to be different

### DIFF
--- a/src/Nest/CommonAbstractions/Reactive/CoordinatedRequestObserverBase.cs
+++ b/src/Nest/CommonAbstractions/Reactive/CoordinatedRequestObserverBase.cs
@@ -8,6 +8,8 @@ namespace Nest
 		public static TimeSpan BulkAllBackOffTimeDefault = TimeSpan.FromMinutes(1);
 		public static int BulkAllBackOffRetriesDefault = 0;
 		public static int BulkAllSizeDefault = 1000;
+		public static int ReindexBackPressureFactor = 4;
+		public static int ReindexScrollSize = 500;
 	}
 
 	public abstract class CoordinatedRequestObserverBase<T> : IObserver<T>

--- a/src/Nest/Document/Multiple/BulkIndexByScrollFailure.cs
+++ b/src/Nest/Document/Multiple/BulkIndexByScrollFailure.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	// ReindexOnServer and UpdateByQuery aggregate failures under a single failures property
+	// TODO: ReindexOnServer and UpdateByQuery aggregate failures under a single failures property
 	// So the shape is a bit odd
 	// https://github.com/elastic/elasticsearch/issues/17539
 	// We could come up with abstractions and normalization here but we should fix this at the root for 5.0

--- a/src/Nest/Document/Multiple/Reindex/ElasticClient-Reindex.cs
+++ b/src/Nest/Document/Multiple/Reindex/ElasticClient-Reindex.cs
@@ -9,10 +9,46 @@ namespace Nest
 		/// Helper method that allows you to reindex from one index into another using ScrollAll and BulkAll.
 		/// </summary>
 		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
-		IObservable<IBulkAllResponse> Reindex<T>(
-			Func<ReindexDescriptor<T>, IReindexRequest<T>> selector,
+		IObservable<IBulkAllResponse> Reindex<TSource,TTarget>(
+			Func<TSource, TTarget> mapper,
+			Func<ReindexDescriptor<TSource,TTarget>, IReindexRequest<TSource,TTarget>> selector,
 			CancellationToken cancellationToken = default(CancellationToken)
-		) where T : class;
+		)
+			where TSource : class
+			where TTarget : class;
+
+		/// <summary>
+		/// Helper method that allows you to reindex from one index into another using ScrollAll and BulkAll.
+		/// </summary>
+		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		IObservable<IBulkAllResponse> Reindex<TSource>(
+			Func<ReindexDescriptor<TSource, TSource>, IReindexRequest<TSource, TSource>> selector,
+			CancellationToken cancellationToken = default(CancellationToken)
+		)
+			where TSource : class;
+
+		/// <summary>
+		/// Helper method that allows you to reindex from one index into another using ScrollAll and BulkAll.
+		/// </summary>
+		/// <param name="request">a request object to describe the reindex operation</param>
+		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		IObservable<IBulkAllResponse> Reindex<TSource,TTarget>(
+			IReindexRequest<TSource,TTarget> request,
+			CancellationToken cancellationToken = default(CancellationToken)
+		)
+			where TSource : class
+			where TTarget : class;
+
+		/// <summary>
+		/// Helper method that allows you to reindex from one index into another using ScrollAll and BulkAll.
+		/// </summary>
+		/// <param name="request">a request object to describe the reindex operation</param>
+		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
+		IObservable<IBulkAllResponse> Reindex<TSource>(
+			IReindexRequest<TSource> request,
+			CancellationToken cancellationToken = default(CancellationToken)
+		)
+			where TSource : class;
 
 		/// <summary>
 		/// Simplified form for reindex which will cover 80% of its usecases. Allows you to index all documents of type T from <paramref name="fromIndex" /> to <paramref name="toIndex" />
@@ -21,51 +57,69 @@ namespace Nest
 		/// <param name="fromIndex">The source index, from which all types will be returned</param>
 		/// <param name="toIndex">The target index, if it does not exist already will be created using the same settings of <paramref name="fromIndex"/></param>
 		/// <param name="selector">an optional query limitting the documents found in <paramref name="fromIndex"/></param>
-		IObservable<IBulkAllResponse> Reindex<T>(
+		IObservable<IBulkAllResponse> Reindex<TSource,TTarget>(
 			IndexName fromIndex,
 			IndexName toIndex,
-			Func<QueryContainerDescriptor<T>, QueryContainer> selector = null,
+			Func<TSource, TTarget> mapper,
+			Func<QueryContainerDescriptor<TSource>, QueryContainer> selector = null,
 			CancellationToken cancellationToken = default(CancellationToken)
-		) where T : class;
+		)
+			where TSource : class
+			where TTarget : class;
 
 		/// <summary>
-		/// Helper method that allows you to reindex from one index into another using ScrollAll and BulkAll.
+		/// Simplified form for reindex which will cover 80% of its usecases. Allows you to index all documents of type T from <paramref name="fromIndex" /> to <paramref name="toIndex" />
+		/// optionally limitting the documents found in <paramref name="fromIndex" /> by using <paramref name="selector"/>.
 		/// </summary>
-		/// <param name="request">a request object to describe the reindex operation</param>
-		/// <returns>An IObservable&lt;IReindexResponse&lt;T&gt;$gt; you can subscribe to to listen to the progress of the reindex process</returns>
-		IObservable<IBulkAllResponse> Reindex<T>(
-			IReindexRequest<T> request,
+		/// <param name="fromIndex">The source index, from which all types will be returned</param>
+		/// <param name="toIndex">The target index, if it does not exist already will be created using the same settings of <paramref name="fromIndex"/></param>
+		/// <param name="selector">an optional query limitting the documents found in <paramref name="fromIndex"/></param>
+		IObservable<IBulkAllResponse> Reindex<TSource>(
+			IndexName fromIndex,
+			IndexName toIndex,
+			Func<QueryContainerDescriptor<TSource>, QueryContainer> selector = null,
 			CancellationToken cancellationToken = default(CancellationToken)
-		) where T : class;
+		)
+			where TSource : class;
+
 	}
 
 	public partial class ElasticClient
 	{
 		/// <inheritdoc />
-		public IObservable<IBulkAllResponse> Reindex<T>(
-			Func<ReindexDescriptor<T>, IReindexRequest<T>> selector,
+		public IObservable<IBulkAllResponse> Reindex<TSource>(
+			Func<ReindexDescriptor<TSource,TSource>, IReindexRequest<TSource,TSource>> selector,
 			CancellationToken cancellationToken = default(CancellationToken)
-		) where T : class =>
-			this.Reindex<T>(selector.InvokeOrDefault(new ReindexDescriptor<T>()));
+		)
+			where TSource : class =>
+			this.Reindex<TSource,TSource>(selector.InvokeOrDefault(new ReindexDescriptor<TSource,TSource>(s=>s)));
 
 		/// <inheritdoc />
-		public IObservable<IBulkAllResponse> Reindex<T>(
-			IndexName fromIndex,
-			IndexName toIndex,
-			Func<QueryContainerDescriptor<T>, QueryContainer> selector = null,
+		public IObservable<IBulkAllResponse> Reindex<TSource,TTarget>(
+			Func<TSource, TTarget> mapper,
+			Func<ReindexDescriptor<TSource,TTarget>, IReindexRequest<TSource,TTarget>> selector,
 			CancellationToken cancellationToken = default(CancellationToken)
-		) where T : class =>
-			this.Reindex<T>(r => r
-					.ScrollAll("1m", -1, search => search.Search(ss => ss.Index(fromIndex).Query(selector)))
-					.BulkAll(b => b.Index(toIndex))
-			, cancellationToken);
+		)
+			where TTarget : class
+			where TSource : class =>
+			this.Reindex<TSource,TTarget>(selector.InvokeOrDefault(new ReindexDescriptor<TSource,TTarget>(mapper)));
+
+		/// <inheritdoc />
+		public IObservable<IBulkAllResponse> Reindex<TSource>(
+			IReindexRequest<TSource> request,
+			CancellationToken cancellationToken = default(CancellationToken)
+		)
+			where TSource : class =>
+			this.Reindex<TSource, TSource>(request, cancellationToken);
 
 
 		/// <inheritdoc />
-		public IObservable<IBulkAllResponse> Reindex<T>(
-			IReindexRequest<T> request,
+		public IObservable<IBulkAllResponse> Reindex<TSource,TTarget>(
+			IReindexRequest<TSource,TTarget> request,
 			CancellationToken cancellationToken = default(CancellationToken)
-		) where T : class
+		)
+			where TTarget : class
+			where TSource : class
 		{
 			if (request.ScrollAll == null)
 				throw new ArgumentException(
@@ -73,7 +127,56 @@ namespace Nest
 			if (request.BulkAll == null)
 				throw new ArgumentException(
 					"Reindex must have BulkAll property set so we know how to get the target of the reindex operation");
-			return new ReindexObservable<T>(this, ConnectionSettings, request, cancellationToken);
+			return new ReindexObservable<TSource,TTarget>(this, ConnectionSettings, request, cancellationToken);
 		}
+
+		/// <inheritdoc />
+		public IObservable<IBulkAllResponse> Reindex<TSource,TTarget>(
+			IndexName fromIndex,
+			IndexName toIndex,
+			Func<TSource, TTarget> mapper,
+			Func<QueryContainerDescriptor<TSource>, QueryContainer> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		)
+			where TTarget : class
+			where TSource : class =>
+			this.Reindex<TSource,TTarget>(
+				mapper,
+				SimplifiedReindexer<TSource, TTarget>(fromIndex, toIndex, selector)
+			, cancellationToken);
+
+		/// <inheritdoc />
+		public IObservable<IBulkAllResponse> Reindex<TSource>(
+			IndexName fromIndex,
+			IndexName toIndex,
+			Func<QueryContainerDescriptor<TSource>, QueryContainer> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		)
+			where TSource : class =>
+			this.Reindex<TSource,TSource>(
+				s=>s,
+				SimplifiedReindexer<TSource, TSource>(fromIndex, toIndex, selector)
+			, cancellationToken);
+
+		private static Func<ReindexDescriptor<TSource,TTarget>, IReindexRequest<TSource,TTarget>> SimplifiedReindexer<TSource, TTarget>(
+			IndexName fromIndex,
+			IndexName toIndex,
+			Func<QueryContainerDescriptor<TSource>, QueryContainer> selector
+		)
+			where TTarget : class
+			where TSource : class
+		{
+			return r => r
+				.ScrollAll("1m", -1, search => search
+					.Search(ss => ss
+						.Size(CoordinatedRequestDefaults.ReindexScrollSize)
+						.Index(fromIndex)
+						.Query(selector)
+					)
+				)
+				.BulkAll(b => b.Index(toIndex));
+		}
+
+
 	}
 }

--- a/src/Nest/Document/Multiple/Reindex/ElasticClient-Reindex.cs
+++ b/src/Nest/Document/Multiple/Reindex/ElasticClient-Reindex.cs
@@ -52,11 +52,11 @@ namespace Nest
 
 		/// <summary>
 		/// Simplified form for reindex which will cover 80% of its usecases. Allows you to index all documents of type T from <paramref name="fromIndex" /> to <paramref name="toIndex" />
-		/// optionally limitting the documents found in <paramref name="fromIndex" /> by using <paramref name="selector"/>.
+		/// optionally limiting the documents found in <paramref name="fromIndex" /> by using <paramref name="selector"/>.
 		/// </summary>
 		/// <param name="fromIndex">The source index, from which all types will be returned</param>
 		/// <param name="toIndex">The target index, if it does not exist already will be created using the same settings of <paramref name="fromIndex"/></param>
-		/// <param name="selector">an optional query limitting the documents found in <paramref name="fromIndex"/></param>
+		/// <param name="selector">an optional query limiting the documents found in <paramref name="fromIndex"/></param>
 		IObservable<IBulkAllResponse> Reindex<TSource,TTarget>(
 			IndexName fromIndex,
 			IndexName toIndex,
@@ -68,12 +68,12 @@ namespace Nest
 			where TTarget : class;
 
 		/// <summary>
-		/// Simplified form for reindex which will cover 80% of its usecases. Allows you to index all documents of type T from <paramref name="fromIndex" /> to <paramref name="toIndex" />
-		/// optionally limitting the documents found in <paramref name="fromIndex" /> by using <paramref name="selector"/>.
+		/// Simplified form for reindex which will cover 80% of its use cases. Allows you to index all documents of type T from <paramref name="fromIndex" /> to <paramref name="toIndex" />
+		/// optionally limiting the documents found in <paramref name="fromIndex" /> by using <paramref name="selector"/>.
 		/// </summary>
 		/// <param name="fromIndex">The source index, from which all types will be returned</param>
 		/// <param name="toIndex">The target index, if it does not exist already will be created using the same settings of <paramref name="fromIndex"/></param>
-		/// <param name="selector">an optional query limitting the documents found in <paramref name="fromIndex"/></param>
+		/// <param name="selector">an optional query limiting the documents found in <paramref name="fromIndex"/></param>
 		IObservable<IBulkAllResponse> Reindex<TSource>(
 			IndexName fromIndex,
 			IndexName toIndex,
@@ -92,7 +92,7 @@ namespace Nest
 			CancellationToken cancellationToken = default(CancellationToken)
 		)
 			where TSource : class =>
-			this.Reindex<TSource,TSource>(selector.InvokeOrDefault(new ReindexDescriptor<TSource,TSource>(s=>s)));
+			this.Reindex(selector.InvokeOrDefault(new ReindexDescriptor<TSource,TSource>(s=>s)));
 
 		/// <inheritdoc />
 		public IObservable<IBulkAllResponse> Reindex<TSource,TTarget>(
@@ -102,7 +102,7 @@ namespace Nest
 		)
 			where TTarget : class
 			where TSource : class =>
-			this.Reindex<TSource,TTarget>(selector.InvokeOrDefault(new ReindexDescriptor<TSource,TTarget>(mapper)));
+			this.Reindex(selector.InvokeOrDefault(new ReindexDescriptor<TSource,TTarget>(mapper)));
 
 		/// <inheritdoc />
 		public IObservable<IBulkAllResponse> Reindex<TSource>(
@@ -140,7 +140,7 @@ namespace Nest
 		)
 			where TTarget : class
 			where TSource : class =>
-			this.Reindex<TSource,TTarget>(
+			this.Reindex(
 				mapper,
 				SimplifiedReindexer<TSource, TTarget>(fromIndex, toIndex, selector)
 			, cancellationToken);
@@ -153,7 +153,7 @@ namespace Nest
 			CancellationToken cancellationToken = default(CancellationToken)
 		)
 			where TSource : class =>
-			this.Reindex<TSource,TSource>(
+			this.Reindex(
 				s=>s,
 				SimplifiedReindexer<TSource, TSource>(fromIndex, toIndex, selector)
 			, cancellationToken);

--- a/src/Nest/Document/Multiple/Reindex/ElasticClient-Reindex.cs
+++ b/src/Nest/Document/Multiple/Reindex/ElasticClient-Reindex.cs
@@ -123,10 +123,10 @@ namespace Nest
 		{
 			if (request.ScrollAll == null)
 				throw new ArgumentException(
-					"Reindex must have ScrollAll property set so we know how to get the source of the reindex operation");
+					"ScrollAll property must be set in order to get the source of a Reindex operation");
 			if (request.BulkAll == null)
 				throw new ArgumentException(
-					"Reindex must have BulkAll property set so we know how to get the target of the reindex operation");
+					"BulkAll property must set in order to get the target of a Reindex operation");
 			return new ReindexObservable<TSource,TTarget>(this, ConnectionSettings, request, cancellationToken);
 		}
 

--- a/src/Nest/Document/Multiple/Reindex/ReindexObserver.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexObserver.cs
@@ -5,15 +5,15 @@ namespace Nest
 {
 	public class ReindexObserver : BulkAllObserver
 	{
-		private long _seenScrollDocuments = 0;
-		private long _seenScrollOperations = 0;
+		private long _seenScrollDocuments;
+		private long _seenScrollOperations;
 
 		public long SeenScrollDocuments => _seenScrollDocuments;
 		public long SeenScrollOperations => _seenScrollOperations;
 
 		internal void IncrementSeenScrollDocuments(long documentCount) => Interlocked.Add(ref _seenScrollDocuments, documentCount);
 		internal void IncrementSeenScrollOperations() => Interlocked.Increment(ref _seenScrollOperations);
-		
+
 		public ReindexObserver(
 			Action<IBulkAllResponse> onNext = null,
 			Action<Exception> onError = null,
@@ -21,6 +21,5 @@ namespace Nest
 			: base(onNext, onError, onCompleted)
 		{
 		}
-
 	}
 }

--- a/src/Nest/Document/Multiple/Reindex/ReindexObserver.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexObserver.cs
@@ -3,7 +3,7 @@ using System.Threading;
 
 namespace Nest
 {
-	public class ReindexObserver<T> : BulkAllObserver where T : class
+	public class ReindexObserver : BulkAllObserver
 	{
 		private long _seenScrollDocuments = 0;
 		private long _seenScrollOperations = 0;

--- a/src/Nest/Document/Multiple/Reindex/ReindexRequest.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexRequest.cs
@@ -18,7 +18,9 @@ namespace Nest
 	/// </para>
 	///
 	/// </summary>
-	public interface IReindexRequest<T> where T : class
+	public interface IReindexRequest<TSource, TTarget>
+		where TSource : class
+		where TTarget : class
 	{
 		/// <summary>
 		/// The scroll typically outperforms the bulk operations by a long shot. If we'd leave things unbounded you'd quickly have way too many pending scroll
@@ -45,7 +47,9 @@ namespace Nest
 		/// <see cref="IBulkAllRequest{T}.BackPressure"/>
 		/// </para>
 		/// </summary>
-		Func<IEnumerable<IHit<T>>, IBulkAllRequest<IHit<T>>> BulkAll { get; set; }
+		Func<IEnumerable<IHitMetadata<TTarget>>, IBulkAllRequest<IHitMetadata<TTarget>>> BulkAll { get; set; }
+
+		Func<TSource, TTarget> Map { get; set; }
 
 		/// <summary>
 		/// Do not send a create index call on the target index, assume the index has been created outside of the reindex.
@@ -60,12 +64,19 @@ namespace Nest
 	}
 
 	/// <inheritdoc/>
-	public class ReindexRequest<T> : IReindexRequest<T> where T : class
+	public interface IReindexRequest<TSource> : IReindexRequest<TSource, TSource> where TSource : class { }
+
+	/// <inheritdoc/>
+	public class ReindexRequest<TSource, TTarget> : IReindexRequest<TSource, TTarget>
+		where TSource : class
+		where TTarget : class
 	{
 		/// <inheritdoc/>
-		IScrollAllRequest IReindexRequest<T>.ScrollAll { get; set; }
+		IScrollAllRequest IReindexRequest<TSource, TTarget>.ScrollAll { get; set; }
 		/// <inheritdoc/>
-		Func<IEnumerable<IHit<T>>,IBulkAllRequest<IHit<T>>> IReindexRequest<T>.BulkAll { get; set; }
+		Func<IEnumerable<IHitMetadata<TTarget>>,IBulkAllRequest<IHitMetadata<TTarget>>> IReindexRequest<TSource, TTarget>.BulkAll { get; set; }
+		/// <inheritdoc/>
+		Func<TSource, TTarget> IReindexRequest<TSource, TTarget>.Map { get; set; }
 
 		/// <inheritdoc/>
 		public bool OmitIndexCreation { get; set; }
@@ -77,49 +88,65 @@ namespace Nest
 		/// <inheritdoc/>
 		/// <param name="scrollSource">The scroll operation yielding the source documents for the reindex operation</param>
 		/// <param name="bulkAllTarget">A factory that instantiates the bulk all operation over the lazy stream of search result hits</param>
-		public ReindexRequest(IScrollAllRequest scrollSource, Func<IEnumerable<IHit<T>>, IBulkAllRequest<IHit<T>>> bulkAllTarget)
+		public ReindexRequest(IScrollAllRequest scrollSource, Func<TSource, TTarget> map, Func<IEnumerable<IHitMetadata<TTarget>>, IBulkAllRequest<IHitMetadata<TTarget>>> bulkAllTarget)
 		{
 			scrollSource.ThrowIfNull(nameof(scrollSource), "without a scroll all request we don't know where to read from!");
 			bulkAllTarget.ThrowIfNull(nameof(bulkAllTarget), "without a bulk all request we don't know where to send documents!");
+			map.ThrowIfNull(nameof(map), "Reindex needs a map function to know how to take TSource and transform it into TTarget!");
 
-			var i = (IReindexRequest<T>) this;
+			var i = (IReindexRequest<TSource, TTarget>) this;
 			i.ScrollAll = scrollSource;
 			i.BulkAll = bulkAllTarget;
+			i.Map = map;
 		}
 	}
 
-	public class ReindexDescriptor<T> : DescriptorBase<ReindexDescriptor<T>, IReindexRequest<T>>, IReindexRequest<T> where T : class
+	public class ReindexRequest<TSource> : ReindexRequest<TSource, TSource>
+		where TSource : class
 	{
-		IScrollAllRequest IReindexRequest<T>.ScrollAll{ get; set; }
-
-		private Func<BulkAllDescriptor<IHit<T>>, IBulkAllRequest<IHit<T>>> _createBulkAll;
-		Func<IEnumerable<IHit<T>>, IBulkAllRequest<IHit<T>>> IReindexRequest<T>.BulkAll { get; set; }
-		bool IReindexRequest<T>.OmitIndexCreation { get; set; }
-		ICreateIndexRequest IReindexRequest<T>.CreateIndexRequest { get; set; }
-		int? IReindexRequest<T>.BackPressureFactor { get; set; }
-
-		public ReindexDescriptor()
+		public ReindexRequest(IScrollAllRequest scrollSource, Func<IEnumerable<IHitMetadata<TSource>>, IBulkAllRequest<IHitMetadata<TSource>>> bulkAllTarget)
+			: base(scrollSource, s=>s, bulkAllTarget)
 		{
-			((IReindexRequest<T>) this).BulkAll = (d) => this._createBulkAll.InvokeOrDefault(new BulkAllDescriptor<IHit<T>>(d));
+		}
+	}
+
+	public class ReindexDescriptor<TSource, TTarget> : DescriptorBase<ReindexDescriptor<TSource, TTarget>, IReindexRequest<TSource, TTarget>>, IReindexRequest<TSource, TTarget>
+		where TSource : class
+		where TTarget : class
+	{
+		IScrollAllRequest IReindexRequest<TSource, TTarget>.ScrollAll{ get; set; }
+
+		private Func<BulkAllDescriptor<IHitMetadata<TTarget>>, IBulkAllRequest<IHitMetadata<TTarget>>> _createBulkAll;
+		Func<IEnumerable<IHitMetadata<TTarget>>, IBulkAllRequest<IHitMetadata<TTarget>>> IReindexRequest<TSource, TTarget>.BulkAll { get; set; }
+		bool IReindexRequest<TSource, TTarget>.OmitIndexCreation { get; set; }
+		ICreateIndexRequest IReindexRequest<TSource, TTarget>.CreateIndexRequest { get; set; }
+		int? IReindexRequest<TSource, TTarget>.BackPressureFactor { get; set; }
+		Func<TSource, TTarget> IReindexRequest<TSource, TTarget>.Map { get; set; }
+
+		public ReindexDescriptor(Func<TSource, TTarget> mapper)
+		{
+			var i = ((IReindexRequest<TSource, TTarget>) this);
+			i.BulkAll = (d) => this._createBulkAll.InvokeOrDefault(new BulkAllDescriptor<IHitMetadata<TTarget>>(d));
+			i.Map = mapper;
 		}
 
 		/// <inheritdoc/>
-		public ReindexDescriptor<T> ScrollAll(Time scrollTime, int slices, Func<ScrollAllDescriptor<T>,IScrollAllRequest> selector = null) =>
-			Assign(a => a.ScrollAll = selector.InvokeOrDefault(new ScrollAllDescriptor<T>(scrollTime, slices)));
+		public ReindexDescriptor<TSource, TTarget> ScrollAll(Time scrollTime, int slices, Func<ScrollAllDescriptor<TSource>,IScrollAllRequest> selector = null) =>
+			Assign(a => a.ScrollAll = selector.InvokeOrDefault(new ScrollAllDescriptor<TSource>(scrollTime, slices)));
 
 		/// <inheritdoc/>
-		public ReindexDescriptor<T> BackPressureFactor(int? maximum) =>
+		public ReindexDescriptor<TSource, TTarget> BackPressureFactor(int? maximum) =>
 			Assign(a => a.BackPressureFactor = maximum);
 
 		/// <inheritdoc/>
-		public ReindexDescriptor<T> BulkAll(Func<BulkAllDescriptor<IHit<T>>, IBulkAllRequest<IHit<T>>> selector) =>
+		public ReindexDescriptor<TSource, TTarget> BulkAll(Func<BulkAllDescriptor<IHitMetadata<TTarget>>, IBulkAllRequest<IHitMetadata<TTarget>>> selector) =>
 			Assign(a => this._createBulkAll = selector);
 
 		/// <inheritdoc/>
-		public ReindexDescriptor<T> OmitIndexCreation(bool omit = true) => Assign(a => a.OmitIndexCreation = true);
+		public ReindexDescriptor<TSource, TTarget> OmitIndexCreation(bool omit = true) => Assign(a => a.OmitIndexCreation = true);
 
 		/// <inheritdoc/>
-		public ReindexDescriptor<T> CreateIndex(Func<CreateIndexDescriptor, ICreateIndexRequest> createIndexSelector) =>
+		public ReindexDescriptor<TSource, TTarget> CreateIndex(Func<CreateIndexDescriptor, ICreateIndexRequest> createIndexSelector) =>
 			Assign(a => a.CreateIndexRequest = createIndexSelector.InvokeOrDefault(new CreateIndexDescriptor("ignored")));
 	}
 }

--- a/src/Tests/CodeStandards/ElasticClient.doc.cs
+++ b/src/Tests/CodeStandards/ElasticClient.doc.cs
@@ -23,8 +23,8 @@ namespace Tests.CodeStandards
 				from m in typeof(IElasticClient).GetMethods()
 				from p in m.GetParameters()
 				where p.ParameterType.BaseType() == typeof(MulticastDelegate)
-				where !p.Name.Equals("selector")
-				select $"method '{nameof(IElasticClient)}.{m.Name}' should have parameter name of 'selector' but has a name of '{p.Name}'";
+				where !p.Name.Equals("selector") && !p.Name.Equals("mapper")
+				select $"method '{nameof(IElasticClient)}.{m.Name}' should have parameter name of 'selector' or 'mapper' but has a name of '{p.Name}'";
 
 			fluentParametersNotNamedSelector.Should().BeEmpty();
 		}


### PR DESCRIPTION
User has to supply an explicit map between TSource and TTarget, the old
overloads where TSource == TTarget still exists.

The simplified helpers for reindex contained a bug, out integration
tests only reindexed 2 documents but if you had more the backpressure
sanity checks would kick in complaining, these now run with sane defaults.