### PR TITLE
NodePredicate support on ConnectionSettings

### DIFF
--- a/src/Elasticsearch.Net/Auditing/AuditEvent.cs
+++ b/src/Elasticsearch.Net/Auditing/AuditEvent.cs
@@ -18,6 +18,7 @@ namespace Elasticsearch.Net
 
 		MaxTimeoutReached,
 		MaxRetriesReached,
-		BadRequest
+		BadRequest,
+		NoNodesAttempted,
 	}
 }

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -171,5 +171,12 @@ namespace Elasticsearch.Net
 		/// received.
 		/// </summary>
 		TimeSpan? KeepAliveInterval { get; }
+
+		/// <summary>
+		/// Register a predicate to select which nodes that you want to execute API calls on. Note that sniffing requests omit this predicate and always execute on all nodes.
+		/// When using an <see cref="IConnectionPool"/> implementation that supports reseeding of nodes, this will default to omitting master only node from regular API calls.
+		/// When using static or single node connection pooling it is assumed the list of node you instantiate the client with should be taken verbatim.
+		/// </summary>
+		Func<Node, bool> NodePredicate { get; }
 	}
 }

--- a/src/Elasticsearch.Net/ConnectionPool/IConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/IConnectionPool.cs
@@ -6,8 +6,8 @@ namespace Elasticsearch.Net
 	public interface IConnectionPool : IDisposable
 	{
 		/// <summary>
-		/// Returns a readonly constant view of all the nodes in the cluster, this might involve creating copies of the nodes e.g 
-		/// if you are using the sniffing connectionpool. If you do not need an isolated copy of the nodes please read `CreateView()` to completion
+		/// Returns a readonly constant view of all the nodes in the cluster, this might involve creating copies of the nodes e.g
+		/// if you are using the sniffing connectionpool. If you do not need an isolated copy of the nodes please read <see cref="CreateView"/> to completion
 		/// </summary>
 		IReadOnlyCollection<Node> Nodes { get; }
 
@@ -17,7 +17,7 @@ namespace Elasticsearch.Net
 		/// in the connection settings
 		/// </summary>
 		int MaxRetries { get; }
-		
+
 		/// <summary>
 		/// Signals that this implemenation can accept new nodes
 		/// </summary>

--- a/src/Elasticsearch.Net/ConnectionPool/Node.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/Node.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Purify;
 
 namespace Elasticsearch.Net
@@ -32,11 +34,21 @@ namespace Elasticsearch.Net
 		/// <summary>Indicates whether this node is master eligible, defaults to true when unknown/unspecified</summary>
 		public bool MasterEligible { get; set; }
 
+		/// <summary>Indicates whether this node is allowed to run ingest pipelines, defaults to true when unknown/unspecified</summary>
+		public bool IngestEnabled { get; set; }
+
+		public bool MasterOnlyNode => this.MasterEligible && !this.HoldsData;
+
+		public bool ClientNode => !this.MasterEligible && !this.HoldsData;
+
 		/// <summary>The id of the node, defaults to null when unknown/unspecified</summary>
 		public string Id { get; set; }
 
 		/// <summary>The name of the node, defaults to null when unknown/unspecified</summary>
 		public string Name { get; set; }
+
+		private static readonly IReadOnlyDictionary<string, string> EmptySettings = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+		public IReadOnlyDictionary<string, string> Settings { get; set; } = EmptySettings;
 
 		/// <summary> The number of failed attempts trying to use this node, resets when a node is marked alive</summary>
 		public int FailedAttempts { get; private set; }
@@ -74,15 +86,17 @@ namespace Elasticsearch.Net
 				MasterEligible = this.MasterEligible,
 				FailedAttempts = this.FailedAttempts,
 				DeadUntil = this.DeadUntil,
-				IsAlive = this.IsAlive
+				IsAlive = this.IsAlive,
+				Settings = this.Settings,
+				IngestEnabled = this.IngestEnabled,
+				HttpEnabled = this.HttpEnabled
 			};
 
 
-		// ReSharper disable once PossibleNullReferenceException
-		public static bool operator ==(Node left, Node right) => left.Equals(right);
+		public static bool operator ==(Node left, Node right) =>
+			ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
 
