### PR TITLE
Fix #2573 bwc support for new cluster allocation explain response

### DIFF
--- a/src/Nest/Cluster/ClusterAllocationExplain/ClusterAllocationExplainResponse.cs
+++ b/src/Nest/Cluster/ClusterAllocationExplain/ClusterAllocationExplainResponse.cs
@@ -1,56 +1,146 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Security.Cryptography.X509Certificates;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
+	[JsonConverter(typeof(ClusterAllocationExplainResponseJsonConverter))]
 	public interface IClusterAllocationExplainResponse : IResponse
 	{
-		[JsonProperty("shard")]
-		ShardAllocationExplanation Shard { get; }
+		[JsonProperty("index")]
+		string Index { get; }
 
-		[JsonProperty("assigned")]
-		bool Assigned { get; }
+		[JsonIgnore]
+		// TODO rename to Shard in 6.0
+		int ShardId { get; }
 
-		[JsonProperty("assigned_node_id")]
-		string AssignedNodeId { get; }
+		[JsonProperty("primary")]
+		bool Primary { get; }
 
-		[JsonProperty("shard_state_fetch_pending")]
-		bool ShardStateFetchPending { get; }
+		[JsonProperty("current_state")]
+		string CurrentState { get; }
 
 		[JsonProperty("unassigned_info")]
 		UnassignedInformation UnassignedInformation { get; }
 
+		[JsonProperty("can_allocate")]
+		Decision? CanAllocate { get; }
+
+		[JsonProperty("allocate_explanation")]
+		string AllocateExplanation { get; }
+
+		[JsonProperty("configured_delay")]
+		string ConfiguredDelay { get; }
+
+		[JsonProperty("configured_delay_in_mills")]
+		long ConfiguredDelayInMilliseconds { get; }
+
+		[JsonProperty("current_node")]
+		CurrentNode CurrentNode { get; }
+
+		[JsonProperty("can_remain_on_current_node")]
+		Decision? CanRemainOnCurrentNode { get; }
+
+		[JsonProperty("can_remain_decisions")]
+		IReadOnlyCollection<AllocationDecision> CanRemainDecisions { get; }
+
+		[JsonProperty("can_rebalance_cluster")]
+		Decision? CanRebalanceCluster { get; }
+
+		[JsonProperty("can_rebalance_to_other_nodes")]
+		Decision? CanRebalanceToOtherNode { get; }
+
+		[JsonProperty("can_rebalance_cluster_decisions")]
+		IReadOnlyCollection<AllocationDecision> CanRebalanceClusterDecisions { get; }
+
+		[JsonProperty("rebalance_explanation")]
+		string RebalanceExplanation { get; }
+
+		[JsonProperty("node_allocation_decisions")]
+		IReadOnlyCollection<NodeAllocationExplanation> NodeAllocationDecisions { get; }
+
+		[JsonProperty("can_move_to_other_node")]
+		Decision? CanMoveToOtherNode { get; }
+
+		[JsonProperty("move_explanation")]
+		string MoveExplanation { get; }
+
 		[JsonProperty("allocation_delay")]
 		string AllocationDelay { get; }
 
-		[JsonProperty("allocation_delay_ms")]
+		[JsonProperty("allocation_delay_in_millis")]
 		long AllocationDelayInMilliseconds { get; }
 
 		[JsonProperty("remaining_delay")]
 		string RemainingDelay { get; }
 
-		[JsonProperty("remaining_delay_ms")]
+		[JsonProperty("remaining_delay_in_millis")]
 		long RemainingDelayInMilliseconds { get; }
 
+		[JsonIgnore]
+		[Obsolete("Removed in Elasticsearch 5.2. Use properties on root object instead.")]
+		ShardAllocationExplanation Shard { get; }
+
+		[JsonProperty("assigned")]
+		[Obsolete("Removed in Elasticsearch 5.2.")]
+		bool Assigned { get; }
+
+		[JsonProperty("assigned_node_id")]
+		[Obsolete("Removed in Elasticsearch 5.2.")]
+		string AssignedNodeId { get; }
+
+		[JsonProperty("shard_state_fetch_pending")]
+		[Obsolete("Removed in Elasticsearch 5.2.")]
+		bool ShardStateFetchPending { get; }
+
 		[JsonProperty("nodes")]
+		[Obsolete("Removed in Elasticsearch 5.2.  Use node_allocation_decisions instead.")]
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, NodeAllocationExplanation>))]
 		IReadOnlyDictionary<string, NodeAllocationExplanation> Nodes { get; }
 	}
 
 	public class ClusterAllocationExplainResponse : ResponseBase, IClusterAllocationExplainResponse
 	{
-		public ShardAllocationExplanation Shard { get; internal set; }
+		public string Index { get; internal set; }
 
-		public bool Assigned { get; internal set; }
+		public int ShardId { get; internal set; }
 
-		public string AssignedNodeId { get; internal set; }
+		public bool Primary { get; internal set; }
 
-		public bool ShardStateFetchPending { get; internal set; }
+		public string CurrentState { get; internal set; }
 
 		public UnassignedInformation UnassignedInformation { get; internal set; }
+
+		public Decision? CanAllocate { get; internal set; }
+
+		public string AllocateExplanation { get; internal set; }
+
+		public string ConfiguredDelay { get; internal set; }
+
+		public long ConfiguredDelayInMilliseconds { get; internal set; }
+
+		public CurrentNode CurrentNode { get; internal set; }
+
+		public Decision? CanRemainOnCurrentNode { get; internal set; }
+
+		public IReadOnlyCollection<AllocationDecision> CanRemainDecisions { get; internal set; }
+
+		public Decision? CanRebalanceCluster { get; internal set; }
+
+		public Decision? CanRebalanceToOtherNode { get; internal set; }
+
+		public IReadOnlyCollection<AllocationDecision> CanRebalanceClusterDecisions { get; internal set; } = EmptyReadOnly<AllocationDecision>.Collection;
+
+		public string RebalanceExplanation { get; internal set; }
+
+		public IReadOnlyCollection<NodeAllocationExplanation> NodeAllocationDecisions { get; internal set; }
+
+		public Decision? CanMoveToOtherNode { get; internal set; }
+
+		public string MoveExplanation { get; internal set; }
 
 		public string AllocationDelay { get; internal set; }
 
@@ -60,7 +150,39 @@ namespace Nest
 
 		public long RemainingDelayInMilliseconds { get; internal set; }
 
+		[Obsolete("Removed in Elasticsearch 5.2. Use properties on root object instead.")]
+		public ShardAllocationExplanation Shard { get; internal set; }
+
+		[Obsolete("Removed in Elasticsearch 5.2.")]
+		public bool Assigned { get; internal set; }
+
+		[Obsolete("Removed in Elasticsearch 5.2.")]
+		public string AssignedNodeId { get; internal set; }
+
+		[Obsolete("Removed in Elasticsearch 5.2.")]
+		public bool ShardStateFetchPending { get; internal set; }
+
+		[Obsolete("Removed in Elasticsearch 5.2. Usage NodeAllocationDecisions instead.")]
 		public IReadOnlyDictionary<string, NodeAllocationExplanation> Nodes { get; internal set; } = EmptyReadOnly<string, NodeAllocationExplanation>.Dictionary;
+	}
+
+	[JsonObject]
+	public class CurrentNode
+	{
+		[JsonProperty("id")]
+		public string Id { get; internal set; }
+
+		[JsonProperty("name")]
+		public string Name { get; internal set; }
+
+		[JsonProperty("transport_address")]
+		public string TransportAddress { get; internal set; }
+
+		[JsonProperty("weight_ranking")]
+		public string WeightRanking { get; internal set; }
+
+		[JsonProperty("attributes")]
+		public IReadOnlyDictionary<string, string> NodeAttributes { get; set; } = EmptyReadOnly<string, string>.Dictionary;
 	}
 
 	[JsonConverter(typeof(StringEnumConverter))]
