### PR TITLE
Index JObject and collection of JObjects

### DIFF
--- a/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerBase.cs
+++ b/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerBase.cs
@@ -64,7 +64,11 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 				return (string.Join("\n", ss) + "\n").Utf8Bytes();
 			}
 
-			if (typeof(IEnumerable<object>).IsAssignableFrom(dataType))
+			// JObject should not be treated as an IEnumerable<object> as doing so
+			// results in malformed json in the request. Allow it to be handled
+			// by the serializer similar to any other type.
+			if (typeof(IEnumerable<object>).IsAssignableFrom(dataType) && 
+				dataType.FullName != "Newtonsoft.Json.Linq.JObject")
 			{
 				var so = (IEnumerable<object>)data;
 				var joined = string.Join("\n", so

--- a/src/Tests/Nest.Tests.Integration/Index/IndexJObjectTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Index/IndexJObjectTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Nest.Tests.Integration.Index
+{
+	[TestFixture]
+	public class IndexJObjectTests : IntegrationTests
+	{
+		private IEnumerable<JObject> _jobjects;
+
+		public IEnumerable<JObject> JObjects
+		{
+			get
+			{
+				if (_jobjects == null)
+				{
+					_jobjects = Enumerable.Range(1, 1000)
+						.Select(i =>
+							new JObject
+							{
+								{ "id", i },
+								{ "name", $"name {i}" },
+								{ "value", Math.Pow(i, 2) },
+								{ "date", new DateTime(2016, 1, 1) },
+								{
+									"child", new JObject
+									{
+										{ "child_name", $"child_name {i}{i}" },
+										{ "child_value", 3 }
+									}
+								}
+							});
+				}
+
+				return _jobjects;
+			}
+		}
+
+		[Test]
+		public void Index()
+		{
+			var jObject = JObjects.First();
+
+			var indexResult = this.Client.Index(jObject, f => f
+				.Id(jObject["id"].Value<int>())
+			);
+
+			indexResult.IsValid.Should().BeTrue();
+			indexResult.RequestInformation.HttpStatusCode.Should().Be(201);
+			indexResult.Created.Should().BeTrue();
+			indexResult.Type.Should().Be("jobject");
+		}
+
+		[Test]
+		public void Bulk()
+		{
+			var bulkResponse = this.Client.Bulk(b => b
+				.IndexMany(JObjects.Skip(1), (bi, d) => bi
+					.Document(d)
+					.Id(d["id"].Value<int>())
+				)
+			);
+
+			bulkResponse.IsValid.Should().BeTrue();
+			bulkResponse.RequestInformation.HttpStatusCode.Should().Be(200);
+
+			foreach (var response in bulkResponse.Items)
+			{
+				response.IsValid.Should().BeTrue();
+				response.Status.Should().Be(201);
+			}
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
+++ b/src/Tests/Nest.Tests.Integration/Nest.Tests.Integration.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Failover\FailoverSniffOnStartupTests.cs" />
     <Compile Include="Failover\FailoverPingTests.cs" />
     <Compile Include="Help\AliasTests.cs" />
+    <Compile Include="Index\IndexJObjectTests.cs" />
     <Compile Include="Index\ReindexTests.cs" />
     <Compile Include="Index\IndexUsingUrlIdTests.cs" />
     <Compile Include="Indices\Analysis\Analyzers\AnalyzerTest.cs" />


### PR DESCRIPTION
Elasticsearch.Net does not have a dependency on Json.NET, so use the fully qualified type name to check the type is not `JObject`.