-		// ReSharper disable once PossibleNullReferenceException
-		public static bool operator !=(Node left, Node right) => !left.Equals(right);
+		public static bool operator !=(Node left, Node right) => !(left == right);
 
 		public static implicit operator Node(Uri uri) => new Node(uri);
 

--- a/src/Elasticsearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
@@ -5,21 +5,31 @@ namespace Elasticsearch.Net
 {
 	public class SingleNodeConnectionPool : IConnectionPool
 	{
+		/// <inheritdoc/>
 		public int MaxRetries => 0;
 
+		/// <inheritdoc/>
 		public bool SupportsReseeding => false;
+
+		/// <inheritdoc/>
 		public bool SupportsPinging => false;
 
+		/// <inheritdoc/>
 		public void Reseed(IEnumerable<Node> nodes) { } //ignored
-		
+
+		/// <inheritdoc/>
 		public bool UsingSsl { get; }
 
+		/// <inheritdoc/>
 		public bool SniffedOnStartup { get { return true; } set {  } }
 
+		/// <inheritdoc/>
 		public IReadOnlyCollection<Node> Nodes { get; }
 
+		/// <inheritdoc/>
 		public DateTime LastUpdate { get; }
 
+		/// <inheritdoc/>
 		public SingleNodeConnectionPool(Uri uri, IDateTimeProvider dateTimeProvider = null)
 		{
 			var node = new Node(uri);
@@ -28,6 +38,7 @@ namespace Elasticsearch.Net
 			this.LastUpdate = (dateTimeProvider ?? DateTimeProvider.Default).Now();
 		}
 
+		/// <inheritdoc/>
 		public IEnumerable<Node> CreateView(Action<AuditEvent, Node> audit = null) => this.Nodes;
 
 		void IDisposable.Dispose() => this.DisposeManagedResources();

--- a/src/Elasticsearch.Net/ConnectionPool/SniffingConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/SniffingConnectionPool.cs
@@ -9,7 +9,10 @@ namespace Elasticsearch.Net
 	{
 		private readonly ReaderWriterLockSlim _readerWriter = new ReaderWriterLockSlim();
 
+		/// <inheritdoc/>
 		public override bool SupportsReseeding => true;
+
+		/// <inheritdoc/>
 		public override bool SupportsPinging => true;
 
 		public SniffingConnectionPool(IEnumerable<Uri> uris, bool randomize = true, IDateTimeProvider dateTimeProvider = null)
@@ -20,6 +23,13 @@ namespace Elasticsearch.Net
 			: base(nodes, randomize, dateTimeProvider)
 		{ }
 
+		public SniffingConnectionPool(IEnumerable<Node> nodes, Func<Node, bool> predicate, bool randomize = true, IDateTimeProvider dateTimeProvider = null)
+			: base(nodes, randomize, dateTimeProvider)
+		{ }
+
+		private static bool DefaultPredicate(Node node) => !node.MasterOnlyNode;
+
+		/// <inheritdoc/>
 		public override IReadOnlyCollection<Node> Nodes
 		{
 			get
@@ -38,6 +48,7 @@ namespace Elasticsearch.Net
 			}
 		}
 
+		/// <inheritdoc/>
 		public override void Reseed(IEnumerable<Node> nodes)
 		{
 			if (!nodes.HasAny()) return;
@@ -60,6 +71,7 @@ namespace Elasticsearch.Net
 			}
 		}
 
+		/// <inheritdoc/>
 		public override IEnumerable<Node> CreateView(Action<AuditEvent, Node> audit = null)
 		{
 			try

--- a/src/Elasticsearch.Net/ConnectionPool/StaticConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/StaticConnectionPool.cs
@@ -13,19 +13,27 @@ namespace Elasticsearch.Net
 
 		protected List<Node> InternalNodes { get; set; }
 
+		/// <inheritdoc/>
 		public virtual IReadOnlyCollection<Node> Nodes => this.InternalNodes;
 
+		/// <inheritdoc/>
 		public int MaxRetries => this.InternalNodes.Count - 1;
 
+		/// <inheritdoc/>
 		public virtual bool SupportsReseeding => false;
+		/// <inheritdoc/>
 		public virtual bool SupportsPinging => true;
 
+		/// <inheritdoc/>
 		public virtual void Reseed(IEnumerable<Node> nodes) { } //ignored
 
+		/// <inheritdoc/>
 		public bool UsingSsl { get; }
 
+		/// <inheritdoc/>
 		public bool SniffedOnStartup { get; set; }
 
+		/// <inheritdoc/>
 		public DateTime LastUpdate { get; protected set; }
 
 		public StaticConnectionPool(IEnumerable<Uri> uris, bool randomize = true, IDateTimeProvider dateTimeProvider = null)

--- a/src/Elasticsearch.Net/Exceptions/ElasticsearchClientException.cs
+++ b/src/Elasticsearch.Net/Exceptions/ElasticsearchClientException.cs
@@ -44,8 +44,9 @@ namespace Elasticsearch.Net
 				{
 					failureReason = "Unrecoverable/Unexpected " + this.AuditTrail.Last().Event.GetStringValue();
 				}
+				var path = Request.Uri != null ? Request.Uri.ToString() : Request.Path + " on an empty node, likely a node predicate on ConnectionSettings not matching ANY nodes";
 
-				sb.AppendLine($"# FailureReason: {failureReason} while attempting {Request.Method.GetStringValue()} {Request.Uri}");
+				sb.AppendLine($"# FailureReason: {failureReason} while attempting {Request.Method.GetStringValue()} on {path}");
 				if (this.Response != null)
 					ResponseStatics.DebugInformationBuilder(this.Response, sb);
 				else

--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -48,7 +48,7 @@ namespace Elasticsearch.Net
 				sb.Append($" - [{a.i + 1}] {audit.Event.GetStringValue()}:");
 				if (audit.Node?.Uri != null) sb.Append($" Node: {audit.Node.Uri}");
 				if (audit.Exception != null) sb.Append($" Exception: {audit.Exception.GetType().Name}");
-				sb.AppendLine($" Took: {(audit.Ended - audit.Started)}");
+				sb.AppendLine($" Took: {(audit.Ended - audit.Started).ToString()}");
 			}
 		}
 	}

