### PR TITLE
Tests: Multiple cluster and exclusive filtering support

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -72,7 +72,7 @@ IF /I "%TARGET%"=="forever" (
 )
 IF /I "%TARGET%"=="integrate" (
 	IF NOT [%2]==[] (set ESVERSIONS="%2")
-	IF NOT [%3]==[] (set NEST_INTEGRATION_CLUSTER="%3")
+	IF NOT [%3]==[] (set NEST_INTEGRATION_CLUSTER="%~3")
 	IF NOT [%4]==[] (set NEST_TEST_FILTER="%4")
 	IF /I "%JAVA_HOME%"=="" (
 	   ECHO JAVA_HOME not set exiting integration tests early!


### PR DESCRIPTION
This PR makes it possible to filter by multiple clusters when running
integration tests and also exclude specific clusters, where previously
cluster filtering was inclusive only.

Examples:

Run readonly tests only (unchanged):

```build integrate 5.2.1 readonly```

Run readonly and writable tests only:

```buld integrate 5.2.1 "readonly,writable"```

Note the quotation marks.  These are required when passing multiple
cluster names due to how bat arguments are processed (commas are treated
like spaces).

Run all tests except xpack:

```build integrate 5.2.1 -xpack```

Run all tests except xpack and intrusiveoperation:

```build integrate 5.2.1 "-xpack,-intrusiveoperation"```

NOTE: both including and excluding clusters is redundant, but we do not throw
an exception.  For instance:

```build integrate 5.2.1 "readonly,-xpack"```

is equivalent to just

```build integrate 5.2.1 readonly```

Relates #2633