### PR TITLE
fix #2556 when writing out reflected properties from AutoMap() check …

### DIFF
--- a/src/Nest/Mapping/Visitor/PropertyWalker.cs
+++ b/src/Nest/Mapping/Visitor/PropertyWalker.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Nest
 {
@@ -37,7 +38,7 @@ namespace Nest
 			if (seenTypes != null && seenTypes.TryGetValue(_type, out seen) && seen > maxRecursion)
 				return properties;
 
-			foreach (var propertyInfo in _type.GetProperties())
+			foreach (var propertyInfo in _type.AllPropertiesCached())
 			{
 				var attribute = ElasticsearchPropertyAttributeBase.From(propertyInfo);
 				if (attribute != null && attribute.Ignore)

--- a/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
@@ -462,6 +462,38 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 				AskSerializer = "serializer fiddled with this one",
 				DefaultFieldNameInferrer = "shouting much?"
 			});
+		}
+
+		public class Parent
+		{
+			public int Id { get; set; }
+			public string Description { get; set; }
+			public string IgnoreMe { get; set; }
+		}
+
+		public class Child : Parent { }
+
+		[U]
+		public void CodeBasedConfigurationInherits()
+		{
+			/** Inherited properties can be ignored and renamed just as one would expect
+			*/
+			var usingSettings = WithConnectionSettings(s => s
+				.InferMappingFor<Child>(m => m
+					.Rename(p => p.Description, "desc")
+					.Ignore(p => p.IgnoreMe)
+				)
+			);
+			usingSettings.Expect(new []
+			{
+				"id",
+				"desc",
+			}).AsPropertiesOf(new Child
+			{
+				Id = 1,
+				Description = "using a nest attribute",
+				IgnoreMe = "the default serializer resolves json property attributes",
+			});
 
 		}
 	}

--- a/src/Tests/CodeStandards/Descriptors.doc.cs
+++ b/src/Tests/CodeStandards/Descriptors.doc.cs
@@ -44,6 +44,7 @@ namespace Tests.CodeStandards
 				{ typeof(ConditionDescriptor), typeof(ConditionContainer) },
 				{ typeof(TriggerDescriptor), typeof(TriggerContainer) },
 				{ typeof(TransformDescriptor), typeof(TransformContainer) },
+				{ typeof(SmoothingModelContainerDescriptor), typeof(SmoothingModelContainer) },
 				{ typeof(InputDescriptor), typeof(InputContainer) },
 				{ typeof(FluentDictionary<,>), typeof(FluentDictionary<,>) }
 			};

--- a/src/Tests/Framework/SerializationTests/Roundtrip.cs
+++ b/src/Tests/Framework/SerializationTests/Roundtrip.cs
@@ -14,7 +14,6 @@ namespace Tests.Framework
 {
 	public class RoundTripper : SerializationTestBase
 	{
-
 		protected override object ExpectJson { get; }
 
 		internal RoundTripper(
@@ -98,7 +97,6 @@ namespace Tests.Framework
 			this._serializerFactory = serializerFactory;
 			return this;
 		}
-
 
 		public RoundTripper Expect(object expected) =>  new RoundTripper(expected, _connectionSettingsModifier, this._serializerFactory);
 	}


### PR DESCRIPTION
…against ConnectionSettings mappings to rename or ignore them in a late bound fashion