### PR TITLE
fix #2673 field stats on geo fields in elasticsearch 5.3

### DIFF
--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -1210,6 +1210,7 @@
     <Compile Include="Search\Explain\Explanation.cs" />
     <Compile Include="Search\Explain\ExplanationDetail.cs" />
     <Compile Include="Search\FieldStats\ElasticClient-FieldStats.cs" />
+    <Compile Include="Search\FieldStats\FieldMinMaxValueJsonConverter.cs" />
     <Compile Include="Search\FieldStats\FieldStatsRequest.cs" />
     <Compile Include="Search\FieldStats\FieldStatsResponse.cs" />
     <Compile Include="Search\FieldStats\IndexConstraint.cs" />

--- a/src/Nest/Search/FieldStats/FieldMinMaxValueJsonConverter.cs
+++ b/src/Nest/Search/FieldStats/FieldMinMaxValueJsonConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	internal class FieldMinMaxValueJsonConverter : JsonConverter
+	{
+		public override bool CanConvert(Type objectType) => true;
+		public override bool CanWrite => false;
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) { }
+
+		public override bool CanRead => true;
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType == JsonToken.StartObject || reader.TokenType == JsonToken.StartArray)
+			{
+				var depth = reader.Depth;
+				do
+				{
+					reader.Read();
+				} while (reader.Depth >= depth && reader.TokenType != JsonToken.EndObject);
+				return null;
+			}
+			return reader.Value.ToString();
+		}
+
+	}
+}

--- a/src/Nest/Search/FieldStats/FieldStatsResponse.cs
+++ b/src/Nest/Search/FieldStats/FieldStatsResponse.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -76,30 +75,6 @@ namespace Nest
 
 		[JsonProperty("max_value_as_string")]
 		public string MaxValueAsString { get; internal set; }
-
-	}
-
-
-	public class FieldMinMaxValueJsonConverter : JsonConverter
-	{
-		public override bool CanConvert(Type objectType) => true;
-		public override bool CanWrite => false;
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) { }
-
-		public override bool CanRead => true;
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-		{
-			if (reader.TokenType == JsonToken.StartObject || reader.TokenType == JsonToken.StartArray)
-			{
-				var depth = reader.Depth;
-				do
-				{
-					reader.Read();
-				} while (reader.Depth >= depth && reader.TokenType != JsonToken.EndObject);
-				return null;
-			}
-			return reader.Value.ToString();
-		}
 
 	}
 }

--- a/src/Tests/tests.default.yaml
+++ b/src/Tests/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: i
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.3.0-SNAPSHOT


### PR DESCRIPTION
`geo_point` and `geo_shape` field types now return a `min_value` and
`max_value` as per Elasticsearch 5.3 but do so as an object. This is
breaking for us in 5.x so for now we keep on ignoring them.

Included support for `min/max_value_as_string` which will never be
null.`