### PR TITLE
Correctly handle terms include/exclude

### DIFF
--- a/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
@@ -15,6 +15,18 @@ please modify the original csharp file found at the link and submit the PR with 
 [[significant-terms-aggregation-usage]]
 == Significant Terms Aggregation Usage
 
+An aggregation that returns interesting or unusual occurrences of terms in a set.
+
+[WARNING]
+--
+The significant_terms aggregation can be very heavy when run on large indices. Work is in progress 
+to provide more lightweight sampling techniques. 
+As a result, the API for this feature may change in non-backwards compatible ways
+
+--
+
+See the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-significantterms-aggregation.html[significant terms aggregation] for more detail.
+
 === Fluent DSL Example
 
 [source,csharp]
@@ -64,6 +76,156 @@ new SearchRequest<Project>
           "background_is_superset": true,
           "include_negatives": true
         }
+      }
+    }
+  }
+}
+----
+
+=== Handling Responses
+
+[source,csharp]
+----
+response.ShouldBeValid();
+var sigNames = response.Aggs.SignificantTerms("significant_names");
+sigNames.Should().NotBeNull();
+sigNames.DocCount.Should().BeGreaterThan(0);
+----
+
+[[significant-terms-pattern-filter]]
+[float]
+== Filtering with a regular expression pattern
+
+Using significant terms aggregation with filtering to include values using a regular expression pattern
+
+=== Fluent DSL Example
+
+[source,csharp]
+----
+s => s
+.Aggregations(a => a
+    .SignificantTerms("significant_names", st => st
+        .Field(p => p.Name)
+        .MinimumDocumentCount(10)
+        .MutualInformation(mi => mi
+            .BackgroundIsSuperSet()
+            .IncludeNegatives()
+        )
+        .Include("pi*")
+    )
+)
+----
+
+=== Object Initializer Syntax Example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    Aggregations = new SignificantTermsAggregation("significant_names")
+    {
+        Field = Field<Project>(p => p.Name),
+        MinimumDocumentCount = 10,
+        MutualInformation = new MutualInformationHeuristic
+        {
+            BackgroundIsSuperSet = true,
+            IncludeNegatives = true
+        },
+        IncludeTerms = new SignificantTermsIncludeExclude("pi*")
+    }
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "aggs": {
+    "significant_names": {
+      "significant_terms": {
+        "field": "name",
+        "min_doc_count": 10,
+        "mutual_information": {
+          "background_is_superset": true,
+          "include_negatives": true
+        },
+        "include": "pi*"
+      }
+    }
+  }
+}
+----
+
+=== Handling Responses
+
+[source,csharp]
+----
+response.ShouldBeValid();
+var sigNames = response.Aggs.SignificantTerms("significant_names");
+sigNames.Should().NotBeNull();
+sigNames.DocCount.Should().BeGreaterThan(0);
+----
+
+[[significant-terms-exact-value-filter]]
+[float]
+== Filtering with exact values
+
+Using significant terms aggregation with filtering to exclude specific values
+
+=== Fluent DSL Example
+
+[source,csharp]
+----
+s => s
+.Aggregations(a => a
+    .SignificantTerms("significant_names", st => st
+        .Field(p => p.Name)
+        .MinimumDocumentCount(10)
+        .MutualInformation(mi => mi
+            .BackgroundIsSuperSet()
+            .IncludeNegatives()
+        )
+        .Exclude(new [] { "pierce" })
+    )
+)
+----
+
+=== Object Initializer Syntax Example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    Aggregations = new SignificantTermsAggregation("significant_names")
+    {
+        Field = Field<Project>(p => p.Name),
+        MinimumDocumentCount = 10,
+        MutualInformation = new MutualInformationHeuristic
+        {
+            BackgroundIsSuperSet = true,
+            IncludeNegatives = true
+        },
+        ExcludeTerms = new SignificantTermsIncludeExclude(new[] { "pierce" })
+    }
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "aggs": {
+    "significant_names": {
+      "significant_terms": {
+        "field": "name",
+        "min_doc_count": 10,
+        "mutual_information": {
+          "background_is_superset": true,
+          "include_negatives": true
+        },
+        "exclude": [
+          "pierce"
+        ]
       }
     }
   }

--- a/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
@@ -15,6 +15,10 @@ please modify the original csharp file found at the link and submit the PR with 
 [[terms-aggregation-usage]]
 == Terms Aggregation Usage
 
+A multi-bucket value source based aggregation where buckets are dynamically built - one per unique value.
+
+See the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-terms-aggregation.html[terms aggregation] for more detail.
+
 === Fluent DSL Example
 
 [source,csharp]
@@ -125,6 +129,12 @@ states.Meta.Should().NotBeNull().And.HaveCount(1);
 states.Meta["foo"].Should().Be("bar");
 ----
 
+[[terms-pattern-filter]]
+[float]
+== Filtering with a regular expression pattern
+
+Using terms aggregation with filtering to include values using a regular expression pattern
+
 === Fluent DSL Example
 
 [source,csharp]