--- a/src/Elasticsearch.Net/Transport/Pipeline/IRequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/IRequestPipeline.cs
@@ -45,5 +45,7 @@ namespace Elasticsearch.Net
 
 		void BadResponse<TReturn>(ref ElasticsearchResponse<TReturn> response, RequestData requestData, List<PipelineException> seenExceptions)
 			where TReturn : class;
+
+		void ThrowNoNodesAttempted(RequestData requestData, List<PipelineException> seenExceptions);
 	}
 }

--- a/src/Elasticsearch.Net/Transport/Pipeline/PipelineFailure.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/PipelineFailure.cs
@@ -10,6 +10,7 @@
 		MaxTimeoutReached,
 		MaxRetriesReached,
 		Unexpected,
-		BadRequest
+		BadRequest,
+		NoNodesAttempted
 	}
 }

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -12,7 +12,7 @@ namespace Elasticsearch.Net
 		public const string MimeType = "application/json";
 		public const string RunAsSecurityHeader = "es-security-runas-user";
 
-		public Uri Uri => new Uri(this.Node.Uri, this.Path).Purify();
+		public Uri Uri => this.Node != null ? new Uri(this.Node.Uri, this.Path).Purify() : null;
 
 		public HttpMethod Method { get; private set; }
 		public string Path { get; }

--- a/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
+++ b/src/Elasticsearch.Net/Transport/Sniff/SniffResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -46,13 +47,14 @@ namespace Elasticsearch.Net
 				var uri = SniffParser.ParseToUri(httpEndpoint, forceHttp);
 				var node = new Node(uri)
 				{
-					Name = kv.Value.name,
+					Name = info.name,
 					Id = kv.Key,
-					MasterEligible = kv.Value.MasterEligible,
-					HoldsData = kv.Value.HoldsData,
-					HttpEnabled = kv.Value.HttpEnabled
+					MasterEligible = info.MasterEligible,
+					HoldsData = info.HoldsData,
+					IngestEnabled = info.IngestEnabled,
+					HttpEnabled = info.HttpEnabled,
+					Settings = new ReadOnlyDictionary<string, string>(info.settings)
 				};
-				//TODO selector
 				yield return node;
 			}
 		}
