### PR TITLE
Added ToString to Nest.CausedBy for proper string representation.

### DIFF
--- a/src/Nest/CommonOptions/Failures/BulkError.cs
+++ b/src/Nest/CommonOptions/Failures/BulkError.cs
@@ -20,6 +20,13 @@ namespace Nest
 		[JsonProperty("caused_by")]
 		public CausedBy CausedBy { get; internal set; }
 
-		public override string ToString() => $"Type: {Type} Reason: \"{Reason}\" CausedBy: \"{CausedBy}\"";
+		public override string ToString()
+		{
+			var cause = (CausedBy != null) ?
+				$" CausedBy:\n{CausedBy}" :
+				string.Empty;
+
+			return $"Type: {Type} Reason: \"{Reason}\"{cause}";
+		}
 	}
 }

--- a/src/Nest/CommonOptions/Failures/ShardFailure.cs
+++ b/src/Nest/CommonOptions/Failures/ShardFailure.cs
@@ -46,5 +46,14 @@ namespace Nest
 
 		[JsonProperty("caused_by")]
 		public CausedBy InnerCausedBy { get; internal set; }
+
+		public override string ToString()
+		{
+			var innerCause = (InnerCausedBy != null) ?
+				$" CausedBy:\n{InnerCausedBy}" :
+				string.Empty;
+
+			return $"Type: {Type} Reason: \"{Reason}\"{innerCause}";
+		}
 	}
 }


### PR DESCRIPTION
Nest.CausedBy didn't have a ToString override, and hence had the default "[Nest.CausedBy]" string representation.
This also caused non-informative string representations of BulkError: 
Type: "type" Reason: "reason" CausedBy: "[Nest.CausedBy]".

Now, string representation of Nest.CausedBy will contain the full cause chain (i.e., including the inner causes, in a way similar to a stack trace).

Should also be ported to 2.x & 5.x.