@@ -132,8 +142,19 @@ states.Meta["foo"].Should().Be("bar");
 s => s
 .Size(0)
 .Aggregations(a => a
-    .Terms("commits", st => st
-        .Field(p => p.NumberOfCommits)
+    .Terms("states", st => st
+        .Field(p => p.State.Suffix("keyword"))
+        .MinimumDocumentCount(2)
+        .Size(5)
+        .ShardSize(100)
+        .ExecutionHint(TermsAggregationExecutionHint.Map)
+        .Missing("n/a")
+        .Include("(Stable|VeryActive)")
+        .Order(TermsOrder.TermAscending)
+        .Order(TermsOrder.CountDescending)
+        .Meta(m => m
+            .Add("foo", "bar")
+        )
     )
 )
 ----
@@ -145,9 +166,24 @@ s => s
 new SearchRequest<Project>
 {
     Size = 0,
-    Aggregations = new TermsAggregation("commits")
+    Aggregations = new TermsAggregation("states")
     {
-        Field = Infer.Field<Project>(p => p.NumberOfCommits),
+        Field = Field<Project>(p => p.State.Suffix("keyword")),
+        MinimumDocumentCount = 2,
+        Size = 5,
+        ShardSize = 100,
+        ExecutionHint = TermsAggregationExecutionHint.Map,
+        Missing = "n/a",
+        Include = new TermsIncludeExclude { Pattern = "(Stable|VeryActive)" },
+        Order = new List<TermsOrder>
+        {
+            TermsOrder.TermAscending,
+            TermsOrder.CountDescending
+        },
+        Meta = new Dictionary<string, object>
+        {
+            { "foo", "bar" }
+        }
     }
 }
 ----
@@ -158,9 +194,26 @@ new SearchRequest<Project>
 {
   "size": 0,
   "aggs": {
-    "commits": {
+    "states": {
+      "meta": {
+        "foo": "bar"
+      },
       "terms": {
-        "field": "numberOfCommits"
+        "field": "state.keyword",
+        "min_doc_count": 2,
+        "size": 5,
+        "shard_size": 100,
+        "execution_hint": "map",
+        "missing": "n/a",
+        "include": "(Stable|VeryActive)",
+        "order": [
+          {
+            "_term": "asc"
+          },
+          {
+            "_count": "desc"
+          }
+        ]
       }
     }
   }
@@ -172,19 +225,151 @@ new SearchRequest<Project>
 [source,csharp]
 ----
 response.IsValid.Should().BeTrue();
-var commits = response.Aggs.Terms<int>("commits");
-commits.Should().NotBeNull();
-commits.DocCountErrorUpperBound.Should().HaveValue();
-commits.SumOtherDocCount.Should().HaveValue();
-commits.Buckets.Should().NotBeNull();
-commits.Buckets.Count.Should().BeGreaterThan(0);
+var states = response.Aggs.Terms("states");
+states.Should().NotBeNull();
+states.DocCountErrorUpperBound.Should().HaveValue();
+states.SumOtherDocCount.Should().HaveValue();
+states.Buckets.Should().NotBeNull();
+states.Buckets.Count.Should().BeGreaterThan(0);
 
-foreach (var item in commits.Buckets)
+foreach (var item in states.Buckets)
 {
-    item.Key.Should().BeGreaterThan(0);
+    item.Key.Should().NotBeNullOrEmpty();
     item.DocCount.Should().BeGreaterOrEqualTo(1);
 }
+
+states.Meta.Should().NotBeNull().And.HaveCount(1);
+states.Meta["foo"].Should().Be("bar");
 ----
+
+[[terms-exact-value-filter]]
+[float]
+== Filtering with exact values
+
+Using terms aggregation with filtering to include only specific values
+
+=== Fluent DSL Example
+
+[source,csharp]
+----
+s => s
+.Size(0)
+.Aggregations(a => a
+    .Terms("states", st => st
+        .Field(p => p.State.Suffix("keyword"))
+        .MinimumDocumentCount(2)
+        .Size(5)
+        .ShardSize(100)
+        .ExecutionHint(TermsAggregationExecutionHint.Map)
+        .Missing("n/a")
+        .Include(new [] { StateOfBeing.Stable.ToString(), StateOfBeing.VeryActive.ToString() })
+        .Order(TermsOrder.TermAscending)
+        .Order(TermsOrder.CountDescending)
+        .Meta(m => m
+            .Add("foo", "bar")
+        )
+    )
+)
+----
+
+=== Object Initializer Syntax Example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    Size = 0,
+    Aggregations = new TermsAggregation("states")
+    {
+        Field = Field<Project>(p => p.State.Suffix("keyword")),
+        MinimumDocumentCount = 2,
+        Size = 5,
+        ShardSize = 100,
+        ExecutionHint = TermsAggregationExecutionHint.Map,
+        Missing = "n/a",
+        Include = new TermsIncludeExclude { Values = new[] { StateOfBeing.Stable.ToString(), StateOfBeing.VeryActive.ToString() } },
+        Order = new List<TermsOrder>
+        {
+            TermsOrder.TermAscending,
+            TermsOrder.CountDescending
+        },
+        Meta = new Dictionary<string, object>
+        {
+            { "foo", "bar" }
+        }
+    }
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "size": 0,
+  "aggs": {
+    "states": {
+      "meta": {
+        "foo": "bar"
+      },
+      "terms": {
+        "field": "state.keyword",
+        "min_doc_count": 2,
+        "size": 5,
+        "shard_size": 100,
+        "execution_hint": "map",
+        "missing": "n/a",
+        "include": [
+          "Stable",
+          "VeryActive"
+        ],
+        "order": [
+          {
+            "_term": "asc"
+          },
+          {
+            "_count": "desc"
+          }
+        ]
+      }
+    }
+  }
+}
+----
+
+=== Handling Responses
+
+[source,csharp]
+----
+response.IsValid.Should().BeTrue();
+var states = response.Aggs.Terms("states");
+states.Should().NotBeNull();
+states.DocCountErrorUpperBound.Should().HaveValue();
+states.SumOtherDocCount.Should().HaveValue();
+states.Buckets.Should().NotBeNull();
+states.Buckets.Count.Should().BeGreaterThan(0);
+
+foreach (var item in states.Buckets)
+{
+    item.Key.Should().NotBeNullOrEmpty();
+    item.DocCount.Should().BeGreaterOrEqualTo(1);
+}
+
+states.Meta.Should().NotBeNull().And.HaveCount(1);
+states.Meta["foo"].Should().Be("bar");
+----
+
+[[filtering-with-partitions]]
+[float]
+== Filtering with partitions
+
+A terms aggregation that uses partitioning to filter the terms that are returned in the response. Further terms
+can be returned by issuing additional requests with an incrementing `partition` number.
+
+[NOTE]
+--
+Partitioning is available only in Elasticsearch 5.2.0+
+
+--
 
 === Fluent DSL Example
 
@@ -195,7 +380,7 @@ s => s
 .Aggregations(a => a
     .Terms("commits", st => st
         .Field(p => p.NumberOfCommits)
-        .Include(partion: 0, numberOfPartitions: 50)
+        .Include(partition: 0, numberOfPartitions: 50)
         .Size(2)
     )
 )
@@ -235,6 +420,73 @@ new SearchRequest<Project>
           "partition": 0,
           "num_partitions": 50
         }
+      }
+    }
+  }
+}
+----
+
+=== Handling Responses
+
+[source,csharp]
+----
+response.IsValid.Should().BeTrue();
+var commits = response.Aggs.Terms<int>("commits");
+commits.Should().NotBeNull();
+commits.DocCountErrorUpperBound.Should().HaveValue();
+commits.SumOtherDocCount.Should().HaveValue();
+commits.Buckets.Should().NotBeNull();
+commits.Buckets.Count.Should().BeGreaterThan(0);
+
+foreach (var item in commits.Buckets)
+{
+    item.Key.Should().BeGreaterThan(0);
+    item.DocCount.Should().BeGreaterOrEqualTo(1);
+}
+----
+
+[[numeric-fields]]
+[float]
+== Numeric fields
+
+A terms aggregation on a numeric field
+
+=== Fluent DSL Example
+
+[source,csharp]
+----
+s => s
+.Size(0)
+.Aggregations(a => a
+    .Terms("commits", st => st
+        .Field(p => p.NumberOfCommits)
+    )
+)
+----
+
+=== Object Initializer Syntax Example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    Size = 0,
+    Aggregations = new TermsAggregation("commits")
+    {
+        Field = Infer.Field<Project>(p => p.NumberOfCommits),
+    }
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "size": 0,
+  "aggs": {
+    "commits": {
+      "terms": {
+        "field": "numberOfCommits"
       }
     }
   }

