### PR TITLE
Add debugging mode to connection settings

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
@@ -365,19 +366,25 @@ namespace Elasticsearch.Net
 
 		/// <summary>
 		/// Turns on settings that aid in debugging like DisableDirectStreaming() and PrettyJson()
-		/// and writes debug information to the output window.
+		/// so that the original request and response JSON can be inspected.
 		/// </summary>
+		/// <param name="onRequestCompleted">
+		/// An optional callback to be performed when the request completes. This will
+		/// not overwrite the global OnRequestCompleted callback that is set directly on
+		/// ConnectionSettings. If no callback is passed, DebugInformation from the response
+		/// will be written to the debug output by default.
+		/// </param>
 		public T EnableDebugMode(Action<IApiCallDetails> onRequestCompleted = null)
 		{
 			this._disableDirectStreaming = true;
 			this._prettyJson = true;
 
 			var originalCompletedRequestHandler = this._completedRequestHandler;
+			var debugCompletedRequestHandler = onRequestCompleted ?? (d => Debug.WriteLine(d.DebugInformation));
 			this._completedRequestHandler = d =>
 			{
 				originalCompletedRequestHandler?.Invoke(d);
-				onRequestCompleted?.Invoke(d);
-				System.Diagnostics.Debug.WriteLine(d.DebugInformation);
+				debugCompletedRequestHandler?.Invoke(d);
 			};
 			return (T)this;
 		}

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -363,6 +363,25 @@ namespace Elasticsearch.Net
 		/// </summary>
 		public T EnableHttpPipelining(bool enabled = true) => Assign(a => a._enableHttpPipelining = enabled);
 
+		/// <summary>
+		/// Turns on settings that aid in debugging like DisableDirectStreaming() and PrettyJson()
+		/// and writes debug information to the output window.
+		/// </summary>
+		public T EnableDebugMode(Action<IApiCallDetails> onRequestCompleted = null)
+		{
+			this._disableDirectStreaming = true;
+			this._prettyJson = true;
+
+			var originalCompletedRequestHandler = this._completedRequestHandler;
+			this._completedRequestHandler = d =>
+			{
+				originalCompletedRequestHandler?.Invoke(d);
+				onRequestCompleted?.Invoke(d);
+				System.Diagnostics.Debug.WriteLine(d.DebugInformation);
+			};
+			return (T)this;
+		}
+
 		void IDisposable.Dispose() => this.DisposeManagedResources();
 
 		protected virtual void DisposeManagedResources()

--- a/src/Tests/ClientConcepts/LowLevel/DirectStreaming.cs
+++ b/src/Tests/ClientConcepts/LowLevel/DirectStreaming.cs
@@ -2,6 +2,7 @@
 using Nest;
 using System;
 using Tests.Framework;
+using Tests.Framework.MockData;
 
 namespace Tests.ClientConcepts.LowLevel
 {
@@ -107,6 +108,30 @@ namespace Tests.ClientConcepts.LowLevel
 			assert(response);
 			response = client.SearchAsync<object>(s => s.RequestConfiguration(r => r.DisableDirectStreaming(false))).Result;
 			assert(response);
+		}
+
+		[U]
+		public void DebugModeRespectsOriginalOnRequestCompleted()
+		{
+			var global = 0;
+			var local = 0;
+			var client = TestClient.GetFixedReturnClient(new { }, 200, s => s
+				.EnableDebugMode(d => local++)
+				.OnRequestCompleted(d => global++)
+			);
+
+			var response = client.Search<Project>(s => s
+				.From(10)
+				.Size(20)
+				.Query(q => q
+					.Match(m => m
+						.Field(p => p.Name)
+						.Query("elastic")
+					)
+				)
+			);
+			global.Should().Be(1);
+			local.Should().Be(1);
 		}
 	}
 }


### PR DESCRIPTION
This commit adds the ability to set .EnableDebugMode() on
ConnectionSettings which turns direct streaming and pretty JSON on and
writes DebugInformation to the output window.

It also accepts an optional Action<IApiCallDetails> to perform when the
request is completed, but preserves the original OnRequestCompleted action
that might be set on ConnectionSettings.

Closes #2535