### PR TITLE
SnowballLanguage.German generates `ferman` due to typo

### DIFF
--- a/src/Nest/Analysis/Languages/SnowballLanguage.cs
+++ b/src/Nest/Analysis/Languages/SnowballLanguage.cs
@@ -26,7 +26,7 @@ namespace Nest
 		Finnish,
 		[EnumMember(Value="French")]
 		French,
-		[EnumMember(Value="Ferman")]
+		[EnumMember(Value="German")]
 		German,
 		[EnumMember(Value="German2")]
 		German2,


### PR DESCRIPTION
fixes #2525