--- a/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
 
@@ -9,42 +10,97 @@ namespace Nest
 	[ContractJsonConverter(typeof(AggregationJsonConverter<SignificantTermsAggregation>))]
 	public interface ISignificantTermsAggregation : IBucketAggregation
 	{
+		/// <summary>
+		/// The field on which to run the aggregation
+		/// </summary>
 		[JsonProperty("field")]
 		Field Field { get; set; }
 
+		/// <summary>
+		/// Defines how many term buckets should be returned out of the overall
+		/// terms list
+		/// </summary>
 		[JsonProperty("size")]
 		int? Size { get; set; }
 
+		/// <summary>
+		/// Controls the number of candidate terms produced by each shard from which
+		/// the <see cref="Size"/> of terms is selected.
+		/// </summary>
 		[JsonProperty("shard_size")]
 		int? ShardSize { get; set; }
 
+		/// <summary>
+		/// Return only terms that match equal to or more than a configurable
+		/// number of hits
+		/// </summary>
 		[JsonProperty("min_doc_count")]
 		int? MinimumDocumentCount { get; set; }
 
+		/// <summary>
+		/// Determines the mechanism by which aggregations are executed
+		/// </summary>
 		[JsonProperty("execution_hint")]
 		TermsAggregationExecutionHint? ExecutionHint { get; set; }
 
-		[JsonProperty("include")]
+		[Obsolete("Deprecated and will be fixed in 6.0. Use IncludeTerms")]
 		IDictionary<string, string> Include { get; set; }
 
-		[JsonProperty("exclude")]
+		/// <summary>
+		/// Include term values for which buckets will be created.
+		/// </summary>
+		[JsonProperty("include")]
+		SignificantTermsIncludeExclude IncludeTerms { get; set; }
+
+		[Obsolete("Deprecated and will be fixed in 6.0. Use ExcludeTerms")]
 		IDictionary<string, string> Exclude { get; set; }
 
+		/// <summary>
+		/// Exclude term values for which buckets will be created.
+		/// </summary>
+		[JsonProperty("exclude")]
+		SignificantTermsIncludeExclude ExcludeTerms { get; set; }
+
+		/// <summary>
+		/// Use mutual information to calculate significance score
+		/// </summary>
 		[JsonProperty("mutual_information")]
 		IMutualInformationHeuristic MutualInformation { get; set; }
 
+		/// <summary>
+		/// Use chi square to calculate significance score
+		/// </summary>
 		[JsonProperty("chi_square")]
 		IChiSquareHeuristic ChiSquare { get; set; }
 
+		/// <summary>
+		/// Use Google normalized distance to calculate significance score
+		/// </summary>
 		[JsonProperty("gnd")]
 		IGoogleNormalizedDistanceHeuristic GoogleNormalizedDistance { get; set; }
 
+		/// <summary>
+		/// Use percentage to calculate significance score.
+		/// <para>A simple calculation of the number of documents in the foreground
+		/// sample with a term divided by the number of documents in the background
+		/// with the term. By default this produces a score greater than zero
+		///  and less than one.</para>
+		/// </summary>
 		[JsonProperty("percentage")]
 		IPercentageScoreHeuristic PercentageScore { get; set; }
 
+		/// <summary>
+		/// Use a script to calculate a custom significance score.
+		/// </summary>
 		[JsonProperty("script_heuristic")]
 		IScriptedHeuristic Script { get; set; }
 
+		/// <summary>
+		/// The default source of statistical information for background term
+		/// frequencies is the entire index. This scope can be narrowed
+		/// through the use of a background filter to focus in on significant
+		/// terms within a narrower context
+		/// </summary>
 		[JsonProperty("background_filter")]
 		QueryContainer BackgroundFilter { get; set; }
 
@@ -52,18 +108,39 @@ namespace Nest
 
 	public class SignificantTermsAggregation : BucketAggregationBase, ISignificantTermsAggregation
 	{
+		/// <inheritdoc />
 		public Field Field { get; set; }
+		/// <inheritdoc />
 		public int? Size { get; set; }
+		/// <inheritdoc />
 		public int? ShardSize { get; set; }
+		/// <inheritdoc />
 		public int? MinimumDocumentCount { get; set; }
+		/// <inheritdoc />
 		public TermsAggregationExecutionHint? ExecutionHint { get; set; }
+
+		[Obsolete("Deprecated and will be fixed in 6.0. Use IncludeTerms")]
 		public IDictionary<string, string> Include { get; set; }
+
+		/// <inheritdoc />
+		public SignificantTermsIncludeExclude IncludeTerms { get; set; }
+
+		[Obsolete("Deprecated and will be fixed in 6.0. Use ExcludeTerms")]
 		public IDictionary<string, string> Exclude { get; set; }
+
+		/// <inheritdoc />
+		public SignificantTermsIncludeExclude ExcludeTerms { get; set; }
+		/// <inheritdoc />
 		public IMutualInformationHeuristic MutualInformation { get; set; }
+		/// <inheritdoc />
 		public IChiSquareHeuristic ChiSquare { get; set; }
+		/// <inheritdoc />
 		public IGoogleNormalizedDistanceHeuristic GoogleNormalizedDistance { get; set; }
+		/// <inheritdoc />
 		public IPercentageScoreHeuristic PercentageScore { get; set; }
+		/// <inheritdoc />
 		public IScriptedHeuristic Script { get; set; }
+		/// <inheritdoc />
 		public QueryContainer BackgroundFilter { get; set; }
 
 		internal SignificantTermsAggregation() { }
@@ -88,9 +165,15 @@ namespace Nest
 
 		TermsAggregationExecutionHint? ISignificantTermsAggregation.ExecutionHint { get; set; }
 
+		[Obsolete("Deprecated and will be fixed in 6.0. Use IncludeTerms")]
 		IDictionary<string, string> ISignificantTermsAggregation.Include { get; set; }
 
+		SignificantTermsIncludeExclude ISignificantTermsAggregation.IncludeTerms { get; set; }
+
+		[Obsolete("Deprecated and will be fixed in 6.0. Use ExcludeTerms")]
 		IDictionary<string, string> ISignificantTermsAggregation.Exclude { get; set; }
+
+		SignificantTermsIncludeExclude ISignificantTermsAggregation.ExcludeTerms { get; set; }
 
 		IMutualInformationHeuristic ISignificantTermsAggregation.MutualInformation { get; set; }
 
@@ -104,40 +187,70 @@ namespace Nest
 
 		QueryContainer ISignificantTermsAggregation.BackgroundFilter { get; set; }
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> Field(Field field) => Assign(a => a.Field = field);
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> Field(Expression<Func<T, object>> field) => Assign(a => a.Field = field);
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> Size(int size) => Assign(a => a.Size = size);
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> ExecutionHint(TermsAggregationExecutionHint? hint) => Assign(a => a.ExecutionHint = hint);
 
+		/// <inheritdoc />
+		public SignificantTermsAggregationDescriptor<T> Include(string includePattern) =>
+			Assign(a => a.IncludeTerms = new SignificantTermsIncludeExclude(includePattern));
+
+		/// <inheritdoc />
+		public SignificantTermsAggregationDescriptor<T> Include(IEnumerable<string> values) =>
+			Assign(a => a.IncludeTerms = new SignificantTermsIncludeExclude(values));
+
+		[Obsolete("Use overload that accepts string or IEnumerable<string>")]
 		public SignificantTermsAggregationDescriptor<T> Include(Func<FluentDictionary<string, string>, FluentDictionary<string, string>> include) =>
 			Assign(a => a.Include = include?.Invoke(new FluentDictionary<string, string>()));
 
+		/// <inheritdoc />
+		public SignificantTermsAggregationDescriptor<T> Exclude(string excludePattern) =>
+			Assign(a => a.ExcludeTerms = new SignificantTermsIncludeExclude(excludePattern));
+
+		/// <inheritdoc />
+		public SignificantTermsAggregationDescriptor<T> Exclude(IEnumerable<string> values) =>
+			Assign(a => a.ExcludeTerms = new SignificantTermsIncludeExclude(values));
+
+		[Obsolete("Use overload that accepts string or IEnumerable<string>")]
 		public SignificantTermsAggregationDescriptor<T> Exclude(Func<FluentDictionary<string, string>, FluentDictionary<string, string>> exclude) =>
 			Assign(a => a.Exclude = exclude?.Invoke(new FluentDictionary<string, string>()));
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> ShardSize(int shardSize) => Assign(a => a.ShardSize = shardSize);
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> MinimumDocumentCount(int minimumDocumentCount) =>
 			Assign(a => a.MinimumDocumentCount = minimumDocumentCount);
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> MutualInformation(Func<MutualInformationHeuristicDescriptor, IMutualInformationHeuristic> mutualInformationSelector = null) =>
 			Assign(a => a.MutualInformation = mutualInformationSelector.InvokeOrDefault(new MutualInformationHeuristicDescriptor()));
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> ChiSquare(Func<ChiSquareHeuristicDescriptor, IChiSquareHeuristic> chiSquareSelector) =>
 			Assign(a => a.ChiSquare = chiSquareSelector.InvokeOrDefault(new ChiSquareHeuristicDescriptor()));
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> GoogleNormalizedDistance(Func<GoogleNormalizedDistanceHeuristicDescriptor, IGoogleNormalizedDistanceHeuristic> gndSelector) =>
 			Assign(a => a.GoogleNormalizedDistance = gndSelector.InvokeOrDefault(new GoogleNormalizedDistanceHeuristicDescriptor()));
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> PercentageScore(Func<PercentageScoreHeuristicDescriptor, IPercentageScoreHeuristic> percentageScoreSelector) =>
 			Assign(a => a.PercentageScore = percentageScoreSelector.InvokeOrDefault(new PercentageScoreHeuristicDescriptor()));
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> Script(Func<ScriptedHeuristicDescriptor, IScriptedHeuristic> scriptSelector) =>
 			Assign(a => a.Script = scriptSelector?.Invoke(new ScriptedHeuristicDescriptor()));
 
+		/// <inheritdoc />
 		public SignificantTermsAggregationDescriptor<T> BackgroundFilter(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(a => a.BackgroundFilter = selector?.Invoke(new QueryContainerDescriptor<T>()));
 	}

--- a/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsIncludeExclude.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsIncludeExclude.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	[JsonConverter(typeof(SignificantTermsIncludeExcludeJsonConverter))]
+	public class SignificantTermsIncludeExclude
+	{
+		[JsonIgnore]
+		public string Pattern { get; set; }
+
+		[JsonIgnore]
+		public IEnumerable<string> Values { get; set; }
+
+		public SignificantTermsIncludeExclude(string pattern)
+		{
+			Pattern = pattern;
+		}
+
+		public SignificantTermsIncludeExclude(IEnumerable<string> values)
+		{
+			Values = values;
+		}
+	}
+
+	internal class SignificantTermsIncludeExcludeJsonConverter : JsonConverter
+	{
+		public override bool CanConvert(Type objectType) => true;
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType == JsonToken.Null) return null;
+
+			SignificantTermsIncludeExclude termsInclude;
+
+			switch (reader.TokenType)
+			{
+				case JsonToken.StartArray:
+					termsInclude = new SignificantTermsIncludeExclude(serializer.Deserialize<IEnumerable<string>>(reader));
+					break;
+				case JsonToken.String:
+					termsInclude = new SignificantTermsIncludeExclude((string)reader.Value);
+					break;
+				default:
+					throw new JsonSerializationException(
+						$"Unexpected token {reader.TokenType} when deserializing {nameof(SignificantTermsIncludeExclude)}");
+			}
+
+			return termsInclude;
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var termsIncludeExclude = (SignificantTermsIncludeExclude)value;
+
+			if (termsIncludeExclude == null)
+				writer.WriteNull();
+			else if (termsIncludeExclude.Values != null)
+				serializer.Serialize(writer, termsIncludeExclude.Values);
+			else
+				writer.WriteValue(termsIncludeExclude.Pattern);
+		}
+	}
+}