@@ -82,8 +204,17 @@ namespace Nest
 	[JsonObject]
 	public class NodeAllocationExplanation
 	{
+		[JsonProperty("node_id")]
+		public string NodeId { get; set; }
+
 		[JsonProperty("node_name")]
 		public string NodeName { get; set; }
+
+		[JsonProperty("transport_address")]
+		public string TransportAddress { get; set; }
+
+		[JsonProperty("node_decision")]
+		public Decision? NodeDecision { get; set; }
 
 		[JsonProperty("node_attributes")]
 		public IReadOnlyDictionary<string, string> NodeAttributes { get; set; } = EmptyReadOnly<string, string>.Dictionary;
@@ -92,19 +223,40 @@ namespace Nest
 		public AllocationStore Store { get; set; }
 
 		[JsonProperty("final_decision")]
+		[Obsolete("Removed in Elasticsearch 5.2.")]
 		public FinalDecision FinalDecision { get; set; }
 
 		[JsonProperty("final_explanation")]
+		[Obsolete("Removed in Elasticsearch 5.2.")]
 		public string FinalExplanation { get; set; }
 
 		[JsonProperty("weight")]
+		[Obsolete("Removed in Elasticsearch 5.2.  Use WeightRanking instead.")]
 		public float Weight { get; set; }
 
+		[JsonProperty("weight_ranking")]
+		public int? WeightRanking { get; set; }
+
 		[JsonProperty("decisions")]
+		[Obsolete("Removed in Elasticsearch 5.2.  Use Deciders instead.")]
 		public IReadOnlyCollection<AllocationDecision> Decisions { get; set; } = EmptyReadOnly<AllocationDecision>.Collection;
+
+		[JsonProperty("deciders")]
+		public IReadOnlyCollection<AllocationDecision> Deciders { get; set; } = EmptyReadOnly<AllocationDecision>.Collection;
 	}
 
 	[JsonConverter(typeof(StringEnumConverter))]
