### PR TITLE
remove validation for uppercases in indexnames, aliases are still all…

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
@@ -45,8 +45,6 @@ namespace Nest
 					+ "or set a default index using ConnectionSettings.DefaultIndex()."
 				);
 
-			if (indexName.HasAny(char.IsUpper))
-				throw new ArgumentException($"Index names cannot contain uppercase characters: {indexName}.");
 		}
 	}
 }


### PR DESCRIPTION
…owed to have uppercase in them

Fixes: https://github.com/elastic/elasticsearch-net/issues/2516