### PR TITLE
Limit the number of TCP connections on .NET core

### DIFF
--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -53,6 +53,13 @@ namespace Elasticsearch.Net
 		int? MaxRetries { get; }
 
 		/// <summary>
+		/// Limits the number of concurrent connections that can be opened to an endpoint. Defaults to 80 (see <see cref="ConnectionConfiguration.DefaultConnectionLimit"/>).
+		/// <para>For Desktop CLR, this setting applies to the DefaultConnectionLimit property on the  ServicePointManager object when creating ServicePoint objects, affecting the default <see cref="IConnection"/> implementation.</para>
+		/// <para>For Core CLR, this setting applies to the MaxConnectionsPerServer property on the HttpClientHandler instances used by the HttpClient inside the default <see cref="IConnection"/> implementation</para>
+		/// </summary>
+		int ConnectionLimit { get; }
+
+		/// <summary>
 		/// This signals that we do not want to send initial pings to unknown/previously dead nodes
 		/// and just send the call straightaway
 		/// </summary>
@@ -68,7 +75,15 @@ namespace Elasticsearch.Net
 		/// When set will force all connections through this proxy
 		/// </summary>
 		string ProxyAddress { get; }
+
+		/// <summary>
+		/// The username for the proxy, when configured
+		/// </summary>
 		string ProxyUsername { get; }
+
+		/// <summary>
+		/// The password for the proxy, when configured
+		/// </summary>
 		string ProxyPassword { get; }
 
 		/// <summary>
@@ -138,6 +153,10 @@ namespace Elasticsearch.Net
 		/// </summary>
 		BasicAuthenticationCredentials BasicAuthenticationCredentials { get; }
 
+		/// <summary>
+		/// An action to run when the <see cref="RequestData"/> for a request has been
+		/// created.
+		/// </summary>
 		Action<RequestData> OnRequestDataCreated { get; }
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -110,7 +110,9 @@ namespace Elasticsearch.Net
 		{
 			var handler = new HttpClientHandler
 			{
-				AutomaticDecompression = requestData.HttpCompression ? GZip | Deflate : None
+				AutomaticDecompression = requestData.HttpCompression ? GZip | Deflate : None,
+				// same limit as desktop clr
+				MaxConnectionsPerServer = requestData.ConnectionSettings.ConnectionLimit
 			};
 
 			if (!requestData.ProxyAddress.IsNullOrEmpty())

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -76,7 +76,7 @@ namespace Elasticsearch.Net
 		{
 			requestServicePoint.UseNagleAlgorithm = false;
 			requestServicePoint.Expect100Continue = false;
-			requestServicePoint.ConnectionLimit = 80;
+			requestServicePoint.ConnectionLimit = requestData.ConnectionSettings.ConnectionLimit;
 			//looking at http://referencesource.microsoft.com/#System/net/System/Net/ServicePoint.cs
 			//this method only sets internal values and wont actually cause timers and such to be reset
 			//So it should be idempotent if called with the same parameters

--- a/src/Tests/Reproduce/ConnectionReuseAndBalancing.cs
+++ b/src/Tests/Reproduce/ConnectionReuseAndBalancing.cs
@@ -52,7 +52,7 @@ namespace Tests.Reproduce
 			this.AssertHttpStats(nodeStats);
 			for (var i = 0; i < 10; i++)
 			{
-				Parallel.For(0, 1000, async (c) => await client.SearchAsync<Project>(s => s));
+				Parallel.For(0, 1000, c => client.Search<Project>(s => s));
 
 				nodeStats = await client.NodesStatsAsync(statsRequest);
 				this.AssertHttpStats(nodeStats);


### PR DESCRIPTION
Remove the async action in the Parallel.For
Add ConnectionLimit to ConnectionConfiguration
Add comments to all options with clear descriptions.

Part of #2476 

(cherry-picked from commit fbdaaee239892ffa6c0f4e1ba729831dc5ac935c)