--- a/src/Nest/Aggregations/Bucket/Terms/TermsAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/Terms/TermsAggregation.cs
@@ -128,17 +128,29 @@ namespace Nest
 			a.Order.Add(new TermsOrder { Key = key, Order = SortOrder.Descending });
 		});
 
-		public TermsAggregationDescriptor<T> Include(long partion, long numberOfPartitions) =>
-			Assign(a => a.Include = new TermsIncludeExclude() {Partition = partion, NumberOfPartitions = numberOfPartitions});
+		public TermsAggregationDescriptor<T> Include(long partition, long numberOfPartitions) =>
+			Assign(a => a.Include = new TermsIncludeExclude() {Partition = partition, NumberOfPartitions = numberOfPartitions});
 
 		public TermsAggregationDescriptor<T> Include(string includePattern, string regexFlags = null) =>
-			Assign(a => a.Include = new TermsIncludeExclude() { Pattern = includePattern, Flags = regexFlags });
+			Assign(a => a.Include = new TermsIncludeExclude
+			{
+				Pattern = includePattern,
+#pragma warning disable 618
+				Flags = regexFlags
+#pragma warning restore 618
+			});
 
 		public TermsAggregationDescriptor<T> Include(IEnumerable<string> values) =>
 			Assign(a => a.Include = new TermsIncludeExclude { Values = values });
 
 		public TermsAggregationDescriptor<T> Exclude(string excludePattern, string regexFlags = null) =>