@@ -72,6 +74,7 @@ namespace Elasticsearch.Net
 
 		internal bool MasterEligible => this.roles?.Contains("master") ?? false;
 		internal bool HoldsData => this.roles?.Contains("data") ?? false;
+		internal bool IngestEnabled => this.roles?.Contains("ingest") ?? false;
 		internal bool HttpEnabled
 		{
 			get

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -97,6 +97,9 @@ namespace Elasticsearch.Net
 					pipeline.MarkAlive(node);
 					break;
 				}
+				if (requestData.Node == null) //foreach never ran
+					pipeline.ThrowNoNodesAttempted(requestData, seenExceptions);
+
 				if (response == null || !response.Success)
 					pipeline.BadResponse(ref response, requestData, seenExceptions);
 
@@ -156,6 +159,9 @@ namespace Elasticsearch.Net
 					pipeline.MarkAlive(node);
 					break;
 				}
+				if (requestData.Node == null) //foreach never ran
+					pipeline.ThrowNoNodesAttempted(requestData, seenExceptions);
+
 				if (response == null || !response.Success)
 					pipeline.BadResponse(ref response, requestData, seenExceptions);
 

--- a/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
@@ -11,7 +12,7 @@ using Tests.Framework.Integration;
 using Tests.Framework.Versions;
 using Xunit;
 using static Tests.Framework.TimesHelper;
