### PR TITLE
Mark type level analyzers as obsolete and add a convenience method fo…

### DIFF
--- a/src/Nest/Analysis/Analyzers/Analyzers.cs
+++ b/src/Nest/Analysis/Analyzers/Analyzers.cs
@@ -26,11 +26,6 @@ namespace Nest
 		public AnalyzersDescriptor UserDefined(string name, IAnalyzer analyzer) => Assign(name, analyzer);
 
 		/// <summary>
-		/// Sets the specified analyzer as the default for the index.
-		/// </summary>
-		public AnalyzersDescriptor Default(IAnalyzer analyzer) => Assign("default", analyzer);
-
-		/// <summary>
 		/// An analyzer of type custom that allows to combine a Tokenizer with zero or more Token Filters,
 		/// and zero or more Char Filters.
 		/// <para>The custom analyzer accepts a logical/registered name of the tokenizer to use, and a list of

--- a/src/Nest/Analysis/Analyzers/Analyzers.cs
+++ b/src/Nest/Analysis/Analyzers/Analyzers.cs
@@ -26,6 +26,11 @@ namespace Nest
 		public AnalyzersDescriptor UserDefined(string name, IAnalyzer analyzer) => Assign(name, analyzer);
 
 		/// <summary>
+		/// Sets the specified analyzer as the default for the index.
+		/// </summary>
+		public AnalyzersDescriptor Default(IAnalyzer analyzer) => Assign("default", analyzer);
+
+		/// <summary>
 		/// An analyzer of type custom that allows to combine a Tokenizer with zero or more Token Filters,
 		/// and zero or more Char Filters.
 		/// <para>The custom analyzer accepts a logical/registered name of the tokenizer to use, and a list of

--- a/src/Nest/Mapping/TypeMapping.cs
+++ b/src/Nest/Mapping/TypeMapping.cs
@@ -20,9 +20,11 @@ namespace Nest
 		[JsonProperty("include_in_all")]
 		bool? IncludeInAll { get; set; }
 
+		[Obsolete("Scheduled to be removed in 6.0. Default analyzers can no longer be specified at the type level.  Use an index or field level analyzer instead.")]
 		[JsonProperty("analyzer")]
 		string Analyzer { get; set; }
 
+		[Obsolete("Scheduled to be removed in 6.0. Default analyzers can no longer be specified at the type level.  Use an index or field level analyzer instead.")]
 		[JsonProperty("search_analyzer")]
 		string SearchAnalyzer { get; set; }
 
@@ -66,8 +68,6 @@ namespace Nest
 		/// <inheritdoc/>
 		public IAllField AllField { get; set; }
 		/// <inheritdoc/>
-		public string Analyzer { get; set; }
-		/// <inheritdoc/>
 		public bool? DateDetection { get; set; }
 		/// <inheritdoc/>
 		public bool? IncludeInAll { get; set; }
@@ -92,6 +92,10 @@ namespace Nest
 		/// <inheritdoc/>
 		public IRoutingField RoutingField { get; set; }
 		/// <inheritdoc/>
+		[Obsolete("Scheduled to be removed in 6.0. Default analyzers can no longer be specified at the type level.  Use an index or field level analyzer instead.")]
+		public string Analyzer { get; set; }
+		/// <inheritdoc/>
+		[Obsolete("Scheduled to be removed in 6.0. Default analyzers can no longer be specified at the type level.  Use an index or field level analyzer instead.")]
 		public string SearchAnalyzer { get; set; }
 		/// <inheritdoc/>
 		public ISizeField SizeField { get; set; }