-			Assign(a => a.Exclude = new TermsIncludeExclude() { Pattern = excludePattern, Flags = regexFlags });
+			Assign(a => a.Exclude = new TermsIncludeExclude
+			{
+				Pattern = excludePattern,
+#pragma warning disable 618
+				Flags = regexFlags
+#pragma warning restore 618
+			});
 
 		public TermsAggregationDescriptor<T> Exclude(IEnumerable<string> values) =>
 			Assign(a => a.Exclude = new TermsIncludeExclude { Values = values });

--- a/src/Nest/Aggregations/Bucket/Terms/TermsIncludeExclude.cs
+++ b/src/Nest/Aggregations/Bucket/Terms/TermsIncludeExclude.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -6,10 +7,11 @@ namespace Nest
 	[JsonConverter(typeof(TermsIncludeExcludeJsonConverter))]
 	public class TermsIncludeExclude
 	{
-		[JsonProperty("pattern")]
+		[JsonIgnore]
 		public string Pattern { get; set; }
 
-		[JsonProperty("flags")]
+		[JsonIgnore]
+		[Obsolete("Deprecated in 2.0. Flags can no longer be specified")]
 		public string Flags { get; set; }
 
 		[JsonIgnore]
@@ -17,13 +19,15 @@ namespace Nest
 
 		//TODO Better types for this in 6.0
 		/// <summary>
-		/// Only valid on terms include, the current partition of terms we are interested in
+		/// The current partition of terms we are interested in
+		/// <para>IMPORTANT: Only valid on terms include</para>
 		/// </summary>
 		[JsonProperty("partition")]
 		public long? Partition { get; set; }
 
 		/// <summary>
-		/// Only valid on terms include, the total number of paritions we are interested in
+		/// The total number of paritions we are interested in
+		/// <para>IMPORTANT: Only valid on terms include</para>
 		/// </summary>
 		[JsonProperty("num_partitions")]
 		public long? NumberOfPartitions { get; set; }

--- a/src/Nest/Aggregations/Bucket/Terms/TermsIncludeExcludeJsonConverter.cs
+++ b/src/Nest/Aggregations/Bucket/Terms/TermsIncludeExcludeJsonConverter.cs
@@ -35,15 +35,12 @@ namespace Nest
 								case "num_partitions":
 									termsInclude.NumberOfPartitions = Convert.ToInt64(reader.ReadAsDouble());
 									break;
-								case "pattern":
-									termsInclude.Pattern = reader.ReadAsString();
-									break;
-								case "flags":
-									termsInclude.Flags = reader.ReadAsString();
-									break;
 							}
 						}
 					}
+					break;
+				case JsonToken.String:
+					termsInclude.Pattern = (string)reader.Value;
 					break;
 				default:
 					throw new JsonSerializationException($"Unexpected token {reader.TokenType} when deserializing {nameof(TermsIncludeExclude)}");
@@ -56,33 +53,21 @@ namespace Nest
 		{
 			var termsIncludeExclude = (TermsIncludeExclude)value;
 
-			if (termsIncludeExclude.Values != null)
-			{
+			if (termsIncludeExclude == null)
+				writer.WriteNull();
+			else if (termsIncludeExclude.Values != null)
 				serializer.Serialize(writer, termsIncludeExclude.Values);
-			}
-			else
+			else if (termsIncludeExclude.Partition.HasValue && termsIncludeExclude.NumberOfPartitions.HasValue)
 			{
 				writer.WriteStartObject();
-				if (termsIncludeExclude.Pattern.IsNullOrEmpty())
-				{
-                    writer.WritePropertyName("partition");
-                    writer.WriteValue(termsIncludeExclude.Partition);
-                    writer.WritePropertyName("num_partitions");
-                    writer.WriteValue(termsIncludeExclude.NumberOfPartitions);
-				}
-				else
-				{
-                    writer.WritePropertyName("pattern");
-                    writer.WriteValue(termsIncludeExclude.Pattern);
-                    if (!termsIncludeExclude.Flags.IsNullOrEmpty())
-                    {
-                        writer.WritePropertyName("flags");
-                        writer.WriteValue(termsIncludeExclude.Flags);
-                    }
-                    writer.WriteEndObject();
-				}
-
+				writer.WritePropertyName("partition");
+				writer.WriteValue(termsIncludeExclude.Partition);
+				writer.WritePropertyName("num_partitions");
+				writer.WriteValue(termsIncludeExclude.NumberOfPartitions);
+				writer.WriteEndObject();
 			}
+			else
+				writer.WriteValue(termsIncludeExclude.Pattern);
 		}
 	}
 }

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Aggregations\Bucket\SignificantTerms\SignificantTermsAggregate.cs" />
     <Compile Include="Aggregations\Bucket\SignificantTerms\SignificantTermsAggregation.cs" />
     <Compile Include="Aggregations\Bucket\SignificantTerms\SignificantTermsBucket.cs" />