+	public enum Decision
+	{
+		[EnumMember(Value = "yes")]
+		Yes,
+
+		[EnumMember(Value = "no")]
+		No
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	[Obsolete("Removed in Elasticsearch 5.2")]
 	public enum FinalDecision
 	{
 		[EnumMember(Value = "YES")]
@@ -159,7 +311,6 @@ namespace Nest
 		public string Explanation { get; set; }
 	}
 
-
 	public class UnassignedInformation
 	{
 		[JsonProperty("reason")]
@@ -167,6 +318,9 @@ namespace Nest
 
 		[JsonProperty("at")]
 		public DateTime At { get; set; }
+
+		[JsonProperty("last_allocation_status")]
+		public string LastAllocationStatus { get; set; }
 	}
 
 	public class ShardAllocationExplanation

--- a/src/Nest/Cluster/ClusterAllocationExplain/ClusterAllocationExplainResponseJsonConverter.cs
+++ b/src/Nest/Cluster/ClusterAllocationExplain/ClusterAllocationExplainResponseJsonConverter.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+
+namespace Nest
+{
+	// TODO this custom converter is in place because the response changed from ES 5.0 to ES 5.2
+	// so we are supporting both formats. In 6.0 we should remove this entirely and only support
+	// the new format.
+	public class ClusterAllocationExplainResponseJsonConverter : JsonConverter
+	{
+		public override bool CanRead { get; } = true;
+
+		public override bool CanWrite { get; } = false;
+
+		public override bool CanConvert(Type objectType) => true;
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var o = JObject.Load(reader);
+			var response = new ClusterAllocationExplainResponse();
+			var newResponseStructure = false;
+			foreach (var p in o.Properties())
+			{
+				switch (p.Name)
+				{
+					case "shard":
+						if (p.Value.Type == JTokenType.Object)
+						{
+							response.Shard = p.Value.ToObject<ShardAllocationExplanation>();
+						}
+						else if (p.Value.Type == JTokenType.Integer)
+						{
+							newResponseStructure = true;
+							response.ShardId = p.Value.ToObject<int>();
+						}
+						break;
+					case "index":
+						response.Index = p.Value.ToString();
+						break;
+					case "primary":
+						response.Primary = p.Value.ToObject<bool>();
+						break;
+					case "can_allocate":
+						response.CanAllocate = p.Value.ToObject<Decision?>();
+						break;
+					case "allocate_explanation":
+						response.AllocateExplanation = p.Value.ToString();
+						break;
+					case "configured_delay":
+						response.ConfiguredDelay = p.Value.ToString();
+						break;
+					case "configured_delay_in_millis":
+						response.ConfiguredDelayInMilliseconds = p.Value.ToObject<long>();
+						break;
+					case "can_remain_decisions":
+						response.CanRemainDecisions = p.Value.ToObject<List<AllocationDecision>>();
+						break;
+					case "can_move_to_other_node":
+						response.CanMoveToOtherNode = p.Value.ToObject<Decision?>();
+						break;
+					case "move_explanation":
+						response.MoveExplanation = p.Value.ToString();
+						break;
+					case "current_state":
+						response.CurrentState = p.Value.ToString();
+						break;
+					case "current_node":
+						response.CurrentNode = p.Value.ToObject<CurrentNode>();
+						break;
+					case "can_remain_on_current_node":
+						response.CanRemainOnCurrentNode = p.Value.ToObject<Decision?>();
+						break;
+					case "can_rebalance_cluster":
+						response.CanRebalanceCluster = p.Value.ToObject<Decision?>();
+						break;
+					case "can_rebalance_cluster_decisions":
+						response.CanRebalanceClusterDecisions = p.Value.ToObject<List<AllocationDecision>>();
+						break;
+					case "can_rebalance_to_other_node":
+						response.CanRebalanceToOtherNode = p.Value.ToObject<Decision?>();
+						break;
+					case "rebalance_explanation":
+						response.RebalanceExplanation = p.Value.ToString();
+						break;
+					case "assigned":
+						response.Assigned = p.Value.ToObject<bool>();
+						break;
+					case "assigned_node_id":
+						response.AssignedNodeId = p.Value.ToString();
+						break;
+					case "shard_state_fetch_pending":
+						response.ShardStateFetchPending = p.Value.ToObject<bool>();
+						break;
+					case "unassigned_info":
+						response.UnassignedInformation = p.Value.ToObject<UnassignedInformation>();
+						break;
+					case "allocation_delay":
+						response.AllocationDelay = p.Value.ToString();
+						break;
+					case "allocation_delay_in_millis":
+					case "allocation_delay_ms":
+						response.AllocationDelayInMilliseconds = p.Value.ToObject<long>();
+						break;
+					case "remaining_delay":
+						response.RemainingDelay = p.Value.ToString();
+						break;
+					case "remaining_delay_in_millis":
+					case "remaining_delay_ms":
+						response.RemainingDelayInMilliseconds = p.Value.ToObject<long>();
+						break;
+					case "node_allocation_decisions":
+						response.NodeAllocationDecisions = p.Value.ToObject<List<NodeAllocationExplanation>>();
+						break;
+					case "nodes":
+						response.Nodes = p.Value.ToObject<Dictionary<string, NodeAllocationExplanation>>();
+						break;
+				}
+			}
+
+			if (newResponseStructure)
+			{
+				// Fill in old properties
+				response.Shard = new ShardAllocationExplanation
+				{
+					Id = response.ShardId,
+					Index = response.Index,
+					Primary = response.Primary
+				};
+
+				if (response.NodeAllocationDecisions != null)
+				{
+					var nodes = new Dictionary<string, NodeAllocationExplanation>();
+					foreach (var explanation in response.NodeAllocationDecisions)
+					{
+						explanation.Decisions = explanation.Deciders;
+						nodes.Add(explanation.NodeId, explanation);
+					}
+				}
+			}
+
+			return response;
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -339,6 +339,7 @@
     <Compile Include="Cat\ICatRecord.cs" />
     <Compile Include="Cluster\ClusterAllocationExplain\ClusterAllocationExplainRequest.cs" />
     <Compile Include="Cluster\ClusterAllocationExplain\ClusterAllocationExplainResponse.cs" />
+    <Compile Include="Cluster\ClusterAllocationExplain\ClusterAllocationExplainResponseJsonConverter.cs" />
     <Compile Include="Cluster\ClusterAllocationExplain\ElasticClient-ClusterAllocationExplain.cs" />
     <Compile Include="Cluster\ClusterHealth.cs" />
     <Compile Include="Cluster\ClusterHealth\ClusterHealthRequest.cs" />

--- a/src/Tests/ClientConcepts/LowLevel/PostData.doc.cs
+++ b/src/Tests/ClientConcepts/LowLevel/PostData.doc.cs
@@ -112,7 +112,7 @@ namespace Tests.ClientConcepts.LowLevel
 			/** If you want to maintain a copy of the request that went out, use `DisableDirectStreaming` */
 			settings = new ConnectionSettings().DisableDirectStreaming();
 
-			/** by forcing `DisableDirectStreaming` on connection settings, serialization happens first in a private `MemoryStream`
+			/** by forcing `DisableDirectStreaming` on connection indexCreationSettings, serialization happens first in a private `MemoryStream`
 			* so we can get hold of the serialized bytes */
 			await Post(() => listOfObjects, writes: multiObjectJson, storesBytes: true, settings: settings);
 

--- a/src/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainApiTests.cs
+++ b/src/Tests/Cluster/ClusterAllocationExplain/ClusterAllocationExplainApiTests.cs
@@ -9,9 +9,10 @@ using Xunit;
 
 namespace Tests.Cluster.ClusterAllocationExplain
 {
-	public class ClusterAllocationExplainApiTests : ApiIntegrationTestBase<ReadOnlyCluster, IClusterAllocationExplainResponse, IClusterAllocationExplainRequest, ClusterAllocationExplainDescriptor, ClusterAllocationExplainRequest>
+	public class ClusterAllocationExplainApiTests : ApiIntegrationTestBase<UnbalancedCluster, IClusterAllocationExplainResponse, IClusterAllocationExplainRequest, ClusterAllocationExplainDescriptor, ClusterAllocationExplainRequest>
 	{
-		public ClusterAllocationExplainApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public ClusterAllocationExplainApiTests(UnbalancedCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
 		protected override LazyResponses ClientUsage() => Calls(
 			fluent: (client, f) => client.ClusterAllocationExplain(f),
 			fluentAsync: (client, f) => client.ClusterAllocationExplainAsync(f),
@@ -51,10 +52,7 @@ namespace Tests.Cluster.ClusterAllocationExplain
 		{
 			response.Shard.Primary.Should().BeTrue();
 			response.Shard.Id.Should().Be(0);
-			response.Shard.IndexUniqueId.Should().NotBeNullOrEmpty();
-			response.Assigned.Should().BeTrue();
-			response.AssignedNodeId.Should().NotBeNullOrWhiteSpace();
-			response.ShardStateFetchPending.Should().BeFalse();
+			response.Shard.Index.Should().NotBeNull();
 
 			foreach (var node in response.Nodes)
 			{
@@ -62,12 +60,54 @@ namespace Tests.Cluster.ClusterAllocationExplain
 
 				explanation.NodeName.Should().NotBeNullOrEmpty();
 				explanation.Weight.Should().BeGreaterOrEqualTo(0);
-				explanation.NodeAttributes.Should().NotBeEmpty();
+				explanation.NodeAttributes.Should().NotBeNull();
 				explanation.Store.Should().NotBeNull();
 				explanation.Store.ShardCopy.Should().Be(StoreCopy.Available);
 				explanation.FinalExplanation.Should().NotBeNullOrEmpty();
 				explanation.Decisions.Should().NotBeNullOrEmpty();
 			}
+		}
+	}
+
+	[SkipVersion(">5.1.2", "")]
+	public class ClusterAllocationExplainOldApiTests : ClusterAllocationExplainApiTests
+	{
+		public ClusterAllocationExplainOldApiTests(UnbalancedCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void ExpectResponse(IClusterAllocationExplainResponse response)
+		{
+			base.ExpectResponse(response);
+			response.Shard.IndexUniqueId.Should().NotBeNullOrEmpty();
+			response.Assigned.Should().BeTrue();
+			response.AssignedNodeId.Should().NotBeNullOrWhiteSpace();
+			response.ShardStateFetchPending.Should().BeFalse();
+		}
+	}
+
+	[SkipVersion("<5.2.0", "")]
+	public class ClusterAllocationExplainNewApiTests : ClusterAllocationExplainApiTests
+	{
+		public ClusterAllocationExplainNewApiTests(UnbalancedCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void ExpectResponse(IClusterAllocationExplainResponse response)
+		{
+			response.Primary.Should().BeTrue();
+			response.ShardId.Should().Be(0);
+			response.Index.Should().NotBeNullOrEmpty();
+			response.CurrentState.Should().NotBeNullOrEmpty();
+			response.CurrentNode.Should().NotBeNull();
+			response.CanRemainOnCurrentNode.Should().NotBeNull();
+			response.CanRebalanceCluster.Should().NotBeNull();
+			response.CanRebalanceClusterDecisions.Should().NotBeNullOrEmpty();
+
+			foreach( var decision in response.CanRebalanceClusterDecisions)
+			{
+				decision.Decider.Should().NotBeNullOrEmpty();
+				decision.Explanation.Should().NotBeNullOrEmpty();
+			}
+
+			response.CanRebalanceToOtherNode.Should().NotBeNull();
+			response.RebalanceExplanation.Should().NotBeNullOrEmpty();
 		}
 	}
 }

--- a/src/Tests/Framework/EndpointTests/Clusters/UnbalancedCluster.cs
+++ b/src/Tests/Framework/EndpointTests/Clusters/UnbalancedCluster.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Nest;
+
+namespace Tests.Framework.Integration
+{
+	public class UnbalancedCluster : ReadOnlyCluster
+	{
+		public override void Bootstrap() =>
+			new Seeder(this.Node, new IndexSettings { NumberOfShards = 3, NumberOfReplicas = 2 }).SeedNode();
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -262,6 +262,7 @@
     <Compile Include="Framework\Benchmarks\BenchmarkTest.cs" />
     <Compile Include="Framework\EndpointTests\ApiIntegrationTestBase.cs" />
     <Compile Include="Framework\EndpointTests\ApiTestBase.cs" />
+    <Compile Include="Framework\EndpointTests\Clusters\UnbalancedCluster.cs" />
     <Compile Include="Framework\EndpointTests\TestState\AsyncLazy.cs" />
     <Compile Include="Framework\EndpointTests\Clusters\IntrusiveOperationCluster.cs" />
     <Compile Include="Framework\EndpointTests\Clusters\WritableCluster.cs" />


### PR DESCRIPTION
Adds the new properties introduced in ES 5.2 and marks the old ones obsolete.

 Test old against new:
`build integrate 5.1.2 unbalanced ClusterAllocationExplainResponseApiTests`

 Test old against old:
`build integrate 5.1.2 unbalanced ClusterAllocationExplainResponseOldApiTests`

 Test new against new:
`build integrate 5.2.0 unbalanced ClusterAllocationExplainResponseNewApiTests`