### PR TITLE
fix #2561  HttpClientHandler.MaxConnectionsPerServer not always available

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -204,10 +204,9 @@ namespace Elasticsearch.Net
 		/// <para>For Desktop CLR, this setting applies to the DefaultConnectionLimit property on the  ServicePointManager object when creating ServicePoint objects, affecting the default <see cref="IConnection"/> implementation.</para>
 		/// <para>For Core CLR, this setting applies to the MaxConnectionsPerServer property on the HttpClientHandler instances used by the HttpClient inside the default <see cref="IConnection"/> implementation</para>
 		/// </summary>
-		/// <param name="connectionLimit">The connection limit</param>
+		/// <param name="connectionLimit">The connection limit, a value lower then 0 will cause the connection limit not to be set at all</param>
 		public T ConnectionLimit(int connectionLimit)
 		{
-			if (connectionLimit <= 0) throw new ArgumentException("must be greater than 0", nameof(connectionLimit));
 			return Assign(a => a._connectionLimit = connectionLimit);
 		}
 

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -77,7 +77,8 @@ namespace Elasticsearch.Net
 		{
 			requestServicePoint.UseNagleAlgorithm = false;
 			requestServicePoint.Expect100Continue = false;
-			requestServicePoint.ConnectionLimit = requestData.ConnectionSettings.ConnectionLimit;
+			if (requestData.ConnectionSettings.ConnectionLimit > 0)
+				requestServicePoint.ConnectionLimit = requestData.ConnectionSettings.ConnectionLimit;
 			//looking at http://referencesource.microsoft.com/#System/net/System/Net/ServicePoint.cs
 			//this method only sets internal values and wont actually cause timers and such to be reset
 			//So it should be idempotent if called with the same parameters


### PR DESCRIPTION
Make the call to HttpClientHandler.MaxConnectionsPerServer optional if our ConnectionLimit setting is greater than zero, we also try catch and throw a nice exception message so folks know how to fix it may they run into this

fix #2581