-using System.Threading;
+using static Elasticsearch.Net.AuditEvent;
 
 namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 {
@@ -35,13 +36,13 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 				.AllDefaults()
 			)
 			{
-				AssertPoolBeforeCall = (pool) =>
+				AssertPoolBeforeStartup = (pool) =>
 				{
 					pool.Should().NotBeNull();
 					pool.Nodes.Should().HaveCount(10);
 					pool.Nodes.Where(n => n.MasterEligible).Should().HaveCount(10);
 				},
-				AssertPoolAfterCall = (pool) =>
+				AssertPoolAfterStartup = (pool) =>
 				{
 					pool.Should().NotBeNull();
 					pool.Nodes.Should().HaveCount(8);
@@ -64,14 +65,14 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 				.AllDefaults()
 			)
 			{
-				AssertPoolBeforeCall = (pool) =>
+				AssertPoolBeforeStartup = (pool) =>
 				{
 					pool.Should().NotBeNull();
 					pool.Nodes.Should().HaveCount(10);
 					pool.Nodes.Where(n => n.HoldsData).Should().HaveCount(10);
 				},
 
-				AssertPoolAfterCall = (pool) =>
+				AssertPoolAfterStartup = (pool) =>
 				{
 					pool.Should().NotBeNull();
 					pool.Nodes.Should().HaveCount(8);
@@ -93,7 +94,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 				.AllDefaults()
 			)
 			{
-				AssertPoolBeforeCall = (pool) =>
+				AssertPoolBeforeStartup = (pool) =>
 				{
 					pool.Should().NotBeNull();
 					pool.Nodes.Should().HaveCount(10);
@@ -102,15 +103,166 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 					pool.Nodes.Should().OnlyContain(n => n.Uri.Host == "localhost");
 				},
 
-				AssertPoolAfterCall = (pool) =>
+				AssertPoolAfterStartup = (pool) =>
 				{
 					pool.Should().NotBeNull();
-					pool.Nodes.Should().HaveCount(7, "we filtered the node that stores no data");
+					pool.Nodes.Should().HaveCount(7, "we filtered the node that has no http enabled");
 					pool.Nodes.Should().NotContain(n=>n.Uri.Port == 9201);
 					pool.Nodes.Where(n => n.HoldsData).Should().HaveCount(5);
 				}
 			};
 			await audit.TraceStartup();
+		}
+
+		[U, SuppressMessage("AsyncUsage", "AsyncFixer001:Unnecessary async/await usage", Justification = "Its a test")]
+		public async Task SkipMasterOnlyNodes()
+		{
+			var masterNodes = new[] {9200, 9201, 9202};
+			var totalNodesInTheCluster = 20;
+			//We create a client with a sniffing node connectionpool that seeds all the known master nodes
+			var audit = new Auditor(() => Framework.Cluster
+				.MasterOnlyNodes(masterNodes.Length)
+				// When the client sniffs on startup we see the cluster is 20 nodes in total
+				.Sniff(s => s.SucceedAlways()
+					.Succeeds(Always, Framework.Cluster.Nodes(totalNodesInTheCluster).StoresNoData(masterNodes).MasterEligible(masterNodes))
+				)
+				.SniffingConnectionPool()
+				.Settings(s=>s.DisablePing()) //for testing simplicity we disable pings
+			)
+			{
+				// before the sniff assert we only see three master only nodes
+				AssertPoolBeforeStartup = (pool) =>
+				{
+					pool.Should().NotBeNull();
+					pool.Nodes.Should().HaveCount(3, "we seeded 3 master only nodes at the start of the application");
+					pool.Nodes.Where(n => n.HoldsData).Should().HaveCount(0, "none of which hold data");
+				},
+				// after sniff assert we now know about the existence of 20 nodes.
+				AssertPoolAfterStartup = (pool) =>
+				{
+					pool.Should().NotBeNull();
+					var nodes = pool.CreateView().ToList();
+					nodes.Count().Should().Be(20, "Master nodes are included in the registration of nodes since we still favor sniffing on them");
+				}
+			};
+			// assert that the sniff happened on 9200 before the first API call and that api call hit the first none master eligable node
+			audit = await audit.TraceStartup(new ClientCall
+			{
+				{ SniffSuccess, 9200},
+				{ HealthyResponse, 9203}
+			});
+
+			//now we do a 1000 different client calls and we assert on each that it was not send to any of the known master only nodes
+			var seenNodes = new HashSet<int>();
+			foreach (var _ in Enumerable.Range(0, 1000))
+			{
+				audit = await audit.TraceCalls(
+					new ClientCall {{HealthyResponse, (a) =>
+					{
+						var port = a.Node.Uri.Port;
+						masterNodes.Should().NotContain(port);
+						seenNodes.Add(port);
+					}}}
+				);
+			}
+			//seen nodes is a hash set of all the ports we hit, we assert that this is the known total nodes - the known master only nodes
+			seenNodes.Should().HaveCount(totalNodesInTheCluster - masterNodes.Length);
+		}
+
+		[U, SuppressMessage("AsyncUsage", "AsyncFixer001:Unnecessary async/await usage", Justification = "Its a test")]
+		public async Task RespectsCustomPredicate()
+		{
+			var totalNodesInTheCluster = 20;
+			var setting = "node.attr.rack_id";
+			var value = "rack_one";
+			var nodesInRackOne = new[] {9204, 9210, 9213};
+
+			//We create a client with a sniffing node connectionpool that seeds all 20 nodes
+			var audit = new Auditor(() => Framework.Cluster
+				.Nodes(totalNodesInTheCluster)
+				// When the client sniffs on startup we see the cluster is still 20 nodes in total
+				// However we are now aware of the actual configured settings on the nodes
+				.Sniff(s => s.SucceedAlways()
+					.Succeeds(Always, Framework.Cluster.Nodes(totalNodesInTheCluster).HasSetting(setting, value, nodesInRackOne))
+				)
+				.SniffingConnectionPool()
+				.Settings(s=>s
+					.DisablePing() //for testing simplicity we disable pings
+					//We only want to execute API calls to nodes in rack_one
+					.NodePredicate(node=>node.Settings.ContainsKey(setting) && node.Settings[setting] == value)
+				)
+			)
+			{
+				AssertPoolAfterStartup = (pool) =>
+				{
+					pool.Should().NotBeNull();
+					var nodes = pool.CreateView().ToList();
+					nodes.Count(n => n.Settings.ContainsKey(setting)).Should().Be(3, "only three nodes are in rack_one");
+				}
+			};
+			// assert that the sniff happened on 9200 before the first API call and that api call hit the first node in rack_one
+			audit = await audit.TraceStartup(new ClientCall
+			{
+				{ SniffSuccess, 9200},
+				{ HealthyResponse, 9204}
+			});
+
+			//now we do a 1000 different client calls and we assert on each that it was sent to a node in rack one only
+			//respecting our node predicate on connection settings
+			var seenNodes = new HashSet<int>();
+			foreach (var _ in Enumerable.Range(0, 1000))
+			{
+				audit = await audit.TraceCalls(
+					new ClientCall {{HealthyResponse, (a) =>
+					{
+						var port = a.Node.Uri.Port;
+						nodesInRackOne.Should().Contain(port);
+						seenNodes.Add(port);
+					}}}
+				);
+			}
+			//assert we hit all the nodes in rack one when we fired off a 1000 api calls.
+			seenNodes.Should().HaveCount(nodesInRackOne.Length);
+		}
+
+		[U, SuppressMessage("AsyncUsage", "AsyncFixer001:Unnecessary async/await usage", Justification = "Its a test")]
+		public async Task CustomPredicateYieldingNothingThrows()
+		{
+			var totalNodesInTheCluster = 20;
+
+			//We create a client with a sniffing node connectionpool that seeds all 20 nodes and returns all 20 on sniff
+			var audit = new Auditor(() => Framework.Cluster
+				.Nodes(totalNodesInTheCluster)
+				.Sniff(s => s.SucceedAlways()
+					.Succeeds(Always, Framework.Cluster.Nodes(totalNodesInTheCluster))
+				)
+				.SniffingConnectionPool()
+				.Settings(s => s
+					.DisablePing()
+					// evil predicate that declines ALL nodes
+					.NodePredicate(node => false)
+				)
+			);
+
+			await audit.TraceUnexpectedElasticsearchException(new ClientCall
+			{
+				{ SniffOnStartup }, //audit logs we are sniffing for the very very first time one startup
+				{ SniffSuccess }, //this goes ok because we ignore predicate when sniffing
+				{ NoNodesAttempted } //when trying to do an actual API call the predicate prevents any nodes from being attempted
+			}, e =>
+			{
+				e.FailureReason.Should().Be(PipelineFailure.Unexpected);
+				//generating the debug information should not throw
+				Func<string> debug = () => e.DebugInformation;
+				debug.Invoking(s =>s()).ShouldNotThrow();
+				/* EXAMPLE OF PREVIOUS
+# FailureReason: Unrecoverable/Unexpected NoNodesAttempted while attempting POST on default-index/project/_search on an empty node, likely a node predicate on ConnectionSettings not matching ANY nodes
+ - [1] SniffOnStartup: Took: 00:00:00
+ - [2] SniffSuccess: Node: http://localhost:9200/ Took: 00:00:00
+ - [3] NoNodesAttempted: Took: 00:00:00
+# Inner Exception: No nodes were attempted, this can happen when a node predicate does not match any nodes
+				*/
+			});
 		}
 
 		[U, SuppressMessage("AsyncUsage", "AsyncFixer001:Unnecessary async/await usage", Justification = "Its a test")]
@@ -125,7 +277,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 				.AllDefaults()
 			)
 			{
-				AssertPoolBeforeCall = (pool) =>
+				AssertPoolBeforeStartup = (pool) =>
 				{
 					pool.Should().NotBeNull();
 					pool.Nodes.Should().HaveCount(10);
@@ -133,7 +285,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 					pool.Nodes.Should().OnlyContain(n => n.Uri.Host == "localhost");
 				},
 
-				AssertPoolAfterCall = (pool) =>
+				AssertPoolAfterStartup = (pool) =>
 				{
 					pool.Should().NotBeNull();
 					pool.Nodes.Should().HaveCount(8);
@@ -157,6 +309,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 				{
 					$"{es}node.data=false",
 					$"{es}node.master=true",
+					$"{es}node.attr.rack_id=rack_one"
 				};
 			}
 		}
