### PR TITLE
More resilient error parsing 

### DIFF
--- a/src/Elasticsearch.Net/Responses/ServerError.cs
+++ b/src/Elasticsearch.Net/Responses/ServerError.cs
@@ -48,11 +48,18 @@ namespace Elasticsearch.Net
 				statusCode = Convert.ToInt32(status);
 
 			if (!dict.TryGetValue("error", out error)) return null;
+			Error err;
+			var s = error as string;
+			if (s != null)
+			{
+				err = new Error {Reason = s};
+			}
+			else err = (Error) strategy.DeserializeObject(error, typeof(Error));
 
 			return new ServerError
 			{
 				Status = statusCode,
-				Error = (Error)strategy.DeserializeObject(error, typeof(Error))
+				Error = err
 			};
 		}
 
@@ -155,6 +162,7 @@ namespace Elasticsearch.Net
 	{
 		public static void FillValues(this IRootCause rootCause, IDictionary<string, object> dict)
 		{
+			if (dict == null) return;
 			object index;
 			if (dict.TryGetValue("index", out index)) rootCause.Index = Convert.ToString(index);
 			object reason;

--- a/src/Tests/Indices/AliasManagement/AliasExists/AliasExistsApiTests.cs
+++ b/src/Tests/Indices/AliasManagement/AliasExists/AliasExistsApiTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Elasticsearch.Net;
+using FluentAssertions;
 using Nest;
 using Tests.Framework;
 using Tests.Framework.Integration;
@@ -13,13 +14,15 @@ namespace Tests.Indices.AliasManagement.AliasExists
 		: ApiIntegrationTestBase<WritableCluster, IExistsResponse, IAliasExistsRequest, AliasExistsDescriptor, AliasExistsRequest>
 
 	{
-		public AliasExistsApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public AliasExistsApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage)
+		{
+		}
 
 		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
 		{
 			foreach (var index in values.Values)
-				client.CreateIndex(index, c=>c
-					.Aliases(aa=>aa.Alias(index + "-alias"))
+				client.CreateIndex(index, c => c
+					.Aliases(aa => aa.Alias(index + "-alias"))
 				);
 		}
 
@@ -41,5 +44,39 @@ namespace Tests.Indices.AliasManagement.AliasExists
 			.Name(CallIsolatedValue + "-alias");
 
 		protected override AliasExistsRequest Initializer => new AliasExistsRequest(Names(CallIsolatedValue + "-alias"));
+	}
+
+	public class AliasExistsNotFoundApiTests
+		: ApiIntegrationTestBase<ReadOnlyCluster, IExistsResponse, IAliasExistsRequest, AliasExistsDescriptor, AliasExistsRequest>
+
+	{
+		public AliasExistsNotFoundApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage)
+		{
+		}
+
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.AliasExists(f),
+			fluentAsync: (client, f) => client.AliasExistsAsync(f),
+			request: (client, r) => client.AliasExists(r),
+			requestAsync: (client, r) => client.AliasExistsAsync(r)
+		);
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 404;
+		protected override HttpMethod HttpMethod => HttpMethod.HEAD;
+		protected override string UrlPath => $"/_alias/unknown-alias";
+
+		protected override bool SupportsDeserialization => false;
+
+		protected override Func<AliasExistsDescriptor, IAliasExistsRequest> Fluent => d => d
+			.Name("unknown-alias");
+
+		protected override AliasExistsRequest Initializer => new AliasExistsRequest(Names("unknown-alias"));
+
+		protected override void ExpectResponse(IExistsResponse response)
+		{
+			response.ServerError.Should().BeNull();
+			response.Exists.Should().BeFalse();
+		}
 	}
 }

--- a/src/Tests/tests.yaml
+++ b/src/Tests/tests.yaml
@@ -1,5 +1,5 @@
 ﻿# mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: i
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.2.0


### PR DESCRIPTION
Relates to: https://github.com/elastic/elasticsearch-net/issues/2582

Could not quite reproduce but the point in the code @niemyjski pointed out could use a null reference check so added it. 

This also makes sure 

```
{ 
   "error" : "some error"
   "status" : 404
}

Is properly deserialized into a `ServerError`, we were incorrectly assuming this is always an object.