@@ -105,7 +109,6 @@ namespace Nest
 		where T : class
 	{
 		IAllField ITypeMapping.AllField { get; set; }
-		string ITypeMapping.Analyzer { get; set; }
 		bool? ITypeMapping.DateDetection { get; set; }
 		bool? ITypeMapping.IncludeInAll { get; set; }
 		Union<bool, DynamicMapping> ITypeMapping.Dynamic { get; set; }
@@ -118,6 +121,9 @@ namespace Nest
 		IParentField ITypeMapping.ParentField { get; set; }
 		IProperties ITypeMapping.Properties { get; set; }
 		IRoutingField ITypeMapping.RoutingField { get; set; }
+		[Obsolete("Scheduled to be removed in 6.0. Default analyzers can no longer be specified at the type level.  Use an index or field level analyzer instead.")]
+		string ITypeMapping.Analyzer { get; set; }
+		[Obsolete("Scheduled to be removed in 6.0. Default analyzers can no longer be specified at the type level.  Use an index or field level analyzer instead.")]
 		string ITypeMapping.SearchAnalyzer { get; set; }
 		ISizeField ITypeMapping.SizeField { get; set; }
 		ISourceField ITypeMapping.SourceField { get; set; }
@@ -150,9 +156,11 @@ namespace Nest
 		public TypeMappingDescriptor<T> Parent<TOther>() where TOther : class => Assign(a => a.ParentField = new ParentField { Type = typeof(TOther) });
 
 		/// <inheritdoc/>
+		[Obsolete("Scheduled to be removed in 6.0. Default analyzers can no longer be specified at the type level.  Use an index or field level analyzer instead.")]
 		public TypeMappingDescriptor<T> Analyzer(string analyzer) => Assign(a => a.Analyzer = analyzer);
 
 		/// <inheritdoc/>
+		[Obsolete("Scheduled to be removed in 6.0. Default analyzers can no longer be specified at the type level.  Use an index or field level analyzer instead.")]
 		public TypeMappingDescriptor<T> SearchAnalyzer(string searchAnalyzer)=> Assign(a => a.SearchAnalyzer = searchAnalyzer);
 
 		/// <inheritdoc/>

--- a/src/Tests/Analysis/Analyzers/AnalyzerUsageTests.cs
+++ b/src/Tests/Analysis/Analyzers/AnalyzerUsageTests.cs
@@ -15,6 +15,10 @@ namespace Tests.Analysis.Analyzers
 			{
 				analyzer = new
 				{
+					@default = new
+					{
+						type = "keyword"
+					},
 					myCustom = new
 					{
 						type = "custom",
@@ -78,6 +82,7 @@ namespace Tests.Analysis.Analyzers
 		public static Func<IndexSettingsDescriptor, IPromise<IndexSettings>> FluentExample => s => s
 			.Analysis(analysis => analysis
 				.Analyzers(analyzers => analyzers
+					.Default(new KeywordAnalyzer())
 					.Custom("myCustom", a => a
 						.Filters("myAscii", "kstem")
 						.CharFilters("stripMe", "patterned")
@@ -111,6 +116,7 @@ namespace Tests.Analysis.Analyzers
 				{
 					Analyzers = new Nest.Analyzers
 					{
+						{ "default", new KeywordAnalyzer() },
 						{ "myCustom", new CustomAnalyzer
 						{
 							CharFilter = new [] { "stripMe", "patterned"},

--- a/src/Tests/Analysis/Analyzers/AnalyzerUsageTests.cs
+++ b/src/Tests/Analysis/Analyzers/AnalyzerUsageTests.cs
@@ -82,7 +82,7 @@ namespace Tests.Analysis.Analyzers
 		public static Func<IndexSettingsDescriptor, IPromise<IndexSettings>> FluentExample => s => s
 			.Analysis(analysis => analysis
 				.Analyzers(analyzers => analyzers
-					.Default(new KeywordAnalyzer())
+					.Keyword("default")
 					.Custom("myCustom", a => a
 						.Filters("myAscii", "kstem")
 						.CharFilters("stripMe", "patterned")


### PR DESCRIPTION
…r setting an index-level default

They've been removed since 2.0 :\

I've also added a `Default()` method for conveniently setting the index-level default analyzer rather than having to do `.Keyword("default")` which might be a little more intuitive.