@@ -179,10 +332,12 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 			var node = SniffAndReturnNode();
 			node.MasterEligible.Should().BeTrue();
 			node.HoldsData.Should().BeFalse();
+			node.Settings.Should().NotBeEmpty().And.Contain("node.attr.rack_id", "rack_one");
 
 			node = await SniffAndReturnNodeAsync();
 			node.MasterEligible.Should().BeTrue();
 			node.HoldsData.Should().BeFalse();
+			node.Settings.Should().NotBeEmpty().And.Contain("node.attr.rack_id", "rack_one");
 		}
 
 		private Node SniffAndReturnNode()

--- a/src/Tests/Framework/VirtualClustering/Cluster.cs
+++ b/src/Tests/Framework/VirtualClustering/Cluster.cs
@@ -12,6 +12,13 @@ namespace Tests.Framework
 				Enumerable.Range(startFrom, numberOfNodes).Select(n => new Node(new Uri($"http://localhost:{n}")))
 			);
 
+		public static VirtualCluster MasterOnlyNodes(int numberOfNodes, int startFrom = 9200) =>
+			new VirtualCluster(
+				Enumerable.Range(startFrom, numberOfNodes)
+					.Select(n=>new Node(new Uri($"http://localhost:{n}")) { HoldsData = false, MasterEligible = true})
+			);
+
+
 		public static VirtualCluster Nodes(IEnumerable<Node> nodes) =>
 			new VirtualCluster(nodes);
 	}