+    <Compile Include="Aggregations\Bucket\SignificantTerms\SignificantTermsIncludeExclude.cs" />
     <Compile Include="Aggregations\Bucket\Terms\TermsAggregate.cs" />
     <Compile Include="Aggregations\Bucket\Terms\TermsAggregation.cs" />
     <Compile Include="Aggregations\Bucket\Terms\TermsAggregationCollectMode.cs" />

--- a/src/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs
@@ -9,6 +9,18 @@ using static Nest.Infer;
 
 namespace Tests.Aggregations.Bucket.SignificantTerms
 {
+	/**
+	 * An aggregation that returns interesting or unusual occurrences of terms in a set.
+	 *
+	 * [WARNING]
+	 * --
+	 * The significant_terms aggregation can be very heavy when run on large indices. Work is in progress 
+	 * to provide more lightweight sampling techniques. 
+	 * As a result, the API for this feature may change in non-backwards compatible ways
+	 * --
+	 * 
+	 * See the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-significantterms-aggregation.html[significant terms aggregation] for more detail.
+	 */
 	public class SignificantTermsAggregationUsageTests : AggregationUsageTestBase
 	{
 		public SignificantTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
@@ -57,6 +69,146 @@ namespace Tests.Aggregations.Bucket.SignificantTerms
 						BackgroundIsSuperSet = true,
 						IncludeNegatives = true
 					}
+				}
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.ShouldBeValid();
+			var sigNames = response.Aggs.SignificantTerms("significant_names");
+			sigNames.Should().NotBeNull();
+			sigNames.DocCount.Should().BeGreaterThan(0);
+		}
+	}
+
+	/**
+	 * [float]
+	 * [[significant-terms-pattern-filter]]
+	 * == Filtering with a regular expression pattern
+	 * 
+	 * Using significant terms aggregation with filtering to include values using a regular expression pattern
+	 */
+	public class SignificantTermsIncludePatternAggregationUsageTests : AggregationUsageTestBase
+	{
+		public SignificantTermsIncludePatternAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			aggs = new
+			{
+				significant_names = new
+				{
+					significant_terms = new
+					{
+						field = "name",
+						min_doc_count = 10,
+						mutual_information = new
+						{
+							background_is_superset = true,
+							include_negatives = true
+						},
+						include = "pi*"
+					}
+				}
+			}
+		};
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.Aggregations(a => a
+				.SignificantTerms("significant_names", st => st
+					.Field(p => p.Name)
+					.MinimumDocumentCount(10)
+					.MutualInformation(mi => mi
+						.BackgroundIsSuperSet()
+						.IncludeNegatives()
+					)
+					.Include("pi*")
+				)
+			);
+
+		protected override SearchRequest<Project> Initializer =>
+			new SearchRequest<Project>
+			{
+				Aggregations = new SignificantTermsAggregation("significant_names")
+				{
+					Field = Field<Project>(p => p.Name),
+					MinimumDocumentCount = 10,
+					MutualInformation = new MutualInformationHeuristic
+					{
+						BackgroundIsSuperSet = true,
+						IncludeNegatives = true
+					},
+					IncludeTerms = new SignificantTermsIncludeExclude("pi*")
+				}
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.ShouldBeValid();
+			var sigNames = response.Aggs.SignificantTerms("significant_names");
+			sigNames.Should().NotBeNull();
+			sigNames.DocCount.Should().BeGreaterThan(0);
+		}
+	}
+
+	/**
+	 * [float]
+	 * [[significant-terms-exact-value-filter]]
+	 * == Filtering with exact values
+	 * 
+	 * Using significant terms aggregation with filtering to exclude specific values
+	 */
+	public class SignificantTermsExcludeExactValuesAggregationUsageTests : AggregationUsageTestBase
+	{
+		public SignificantTermsExcludeExactValuesAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			aggs = new
+			{
+				significant_names = new
+				{
+					significant_terms = new
+					{
+						field = "name",
+						min_doc_count = 10,
+						mutual_information = new
+						{
+							background_is_superset = true,
+							include_negatives = true
+						},
+						exclude = new[] { "pierce" }
+					}
+				}
+			}
+		};
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.Aggregations(a => a
+				.SignificantTerms("significant_names", st => st
+					.Field(p => p.Name)
+					.MinimumDocumentCount(10)
+					.MutualInformation(mi => mi
+						.BackgroundIsSuperSet()
+						.IncludeNegatives()
+					)
+					.Exclude(new [] { "pierce" })
+				)
+			);
+
+		protected override SearchRequest<Project> Initializer =>
+			new SearchRequest<Project>
+			{
+				Aggregations = new SignificantTermsAggregation("significant_names")
+				{
+					Field = Field<Project>(p => p.Name),
+					MinimumDocumentCount = 10,
+					MutualInformation = new MutualInformationHeuristic
+					{
+						BackgroundIsSuperSet = true,
+						IncludeNegatives = true
+					},
+					ExcludeTerms = new SignificantTermsIncludeExclude(new[] { "pierce" })
 				}
 			};
 

