### PR TITLE
Fix for covariant search date parsing

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/StatefulDeserialization/ConcreteTypeConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/StatefulDeserialization/ConcreteTypeConverter.cs
@@ -95,6 +95,12 @@ namespace Nest
 		private static JObject CreateIntermediateJObject(JsonReader reader)
 		{
 			var original = reader.DateParseHandling;
+			// Temporarily turn off DateTime parsing since we deserialize
+			// to a dynamic object and the date could be stored as a string
+			// in the users POCO and we need to preserve its format. This is
+			// side-effect free since we read the reader to completion using
+			// JObject.Load before handing off a new one to the deserialized
+			// hit object.
 			reader.DateParseHandling = DateParseHandling.None;
 			var jObject = JObject.Load(reader);
 			reader.DateParseHandling = original;

--- a/src/Nest/CommonAbstractions/SerializationBehavior/StatefulDeserialization/ConcreteTypeConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/StatefulDeserialization/ConcreteTypeConverter.cs
@@ -94,7 +94,10 @@ namespace Nest
 
 		private static JObject CreateIntermediateJObject(JsonReader reader)
 		{
+			var original = reader.DateParseHandling;
+			reader.DateParseHandling = DateParseHandling.None;
 			var jObject = JObject.Load(reader);
+			reader.DateParseHandling = original;
 			return jObject;
 		}
 

--- a/src/Tests/Reproduce/CovariantSearchDateParsing.cs
+++ b/src/Tests/Reproduce/CovariantSearchDateParsing.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using Nest;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Tests.Framework;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using Xunit;
+
+namespace Tests.Reproduce
+{
+	public class CovariantSearchDateParsing : IClusterFixture<WritableCluster>
+	{
+		public interface ISearchResult
+		{
+			DateTime Date { get; set; }
+			string DateAsString { get; set; }
+		}
+
+		public class SearchResult : ISearchResult
+		{
+			public DateTime Date { get; set; }
+			public string DateAsString { get; set; }
+		}
+
+		private readonly WritableCluster _cluster;
+
+		public CovariantSearchDateParsing(WritableCluster cluster)
+		{
+			_cluster = cluster;
+		}
+
+		[I] public void CovariantSearchDateParsingTest()
+		{
+			var client = _cluster.Client;
+			var index = "convariantsearchconverstiontest";
+			if (client.IndexExists(index).Exists)
+				client.DeleteIndex(index);
+
+			var date = "2013-06-24T00:00:00.000";
+			var indexResult = client.Index(new SearchResult { DateAsString = date, Date = DateTime.Parse(date) }, i => i.Id(1).Index(index));
+			indexResult.IsValid.Should().BeTrue();
+			client.Refresh(Nest.Indices.All);
+			var response = client.Search<ISearchResult>(new SearchRequest<ISearchResult>(index, typeof(SearchResult)));
+			response.IsValid.Should().BeTrue();
+			response.Documents.Count.Should().Be(1);
+			var document = response.Documents.SingleOrDefault();
+			document.Should().NotBeNull();
+			document.DateAsString.Should().Be(date);
+			document.Date.ShouldBeEquivalentTo(DateTime.Parse(date));
+		}
+	}
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -711,6 +711,7 @@
     <Compile Include="QueryDsl\NotConditionlessWhen.cs" />
     <Compile Include="QueryDsl\Specialized\Percolate\PercolateQueryUsageTests.cs" />
     <Compile Include="Reproduce\ConnectionReuseAndBalancing.cs" />
+    <Compile Include="Reproduce\CovariantSearchDateParsing.cs" />
     <Compile Include="Reproduce\DateSerialization.cs" />
     <Compile Include="Reproduce\GithubIssue2152.cs" />
     <Compile Include="Reproduce\GithubIssue2306.cs" />


### PR DESCRIPTION
This commit fixes an issue where indexing dates as strings and pulling
them back out using covariant search would result in the format being
different due to the default DateParseHandling serialization settings.

ConcereteTypeConverter now temporarily sets DateParseHandling to None
when deserializing covariant results.

/cc @gmoskovicz 