### PR TITLE
Fix broken test related to index name casing

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
@@ -41,10 +41,9 @@ namespace Nest
 			if (string.IsNullOrWhiteSpace(indexName))
 				throw new ArgumentException(
 					"Index name is null for the given type and no default index is set. "
-					+ "Map an index name using ConnectionSettings.MapDefaultTypeIndices() "
+					+ "Map an index name using ConnectionSettings.MapDefaultTypeIndices(), ConnectionSettings.InferMappingFor<TDocument>() "
 					+ "or set a default index using ConnectionSettings.DefaultIndex()."
 				);
-
 		}
 	}
 }

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -475,6 +475,11 @@ namespace Nest
 		public QueryContainer FunctionScore(Func<FunctionScoreQueryDescriptor<T>, IFunctionScoreQuery> selector) =>
 			WrapInContainer(selector, (query, container) => container.FunctionScore = query);
 
+		/// <summary>
+		/// A query that accepts a query template and a map of key/value pairs to fill in template parameters.
+		/// Templating is based on Mustache.
+		/// </summary>
+		[Obsolete("Deprecated in 5.0.0. Use Search Template API instead")]
 		public QueryContainer Template(Func<TemplateQueryDescriptor<T>, ITemplateQuery> selector) =>
 			WrapInContainer(selector, (query, container) => container.Template = query);
 

--- a/src/Nest/QueryDsl/Query.cs
+++ b/src/Nest/QueryDsl/Query.cs
@@ -168,6 +168,7 @@ namespace Nest
 		public static QueryContainer SpanFieldMasking(Func<SpanFieldMaskingQueryDescriptor<T>, ISpanFieldMaskingQuery> selector) =>
 			new QueryContainerDescriptor<T>().SpanFieldMasking(selector);
 
+		[Obsolete("Deprecated in 5.0.0. Use Search Template API instead")]
 		public static QueryContainer Template(Func<TemplateQueryDescriptor<T>, ITemplateQuery> selector) =>
 			new QueryContainerDescriptor<T>().Template(selector);
 

--- a/src/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
@@ -100,27 +100,6 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		}
 
 		//hide
-		[U] public void UppercaseCharacterThrowsArgumentException()
-		{
-			var settings = new ConnectionSettings()
-				.DefaultIndex("Default")
-				.MapDefaultTypeIndices(m => m
-					.Add(typeof(Project), "myProjects")
-				);
-
-			var resolver = new IndexNameResolver(settings);
-
-			var e = Assert.Throws<ArgumentException>(() => resolver.Resolve<Project>());
-			e.Message.Should().Be($"Index names cannot contain uppercase characters: myProjects.");
-
-			e = Assert.Throws<ArgumentException>(() => resolver.Resolve<Tag>());
-			e.Message.Should().Be($"Index names cannot contain uppercase characters: Default.");
-
-			e = Assert.Throws<ArgumentException>(() => resolver.Resolve("Foo"));
-			e.Message.Should().Be($"Index names cannot contain uppercase characters: Foo.");
-		}
-
-		//hide
 		[U] public void NoIndexThrowsArgumentException()
 		{
 			var settings = new ConnectionSettings();


### PR DESCRIPTION
Deprecate Template query. Can't deprecate the query types as they are used in the phrase suggester.