--- a/src/Tests/Framework/VirtualClustering/MockResponses/SniffingResponse.cs
+++ b/src/Tests/Framework/VirtualClustering/MockResponses/SniffingResponse.cs
@@ -36,6 +36,13 @@ namespace Tests.Framework.MockResponses
 			var fqdn = randomFqdn ? $"fqdn{port}/" : "";
 			var host = !string.IsNullOrWhiteSpace(publishAddressOverride) ? publishAddressOverride : "127.0.0.1";
 
+			var settings = new Dictionary<string, object>
+			{
+				{"cluster.name", ClusterName},
+				{"node.name", name}
+			};
+			foreach (var kv in node.Settings) settings[kv.Key] = kv.Value;
+
 			var nodeResponse = new
 			{
 				name = name,
@@ -54,14 +61,11 @@ namespace Tests.Framework.MockResponses
 					//publish_address = $"{fqdn}${publishAddress}"
 					publish_address = $"{fqdn}{host}:{port}"
 				} : null,
-				settings = new Dictionary<string, object>
-				{
-					{ "cluster.name", ClusterName },
-					{ "node.name", name }
-				}
+				settings = settings
 			};
 			if (node.MasterEligible) nodeResponse.roles.Add("master");
 			if (node.HoldsData) nodeResponse.roles.Add("data");
+			if (node.IngestEnabled) nodeResponse.roles.Add("ingest");
 			if (!node.HttpEnabled)
 				nodeResponse.settings.Add("http.enabled", false);
 			return nodeResponse;

--- a/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Elasticsearch.Net;
 
@@ -50,6 +51,12 @@ namespace Tests.Framework
 		{
 			foreach (var node in this._nodes.Where(n => ports.Contains(n.Uri.Port)))
 				node.HoldsData = false;
+			return this;
+		}
+		public VirtualCluster HasSetting(string key, string value, params int[] ports)
+		{
+			foreach (var node in this._nodes.Where(n => ports.Contains(n.Uri.Port)))
+				node.Settings = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>{{key, value}});
 			return this;
 		}
 		public VirtualCluster HttpDisabled(params int[] ports)


### PR DESCRIPTION
You can now set `NodePredicate(Func<Node, bool> filter)` on `ConnectionSettings`. 

This allows you to control which nodes are considered targets in the `RequestPipeline` for *normal* Elasticsearch API calls. Sniffing in the `RequestPipeline` does not take this predicate into account allowing you to seed your `SniffingConnectionPool` with master nodes and have it sniff on startup afterwhich none of the API calls will touch the master nodes.

The default predicate for any `IConnectionPool` that supports reseeding of nodes (`SniffingConnectionPool`) is to filter out `master only` nodes. 

For those that don't `SingleNode-, Static-, StickyConnectionPool et all) the default `NodePredicate` returns true for all nodes, assuming the list of nodes you pass are correct from the get go.

Our `Node` type returns a bunch of interesting information so you could use it to sniff all the warm or cold nodes in the cluster and only talk to those for instance. 

See the > [tests](https://github.com/elastic/elasticsearch-net/blob/2a4ac8b214df2f109074e983473a4f29fde1c80c/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs#L118) <  for more examples. 

We also protect against a predicate filtering out all the nodes by throwing a new `UnexpectedElasticsearchClientException()` where its`DebugInformation` fully explaina what just happened.

cc @bleskes @gmoskovicz and @ppf2 (whom i too easily dismissed on #1322, while sub classing SniffingConnectionPool and overriding `Reseed` was **A** solution its far from pretty).







