### PR TITLE
Continuation of #2648 

### DIFF
--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -206,11 +206,11 @@ namespace Nest
 
 		internal static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> xs) => xs ?? new T[0];
 
-		internal static Task ForEachAsync<TSource, TResult>(
+		internal static async Task ForEachAsync<TSource, TResult>(
 			this IEnumerable<TSource> lazyList,
 			Func<TSource, long, Task<TResult>> taskSelector,
 			Action<TSource, TResult> resultProcessor,
-			Action<Task> done,
+			Action<Exception> done,
 			int maxDegreeOfParallelism,
 			SemaphoreSlim additionalRateLimitter = null
 		)
@@ -218,10 +218,27 @@ namespace Nest
 			var semaphore = new SemaphoreSlim(initialCount: maxDegreeOfParallelism, maxCount: maxDegreeOfParallelism);
 			long page = 0;
 
-			return Task.WhenAll(
-					from item in lazyList
-					select ProcessAsync<TSource, TResult>(item, taskSelector, resultProcessor, semaphore, additionalRateLimitter, page++)
-				).ContinueWith(done);
+			try
+			{
+				var tasks = new List<Task>();
+				foreach (var item in lazyList)
+				{
+					tasks.Add(ProcessAsync<TSource, TResult>(item, taskSelector, resultProcessor, semaphore, additionalRateLimitter, page++));
+					if (tasks.Count <= maxDegreeOfParallelism)
+						continue;
+
+					var task = await Task.WhenAny(tasks);
+					tasks.Remove(task);
+				}
+
+				await Task.WhenAll(tasks);
+				done(null);
+			}
+			catch (Exception e)
+			{
+				done(e);
+				throw;
+			}
 		}
 
 		private static async Task ProcessAsync<TSource, TResult>(

--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -223,7 +223,7 @@ namespace Nest
 				var tasks = new List<Task>();
 				foreach (var item in lazyList)
 				{
-					tasks.Add(ProcessAsync<TSource, TResult>(item, taskSelector, resultProcessor, semaphore, additionalRateLimitter, page++));
+					tasks.Add(ProcessAsync(item, taskSelector, resultProcessor, semaphore, additionalRateLimitter, page++));
 					if (tasks.Count <= maxDegreeOfParallelism)
 						continue;
 
@@ -255,10 +255,6 @@ namespace Nest
 			{
 				var result = await taskSelector(item, page).ConfigureAwait(false);
 				resultProcessor(item, result);
-			}
-			catch
-			{
-				throw;
 			}
 			finally
 			{

--- a/src/Nest/CommonAbstractions/Reactive/BlockingSubscribeExtensions.cs
+++ b/src/Nest/CommonAbstractions/Reactive/BlockingSubscribeExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+
+namespace Nest
+{
+	public static class BlockingSubscribeExtensions
+	{
+		public static BulkAllObserver Wait<T>(this BulkAllObservable<T> observable, TimeSpan maximumRunTime, Action<IBulkAllResponse> onNext)
+			where T : class =>
+			WaitOnObservable<BulkAllObservable<T>, IBulkAllResponse, BulkAllObserver>(
+				observable, maximumRunTime, (e, c) => new BulkAllObserver(onNext, e, c));
+
+		public static ScrollAllObserver<T> Wait<T>(this IObservable<IScrollAllResponse<T>> observable, TimeSpan maximumRunTime, Action<IScrollAllResponse<T>> onNext)
+			where T : class =>
+			WaitOnObservable<IObservable<IScrollAllResponse<T>>, IScrollAllResponse<T>, ScrollAllObserver<T>>(
+				observable, maximumRunTime, (e, c) => new ScrollAllObserver<T>(onNext, e, c));
+
+		public static ReindexObserver Wait(this IObservable<IBulkAllResponse> observable, TimeSpan maximumRunTime, Action<IBulkAllResponse> onNext) =>
+			WaitOnObservable<IObservable<IBulkAllResponse>, IBulkAllResponse, ReindexObserver>(
+				observable, maximumRunTime, (e, c) => new ReindexObserver(onNext, e, c));
+
+		private static TObserver WaitOnObservable<TObservable, TObserve, TObserver>(
+			TObservable observable,
+			TimeSpan maximumRunTime,
+			Func<Action<Exception>, Action, TObserver> factory
+		)
+			where TObservable : IObservable<TObserve>
+			where TObserver : IObserver<TObserve>
+		{
+			observable.ThrowIfNull(nameof(observable));
+			maximumRunTime.ThrowIfNull(nameof(maximumRunTime));
+			Exception ex = null;
+			var handle = new ManualResetEvent(false);
+			var observer = factory(
+				e =>
+				{
+					ex = e;
+					handle.Set();
+				},
+				() => handle.Set()
+			);
+			observable.Subscribe(observer);
+			handle.WaitOne(maximumRunTime);
+			if (ex != null) throw ex;
+			return observer;
+		}
+	}
+}

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
@@ -22,7 +22,7 @@ namespace Nest
 		private readonly ProducerConsumerBackPressure _backPressure;
 
 		public ScrollAllObservable(
-			IElasticClient client, 
+			IElasticClient client,
 			IScrollAllRequest scrollAllRequest,
 			CancellationToken cancellationToken = default(CancellationToken)
 			)
@@ -41,14 +41,7 @@ namespace Nest
 		public IDisposable Subscribe(IObserver<IScrollAllResponse<T>> observer)
 		{
 			observer.ThrowIfNull(nameof(observer));
-			try
-			{
-				this.ScrollAll(observer);
-			}
-			catch (Exception e)
-			{
-				observer.OnError(e);
-			}
+			this.ScrollAll(observer);
 			return this;
 		}
 
@@ -57,7 +50,9 @@ namespace Nest
 			var slices = this._scrollAllRequest.Slices;
 			var maxSlicesAtOnce = this._scrollAllRequest.MaxDegreeOfParallelism ?? this._scrollAllRequest.Slices;
 
-			Enumerable.Range(0, slices).ForEachAsync<int, bool>(
+#pragma warning disable 4014
+			Enumerable.Range(0, slices).ForEachAsync(
+#pragma warning restore 4014
 				(slice, l) => this.ScrollSliceAsync(observer, slice),
 				(slice, r) => { },
 				t => OnCompleted(t, observer),
@@ -131,13 +126,9 @@ namespace Nest
 		private static void OnCompleted(Exception exception, IObserver<IScrollAllResponse<T>> observer)
 		{
 			if (exception == null)
-			{
 				observer.OnCompleted();
-			}
 			else
-			{
 				observer.OnError(exception);
-			}
 		}
 
 		public bool IsDisposed { get; private set; }

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
@@ -128,19 +128,15 @@ namespace Nest
 			finally { _scrollInitiationLock.Release(); }
 		}
 
-		private static void OnCompleted(Task task, IObserver<IScrollAllResponse<T>> observer)
+		private static void OnCompleted(Exception exception, IObserver<IScrollAllResponse<T>> observer)
 		{
-			switch (task.Status)
+			if (exception == null)
 			{
-				case System.Threading.Tasks.TaskStatus.RanToCompletion:
-					observer.OnCompleted();
-					break;
-				case System.Threading.Tasks.TaskStatus.Faulted:
-					observer.OnError(task.Exception.InnerException);
-					break;
-				case System.Threading.Tasks.TaskStatus.Canceled:
-					observer.OnError(new TaskCanceledException(task));
-					break;
+				observer.OnCompleted();
+			}
+			else
+			{
+				observer.OnError(exception);
 			}
 		}
 

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObserver.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObserver.cs
@@ -11,4 +11,6 @@ namespace Nest
 			: base(onNext, onError, onCompleted) { }
 
 	}
+
+
 }

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -482,6 +482,7 @@
     <Compile Include="CommonAbstractions\LowLevelDispatch\IHighLevelToLowLevelDispatcher.cs" />
     <Compile Include="CommonAbstractions\LowLevelDispatch\LowLevelDispatch.cs" />
     <Compile Include="CommonAbstractions\RawJson\RawJson.cs" />
+    <Compile Include="CommonAbstractions\Reactive\BlockingSubscribeExtensions.cs" />
     <Compile Include="CommonAbstractions\Reactive\CoordinatedRequestObserverBase.cs" />
     <Compile Include="CommonAbstractions\Reactive\GetEnumerator.cs" />
     <Compile Include="CommonAbstractions\Reactive\PartitionHelper.cs" />

--- a/src/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
+++ b/src/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
@@ -123,20 +123,22 @@ namespace Tests.Document.Multiple.Reindex
 
 			Exception ex = null;
 			var manyTypesObserver = new ReindexObserver(
-				onError: (e) => { ex = e; observableWait.Signal(); throw e; },
+				onError: (e) => { ex = e; observableWait.Signal(); },
 				onCompleted: () => ReindexManyTypesCompleted(observableWait)
 			);
 
 			this._reindexManyTypesResult.Subscribe(manyTypesObserver);
+			this._reindexManyTypesResult.Wait(TimeSpan.FromMinutes(5), r => { });
+
 
 			var singleTypeObserver = new ReindexObserver(
-				onError: (e) => { ex = e; observableWait.Signal(); throw e; },
+				onError: (e) => { ex = e; observableWait.Signal(); },
 				onCompleted: () => ReindexSingleTypeCompleted(observableWait)
 			);
 			this._reindexSingleTypeResult.Subscribe(singleTypeObserver);
 
 			var projectionObserver = new ReindexObserver(
-				onError: (e) => { ex = e; observableWait.Signal(); throw e; },
+				onError: (e) => { ex = e; observableWait.Signal(); },
 				onCompleted: () => ProjectionCompleted(observableWait)
 			);
 			this._reindexProjectionResult.Subscribe(projectionObserver);

--- a/src/Tests/Framework/Xunit/TestAssemblyRunner.cs
+++ b/src/Tests/Framework/Xunit/TestAssemblyRunner.cs
@@ -122,6 +122,7 @@ namespace Xunit
 
 		private IEnumerable<string> ParseExcludedClusters(string clusterFilter)
 		{
+			if (string.IsNullOrWhiteSpace(clusterFilter)) return Enumerable.Empty<string>();
 			var clusters =
 #if DOTNETCORE
 				typeof(ClusterBase).Assembly()

--- a/src/Tests/Framework/Xunit/TestFrameworkExecutor.cs
+++ b/src/Tests/Framework/Xunit/TestFrameworkExecutor.cs
@@ -15,8 +15,17 @@ namespace Xunit
 
 		protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
 		{
-			using (var assemblyRunner = new TestAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
-				await assemblyRunner.RunAsync();
+			try
+			{
+                using (var assemblyRunner = new TestAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+                    await assemblyRunner.RunAsync();
+
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+				throw;
+			}
 		}
 	}
 }

--- a/src/Tests/tests.default.yaml
+++ b/src/Tests/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: i
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.3.0-SNAPSHOT

--- a/src/Tests/tests.default.yaml
+++ b/src/Tests/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
+mode: u
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.3.0-SNAPSHOT


### PR DESCRIPTION
@sergii-sakharov rightfully pointed out in #2648 the Task.WhenAll is not the most
resource friendly solution and replaced it with bounded list we await
WhenAny is released and then continue.

That change had impact though on the way we relied on Task.WhenAll to be
blocking and being able to catch exceptions in Subscribe. This is now no
longer possible because we return early from calling an async method.
This is fine in our case because the returned Observable allows you to
track and dispose that async process.

This also introduces Wait(TimeSpan, Action onNext) extension methods for
period and have the exceptions propagated out of the subscribe as
expected. Fixes https://github.com/elastic/elasticsearch-net/issues/2634