### PR TITLE
Introduce MultiTermQueryRewrite type

### DIFF
--- a/docs/query-dsl/compound/full-text/match/match-usage.asciidoc
+++ b/docs/query-dsl/compound/full-text/match/match-usage.asciidoc
@@ -31,7 +31,7 @@ q
     .FuzzyTranspositions()
     .MinimumShouldMatch(2)
     .Operator(Operator.Or)
-    .FuzzyRewrite(RewriteMultiTerm.ConstantScoreBoolean)
+    .FuzzyRewrite(MultiTermQueryRewrite.TopTermsBlendedFreqs(10))
     .Name("named_query")
 )
 ----
@@ -51,7 +51,7 @@ new MatchQuery
     Fuzziness = Fuzziness.Auto,
     FuzzyTranspositions = true,
     MinimumShouldMatch = 2,
-    FuzzyRewrite = RewriteMultiTerm.ConstantScoreBoolean,
+    FuzzyRewrite = MultiTermQueryRewrite.TopTermsBlendedFreqs(10),
     Lenient = true,
     Operator = Operator.Or,
 }
@@ -67,7 +67,7 @@ new MatchQuery
       "boost": 1.1,
       "query": "hello world",
       "analyzer": "standard",
-      "fuzzy_rewrite": "constant_score_boolean",
+      "fuzzy_rewrite": "top_terms_blended_freqs_10",
       "fuzziness": "AUTO",
       "fuzzy_transpositions": true,
       "cutoff_frequency": 0.001,

--- a/docs/query-dsl/compound/full-text/multi-match/multi-match-usage.asciidoc
+++ b/docs/query-dsl/compound/full-text/multi-match/multi-match-usage.asciidoc
@@ -31,7 +31,7 @@ q
     .MaxExpansions(2)
     .Operator(Operator.Or)
     .MinimumShouldMatch(2)
-    .FuzzyRewrite(RewriteMultiTerm.ConstantScoreBoolean)
+    .FuzzyRewrite(MultiTermQueryRewrite.ConstantScoreBoolean)
     .TieBreaker(1.1)
     .CutoffFrequency(0.001)
     .Lenient()
@@ -56,7 +56,7 @@ new MultiMatchQuery
     MaxExpansions = 2,
     Operator = Operator.Or,
     MinimumShouldMatch = 2,
-    FuzzyRewrite = RewriteMultiTerm.ConstantScoreBoolean,
+    FuzzyRewrite = MultiTermQueryRewrite.ConstantScoreBoolean,
     TieBreaker = 1.1,
     CutoffFrequency = 0.001,
     Lenient = true,

--- a/docs/query-dsl/compound/full-text/query-string/query-string-usage.asciidoc
+++ b/docs/query-dsl/compound/full-text/query-string/query-string-usage.asciidoc
@@ -38,8 +38,8 @@ q
     .UseDisMax()
     .FuzzyPrefixLength(2)
     .FuzzyMaxExpansions(3)
-    .FuzzyRewrite(RewriteMultiTerm.ConstantScore)
-    .Rewrite(RewriteMultiTerm.ConstantScore)
+    .FuzzyRewrite(MultiTermQueryRewrite.ConstantScore)
+    .Rewrite(MultiTermQueryRewrite.ConstantScore)
     .Fuzziness(Fuzziness.Auto)
     .TieBreaker(1.2)
     .AnalyzeWildcard()
@@ -74,8 +74,8 @@ new QueryStringQuery
     UseDisMax = true,
     FuzzyPrefixLength = 2,
     FuzzyMaxExpansions = 3,
-    FuzzyRewrite = RewriteMultiTerm.ConstantScore,
-    Rewrite = RewriteMultiTerm.ConstantScore,
+    FuzzyRewrite = MultiTermQueryRewrite.ConstantScore,
+    Rewrite = MultiTermQueryRewrite.ConstantScore,
     Fuzziness = Fuzziness.Auto,
     TieBreaker = 1.2,
     AnalyzeWildcard = true,

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-date-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-date-query-usage.asciidoc
@@ -28,7 +28,7 @@ q
     .Value(Project.Instance.StartedOn)
     .MaxExpansions(100)
     .PrefixLength(3)
-    .Rewrite(RewriteMultiTerm.ConstantScore)
+    .Rewrite(MultiTermQueryRewrite.ConstantScore)
     .Transpositions()
 )
 ----
@@ -46,7 +46,7 @@ new FuzzyDateQuery
     Value = Project.Instance.StartedOn,
     MaxExpansions = 100,
     PrefixLength = 3,
-    Rewrite = RewriteMultiTerm.ConstantScore,
+    Rewrite = MultiTermQueryRewrite.ConstantScore,
     Transpositions = true
 }
 ----

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-numeric-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-numeric-query-usage.asciidoc
@@ -28,7 +28,7 @@ q
     .Value(12)
     .MaxExpansions(100)
     .PrefixLength(3)
-    .Rewrite(RewriteMultiTerm.ConstantScore)
+    .Rewrite(MultiTermQueryRewrite.ConstantScore)
     .Transpositions()
 )
 ----
@@ -46,7 +46,7 @@ new FuzzyNumericQuery
     Value = 12,
     MaxExpansions = 100,
     PrefixLength = 3,
-    Rewrite = RewriteMultiTerm.ConstantScore,
+    Rewrite = MultiTermQueryRewrite.ConstantScore,
     Transpositions = true
 }
 ----

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-query-usage.asciidoc
@@ -28,7 +28,7 @@ q
     .Value("ki")
     .MaxExpansions(100)
     .PrefixLength(3)
-    .Rewrite(RewriteMultiTerm.ConstantScore)
+    .Rewrite(MultiTermQueryRewrite.ConstantScore)
     .Transpositions()
 )
 ----
@@ -46,7 +46,7 @@ new FuzzyQuery
     Value = "ki",
     MaxExpansions = 100,
     PrefixLength = 3,
-    Rewrite = RewriteMultiTerm.ConstantScore,
+    Rewrite = MultiTermQueryRewrite.ConstantScore,
     Transpositions = true
 }
 ----

--- a/docs/query-dsl/term-level/prefix/prefix-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/prefix/prefix-query-usage.asciidoc
@@ -25,7 +25,7 @@ q
     .Boost(1.1)
     .Field(p => p.Description)
     .Value("proj")
-    .Rewrite(RewriteMultiTerm.TopTermsBoostN)
+    .Rewrite(MultiTermQueryRewrite.TopTerms(10))
 )
 ----
 
@@ -39,7 +39,7 @@ new PrefixQuery
     Boost = 1.1,
     Field = "description",
     Value = "proj",
-    Rewrite = RewriteMultiTerm.TopTermsBoostN
+    Rewrite = MultiTermQueryRewrite.TopTerms(10)
 }
 ----
 
@@ -51,7 +51,7 @@ new PrefixQuery
     "description": {
       "_name": "named_query",
       "boost": 1.1,
-      "rewrite": "top_terms_boost_N",
+      "rewrite": "top_terms_10",
       "value": "proj"
     }
   }

--- a/docs/query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc
@@ -25,7 +25,7 @@ q
     .Boost(1.1)
     .Field(p => p.Description)
     .Value("p*oj")
-    .Rewrite(RewriteMultiTerm.TopTermsBoostN)
+    .Rewrite(MultiTermQueryRewrite.TopTermsBoost(10))
 )
 ----
 
