### PR TITLE
Modified ForEachAsync to release items as processed

### DIFF
--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -206,11 +206,11 @@ namespace Nest
 
 		internal static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> xs) => xs ?? new T[0];
 
-		internal static Task ForEachAsync<TSource, TResult>(
+		internal static async Task ForEachAsync<TSource, TResult>(
 			this IEnumerable<TSource> lazyList,
 			Func<TSource, long, Task<TResult>> taskSelector,
 			Action<TSource, TResult> resultProcessor,
-			Action<Task> done,
+			Action<Exception> done,
 			int maxDegreeOfParallelism,
 			SemaphoreSlim additionalRateLimitter = null
 		)
@@ -218,10 +218,27 @@ namespace Nest
 			var semaphore = new SemaphoreSlim(initialCount: maxDegreeOfParallelism, maxCount: maxDegreeOfParallelism);
 			long page = 0;
 
-			return Task.WhenAll(
-					from item in lazyList
-					select ProcessAsync<TSource, TResult>(item, taskSelector, resultProcessor, semaphore, additionalRateLimitter, page++)
-				).ContinueWith(done);
+			try
+			{
+				var tasks = new List<Task>();
+				foreach (var item in lazyList)
+				{
+					tasks.Add(ProcessAsync<TSource, TResult>(item, taskSelector, resultProcessor, semaphore, additionalRateLimitter, page++));
+					if (tasks.Count <= maxDegreeOfParallelism)
+						continue;
+
+					var task = await Task.WhenAny(tasks);
+					tasks.Remove(task);
+				}
+
+				await Task.WhenAll(tasks);
+				done(null);
+			}
+			catch (Exception e)
+			{
+				done(e);
+				throw;
+			}
 		}
 
 		private static async Task ProcessAsync<TSource, TResult>(

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
@@ -128,19 +128,15 @@ namespace Nest
 			finally { _scrollInitiationLock.Release(); }
 		}
 
-		private static void OnCompleted(Task task, IObserver<IScrollAllResponse<T>> observer)
+		private static void OnCompleted(Exception exception, IObserver<IScrollAllResponse<T>> observer)
 		{
-			switch (task.Status)
+			if (exception == null)
 			{
-				case System.Threading.Tasks.TaskStatus.RanToCompletion:
-					observer.OnCompleted();
-					break;
-				case System.Threading.Tasks.TaskStatus.Faulted:
-					observer.OnError(task.Exception.InnerException);
-					break;
-				case System.Threading.Tasks.TaskStatus.Canceled:
-					observer.OnError(new TaskCanceledException(task));
-					break;
+				observer.OnCompleted();
+			}
+			else
+			{
+				observer.OnError(exception);
 			}
 		}
 


### PR DESCRIPTION
#2644

Memory leak is caused by WhenAll that expects all of the tasks in the
bulk operations to complete to further invoke done() delegate in
ForEachAsync. Referencing all of the tasks in WhenAll causes them to
prevent GC from collecting processed items.