--- a/src/Tests/Aggregations/Bucket/Terms/TermsAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Bucket/Terms/TermsAggregationUsageTests.cs
@@ -10,6 +10,11 @@ using static Nest.Infer;
 
 namespace Tests.Aggregations.Bucket.Terms
 {
+	/**
+	 * A multi-bucket value source based aggregation where buckets are dynamically built - one per unique value.
+	 * 
+	 * See the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-terms-aggregation.html[terms aggregation] for more detail.
+	 */
 	public class TermsAggregationUsageTests : AggregationUsageTestBase
 	{
 		public TermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
@@ -111,21 +116,43 @@ namespace Tests.Aggregations.Bucket.Terms
 		}
 	}
 
-	public class NumericTermsAggregationUsageTests : AggregationUsageTestBase
+	/**
+	 * [float]
+	 * [[terms-pattern-filter]]
+	 * == Filtering with a regular expression pattern
+	 * 
+	 * Using terms aggregation with filtering to include values using a regular expression pattern
+	 * 
+	 */
+	public class TermsAggregationIncludePatternUsageTests : AggregationUsageTestBase
 	{
-		public NumericTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+		public TermsAggregationIncludePatternUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
 		protected override object ExpectJson => new
 		{
 			size = 0,
 			aggs = new
 			{
-				commits = new
+				states = new
 				{
-
+					meta = new
+					{
+						foo = "bar"
+					},
 					terms = new
 					{
-						field = "numberOfCommits"
+						field = "state.keyword",
+						min_doc_count = 2,
+						size = 5,
+						shard_size = 100,
+						execution_hint = "map",
+						missing = "n/a",
+						include = "(Stable|VeryActive)",
+						order = new object[]
+						{
+							new { _term = "asc" },
+							new { _count = "desc" }
+						}
 					}
 				}
 			}
@@ -134,8 +161,19 @@ namespace Tests.Aggregations.Bucket.Terms
 		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
 			.Size(0)
 			.Aggregations(a => a
-				.Terms("commits", st => st
-					.Field(p => p.NumberOfCommits)
+				.Terms("states", st => st
+					.Field(p => p.State.Suffix("keyword"))
+					.MinimumDocumentCount(2)
+					.Size(5)
+					.ShardSize(100)
+					.ExecutionHint(TermsAggregationExecutionHint.Map)
+					.Missing("n/a")
+					.Include("(Stable|VeryActive)")
+					.Order(TermsOrder.TermAscending)
+					.Order(TermsOrder.CountDescending)
+					.Meta(m => m
+						.Add("foo", "bar")
+					)
 				)
 			);
 
@@ -143,29 +181,163 @@ namespace Tests.Aggregations.Bucket.Terms
 			new SearchRequest<Project>
 			{
 				Size = 0,
-				Aggregations = new TermsAggregation("commits")
+				Aggregations = new TermsAggregation("states")
 				{
-					Field = Infer.Field<Project>(p => p.NumberOfCommits),
+					Field = Field<Project>(p => p.State.Suffix("keyword")),
+					MinimumDocumentCount = 2,
+					Size = 5,
+					ShardSize = 100,
+					ExecutionHint = TermsAggregationExecutionHint.Map,
+					Missing = "n/a",
+					Include = new TermsIncludeExclude { Pattern = "(Stable|VeryActive)" },
+					Order = new List<TermsOrder>
+					{
+						TermsOrder.TermAscending,
+						TermsOrder.CountDescending
+					},
+					Meta = new Dictionary<string, object>
+					{
+						{ "foo", "bar" }
+					}
 				}
 			};
 
 		protected override void ExpectResponse(ISearchResponse<Project> response)
 		{
 			response.IsValid.Should().BeTrue();
-			var commits = response.Aggs.Terms<int>("commits");
-			commits.Should().NotBeNull();
-			commits.DocCountErrorUpperBound.Should().HaveValue();
-			commits.SumOtherDocCount.Should().HaveValue();
-			commits.Buckets.Should().NotBeNull();
-			commits.Buckets.Count.Should().BeGreaterThan(0);
-			foreach (var item in commits.Buckets)
+			var states = response.Aggs.Terms("states");
+			states.Should().NotBeNull();
+			states.DocCountErrorUpperBound.Should().HaveValue();
+			states.SumOtherDocCount.Should().HaveValue();
+			states.Buckets.Should().NotBeNull();
+			states.Buckets.Count.Should().BeGreaterThan(0);
+			foreach (var item in states.Buckets)
 			{
-				item.Key.Should().BeGreaterThan(0);
+				item.Key.Should().NotBeNullOrEmpty();
 				item.DocCount.Should().BeGreaterOrEqualTo(1);
 			}
+			states.Meta.Should().NotBeNull().And.HaveCount(1);
+			states.Meta["foo"].Should().Be("bar");
 		}
 	}
 
+	/**
+	 * [[terms-exact-value-filter]]
+	 * [float]
+	 * == Filtering with exact values
+	 * 
+	 * Using terms aggregation with filtering to include only specific values
+	 * 
+	 */
+	public class TermsAggregationIncludeExactValuesUsageTests : AggregationUsageTestBase
+	{
+		public TermsAggregationIncludeExactValuesUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			size = 0,
+			aggs = new
+			{
+				states = new
+				{
+					meta = new
+					{
+						foo = "bar"
+					},
+					terms = new
+					{
+						field = "state.keyword",
+						min_doc_count = 2,
+						size = 5,
+						shard_size = 100,
+						execution_hint = "map",
+						missing = "n/a",
+						include = new [] { "Stable", "VeryActive" },
+						order = new object[]
+						{
+							new { _term = "asc" },
+							new { _count = "desc" }
+						}
+					}
+				}
+			}
+		};
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.Size(0)
+			.Aggregations(a => a
+				.Terms("states", st => st
+					.Field(p => p.State.Suffix("keyword"))
+					.MinimumDocumentCount(2)
+					.Size(5)
+					.ShardSize(100)
+					.ExecutionHint(TermsAggregationExecutionHint.Map)
+					.Missing("n/a")
+					.Include(new [] { StateOfBeing.Stable.ToString(), StateOfBeing.VeryActive.ToString() })
+					.Order(TermsOrder.TermAscending)
+					.Order(TermsOrder.CountDescending)
+					.Meta(m => m
+						.Add("foo", "bar")
+					)
+				)
+			);
+
+		protected override SearchRequest<Project> Initializer =>
+			new SearchRequest<Project>
+			{
+				Size = 0,
+				Aggregations = new TermsAggregation("states")
+				{
+					Field = Field<Project>(p => p.State.Suffix("keyword")),
+					MinimumDocumentCount = 2,
+					Size = 5,
+					ShardSize = 100,
+					ExecutionHint = TermsAggregationExecutionHint.Map,
+					Missing = "n/a",
+					Include = new TermsIncludeExclude { Values = new[] { StateOfBeing.Stable.ToString(), StateOfBeing.VeryActive.ToString() } },
+					Order = new List<TermsOrder>
+					{
+						TermsOrder.TermAscending,
+						TermsOrder.CountDescending
+					},
+					Meta = new Dictionary<string, object>
+					{
+						{ "foo", "bar" }
+					}
+				}
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.IsValid.Should().BeTrue();
+			var states = response.Aggs.Terms("states");
+			states.Should().NotBeNull();
+			states.DocCountErrorUpperBound.Should().HaveValue();
+			states.SumOtherDocCount.Should().HaveValue();
+			states.Buckets.Should().NotBeNull();
+			states.Buckets.Count.Should().BeGreaterThan(0);
+			foreach (var item in states.Buckets)
+			{
+				item.Key.Should().NotBeNullOrEmpty();
+				item.DocCount.Should().BeGreaterOrEqualTo(1);
+			}
+			states.Meta.Should().NotBeNull().And.HaveCount(1);
+			states.Meta["foo"].Should().Be("bar");
+		}
+	}
+
+	/**
+	 * [float]
+	 * == Filtering with partitions
+	 * 
+	 * A terms aggregation that uses partitioning to filter the terms that are returned in the response. Further terms
+	 * can be returned by issuing additional requests with an incrementing `partition` number.
+	 * 
+	 * [NOTE]
+	 * --
+	 * Partitioning is available only in Elasticsearch 5.2.0+
+	 * --
+	 */
 	[SkipVersion("<5.2.0", "Partitioning term aggregations responses is a new feature in 5.2.0")]
 	public class PartitionTermsAggregationUsageTests : AggregationUsageTestBase
 	{
@@ -197,7 +369,7 @@ namespace Tests.Aggregations.Bucket.Terms
 			.Aggregations(a => a
 				.Terms("commits", st => st
 					.Field(p => p.NumberOfCommits)
-					.Include(partion: 0, numberOfPartitions: 50)
+					.Include(partition: 0, numberOfPartitions: 50)
 					.Size(2)
 				)
 			);
@@ -215,6 +387,66 @@ namespace Tests.Aggregations.Bucket.Terms
 						NumberOfPartitions = 50
 					},
 					Size = 2
+				}
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.IsValid.Should().BeTrue();
+			var commits = response.Aggs.Terms<int>("commits");
+			commits.Should().NotBeNull();
+			commits.DocCountErrorUpperBound.Should().HaveValue();
+			commits.SumOtherDocCount.Should().HaveValue();
+			commits.Buckets.Should().NotBeNull();
+			commits.Buckets.Count.Should().BeGreaterThan(0);
+			foreach (var item in commits.Buckets)
+			{
+				item.Key.Should().BeGreaterThan(0);
+				item.DocCount.Should().BeGreaterOrEqualTo(1);
+			}
+		}
+	}
+
+	/**
+	 * [float]
+	 * == Numeric fields
+	 * 
+	 * A terms aggregation on a numeric field
+	 */
+	public class NumericTermsAggregationUsageTests : AggregationUsageTestBase
+	{
+		public NumericTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			size = 0,
+			aggs = new
+			{
+				commits = new
+				{
+					terms = new
+					{
+						field = "numberOfCommits"
+					}
+				}
+			}
+		};
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.Size(0)
+			.Aggregations(a => a
+				.Terms("commits", st => st
+					.Field(p => p.NumberOfCommits)
+				)
+			);
+
+		protected override SearchRequest<Project> Initializer =>
+			new SearchRequest<Project>
+			{
+				Size = 0,
+				Aggregations = new TermsAggregation("commits")
+				{
+					Field = Infer.Field<Project>(p => p.NumberOfCommits),
 				}
 			};
 