@@ -39,7 +39,7 @@ new WildcardQuery
     Boost = 1.1,
     Field = "description",
     Value = "p*oj",
-    Rewrite = RewriteMultiTerm.TopTermsBoostN
+    Rewrite = MultiTermQueryRewrite.TopTermsBoost(10)
 }
 ----
 
@@ -51,7 +51,7 @@ new WildcardQuery
     "description": {
       "_name": "named_query",
       "boost": 1.1,
-      "rewrite": "top_terms_boost_N",
+      "rewrite": "top_terms_boost_10",
       "value": "p*oj"
     }
   }

--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -56,6 +56,23 @@ namespace Nest
 		}
 
 		internal static ConcurrentDictionary<string, object> _enumCache = new ConcurrentDictionary<string, object>();
+
+		internal static string ToEnumValue<T>(this T enumValue) where T : struct
+		{
+			var enumType = typeof(T);
+			var name = Enum.GetName(enumType, enumValue);
+			var enumMemberAttribute = enumType.GetField(name).GetCustomAttribute<EnumMemberAttribute>();
+
+			if (enumMemberAttribute != null)
+				return enumMemberAttribute.Value;
+
+			var alternativeEnumMemberAttribute = enumType.GetField(name).GetCustomAttribute<AlternativeEnumMemberAttribute>();
+
+			return alternativeEnumMemberAttribute != null
+				? alternativeEnumMemberAttribute.Value
+				: enumValue.ToString();
+		}
+
 		internal static T? ToEnum<T>(this string str, StringComparison comparison = StringComparison.OrdinalIgnoreCase) where T : struct
 		{
 			if (str == null) return null;

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -348,7 +348,7 @@ namespace Nest
 		/// over many terms. In order to prevent extremely slow wildcard queries, a wildcard term should
 		/// not start with one of the wildcards * or ?. The wildcard query maps to Lucene WildcardQuery.
 		/// </summary>
-		public QueryContainer Wildcard(Expression<Func<T, object>> field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+		public QueryContainer Wildcard(Expression<Func<T, object>> field, string value, double? boost = null, MultiTermQueryRewrite rewrite = null, string name = null) =>
 			this.Wildcard(t => t.Field(field).Value(value).Rewrite(rewrite).Boost(boost).Name(name));
 
 		/// <summary>
@@ -358,7 +358,7 @@ namespace Nest
 		/// In order to prevent extremely slow wildcard queries, a wildcard term should not start with
 		/// one of the wildcards * or ?. The wildcard query maps to Lucene WildcardQuery.
 		/// </summary>
-		public QueryContainer Wildcard(Field field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+		public QueryContainer Wildcard(Field field, string value, double? boost = null, MultiTermQueryRewrite rewrite = null, string name = null) =>
 			this.Wildcard(t => t.Field(field).Value(value).Rewrite(rewrite).Boost(boost).Name(name));
 
 		/// <summary>
@@ -375,14 +375,14 @@ namespace Nest
 		/// Matches documents that have fields containing terms with a specified prefix (not analyzed).
 		/// The prefix query maps to Lucene PrefixQuery.
 		/// </summary>
-		public QueryContainer Prefix(Expression<Func<T, object>> field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+		public QueryContainer Prefix(Expression<Func<T, object>> field, string value, double? boost = null, MultiTermQueryRewrite rewrite = null, string name = null) =>
 			this.Prefix(t => t.Field(field).Value(value).Boost(boost).Rewrite(rewrite).Name(name));
 
 		/// <summary>
 		/// Matches documents that have fields containing terms with a specified prefix (not analyzed).
 		/// The prefix query maps to Lucene PrefixQuery.
 		/// </summary>
-		public QueryContainer Prefix(Field field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+		public QueryContainer Prefix(Field field, string value, double? boost = null, MultiTermQueryRewrite rewrite = null, string name = null) =>
 			this.Prefix(t => t.Field(field).Value(value).Boost(boost).Rewrite(rewrite).Name(name));
 
 		/// <summary>

--- a/src/Nest/QueryDsl/FullText/Match/MatchQuery.cs
+++ b/src/Nest/QueryDsl/FullText/Match/MatchQuery.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
@@ -7,35 +6,34 @@ namespace Nest
 	[JsonConverter(typeof(FieldNameQueryJsonConverter<MatchQuery>))]
 	public interface IMatchQuery : IFieldNameQuery
 	{
-		[JsonProperty(PropertyName = "query")]
+		[JsonProperty("query")]
 		string Query { get; set; }
 
-		[JsonProperty(PropertyName = "analyzer")]
+		[JsonProperty("analyzer")]
 		string Analyzer { get; set; }
 
-		[JsonProperty(PropertyName = "fuzzy_rewrite")]
-		[JsonConverter(typeof (StringEnumConverter))]
-		RewriteMultiTerm? FuzzyRewrite { get; set; }
+		[JsonProperty("fuzzy_rewrite")]
+		MultiTermQueryRewrite FuzzyRewrite { get; set; }
 
-		[JsonProperty(PropertyName = "fuzziness")]
+		[JsonProperty("fuzziness")]
 		IFuzziness Fuzziness { get; set; }
 
-		[JsonProperty(PropertyName = "fuzzy_transpositions")]
+		[JsonProperty("fuzzy_transpositions")]
 		bool? FuzzyTranspositions { get; set; }
 
-		[JsonProperty(PropertyName = "cutoff_frequency")]
+		[JsonProperty("cutoff_frequency")]
 		double? CutoffFrequency { get; set; }
 
-		[JsonProperty(PropertyName = "lenient")]
+		[JsonProperty("lenient")]
 		bool? Lenient { get; set; }
 
 		[JsonProperty("minimum_should_match")]
 		MinimumShouldMatch MinimumShouldMatch { get; set; }
 
-		[JsonProperty(PropertyName = "operator")]
+		[JsonProperty("operator")]
 		Operator? Operator { get; set; }
 
-		[JsonProperty(PropertyName = "zero_terms_query")]
+		[JsonProperty("zero_terms_query")]
 		ZeroTermsQuery? ZeroTermsQuery { get; set; }
 	}
 
@@ -45,7 +43,7 @@ namespace Nest
 
 		public string Query { get; set; }
 		public string Analyzer { get; set; }
-		public RewriteMultiTerm? FuzzyRewrite { get; set; }
+		public MultiTermQueryRewrite FuzzyRewrite { get; set; }
 		public IFuzziness Fuzziness { get; set; }
 		public bool? FuzzyTranspositions { get; set; }
 		public double? CutoffFrequency { get; set; }
@@ -69,7 +67,7 @@ namespace Nest
 		string IMatchQuery.Query { get; set; }
 		string IMatchQuery.Analyzer { get; set; }
 		MinimumShouldMatch IMatchQuery.MinimumShouldMatch { get; set; }
-		RewriteMultiTerm? IMatchQuery.FuzzyRewrite { get; set; }
+		MultiTermQueryRewrite IMatchQuery.FuzzyRewrite { get; set; }
 		IFuzziness IMatchQuery.Fuzziness { get; set; }
 		bool? IMatchQuery.FuzzyTranspositions { get; set; }
 		double? IMatchQuery.CutoffFrequency { get; set; }
@@ -89,7 +87,7 @@ namespace Nest
 
 		public MatchQueryDescriptor<T> CutoffFrequency(double? cutoffFrequency) => Assign(a => a.CutoffFrequency = cutoffFrequency);
 
-		public MatchQueryDescriptor<T> FuzzyRewrite(RewriteMultiTerm? rewrite) => Assign(a => a.FuzzyRewrite = rewrite);
+		public MatchQueryDescriptor<T> FuzzyRewrite(MultiTermQueryRewrite rewrite) => Assign(a => Self.FuzzyRewrite = rewrite);
 
 		public MatchQueryDescriptor<T> MinimumShouldMatch(MinimumShouldMatch minimumShouldMatch) => Assign(a => a.MinimumShouldMatch = minimumShouldMatch);
 

--- a/src/Nest/QueryDsl/FullText/MultiMatch/MultiMatchQuery.cs
+++ b/src/Nest/QueryDsl/FullText/MultiMatch/MultiMatchQuery.cs
@@ -18,7 +18,7 @@ namespace Nest
 		string Analyzer { get; set; }
 
 		[JsonProperty("fuzzy_rewrite")]
-		RewriteMultiTerm? FuzzyRewrite { get; set; }
+		MultiTermQueryRewrite FuzzyRewrite { get; set; }
 
 		/// <summary>
 		/// Allows fuzzy matching based on the type of field being queried.
@@ -70,7 +70,7 @@ namespace Nest
 		public TextQueryType? Type { get; set; }
 		public string Query { get; set; }
 		public string Analyzer { get; set; }
-		public RewriteMultiTerm? FuzzyRewrite { get; set; }
+		public MultiTermQueryRewrite FuzzyRewrite { get; set; }
 
 		/// <summary>
 		/// Allows fuzzy matching based on the type of field being queried.
@@ -106,7 +106,7 @@ namespace Nest
 		TextQueryType? IMultiMatchQuery.Type { get; set; }
 		string IMultiMatchQuery.Query { get; set; }
 		string IMultiMatchQuery.Analyzer { get; set; }
-		RewriteMultiTerm? IMultiMatchQuery.FuzzyRewrite { get; set; }
+		MultiTermQueryRewrite IMultiMatchQuery.FuzzyRewrite { get; set; }
 		Fuzziness IMultiMatchQuery.Fuzziness { get; set; }
 		double? IMultiMatchQuery.CutoffFrequency { get; set; }
 		int? IMultiMatchQuery.PrefixLength { get; set; }
@@ -144,7 +144,7 @@ namespace Nest
 		public MultiMatchQueryDescriptor<T> MinimumShouldMatch(MinimumShouldMatch minimumShouldMatch)
 			=> Assign(a => a.MinimumShouldMatch = minimumShouldMatch);
 
-		public MultiMatchQueryDescriptor<T> FuzzyRewrite(RewriteMultiTerm rewrite) => Assign(a => a.FuzzyRewrite = rewrite);
+		public MultiMatchQueryDescriptor<T> FuzzyRewrite(MultiTermQueryRewrite rewrite) => Assign(a => Self.FuzzyRewrite = rewrite);
 
 		public MultiMatchQueryDescriptor<T> Lenient(bool? lenient = true) => Assign(a => a.Lenient = lenient);
 

--- a/src/Nest/QueryDsl/FullText/QueryString/QueryStringQuery.cs
+++ b/src/Nest/QueryDsl/FullText/QueryString/QueryStringQuery.cs
@@ -8,85 +8,83 @@ namespace Nest
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<QueryStringQueryDescriptor<object>>))]
 	public interface IQueryStringQuery : IQuery
 	{
-		[JsonProperty(PropertyName = "query")]
+		[JsonProperty("query")]
 		string Query { get; set; }
 
-		[JsonProperty(PropertyName = "default_field")]
+		[JsonProperty("default_field")]
 		Field DefaultField { get; set; }
 
-		[JsonProperty(PropertyName = "default_operator")]
+		[JsonProperty("default_operator")]
 		Operator? DefaultOperator { get; set; }
 
-		[JsonProperty(PropertyName = "analyzer")]
+		[JsonProperty("analyzer")]
 		string Analyzer { get; set; }
 
-		[JsonProperty(PropertyName = "quote_analyzer")]
+		[JsonProperty("quote_analyzer")]
 		string QuoteAnalyzer { get; set; }
 
-		[JsonProperty(PropertyName = "allow_leading_wildcard")]
+		[JsonProperty("allow_leading_wildcard")]
 		bool? AllowLeadingWildcard { get; set; }
 
-		[JsonProperty(PropertyName = "lowercase_expanded_terms")]
+		[JsonProperty("lowercase_expanded_terms")]
 		bool? LowercaseExpendedTerms { get; set; }
 
-		[JsonProperty(PropertyName = "enable_position_increments")]
+		[JsonProperty("enable_position_increments")]
 		bool? EnablePositionIncrements { get; set; }
 
-		[JsonProperty(PropertyName = "fuzzy_max_expansions")]
+		[JsonProperty("fuzzy_max_expansions")]
 		int? FuzzyMaxExpansions { get; set; }
 
-		[JsonProperty(PropertyName = "fuzziness")]
+		[JsonProperty("fuzziness")]
 		Fuzziness Fuzziness { get; set; }
 
-		[JsonProperty(PropertyName = "fuzzy_prefix_length")]
+		[JsonProperty("fuzzy_prefix_length")]
 		int? FuzzyPrefixLength { get; set; }
 
-		[JsonProperty(PropertyName = "phrase_slop")]
+		[JsonProperty("phrase_slop")]
 		double? PhraseSlop { get; set; }
 
-		[JsonProperty(PropertyName = "analyze_wildcard")]
+		[JsonProperty("analyze_wildcard")]
 		bool? AnalyzeWildcard { get; set; }
 
-		[JsonProperty(PropertyName = "auto_generate_phrase_queries")]
+		[JsonProperty("auto_generate_phrase_queries")]
 		bool? AutoGeneratePhraseQueries { get; set; }
 
-		[JsonProperty(PropertyName = "max_determinized_states")]
+		[JsonProperty("max_determinized_states")]
 		int? MaximumDeterminizedStates { get; set; }
 
-		[JsonProperty(PropertyName = "minimum_should_match")]
+		[JsonProperty("minimum_should_match")]
 		MinimumShouldMatch MinimumShouldMatch { get; set; }
 
-		[JsonProperty(PropertyName = "lenient")]
+		[JsonProperty("lenient")]
 		bool? Lenient { get; set; }
 
-		[JsonProperty(PropertyName = "locale")]
+		[JsonProperty("locale")]
 		string Locale { get; set; }
 
-		[JsonProperty(PropertyName = "time_zone")]
+		[JsonProperty("time_zone")]
 		string Timezone { get; set; }
 
-		[JsonProperty(PropertyName = "fields")]
+		[JsonProperty("fields")]
 		Fields Fields { get; set; }
 
-		[JsonProperty(PropertyName = "use_dis_max")]
+		[JsonProperty("use_dis_max")]
 		bool? UseDisMax { get; set; }
 
-		[JsonProperty(PropertyName = "tie_breaker")]
+		[JsonProperty("tie_breaker")]
 		double? TieBreaker { get; set; }
 
-		[JsonProperty(PropertyName = "rewrite")]
-		RewriteMultiTerm? Rewrite { get; set; }
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite Rewrite { get; set; }
 
-		[JsonProperty(PropertyName = "fuzzy_rewrite")]
-		RewriteMultiTerm? FuzzyRewrite { get; set; }
+		[JsonProperty("fuzzy_rewrite")]
+		MultiTermQueryRewrite FuzzyRewrite { get; set; }
 
-		[JsonProperty(PropertyName = "quote_field_suffix")]
+		[JsonProperty("quote_field_suffix")]
 		string QuoteFieldSuffix { get; set; }
 
-		[JsonProperty(PropertyName = "escape")]
+		[JsonProperty("escape")]
 		bool? Escape { get; set; }
-
-
 	}
 
 	public class QueryStringQuery : QueryBase, IQueryStringQuery
@@ -96,8 +94,8 @@ namespace Nest
 		public Fuzziness Fuzziness { get; set; }
 		public MinimumShouldMatch MinimumShouldMatch { get; set; }
 		public string Locale { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
-		public RewriteMultiTerm? FuzzyRewrite { get; set; }
+		public MultiTermQueryRewrite Rewrite { get; set; }
+		public MultiTermQueryRewrite FuzzyRewrite { get; set; }
 		public string QuoteFieldSuffix { get; set; }
 		public bool? Escape { get; set; }
 		public string Query { get; set; }
@@ -152,8 +150,8 @@ namespace Nest
 		bool? IQueryStringQuery.UseDisMax { get; set; }
 		double? IQueryStringQuery.TieBreaker { get; set; }
 		int? IQueryStringQuery.MaximumDeterminizedStates { get; set; }
-		RewriteMultiTerm? IQueryStringQuery.FuzzyRewrite { get; set; }
-		RewriteMultiTerm? IQueryStringQuery.Rewrite { get; set; }
+		MultiTermQueryRewrite IQueryStringQuery.FuzzyRewrite { get; set; }
+		MultiTermQueryRewrite IQueryStringQuery.Rewrite { get; set; }
 		string IQueryStringQuery.QuoteFieldSuffix { get; set; }
 		bool? IQueryStringQuery.Escape { get; set; }
 
@@ -209,9 +207,9 @@ namespace Nest
 
 		public QueryStringQueryDescriptor<T> MaximumDeterminizedStates(int? maxDeterminizedStates) => Assign(a => a.MaximumDeterminizedStates = maxDeterminizedStates);
 
-		public QueryStringQueryDescriptor<T> FuzzyRewrite(RewriteMultiTerm? rewriteMultiTerm) => Assign(a => a.FuzzyRewrite = rewriteMultiTerm);
+		public QueryStringQueryDescriptor<T> FuzzyRewrite(MultiTermQueryRewrite rewrite) => Assign(a => Self.FuzzyRewrite = rewrite);
 
-		public QueryStringQueryDescriptor<T> Rewrite(RewriteMultiTerm? rewriteMultiTerm) => Assign(a => a.Rewrite = rewriteMultiTerm);
+		public QueryStringQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite) => Assign(a => Self.Rewrite = rewrite);
 
 		public QueryStringQueryDescriptor<T> QuoteFieldSuffix(string quoteFieldSuffix) => Assign(a => a.QuoteFieldSuffix = quoteFieldSuffix);
 

--- a/src/Nest/QueryDsl/MultiTermQueryRewrite/RewriteMultiTerm.cs
+++ b/src/Nest/QueryDsl/MultiTermQueryRewrite/RewriteMultiTerm.cs
@@ -1,9 +1,13 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
+	/// <summary>
+	/// Multi term query rewrite method
+	/// </summary>
 	[JsonConverter(typeof(StringEnumConverter))]
 	public enum RewriteMultiTerm
 	{
@@ -24,20 +28,20 @@ namespace Nest
 		ScoringBoolean,
 		/// <summary>
 		/// Similar to scoring_boolean except scores are not computed. Instead, each matching document receives a constant
-		///  score equal to the query’s boost. This rewrite method will hit too many clauses failure if it exceeds the 
+		///  score equal to the query’s boost. This rewrite method will hit too many clauses failure if it exceeds the
 		/// boolean query limit (defaults to 1024).
 		/// </summary>
 		[EnumMember(Value = "constant_score_boolean")]
 		ConstantScoreBoolean,
 		/// <summary>
-		/// A rewrite method that first translates each term into should clause in boolean query, and keeps the scores 
+		/// A rewrite method that first translates each term into should clause in boolean query, and keeps the scores
 		/// as computed by the query. This rewrite method only uses the top scoring terms so it will not overflow boolean
 		///  max clause count. The N controls the size of the top scoring terms to use.
 		/// </summary>
 		[EnumMember(Value = "top_terms_N")]
 		TopTermsN,
 		/// <summary>
-		/// A rewrite method that first translates each term into should clause in boolean query, but the scores are only 
+		/// A rewrite method that first translates each term into should clause in boolean query, but the scores are only
 		/// computed as the boost. This rewrite method only uses the top scoring terms so it will not overflow the boolean
 		///  max clause count. The N controls the size of the top scoring terms to use.
 		/// </summary>
@@ -46,10 +50,194 @@ namespace Nest
 		/// <summary>
 		/// A rewrite method that first translates each term into should clause in boolean query, but all term queries compute
 		///  scores as if they had the same frequency. In practice the frequency which is used is the maximum frequency of all
-		///  matching terms. This rewrite method only uses the top scoring terms so it will not overflow boolean max clause count. 
+		///  matching terms. This rewrite method only uses the top scoring terms so it will not overflow boolean max clause count.
 		/// The N controls the size of the top scoring terms to use.
 		/// </summary>
 		[EnumMember(Value = "top_terms_blended_freqs_N")]
 		TopTermsBlendedFreqsN
+	}
+
+	/// <summary>
+	/// Controls how a multi term query such as a wildcard or prefix query, is rewritten.
+	/// </summary>
+	[JsonConverter(typeof(MultiTermQueryRewriteConverter))]
+	public class MultiTermQueryRewrite : IEquatable<MultiTermQueryRewrite>
+	{
+		private static readonly char[] DigitCharacters = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+
+		private readonly string _value;
+
+		/// <summary>
+		/// The type of multi term rewrite to perform
+		/// </summary>
+		public RewriteMultiTerm Rewrite { get; }
+
+		/// <summary>
+		/// The size of the top scoring terms to use
+		/// </summary>
+		public int? Size { get; }
+
+		internal MultiTermQueryRewrite(RewriteMultiTerm rewrite, int? size = null)
+		{
+			switch (rewrite)
+			{
+				case RewriteMultiTerm.ConstantScore:
+				case RewriteMultiTerm.ScoringBoolean:
+				case RewriteMultiTerm.ConstantScoreBoolean:
+					_value = rewrite.ToEnumValue();
+					break;
+				case RewriteMultiTerm.TopTermsN:
+				case RewriteMultiTerm.TopTermsBoostN:
+				case RewriteMultiTerm.TopTermsBlendedFreqsN:
+					if (size == null)
+						throw new ArgumentException($"{nameof(size)} must be specified with {nameof(RewriteMultiTerm)}.{rewrite}");
+
+					var rewriteType = rewrite.ToEnumValue();
+					rewriteType = rewriteType.Substring(0, rewriteType.Length - 1);
+					_value = rewriteType + size;
+					break;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(rewrite));
+			}
+
+			Rewrite = rewrite;
+			Size = size;
+		}
+
+		/// <summary>
+		///  A rewrite method that performs like constant_score_boolean when there are few matching terms and otherwise
+		///  visits all matching terms in sequence and marks documents for that term. Matching documents are assigned a
+		///  constant score equal to the query’s boost.
+		/// </summary>
+		public static MultiTermQueryRewrite ConstantScore { get; } = new MultiTermQueryRewrite(RewriteMultiTerm.ConstantScore);
+
+		/// <summary>
+		/// A rewrite method that first translates each term into a should clause in a boolean query, and keeps the scores
+		///  as computed by the query. Note that typically such scores are meaningless to the user, and require non-trivial
+		///  CPU to compute, so it’s almost always better to use constant_score_auto. This rewrite method will hit too many
+		///  clauses failure if it exceeds the boolean query limit (defaults to 1024).
+		/// </summary>
+		public static MultiTermQueryRewrite ScoringBoolean { get; } = new MultiTermQueryRewrite(RewriteMultiTerm.ScoringBoolean);
+
+		/// <summary>
+		/// Similar to scoring_boolean except scores are not computed. Instead, each matching document receives a constant
+		///  score equal to the query’s boost. This rewrite method will hit too many clauses failure if it exceeds the
+		/// boolean query limit (defaults to 1024).
+		/// </summary>
+		public static MultiTermQueryRewrite ConstantScoreBoolean { get; } = new MultiTermQueryRewrite(RewriteMultiTerm.ConstantScoreBoolean);
+
+		/// <summary>
+		/// A rewrite method that first translates each term into should clause in boolean query, and keeps the scores
+		/// as computed by the query. This rewrite method only uses the top scoring terms so it will not overflow boolean
+		///  max clause count. <param name="size" /> controls the size of the top scoring terms to use.
+		/// </summary>
+		public static MultiTermQueryRewrite TopTerms(int size) => new MultiTermQueryRewrite(RewriteMultiTerm.TopTermsN, size);
+
+		/// <summary>
+		/// A rewrite method that first translates each term into should clause in boolean query, but the scores are only
+		/// computed as the boost. This rewrite method only uses the top scoring terms so it will not overflow the boolean
+		///  max clause count. <param name="size" /> controls the size of the top scoring terms to use.
+		/// </summary>
+		public static MultiTermQueryRewrite TopTermsBoost(int size) => new MultiTermQueryRewrite(RewriteMultiTerm.TopTermsBoostN, size);
+
+		/// <summary>
+		/// A rewrite method that first translates each term into should clause in boolean query, but all term queries compute
+		///  scores as if they had the same frequency. In practice the frequency which is used is the maximum frequency of all
+		///  matching terms. This rewrite method only uses the top scoring terms so it will not overflow boolean max clause count.
+		/// <param name="size" /> controls the size of the top scoring terms to use.
+		/// </summary>
+		public static MultiTermQueryRewrite TopTermsBlendedFreqs(int size) => new MultiTermQueryRewrite(RewriteMultiTerm.TopTermsBlendedFreqsN, size);
+
+		internal static MultiTermQueryRewrite Create(string value)
+		{
+			if (value == null) throw new ArgumentNullException(nameof(value));
+
+			var rewriteType = value;
+			var size = 0;
+			var firstDigitIndex = value.IndexOfAny(DigitCharacters);
+
+			if (firstDigitIndex > -1)
+			{
+				rewriteType = $"{value.Substring(0, firstDigitIndex)}N";
+				size = int.Parse(value.Substring(firstDigitIndex));
+			}
+
+			var rewriteMultiTerm = rewriteType.ToEnum<RewriteMultiTerm>();
+			if (rewriteMultiTerm == null)
+				throw new InvalidOperationException($"Unsupported {nameof(RewriteMultiTerm)} value: '{rewriteType}'");
+
+			switch (rewriteMultiTerm)
+			{
+				case RewriteMultiTerm.ConstantScore:
+					return ConstantScore;
+				case RewriteMultiTerm.ScoringBoolean:
+					return ScoringBoolean;
+				case RewriteMultiTerm.ConstantScoreBoolean:
+					return ConstantScoreBoolean;
+				case RewriteMultiTerm.TopTermsN:
+					return TopTerms(size);
+				case RewriteMultiTerm.TopTermsBoostN:
+					return TopTermsBoost(size);
+				case RewriteMultiTerm.TopTermsBlendedFreqsN:
+					return TopTermsBlendedFreqs(size);
+				default:
+					throw new InvalidOperationException($"Unsupported {nameof(RewriteMultiTerm)} value: '{rewriteMultiTerm}'");
+			}
+		}
+
+		public override string ToString() => this._value;
+
+		public bool Equals(MultiTermQueryRewrite other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+			return Rewrite == other.Rewrite && Size == other.Size;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+
+			var value = obj as string;
+			if (value != null)
+				return string.Equals(value, _value);
+
+			return obj.GetType() == this.GetType() && Equals((MultiTermQueryRewrite)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return ((int)Rewrite * 397) ^ Size.GetHashCode();
+			}
+		}
+
+		public static bool operator ==(MultiTermQueryRewrite left, MultiTermQueryRewrite right) => Equals(left, right);
+
+		public static bool operator !=(MultiTermQueryRewrite left, MultiTermQueryRewrite right) => !Equals(left, right);
+	}
+
+	internal class MultiTermQueryRewriteConverter : JsonConverter
+	{
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var multiTerm = (MultiTermQueryRewrite)value;
+			writer.WriteValue(multiTerm?.ToString());
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType == JsonToken.Null)
+				return null;
+
+			if (reader.TokenType != JsonToken.String)
+				throw new JsonSerializationException($"Invalid token type {reader.TokenType} to deserialize {nameof(MultiTermQueryRewrite)} from");
+
+			return MultiTermQueryRewrite.Create((string)reader.Value);
+		}
+
+		public override bool CanConvert(Type objectType) => typeof(MultiTermQueryRewrite).IsAssignableFrom(objectType);
 	}
 }