--- a/src/Tests/Framework/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
@@ -226,6 +226,9 @@ namespace Tests.Framework.ManagedElasticsearch.NodeSeeders
 						.Name("offsets")
 						.IndexOptions(IndexOptions.Offsets)
 					)
+					.Keyword(sk => sk
+						.Name("keyword")
+					)
 				)
 			)
 			.Nested<Tag>(mo => mo

--- a/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -50,7 +50,7 @@ namespace Tests.Indices.MappingManagement.GetMapping
 			visitor.CountsShouldContainKeyAndCountBe("object", supportsRanges ? 5 : 4);
 			visitor.CountsShouldContainKeyAndCountBe("date", 4);
 			visitor.CountsShouldContainKeyAndCountBe("text", 11);
-			visitor.CountsShouldContainKeyAndCountBe("keyword", 9);
+			visitor.CountsShouldContainKeyAndCountBe("keyword", 10);
 			visitor.CountsShouldContainKeyAndCountBe("ip", 1);
 			visitor.CountsShouldContainKeyAndCountBe("number", 3);
 			visitor.CountsShouldContainKeyAndCountBe("geo_point", 2);

--- a/src/Tests/Reproduce/GithubIssue2503.cs
+++ b/src/Tests/Reproduce/GithubIssue2503.cs
@@ -44,9 +44,7 @@ namespace Tests.Reproduce
 				  ""terms"": {
 					""field"": ""size"",
 					""size"": 20,
-					""include"": {
-					  ""pattern"" : ""\\d+""
-					}
+					""include"": ""\\d+""
 				  }
 				}
 			  }


### PR DESCRIPTION
for Terms aggregation
- the flags property is no longer supported and a regular expression pattern is sent as a string value against the "include" key
- exact values are sent as an array of strings

for Significant Terms aggregation
- a dictionary was incorrectly used to filter terms. Introduce a `SignificantTermsIncludeExclude` type to represent the available options. Don't reuse the `TermsIncludeExclude` type because it includes properties that are not applicable for filtering on Significant Terms aggregation.

Add unit and integration tests for include and exclude filtering

Fixes #2682
Fixes #2676 