--- a/src/Nest/QueryDsl/Query.cs
+++ b/src/Nest/QueryDsl/Query.cs
@@ -117,10 +117,10 @@ namespace Nest
 		public static QueryContainer Percolate(Func<PercolateQueryDescriptor<T>, IPercolateQuery> selector) =>
 			new QueryContainerDescriptor<T>().Percolate(selector);
 
-		public static QueryContainer Prefix(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+		public static QueryContainer Prefix(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null, MultiTermQueryRewrite rewrite = null, string name = null) =>
 			new QueryContainerDescriptor<T>().Prefix(fieldDescriptor, value, boost, rewrite, name);
 
-		public static QueryContainer Prefix(Field field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+		public static QueryContainer Prefix(Field field, string value, double? boost = null, MultiTermQueryRewrite rewrite = null, string name = null) =>
 			new QueryContainerDescriptor<T>().Prefix(field, value, boost, rewrite, name);
 
 		public static QueryContainer Prefix(Func<PrefixQueryDescriptor<T>, IPrefixQuery> selector) =>
@@ -192,10 +192,10 @@ namespace Nest
 
 		public static QueryContainer Type<TOther>() => Type(q => q.Value<TOther>());
 
-		public static QueryContainer Wildcard(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+		public static QueryContainer Wildcard(Expression<Func<T, object>> fieldDescriptor, string value, double? boost = null, MultiTermQueryRewrite rewrite = null, string name = null) =>
 			new QueryContainerDescriptor<T>().Wildcard(fieldDescriptor, value, boost, rewrite, name);
 
-		public static QueryContainer Wildcard(Field field, string value, double? boost = null, RewriteMultiTerm? rewrite = null, string name = null) =>
+		public static QueryContainer Wildcard(Field field, string value, double? boost = null, MultiTermQueryRewrite rewrite = null, string name = null) =>
 			new QueryContainerDescriptor<T>().Wildcard(field, value, boost, rewrite, name);
 
 		public static QueryContainer Wildcard(Func<WildcardQueryDescriptor<T>, IWildcardQuery> selector) =>

--- a/src/Nest/QueryDsl/Span/Term/SpanTermQuery.cs
+++ b/src/Nest/QueryDsl/Span/Term/SpanTermQuery.cs
@@ -7,7 +7,7 @@ namespace Nest
 	public interface ISpanTermQuery : ITermQuery, ISpanSubQuery
 	{
 	}
-	
+
 	public class SpanTermQuery : FieldNameQueryBase, ISpanTermQuery
 	{
 		protected override bool Conditionless => TermQuery.IsConditionless(this);
@@ -17,7 +17,7 @@ namespace Nest
 	}
 
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	public class SpanTermQueryDescriptor<T> : TermQueryDescriptorBase<SpanTermQueryDescriptor<T>, T>, ISpanTermQuery
+	public class SpanTermQueryDescriptor<T> : TermQueryDescriptorBase<SpanTermQueryDescriptor<T>, ISpanTermQuery, T>, ISpanTermQuery
 		where T : class
 	{
 	}

--- a/src/Nest/QueryDsl/TermLevel/Fuzzy/FuzzyQueryBase.cs
+++ b/src/Nest/QueryDsl/TermLevel/Fuzzy/FuzzyQueryBase.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Nest
 {
@@ -6,42 +7,42 @@ namespace Nest
 	[JsonConverter(typeof(FuzzyQueryJsonConverter))]
 	public interface IFuzzyQuery : IFieldNameQuery
 	{
-		[JsonProperty(PropertyName = "prefix_length")]
+		[JsonProperty("prefix_length")]
 		int? PrefixLength { get; set; }
-		
-		[JsonProperty(PropertyName = "rewrite")]
-		RewriteMultiTerm? Rewrite { get; set; }
 
-		[JsonProperty(PropertyName = "max_expansions")]
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite Rewrite { get; set; }
+
+		[JsonProperty("max_expansions")]
 		int? MaxExpansions { get; set; }
 
-		[JsonProperty(PropertyName = "transpositions")]
+		[JsonProperty("transpositions")]
 		bool? Transpositions { get; set; }
 	}
 	public interface IFuzzyQuery<TValue, TFuzziness> : IFuzzyQuery
 	{
-		[JsonProperty(PropertyName = "value")]
+		[JsonProperty("value")]
 		TValue Value { get; set; }
 
-		[JsonProperty(PropertyName = "fuzziness")]
+		[JsonProperty("fuzziness")]
 		TFuzziness Fuzziness { get; set; }
 	}
 
 	internal static class FuzzyQueryBase
 	{
-		internal static bool IsConditionless<TValue, TFuzziness>(IFuzzyQuery<TValue, TFuzziness> fuzzy) => 
+		internal static bool IsConditionless<TValue, TFuzziness>(IFuzzyQuery<TValue, TFuzziness> fuzzy) =>
 			fuzzy == null || fuzzy.Value == null || fuzzy.Field == null;
 	}
 
 	public abstract class FuzzyQueryBase<TValue, TFuzziness> : FieldNameQueryBase, IFuzzyQuery<TValue, TFuzziness>
 	{
 		public int? PrefixLength { get; set; }
-		
+
 		public TValue Value { get; set; }
 
 		public TFuzziness Fuzziness { get; set; }
 
-		public RewriteMultiTerm? Rewrite { get; set; }
+		public MultiTermQueryRewrite Rewrite { get; set; }
 
 		public int? MaxExpansions { get; set; }
 
@@ -53,7 +54,7 @@ namespace Nest
 
 	}
 
-	public abstract class FuzzyQueryDescriptorBase<TDescriptor, T, TValue, TFuzziness> 
+	public abstract class FuzzyQueryDescriptorBase<TDescriptor, T, TValue, TFuzziness>
 		: FieldNameQueryDescriptorBase<TDescriptor, IFuzzyQuery<TValue, TFuzziness>, T> , IFuzzyQuery<TValue, TFuzziness>
 		where T : class
 		where TDescriptor : FieldNameQueryDescriptorBase<TDescriptor, IFuzzyQuery<TValue, TFuzziness>, T>, IFuzzyQuery<TValue, TFuzziness>
@@ -62,7 +63,7 @@ namespace Nest
 		int? IFuzzyQuery.PrefixLength { get; set; }
 		int? IFuzzyQuery.MaxExpansions { get; set; }
 		bool? IFuzzyQuery.Transpositions { get; set; }
-		RewriteMultiTerm? IFuzzyQuery.Rewrite { get; set; }
+		MultiTermQueryRewrite IFuzzyQuery.Rewrite { get; set; }
 		TFuzziness IFuzzyQuery<TValue, TFuzziness>.Fuzziness { get; set; }
 		TValue IFuzzyQuery<TValue, TFuzziness>.Value { get; set; }
 
@@ -72,7 +73,6 @@ namespace Nest
 
 		public TDescriptor Transpositions(bool? enable = true) => Assign(a => a.Transpositions = enable);
 
-		public TDescriptor Rewrite(RewriteMultiTerm? rewrite) => Assign(a => a.Rewrite = rewrite);
-
+		public TDescriptor Rewrite(MultiTermQueryRewrite rewrite) => Assign(a => Self.Rewrite = rewrite);
 	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Fuzzy/FuzzyQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/TermLevel/Fuzzy/FuzzyQueryJsonConverter.cs
@@ -31,7 +31,7 @@ namespace Nest
 			IFuzzyQuery fq;
 			if (v.Type == JTokenType.String)
 			{
-				fq = new FuzzyQuery()
+				fq = new FuzzyQuery
 				{
 					Value = GetPropValue<string>(jo, "value"),
 					Fuzziness = GetPropObject<Fuzziness>(jo, "fuzziness")
@@ -39,7 +39,7 @@ namespace Nest
 			}
 			else if (v.Type == JTokenType.Date)
 			{
-				fq = new FuzzyDateQuery()
+				fq = new FuzzyDateQuery
 				{
 					Value = GetPropValue<DateTime?>(jo, "value"),
 					Fuzziness = GetPropObject<Time>(jo, "fuzziness")
@@ -47,7 +47,7 @@ namespace Nest
 			}
 			else if (v.Type == JTokenType.Integer || v.Type == JTokenType.Float)
 			{
-				fq = new FuzzyNumericQuery()
+				fq = new FuzzyNumericQuery
 				{
 					Value = GetPropValue<double?>(jo, "value"),
 					Fuzziness = GetPropValue<double?>(jo, "fuzziness")
@@ -60,7 +60,7 @@ namespace Nest
 			fq.Transpositions = GetPropValue<bool?>(jo, "transpositions");
 			var rewriteString = GetPropValue<string>(jo, "rewrite");
 			if (!rewriteString.IsNullOrEmpty())
-				fq.Rewrite = rewriteString.ToEnum<RewriteMultiTerm>();
+				fq.Rewrite = MultiTermQueryRewrite.Create(rewriteString);
 
 			fq.Name = GetPropValue<string>(jo, "_name");
 			fq.Boost = GetPropValue<double?>(jo, "boost");

--- a/src/Nest/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
@@ -7,29 +6,25 @@ namespace Nest
 	[JsonConverter(typeof (FieldNameQueryJsonConverter<PrefixQuery>))]
 	public interface IPrefixQuery : ITermQuery
 	{
-		[JsonProperty(PropertyName = "rewrite")]
-		[JsonConverter(typeof (StringEnumConverter))]
-		RewriteMultiTerm? Rewrite { get; set; }
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite Rewrite { get; set; }
 	}
 
 	public class PrefixQuery : FieldNameQueryBase, IPrefixQuery
 	{
 		protected override bool Conditionless => TermQuery.IsConditionless(this);
 		public object Value { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+
+		public MultiTermQueryRewrite Rewrite { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Prefix = this;
 	}
 
-	public class PrefixQueryDescriptor<T> : TermQueryDescriptorBase<PrefixQueryDescriptor<T>, T>, 
+	public class PrefixQueryDescriptor<T> : TermQueryDescriptorBase<PrefixQueryDescriptor<T>, IPrefixQuery, T>,
 		IPrefixQuery where T : class
 	{
-		RewriteMultiTerm? IPrefixQuery.Rewrite { get; set; }
+		MultiTermQueryRewrite IPrefixQuery.Rewrite { get; set; }
 
-		public PrefixQueryDescriptor<T> Rewrite(RewriteMultiTerm? rewrite) 
-		{
-			((IPrefixQuery)this).Rewrite = rewrite;
-			return this;
-		}
+		public PrefixQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite) => Assign(a => a.Rewrite = rewrite);
 	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Term/TermQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Term/TermQuery.cs
@@ -20,9 +20,10 @@ namespace Nest
 		internal static bool IsConditionless(ITermQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
 	}
 
-	public abstract class TermQueryDescriptorBase<TDescriptor, T> : FieldNameQueryDescriptorBase<TDescriptor, ITermQuery, T>
+	public abstract class TermQueryDescriptorBase<TDescriptor, TInterface, T> : FieldNameQueryDescriptorBase<TDescriptor, TInterface, T>
 		, ITermQuery
-		where TDescriptor : TermQueryDescriptorBase<TDescriptor, T>
+		where TDescriptor : TermQueryDescriptorBase<TDescriptor, TInterface, T>, TInterface
+		where TInterface : class, ITermQuery
 		where T : class
 	{
 		protected override bool Conditionless => TermQuery.IsConditionless(this);
@@ -35,8 +36,8 @@ namespace Nest
 		}
 	}
 
-	public class TermQueryDescriptor<T> : TermQueryDescriptorBase<TermQueryDescriptor<T>, T>
+	public class TermQueryDescriptor<T> : TermQueryDescriptorBase<TermQueryDescriptor<T>, ITermQuery, T>
 		where T : class
-	{	
+	{
 	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
@@ -9,9 +8,8 @@ namespace Nest
 	[JsonConverter(typeof (FieldNameQueryJsonConverter<WildcardQuery>))]
 	public interface IWildcardQuery : ITermQuery
 	{
-		[JsonProperty(PropertyName = "rewrite")]
-		[JsonConverter(typeof (StringEnumConverter))]
-		RewriteMultiTerm? Rewrite { get; set; }
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite Rewrite { get; set; }
 	}
 
 	public class WildcardQuery<T> : WildcardQuery
@@ -24,21 +22,18 @@ namespace Nest
 	{
 		protected override bool Conditionless => TermQuery.IsConditionless(this);
 		public object Value { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+
+		public MultiTermQueryRewrite Rewrite { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Wildcard = this;
 	}
 
-	public class WildcardQueryDescriptor<T> : TermQueryDescriptorBase<WildcardQueryDescriptor<T>, T>,
+	public class WildcardQueryDescriptor<T> : TermQueryDescriptorBase<WildcardQueryDescriptor<T>, IWildcardQuery, T>,
 		IWildcardQuery
 		where T : class
 	{
-		RewriteMultiTerm? IWildcardQuery.Rewrite { get; set; }
+		MultiTermQueryRewrite IWildcardQuery.Rewrite { get; set; }
 
-		public WildcardQueryDescriptor<T> Rewrite(RewriteMultiTerm? rewrite)
-		{
-			((IWildcardQuery)this).Rewrite = rewrite;
-			return this;
-		}
+		public WildcardQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite) => Assign(a => a.Rewrite = rewrite);
 	}
 }

--- a/src/Tests/QueryDsl/Compound/FullText/Match/MatchUsageTests.cs
+++ b/src/Tests/QueryDsl/Compound/FullText/Match/MatchUsageTests.cs
@@ -20,7 +20,7 @@ namespace Tests.QueryDsl.FullText.Match
 					boost = 1.1,
 					query = "hello world",
 					analyzer = "standard",
-					fuzzy_rewrite = "constant_score_boolean",
+					fuzzy_rewrite = "top_terms_blended_freqs_10",
 					fuzziness = "AUTO",
 					fuzzy_transpositions = true,
 					cutoff_frequency = 0.001,
@@ -43,7 +43,7 @@ namespace Tests.QueryDsl.FullText.Match
 			Fuzziness = Fuzziness.Auto,
 			FuzzyTranspositions = true,
 			MinimumShouldMatch = 2,
-			FuzzyRewrite = RewriteMultiTerm.ConstantScoreBoolean,
+			FuzzyRewrite = MultiTermQueryRewrite.TopTermsBlendedFreqs(10),
 			Lenient = true,
 			Operator = Operator.Or,
 		};
@@ -60,7 +60,7 @@ namespace Tests.QueryDsl.FullText.Match
 				.FuzzyTranspositions()
 				.MinimumShouldMatch(2)
 				.Operator(Operator.Or)
-				.FuzzyRewrite(RewriteMultiTerm.ConstantScoreBoolean)
+				.FuzzyRewrite(MultiTermQueryRewrite.TopTermsBlendedFreqs(10))
 				.Name("named_query")
 			);
 

--- a/src/Tests/QueryDsl/Compound/FullText/MultiMatch/MultiMatchUsageTests.cs
+++ b/src/Tests/QueryDsl/Compound/FullText/MultiMatch/MultiMatchUsageTests.cs
@@ -48,7 +48,7 @@ namespace Tests.QueryDsl.FullText.MultiMatch
 			MaxExpansions = 2,
 			Operator = Operator.Or,
 			MinimumShouldMatch = 2,
-			FuzzyRewrite = RewriteMultiTerm.ConstantScoreBoolean,
+			FuzzyRewrite = MultiTermQueryRewrite.ConstantScoreBoolean,
 			TieBreaker = 1.1,
 			CutoffFrequency = 0.001,
 			Lenient = true,
@@ -68,7 +68,7 @@ namespace Tests.QueryDsl.FullText.MultiMatch
 				.MaxExpansions(2)
 				.Operator(Operator.Or)
 				.MinimumShouldMatch(2)
-				.FuzzyRewrite(RewriteMultiTerm.ConstantScoreBoolean)
+				.FuzzyRewrite(MultiTermQueryRewrite.ConstantScoreBoolean)
 				.TieBreaker(1.1)
 				.CutoffFrequency(0.001)
 				.Lenient()

--- a/src/Tests/QueryDsl/Compound/FullText/QueryString/QueryStringUsageTests.cs
+++ b/src/Tests/QueryDsl/Compound/FullText/QueryString/QueryStringUsageTests.cs
@@ -63,8 +63,8 @@ namespace Tests.QueryDsl.FullText.QueryString
 			UseDisMax = true,
 			FuzzyPrefixLength = 2,
 			FuzzyMaxExpansions = 3,
-			FuzzyRewrite = RewriteMultiTerm.ConstantScore,
-			Rewrite = RewriteMultiTerm.ConstantScore,
+			FuzzyRewrite = MultiTermQueryRewrite.ConstantScore,
+			Rewrite = MultiTermQueryRewrite.ConstantScore,
 			Fuzziness = Fuzziness.Auto,
 			TieBreaker = 1.2,
 			AnalyzeWildcard = true,
@@ -94,8 +94,8 @@ namespace Tests.QueryDsl.FullText.QueryString
 				.UseDisMax()
 				.FuzzyPrefixLength(2)
 				.FuzzyMaxExpansions(3)
-				.FuzzyRewrite(RewriteMultiTerm.ConstantScore)
-				.Rewrite(RewriteMultiTerm.ConstantScore)
+				.FuzzyRewrite(MultiTermQueryRewrite.ConstantScore)
+				.Rewrite(MultiTermQueryRewrite.ConstantScore)
 				.Fuzziness(Fuzziness.Auto)
 				.TieBreaker(1.2)
 				.AnalyzeWildcard()

--- a/src/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyDateQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyDateQueryUsageTests.cs
@@ -38,7 +38,7 @@ namespace Tests.QueryDsl.TermLevel.Fuzzy
 			Value = Project.Instance.StartedOn,
 			MaxExpansions = 100,
 			PrefixLength = 3,
-			Rewrite = RewriteMultiTerm.ConstantScore,
+			Rewrite = MultiTermQueryRewrite.ConstantScore,
 			Transpositions = true
 		};
 
@@ -51,7 +51,7 @@ namespace Tests.QueryDsl.TermLevel.Fuzzy
 				.Value(Project.Instance.StartedOn)
 				.MaxExpansions(100)
 				.PrefixLength(3)
-				.Rewrite(RewriteMultiTerm.ConstantScore)
+				.Rewrite(MultiTermQueryRewrite.ConstantScore)
 				.Transpositions()
 			);
 

--- a/src/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyNumericQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyNumericQueryUsageTests.cs
@@ -37,7 +37,7 @@ namespace Tests.QueryDsl.TermLevel.Fuzzy
 			Value = 12,
 			MaxExpansions = 100,
 			PrefixLength = 3,
-			Rewrite = RewriteMultiTerm.ConstantScore,
+			Rewrite = MultiTermQueryRewrite.ConstantScore,
 			Transpositions = true
 		};
 
@@ -50,7 +50,7 @@ namespace Tests.QueryDsl.TermLevel.Fuzzy
 				.Value(12)
 				.MaxExpansions(100)
 				.PrefixLength(3)
-				.Rewrite(RewriteMultiTerm.ConstantScore)
+				.Rewrite(MultiTermQueryRewrite.ConstantScore)
 				.Transpositions()
 			);
 

--- a/src/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyQueryUsageTests.cs
@@ -36,7 +36,7 @@ namespace Tests.QueryDsl.TermLevel.Fuzzy
 			Value = "ki",
 			MaxExpansions = 100,
 			PrefixLength = 3,
-			Rewrite = RewriteMultiTerm.ConstantScore,
+			Rewrite = MultiTermQueryRewrite.ConstantScore,
 			Transpositions = true
 		};
 
@@ -49,7 +49,7 @@ namespace Tests.QueryDsl.TermLevel.Fuzzy
 				.Value("ki")
 				.MaxExpansions(100)
 				.PrefixLength(3)
-				.Rewrite(RewriteMultiTerm.ConstantScore)
+				.Rewrite(MultiTermQueryRewrite.ConstantScore)
 				.Transpositions()
 			);
 

--- a/src/Tests/QueryDsl/TermLevel/Prefix/PrefixQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Prefix/PrefixQueryUsageTests.cs
@@ -17,7 +17,7 @@ namespace Tests.QueryDsl.PrefixLevel.Prefix
 				{
 					_name = "named_query",
 					boost = 1.1,
-					rewrite = "top_terms_boost_N",
+					rewrite = "top_terms_10",
 					value = "proj"
 				}
 			}
@@ -29,7 +29,7 @@ namespace Tests.QueryDsl.PrefixLevel.Prefix
 			Boost = 1.1,
 			Field = "description",
 			Value = "proj",
-			Rewrite = RewriteMultiTerm.TopTermsBoostN
+			Rewrite = MultiTermQueryRewrite.TopTerms(10)
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -38,7 +38,7 @@ namespace Tests.QueryDsl.PrefixLevel.Prefix
 				.Boost(1.1)
 				.Field(p => p.Description)
 				.Value("proj")
-				.Rewrite(RewriteMultiTerm.TopTermsBoostN)
+				.Rewrite(MultiTermQueryRewrite.TopTerms(10))
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IPrefixQuery>(a => a.Prefix)

--- a/src/Tests/QueryDsl/TermLevel/Wildcard/WildcardQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Wildcard/WildcardQueryUsageTests.cs
@@ -17,7 +17,7 @@ namespace Tests.QueryDsl.TermLevel.Wildcard
 				{
 					_name = "named_query",
 					boost = 1.1,
-					rewrite = "top_terms_boost_N",
+					rewrite = "top_terms_boost_10",
 					value = "p*oj"
 				}
 			}
@@ -29,7 +29,7 @@ namespace Tests.QueryDsl.TermLevel.Wildcard
 			Boost = 1.1,
 			Field = "description",
 			Value = "p*oj",
-			Rewrite = RewriteMultiTerm.TopTermsBoostN
+			Rewrite = MultiTermQueryRewrite.TopTermsBoost(10)
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
@@ -38,7 +38,7 @@ namespace Tests.QueryDsl.TermLevel.Wildcard
 				.Boost(1.1)
 				.Field(p => p.Description)
 				.Value("p*oj")
-				.Rewrite(RewriteMultiTerm.TopTermsBoostN)
+				.Rewrite(MultiTermQueryRewrite.TopTermsBoost(10))
 			);
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IWildcardQuery>(a => a.Wildcard)


### PR DESCRIPTION
TopTermsN, TopTermsBoostN, TopTermsBlendedFreqsN require the ability to pass a value for N.

Remove the direct usage of RewriteMultiTerm enum in favour of MultiTermQueryRewrite type. Keep the enum in source to serve as the rewrite property on MultiTermQueryRewrite

Fixes #2688

(cherry picked from commit 5784bdbf2f78cac40f7695c736df40b17e249fca)