### PR TITLE
Introduce MultiTermQueryRewrite type

### DIFF
--- a/src/Nest/DSL/Query/FuzzyDateQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FuzzyDateQueryDescriptor.cs
@@ -29,7 +29,14 @@ namespace Nest
 		public PropertyPathMarker Field { get; set; }
 		public double? Boost { get; set; }
 		public string Fuzziness { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		public RewriteMultiTerm? Rewrite
+		{
+			get { return MultiTermQueryRewrite?.Rewrite; }
+			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+
+		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 		public int? MaxExpansions { get; set; }
 		public bool? Transpositions { get; set; }
 		public bool? UnicodeAware { get; set; }
@@ -54,8 +61,15 @@ namespace Nest
 
 		bool? IFuzzyQuery.UnicodeAware { get; set; }
 
-		RewriteMultiTerm? IFuzzyQuery.Rewrite { get; set; }
-		
+		[Obsolete("Use MultiTermQueryRewrite")]
+		RewriteMultiTerm? IFuzzyQuery.Rewrite
+		{
+			get { return Self.MultiTermQueryRewrite?.Rewrite; }
+			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+
+		MultiTermQueryRewrite IFuzzyQuery.MultiTermQueryRewrite { get; set; }
+
 		string IQuery.Name { get; set; }
 
 		bool IQuery.IsConditionless
@@ -119,9 +133,16 @@ namespace Nest
 			return this;
 		}
 		
+		[Obsolete("Use overload that accepts MultiTermQueryRewrite")]
 		public FuzzyDateQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
 		{
-			Self.Rewrite = rewrite;
+			Self.MultiTermQueryRewrite = new MultiTermQueryRewrite(rewrite);
+			return this;
+		}
+
+		public FuzzyDateQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite)
+		{
+			Self.MultiTermQueryRewrite = rewrite;
 			return this;
 		}
 

--- a/src/Nest/DSL/Query/FuzzyNumericQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FuzzyNumericQueryDescriptor.cs
@@ -29,7 +29,14 @@ namespace Nest
 		public PropertyPathMarker Field { get; set; }
 		public double? Boost { get; set; }
 		public string Fuzziness { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		public RewriteMultiTerm? Rewrite
+		{
+			get { return MultiTermQueryRewrite?.Rewrite; }
+			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+
+		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 		public int? MaxExpansions { get; set; }
 		public bool? Transpositions { get; set; }
 		public bool? UnicodeAware { get; set; }
@@ -54,7 +61,14 @@ namespace Nest
 
 		bool? IFuzzyQuery.UnicodeAware { get; set; }
 
-		RewriteMultiTerm? IFuzzyQuery.Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		RewriteMultiTerm? IFuzzyQuery.Rewrite
+		{
+			get { return Self.MultiTermQueryRewrite?.Rewrite; }
+			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+
+		MultiTermQueryRewrite IFuzzyQuery.MultiTermQueryRewrite { get; set; }
 
 		string IQuery.Name { get; set; }
 
@@ -123,9 +137,16 @@ namespace Nest
 			Self.UnicodeAware = enable;
 			return this;
 		}
+		[Obsolete("Use overload that accepts MultiTermQueryRewrite")]
 		public FuzzyNumericQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
 		{
-			Self.Rewrite = rewrite;
+			Self.MultiTermQueryRewrite = new MultiTermQueryRewrite(rewrite);
+			return this;
+		}
+
+		public FuzzyNumericQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite)
+		{
+			Self.MultiTermQueryRewrite = rewrite;
 			return this;
 		}
 		public FuzzyNumericQueryDescriptor<T> Value(int? value)

--- a/src/Nest/DSL/Query/FuzzyQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FuzzyQueryDescriptor.cs
@@ -20,8 +20,12 @@ namespace Nest
 		[JsonProperty(PropertyName = "fuzziness")]
 		string Fuzziness { get; set; }
 
-		[JsonProperty(PropertyName = "rewrite")]
+		[JsonIgnore]
+		[Obsolete("Use MultiTermQueryRewrite")]
 		RewriteMultiTerm? Rewrite { get; set; }
+
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 
 		[JsonProperty(PropertyName = "max_expansions")]
 		int? MaxExpansions { get; set; }
@@ -57,7 +61,13 @@ namespace Nest
 		public PropertyPathMarker Field { get; set; }
 		public double? Boost { get; set; }
 		public string Fuzziness { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		public RewriteMultiTerm? Rewrite
+		{
+			get { return MultiTermQueryRewrite?.Rewrite; }
+			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 		public int? MaxExpansions { get; set; }
 		public bool? Transpositions { get; set; }
 		public bool? UnicodeAware { get; set; }
@@ -85,8 +95,15 @@ namespace Nest
 
 		bool? IFuzzyQuery.UnicodeAware { get; set; }
 
-		RewriteMultiTerm? IFuzzyQuery.Rewrite { get; set; }
-		
+		[Obsolete("Use MultiTermQueryRewrite")]
+		RewriteMultiTerm? IFuzzyQuery.Rewrite
+		{
+			get { return Self.MultiTermQueryRewrite?.Rewrite; }
+			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+
+		MultiTermQueryRewrite IFuzzyQuery.MultiTermQueryRewrite { get; set; }
+
 		bool IQuery.IsConditionless
 		{
 			get
@@ -163,12 +180,20 @@ namespace Nest
 			((IFuzzyQuery)this).UnicodeAware = enable;
 			return this;
 		}
-		
+
+		[Obsolete("Use overload that accepts MultiTermQueryRewrite")]
 		public FuzzyQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
 		{
-			((IFuzzyQuery)this).Rewrite = rewrite;
+			((IFuzzyQuery)this).MultiTermQueryRewrite = new MultiTermQueryRewrite(rewrite);
 			return this;
 		}
+
+		public FuzzyQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite)
+		{
+			((IFuzzyQuery)this).MultiTermQueryRewrite = rewrite;
+			return this;
+		}
+
 		public FuzzyQueryDescriptor<T> Value(string value)
 		{
 			Self.Value = value;

--- a/src/Nest/DSL/Query/IdsQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/IdsQueryDescriptor.cs
@@ -104,9 +104,7 @@ namespace Nest
 			return this.Values(values.ToArray());
 		}
 	}
-
 	
-	[Obsolete("Scheduled to be removed in 2.0")]
 	public class IdsQueryDescriptor : IIdsQuery
 	{
 		[JsonProperty(PropertyName = "_name")]

--- a/src/Nest/DSL/Query/MatchQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MatchQueryDescriptor.cs
@@ -22,9 +22,12 @@ namespace Nest
 		[JsonProperty(PropertyName = "analyzer")]
 		string Analyzer { get; set; }
 
-		[JsonProperty(PropertyName = "rewrite")]
-		[JsonConverter(typeof (StringEnumConverter))]
+		[JsonIgnore]
+		[Obsolete("Use MultiTermQueryRewrite")]
 		RewriteMultiTerm? Rewrite { get; set; }
+
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 
 		[JsonProperty(PropertyName = "fuzziness")]
 		double? Fuzziness { get; set; }
@@ -83,7 +86,13 @@ namespace Nest
 		public string Type { get; set; }
 		public string Query { get; set; }
 		public string Analyzer { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		public RewriteMultiTerm? Rewrite
+		{
+			get { return MultiTermQueryRewrite?.Rewrite; }
+			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 		public double? Fuzziness { get; set; }
 		public bool? FuzzyTranspositions { get; set; }
 		public double? CutoffFrequency { get; set; }
@@ -113,7 +122,13 @@ namespace Nest
 
 		string IMatchQuery.MinimumShouldMatch { get; set; }
 
-		RewriteMultiTerm? IMatchQuery.Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		RewriteMultiTerm? IMatchQuery.Rewrite
+		{
+			get { return Self.MultiTermQueryRewrite?.Rewrite; }
+			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		MultiTermQueryRewrite IMatchQuery.MultiTermQueryRewrite { get; set; }
 
 		double? IMatchQuery.Fuzziness { get; set; }
 		bool? IMatchQuery.FuzzyTranspositions { get; set; }
@@ -205,9 +220,16 @@ namespace Nest
 			return this;
 		}
 
+		[Obsolete("Use overload that accepts MultiTermQueryRewrite")]
 		public MatchQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
 		{
-			Self.Rewrite = rewrite;
+			Self.MultiTermQueryRewrite = new MultiTermQueryRewrite(rewrite);
+			return this;
+		}
+
+		public MatchQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite)
+		{
+			Self.MultiTermQueryRewrite = rewrite;
 			return this;
 		}
 

--- a/src/Nest/DSL/Query/MultiMatchQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/MultiMatchQueryDescriptor.cs
@@ -22,9 +22,12 @@ namespace Nest
 		[JsonProperty(PropertyName = "analyzer")]
 		string Analyzer { get; set; }
 
-		[JsonProperty(PropertyName = "rewrite")]
-		[JsonConverter(typeof(StringEnumConverter))]
+		[JsonIgnore]
+		[Obsolete("Use MultiTermQueryRewrite")]
 		RewriteMultiTerm? Rewrite { get; set; }
+
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 
 		[JsonProperty(PropertyName = "fuzziness")]
 		double? Fuzziness { get; set; }
@@ -76,7 +79,13 @@ namespace Nest
 		public TextQueryType? Type { get; set; }
 		public string Query { get; set; }
 		public string Analyzer { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		public RewriteMultiTerm? Rewrite
+		{
+			get { return MultiTermQueryRewrite?.Rewrite; }
+			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 		public double? Fuzziness { get; set; }
 		public double? CutoffFrequency { get; set; }
 		public int? PrefixLength { get; set; }
@@ -102,7 +111,14 @@ namespace Nest
 
 		string IMultiMatchQuery.Analyzer { get; set; }
 
-		RewriteMultiTerm? IMultiMatchQuery.Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		RewriteMultiTerm? IMultiMatchQuery.Rewrite
+		{
+			get { return Self.MultiTermQueryRewrite?.Rewrite; }
+			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+
+		MultiTermQueryRewrite IMultiMatchQuery.MultiTermQueryRewrite { get; set; }
 
 		double? IMultiMatchQuery.Fuzziness { get; set; }
 
@@ -197,9 +213,16 @@ namespace Nest
 			return this;
 		}
 
+		[Obsolete("Use overload that accepts MultiTermQueryRewrite")]
 		public MultiMatchQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
 		{
-			Self.Rewrite = rewrite;
+			Self.MultiTermQueryRewrite = new MultiTermQueryRewrite(rewrite);
+			return this;
+		}
+
+		public MultiMatchQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite)
+		{
+			Self.MultiTermQueryRewrite = rewrite;
 			return this;
 		}
 

--- a/src/Nest/DSL/Query/PrefixQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/PrefixQueryDescriptor.cs
@@ -10,9 +10,12 @@ namespace Nest
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public interface IPrefixQuery : ITermQuery
 	{
-		[JsonProperty(PropertyName = "rewrite")]
-		[JsonConverter(typeof (StringEnumConverter))]
+		[JsonIgnore]
+		[Obsolete("Use MultiTermQueryRewrite")]
 		RewriteMultiTerm? Rewrite { get; set; }
+
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 	}
 
 	public class PrefixQuery : PlainQuery, IPrefixQuery
@@ -38,19 +41,39 @@ namespace Nest
 		public PropertyPathMarker Field { get; set; }
 		public object Value { get; set; }
 		public double? Boost { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		public RewriteMultiTerm? Rewrite
+		{
+			get { return MultiTermQueryRewrite?.Rewrite; }
+			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 	}
 
 	public class PrefixQueryDescriptor<T> : TermQueryDescriptorBase<PrefixQueryDescriptor<T>, T>, 
 		IPrefixQuery where T : class
 	{
-		RewriteMultiTerm? IPrefixQuery.Rewrite { get; set; }
+		protected IPrefixQuery Self { get { return this; } }
 
+		[Obsolete("Use MultiTermQueryRewrite")]
+		RewriteMultiTerm? IPrefixQuery.Rewrite
+		{
+			get { return Self.MultiTermQueryRewrite?.Rewrite; }
+			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		MultiTermQueryRewrite IPrefixQuery.MultiTermQueryRewrite { get; set; }
+
+		[Obsolete("Use overload that accepts MultiTermQueryRewrite")]
 		public PrefixQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
 		{
-			((IPrefixQuery)this).Rewrite = rewrite;
+			Self.MultiTermQueryRewrite = new MultiTermQueryRewrite(rewrite);
 			return this;
 		}
-		
+
+		public PrefixQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite)
+		{
+			Self.MultiTermQueryRewrite = rewrite;
+			return this;
+		}
 	}
 }

--- a/src/Nest/DSL/Query/QueryDescriptor.cs
+++ b/src/Nest/DSL/Query/QueryDescriptor.cs
@@ -656,7 +656,7 @@ namespace Nest
 			termSelector(termQuery);
 			return this.New(termQuery, q => q.Term = termQuery);
 		}
-		
+
 		/// <summary>
 		/// Matches documents that have fields matching a wildcard expression (not analyzed). 
 		/// Supported wildcards are *, which matches any character sequence (including the empty one), and ?, 
@@ -664,6 +664,7 @@ namespace Nest
 		/// over many terms. In order to prevent extremely slow wildcard queries, a wildcard term should 
 		/// not start with one of the wildcards * or ?. The wildcard query maps to Lucene WildcardQuery.
 		/// </summary>
+		[Obsolete("Use overload that accepts Action<WildcardQueryDescriptor<T>> wildcardSelector. MultiTermQueryRewrite should be used instead of RewriteMultiTerm")]
 		public QueryContainer Wildcard(Expression<Func<T, object>> fieldDescriptor, string value, double? Boost = null, RewriteMultiTerm? Rewrite = null)
 		{
 			return this.Wildcard(t =>
@@ -673,7 +674,7 @@ namespace Nest
 				if (Rewrite.HasValue) t.Rewrite(Rewrite.Value);
 			});
 		}
-		
+
 		/// <summary>
 		/// Matches documents that have fields matching a wildcard expression (not analyzed). 
 		/// Supported wildcards are *, which matches any character sequence (including the empty one), and ?,
@@ -681,6 +682,7 @@ namespace Nest
 		/// In order to prevent extremely slow wildcard queries, a wildcard term should not start with 
 		/// one of the wildcards * or ?. The wildcard query maps to Lucene WildcardQuery.
 		/// </summary>
+		[Obsolete("Use overload that accepts Action<WildcardQueryDescriptor<T>> wildcardSelector. MultiTermQueryRewrite should be used instead of RewriteMultiTerm")]
 		public QueryContainer Wildcard(string field, string value, double? Boost = null, RewriteMultiTerm? Rewrite = null)
 		{
 			return this.Wildcard(t =>
@@ -689,8 +691,8 @@ namespace Nest
 				if (Boost.HasValue) t.Boost(Boost.Value);
 				if (Rewrite.HasValue) t.Rewrite(Rewrite.Value);
 			});
-		}
-		
+		}		
+			
 		/// <summary>
 		/// Matches documents that have fields matching a wildcard expression (not analyzed). 
 		/// Supported wildcards are *, which matches any character sequence (including the empty one), and ?,
@@ -704,11 +706,12 @@ namespace Nest
 			wildcardSelector(wildcardQuery);
 			return this.New(wildcardQuery, q => q.Wildcard = wildcardQuery);
 		}
-		
+
 		/// <summary>
 		/// Matches documents that have fields containing terms with a specified prefix (not analyzed). 
 		/// The prefix query maps to Lucene PrefixQuery. 
 		/// </summary>
+		[Obsolete("Use overload that accepts Action<PrefixQueryDescriptor<T>> prefixSelector. MultiTermQueryRewrite should be used instead of RewriteMultiTerm")]
 		public QueryContainer Prefix(Expression<Func<T, object>> fieldDescriptor, string value, double? Boost = null, RewriteMultiTerm? Rewrite = null)
 		{
 			return this.Prefix(t =>
@@ -723,6 +726,7 @@ namespace Nest
 		/// Matches documents that have fields containing terms with a specified prefix (not analyzed). 
 		/// The prefix query maps to Lucene PrefixQuery. 
 		/// </summary>	
+		[Obsolete("Use overload that accepts Action<PrefixQueryDescriptor<T>> prefixSelector. MultiTermQueryRewrite should be used instead of RewriteMultiTerm")]
 		public QueryContainer Prefix(string field, string value, double? Boost = null, RewriteMultiTerm? Rewrite = null)
 		{
 			return this.Prefix(t =>
@@ -732,7 +736,7 @@ namespace Nest
 				if (Rewrite.HasValue) t.Rewrite(Rewrite.Value);
 			});
 		}
-		
+
 		/// <summary>
 		/// Matches documents that have fields containing terms with a specified prefix (not analyzed). 
 		/// The prefix query maps to Lucene PrefixQuery. 
@@ -782,11 +786,13 @@ namespace Nest
 		/// Note, this filter does not require the _id field to be indexed since 
 		/// it works using the _uid field.
 		/// </summary>
+#pragma warning disable 618
 		public QueryContainer Ids(Func<IdsQueryProperDescriptor, IdsQueryProperDescriptor> selector)
 		{
 			var ids = selector(new IdsQueryProperDescriptor());
 			return this.New(ids, c => c.Ids = ids);
 		}
+#pragma warning restore 618
 
 		/// <summary>
 		/// Matches spans containing a term. The span term query maps to Lucene SpanTermQuery. 

--- a/src/Nest/DSL/Query/QueryStringDescriptor.cs
+++ b/src/Nest/DSL/Query/QueryStringDescriptor.cs
@@ -73,9 +73,12 @@ namespace Nest
 		[JsonProperty(PropertyName = "max_determinized_states")]
 		int? MaximumDeterminizedStates { get; set; }
 
-		[JsonProperty(PropertyName = "rewrite")]
-		[JsonConverter(typeof (StringEnumConverter))]
+		[JsonIgnore]
+		[Obsolete("Use MultiTermQueryRewrite")]
 		RewriteMultiTerm? Rewrite { get; set; }
+
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 	}
 
 	public class QueryStringQuery : PlainQuery, IQueryStringQuery
@@ -114,7 +117,13 @@ namespace Nest
 		public bool? UseDisMax { get; set; }
 		public double? TieBreaker { get; set; }
 		public int? MaximumDeterminizedStates { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
+		[Obsolete("Use MultiTermQueryRewrite")]
+		public RewriteMultiTerm? Rewrite
+		{
+			get { return MultiTermQueryRewrite?.Rewrite; }
+			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 	}
 
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
@@ -161,8 +170,15 @@ namespace Nest
 		double? IQueryStringQuery.TieBreaker { get; set; }
 
 		int? IQueryStringQuery.MaximumDeterminizedStates { get; set; }
-		
-		RewriteMultiTerm? IQueryStringQuery.Rewrite { get; set; }
+
+		[Obsolete("Use MultiTermQueryRewrite")]
+		RewriteMultiTerm? IQueryStringQuery.Rewrite
+		{
+			get { return Self.MultiTermQueryRewrite?.Rewrite; }
+			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+
+		MultiTermQueryRewrite IQueryStringQuery.MultiTermQueryRewrite { get; set; }
 
 		bool IQuery.IsConditionless
 		{
@@ -274,9 +290,16 @@ namespace Nest
 			Self.Boost = boost;
 			return this;
 		}
-		public QueryStringQueryDescriptor<T> Rewrite(RewriteMultiTerm rewriteMultiTerm)
+		[Obsolete("Use overload that accepts MultiTermQueryRewrite")]
+		public QueryStringQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
 		{
-			Self.Rewrite = rewriteMultiTerm;
+			Self.MultiTermQueryRewrite = new MultiTermQueryRewrite(rewrite);
+			return this;
+		}
+
+		public QueryStringQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite)
+		{
+			Self.MultiTermQueryRewrite = rewrite;
 			return this;
 		}
 		public QueryStringQueryDescriptor<T> Lenient(bool lenient = true)

--- a/src/Nest/DSL/Query/WildcardQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/WildcardQueryDescriptor.cs
@@ -11,9 +11,12 @@ namespace Nest
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public interface IWildcardQuery : ITermQuery
 	{
-		[JsonProperty(PropertyName = "rewrite")]
-		[JsonConverter(typeof (StringEnumConverter))]
+		[JsonIgnore]
+		[Obsolete("Use MultiTermQueryRewrite")]
 		RewriteMultiTerm? Rewrite { get; set; }
+
+		[JsonProperty("rewrite")]
+		MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 	}
 
 	public class WildcardQuery<T> : WildcardQuery
@@ -35,8 +38,13 @@ namespace Nest
 		public PropertyPathMarker Field { get; set; }
 		public object Value { get; set; }
 		public double? Boost { get; set; }
-		public RewriteMultiTerm? Rewrite { get; set; }
-
+		[Obsolete("Use MultiTermQueryRewrite")]
+		public RewriteMultiTerm? Rewrite
+		{
+			get { return MultiTermQueryRewrite?.Rewrite; }
+			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 
 		protected override void WrapInContainer(IQueryContainer container)
 		{
@@ -49,11 +57,26 @@ namespace Nest
 		IWildcardQuery 
 		where T : class
 	{
-		RewriteMultiTerm? IWildcardQuery.Rewrite { get; set; }
+		protected IWildcardQuery Self { get { return this; } }
 
+		[Obsolete("Use MultiTermQueryRewrite")]
+		RewriteMultiTerm? IWildcardQuery.Rewrite
+		{
+			get { return Self.MultiTermQueryRewrite?.Rewrite; }
+			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+		}
+		MultiTermQueryRewrite IWildcardQuery.MultiTermQueryRewrite { get; set; }
+
+		[Obsolete("Use overload that accepts MultiTermQueryRewrite")]
 		public WildcardQueryDescriptor<T> Rewrite(RewriteMultiTerm rewrite)
 		{
-			((IWildcardQuery)this).Rewrite = rewrite;
+			Self.MultiTermQueryRewrite = new MultiTermQueryRewrite(rewrite);
+			return this;
+		}
+
+		public WildcardQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite)
+		{
+			Self.MultiTermQueryRewrite = rewrite;
 			return this;
 		}
 

--- a/src/Nest/Domain/DSL/Query.cs
+++ b/src/Nest/Domain/DSL/Query.cs
@@ -117,12 +117,16 @@ namespace Nest
 
 		public static QueryContainer Prefix(Expression<Func<T, object>> fieldDescriptor, string value, double? Boost = null)
 		{
+#pragma warning disable 618
 			return new QueryDescriptor<T>().Prefix(fieldDescriptor, value, Boost);
+#pragma warning restore 618
 		}
 
 		public static QueryContainer Prefix(string field, string value, double? Boost = null)
 		{
+#pragma warning disable 618
 			return new QueryDescriptor<T>().Prefix(field, value, Boost);
+#pragma warning restore 618
 		}
 
 		public static QueryContainer SimpleQueryString(Action<SimpleQueryStringQueryDescriptor<T>> selector)
@@ -272,7 +276,9 @@ namespace Nest
 
 		public static QueryContainer Wildcard(Expression<Func<T, object>> fieldDescriptor, string value, double? Boost = null)
 		{
+#pragma warning disable 618
 			return new QueryDescriptor<T>().Wildcard(fieldDescriptor, value, Boost);
+#pragma warning restore 618
 		}
 
 		public static QueryContainer Wildcard(Action<WildcardQueryDescriptor<T>> selector)
@@ -282,7 +288,9 @@ namespace Nest
 
 		public static QueryContainer Wildcard(string field, string value, double? Boost = null)
 		{
+#pragma warning disable 618
 			return new QueryDescriptor<T>().Wildcard(field, value, Boost);
+#pragma warning restore 618
 		}
 
 	  public static QueryContainer FunctionScore(Action<FunctionScoreQueryDescriptor<T>> functionScoreQuery)

--- a/src/Nest/Enums/RewriteMultiTerm.cs
+++ b/src/Nest/Enums/RewriteMultiTerm.cs
@@ -7,12 +7,10 @@ using System.Runtime.Serialization;
 
 namespace Nest
 {
-	//TODO NEST 2.0 should this really be a flag enum?
-	[Flags]
 	[JsonConverter(typeof(StringEnumConverter))]
 	public enum RewriteMultiTerm
 	{
-		[EnumMember(Value = "constant_score_default")]
+		[EnumMember(Value = "constant_score_auto")]
 		ConstantScoreDefault,
 		[EnumMember(Value = "scoring_boolean")]
 		ScoringBoolean,
@@ -24,5 +22,187 @@ namespace Nest
 		TopTermsN,
 		[EnumMember(Value = "top_terms_boost_N")]
 		TopTermsBoostN
+	}
+
+	/// <summary>
+	/// Controls how a multi term query such as a wildcard or prefix query, is rewritten.
+	/// </summary>
+	[JsonConverter(typeof(MultiTermQueryRewriteConverter))]
+	public class MultiTermQueryRewrite : IEquatable<MultiTermQueryRewrite>
+	{
+		private static readonly char[] DigitCharacters = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+
+		private readonly string _value;
+
+		/// <summary>
+		/// The type of multi term rewrite to perform
+		/// </summary>
+		public RewriteMultiTerm Rewrite { get; }
+
+		/// <summary>
+		/// The size of the top scoring terms to use
+		/// </summary>
+		public int? Size { get; }
+
+		internal MultiTermQueryRewrite(RewriteMultiTerm rewrite, int? size = null)
+		{
+			switch (rewrite)
+			{
+				case RewriteMultiTerm.ConstantScoreDefault:
+				case RewriteMultiTerm.ScoringBoolean:
+				case RewriteMultiTerm.ConstantScoreBoolean:
+				case RewriteMultiTerm.ConstantScoreFilter:
+					_value = rewrite.ToEnumValue();
+					break;
+				case RewriteMultiTerm.TopTermsN:
+				case RewriteMultiTerm.TopTermsBoostN:
+					if (size == null)
+						throw new ArgumentException($"{nameof(size)} must be specified with {nameof(RewriteMultiTerm)}.{rewrite}");
+
+					var rewriteType = rewrite.ToEnumValue();
+					rewriteType = rewriteType.Substring(0, rewriteType.Length - 1);
+					_value = rewriteType + size;
+					break;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(rewrite));
+			}
+
+			Rewrite = rewrite;
+			Size = size;
+		}
+
+		/// <summary>
+		///  A rewrite method that performs like constant_score_boolean when there are few matching terms and otherwise
+		///  visits all matching terms in sequence and marks documents for that term. Matching documents are assigned a
+		///  constant score equal to the query’s boost.
+		/// </summary>
+		public static MultiTermQueryRewrite ConstantScoreDefault { get; } = new MultiTermQueryRewrite(RewriteMultiTerm.ConstantScoreDefault);
+
+		/// <summary>
+		/// A rewrite method that first creates a private Filter by visiting each term in sequence and marking 
+		/// all docs for that term. Matching documents are assigned a constant score equal to the query’s boost.
+		/// </summary>
+		public static MultiTermQueryRewrite ConstantScoreFilter { get; } = new MultiTermQueryRewrite(RewriteMultiTerm.ConstantScoreFilter);
+
+		/// <summary>
+		/// A rewrite method that first translates each term into a should clause in a boolean query, and keeps the scores
+		///  as computed by the query. Note that typically such scores are meaningless to the user, and require non-trivial
+		///  CPU to compute, so it’s almost always better to use constant_score_auto. This rewrite method will hit too many
+		///  clauses failure if it exceeds the boolean query limit (defaults to 1024).
+		/// </summary>
+		public static MultiTermQueryRewrite ScoringBoolean { get; } = new MultiTermQueryRewrite(RewriteMultiTerm.ScoringBoolean);
+
+		/// <summary>
+		/// Similar to scoring_boolean except scores are not computed. Instead, each matching document receives a constant
+		///  score equal to the query’s boost. This rewrite method will hit too many clauses failure if it exceeds the
+		/// boolean query limit (defaults to 1024).
+		/// </summary>
+		public static MultiTermQueryRewrite ConstantScoreBoolean { get; } = new MultiTermQueryRewrite(RewriteMultiTerm.ConstantScoreBoolean);
+
+		/// <summary>
+		/// A rewrite method that first translates each term into should clause in boolean query, and keeps the scores
+		/// as computed by the query. This rewrite method only uses the top scoring terms so it will not overflow boolean
+		///  max clause count. <param name="size" /> controls the size of the top scoring terms to use.
+		/// </summary>
+		public static MultiTermQueryRewrite TopTerms(int size) => new MultiTermQueryRewrite(RewriteMultiTerm.TopTermsN, size);
+
+		/// <summary>
+		/// A rewrite method that first translates each term into should clause in boolean query, but the scores are only
+		/// computed as the boost. This rewrite method only uses the top scoring terms so it will not overflow the boolean
+		///  max clause count. <param name="size" /> controls the size of the top scoring terms to use.
+		/// </summary>
+		public static MultiTermQueryRewrite TopTermsBoost(int size) => new MultiTermQueryRewrite(RewriteMultiTerm.TopTermsBoostN, size);
+
+		internal static MultiTermQueryRewrite Create(string value)
+		{
+			if (value == null) throw new ArgumentNullException(nameof(value));
+
+			var rewriteType = value;
+			var size = 0;
+			var firstDigitIndex = value.IndexOfAny(DigitCharacters);
+
+			if (firstDigitIndex > -1)
+			{
+				rewriteType = $"{value.Substring(0, firstDigitIndex)}N";
+				size = int.Parse(value.Substring(firstDigitIndex));
+			}
+
+			var rewriteMultiTerm = rewriteType.ToEnum<RewriteMultiTerm>();
+			if (rewriteMultiTerm == null)
+				throw new InvalidOperationException($"Unsupported {nameof(RewriteMultiTerm)} value: '{rewriteType}'");
+
+			switch (rewriteMultiTerm)
+			{
+				case RewriteMultiTerm.ConstantScoreDefault:
+					return ConstantScoreDefault;
+				case RewriteMultiTerm.ScoringBoolean:
+					return ScoringBoolean;
+				case RewriteMultiTerm.ConstantScoreBoolean:
+					return ConstantScoreBoolean;
+				case RewriteMultiTerm.ConstantScoreFilter:
+					return ConstantScoreFilter;
+				case RewriteMultiTerm.TopTermsN:
+					return TopTerms(size);
+				case RewriteMultiTerm.TopTermsBoostN:
+					return TopTermsBoost(size);
+				default:
+					throw new InvalidOperationException($"Unsupported {nameof(RewriteMultiTerm)} value: '{rewriteMultiTerm}'");
+			}
+		}
+
+		public override string ToString() => this._value;
+
+		public bool Equals(MultiTermQueryRewrite other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+			return Rewrite == other.Rewrite && Size == other.Size;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+
+			var value = obj as string;
+			if (value != null)
+				return string.Equals(value, _value);
+
+			return obj.GetType() == this.GetType() && Equals((MultiTermQueryRewrite)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return ((int)Rewrite * 397) ^ Size.GetHashCode();
+			}
+		}
+
+		public static bool operator ==(MultiTermQueryRewrite left, MultiTermQueryRewrite right) => Equals(left, right);
+
+		public static bool operator !=(MultiTermQueryRewrite left, MultiTermQueryRewrite right) => !Equals(left, right);
+	}
+
+	internal class MultiTermQueryRewriteConverter : JsonConverter
+	{
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var multiTerm = (MultiTermQueryRewrite)value;
+			writer.WriteValue(multiTerm?.ToString());
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType == JsonToken.Null)
+				return null;
+
+			if (reader.TokenType != JsonToken.String)
+				throw new JsonSerializationException($"Invalid token type {reader.TokenType} to deserialize {nameof(MultiTermQueryRewrite)} from");
+
+			return MultiTermQueryRewrite.Create((string)reader.Value);
+		}
+
+		public override bool CanConvert(Type objectType) => typeof(MultiTermQueryRewrite).IsAssignableFrom(objectType);
 	}
 }

--- a/src/Nest/Extensions/Extensions.cs
+++ b/src/Nest/Extensions/Extensions.cs
@@ -24,6 +24,16 @@ namespace Nest
 				return string.Empty;
 		}
 
+		internal static string ToEnumValue<T>(this T enumValue) where T : struct
+		{
+			var enumType = typeof(T);
+			var name = Enum.GetName(enumType, enumValue);
+			var enumMemberAttribute = ((EnumMemberAttribute[])enumType.GetField(name).GetCustomAttributes(typeof(EnumMemberAttribute), true)).FirstOrDefault();
+
+			return enumMemberAttribute != null 
+				? enumMemberAttribute.Value 
+				: enumValue.ToString();
+		}
 
 		public static T? ToEnum<T>(this string str) where T : struct
 		{
@@ -36,6 +46,7 @@ namespace Nest
 			//throw exception or whatever handling you want or
 			return null;
 		}
+
 		internal static string Utf8String(this byte[] bytes)
 		{
 			return bytes == null ? null : Encoding.UTF8.GetString(bytes);

--- a/src/Nest/Resolvers/Converters/Queries/FuzzyQueryJsonConverter.cs
+++ b/src/Nest/Resolvers/Converters/Queries/FuzzyQueryJsonConverter.cs
@@ -53,7 +53,7 @@ namespace Nest
 			fq.Transpositions = GetPropValue<bool?>(jo, "transpositions");
 			var rewriteString = GetPropValue<string>(jo, "rewrite");
 			if (!rewriteString.IsNullOrEmpty())
-				fq.Rewrite = rewriteString.ToEnum<RewriteMultiTerm>();
+				fq.MultiTermQueryRewrite = MultiTermQueryRewrite.Create(rewriteString);
 			
 			if (fq is IStringFuzzyQuery)
 			{

--- a/src/Nest/Resolvers/Converters/Queries/MatchQueryJsonConverter.cs
+++ b/src/Nest/Resolvers/Converters/Queries/MatchQueryJsonConverter.cs
@@ -54,7 +54,7 @@ namespace Nest
 			
 			var rewriteString = GetPropValue<string>(jo, "rewrite");
 			if (!rewriteString.IsNullOrEmpty())
-				fq.Rewrite = rewriteString.ToEnum<RewriteMultiTerm>();
+				fq.MultiTermQueryRewrite = MultiTermQueryRewrite.Create(rewriteString);
 			
 			var operatorString = GetPropValue<string>(jo, "operator");
 			if (!rewriteString.IsNullOrEmpty())

--- a/src/Tests/Nest.Tests.Integration/Search/QueryDSLTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Search/QueryDSLTests.cs
@@ -101,6 +101,7 @@ namespace Nest.Tests.Integration.Search
 		[Test]
 		public void TestPrefixQuery()
 		{
+#pragma warning disable 618
 			var results = this.Client.Search<ElasticsearchProject>(s => s
 				.From(0)
 				.Size(10)
@@ -110,6 +111,7 @@ namespace Nest.Tests.Integration.Search
 				.Query(q => q
 					.Prefix(f => f.Name.Suffix("sort"), "el")
 				)
+#pragma warning restore 618
 			);
 			Assert.NotNull(results);
 			Assert.True(results.IsValid);

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Count/CountRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Count/CountRequestTests.cs
@@ -25,7 +25,7 @@ namespace Nest.Tests.Unit.ObjectInitializer.Count
 			{
 				Field = "prefix_field", 
 				Value = "prefi", 
-				Rewrite = RewriteMultiTerm.ConstantScoreBoolean
+				MultiTermQueryRewrite = MultiTermQueryRewrite.ConstantScoreBoolean
 			};
 
 			var request = new CountRequest()

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/DeleteByQuery/DeleteByQueryRequestTests.cs
@@ -25,7 +25,7 @@ namespace Nest.Tests.Unit.ObjectInitializer.DeleteByQuery
 			{
 				Field = "prefix_field", 
 				Value = "prefi", 
-				Rewrite = RewriteMultiTerm.ConstantScoreBoolean
+				MultiTermQueryRewrite = MultiTermQueryRewrite.ConstantScoreBoolean
 			};
 
 			var request = new DeleteByQueryRequest()

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/MoreLikeThis/MoreLikeThisRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/MoreLikeThis/MoreLikeThisRequestTests.cs
@@ -25,7 +25,7 @@ namespace Nest.Tests.Unit.ObjectInitializer.MoreLikeThis
 			{
 				Field = "prefix_field", 
 				Value = "prefi", 
-				Rewrite = RewriteMultiTerm.ConstantScoreBoolean
+				MultiTermQueryRewrite = MultiTermQueryRewrite.ConstantScoreBoolean
 			};
 			var search = new SearchRequest
 			{

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Search/SearchRequestTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Search/SearchRequestTests.cs
@@ -25,7 +25,7 @@ namespace Nest.Tests.Unit.ObjectInitializer.Search
 			{
 				Field = "prefix_field", 
 				Value = "prefi", 
-				Rewrite = RewriteMultiTerm.ConstantScoreBoolean
+				MultiTermQueryRewrite = MultiTermQueryRewrite.ConstantScoreBoolean
 			};
 
 			var request = new SearchRequest<ElasticsearchProject>

--- a/src/Tests/Nest.Tests.Unit/ObjectInitializer/Search/SearchRequestUntypedTests.cs
+++ b/src/Tests/Nest.Tests.Unit/ObjectInitializer/Search/SearchRequestUntypedTests.cs
@@ -25,7 +25,7 @@ namespace Nest.Tests.Unit.ObjectInitializer.Search
 			{
 				Field = "prefix_field", 
 				Value = "prefi", 
-				Rewrite = RewriteMultiTerm.ConstantScoreBoolean
+				MultiTermQueryRewrite = MultiTermQueryRewrite.ConstantScoreBoolean
 			};
 
 			var request = new SearchRequest

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MatchQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MatchQueryTests.cs
@@ -23,7 +23,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 					.Operator(Operator.And)
 					.PrefixLength(2)
 					.Query("querytext")
-					.Rewrite(RewriteMultiTerm.ConstantScoreBoolean)
+					.Rewrite(MultiTermQueryRewrite.ConstantScoreBoolean)
 					.Slop(2)
 					)
 				);
@@ -40,7 +40,10 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Operator.Should().Be(Operator.And);
 			q.PrefixLength.Should().Be(2);
 			q.Query.Should().Be("querytext");
+			q.MultiTermQueryRewrite.Should().Be(MultiTermQueryRewrite.ConstantScoreBoolean);
+#pragma warning disable 618
 			q.Rewrite.Should().Be(RewriteMultiTerm.ConstantScoreBoolean);
+#pragma warning restore 618
 			q.Slop.Should().Be(2);
 		}
 
@@ -61,7 +64,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 					.Operator(Operator.And)
 					.PrefixLength(2)
 					.Query("querytext")
-					.Rewrite(RewriteMultiTerm.ConstantScoreBoolean)
+					.Rewrite(MultiTermQueryRewrite.ConstantScoreBoolean)
 					.Slop(2)
 					)
 				);
@@ -77,7 +80,10 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Operator.Should().Be(Operator.And);
 			q.PrefixLength.Should().Be(2);
 			q.Query.Should().Be("querytext");
+			q.MultiTermQueryRewrite.Should().Be(MultiTermQueryRewrite.ConstantScoreBoolean);
+#pragma warning disable 618
 			q.Rewrite.Should().Be(RewriteMultiTerm.ConstantScoreBoolean);
+#pragma warning restore 618
 			q.Slop.Should().Be(2);
 		}
 
@@ -98,7 +104,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 					.Operator(Operator.And)
 					.PrefixLength(2)
 					.Query("querytext")
-					.Rewrite(RewriteMultiTerm.ConstantScoreBoolean)
+					.Rewrite(MultiTermQueryRewrite.ConstantScoreBoolean)
 					.Slop(2)
 					)
 				);
@@ -114,7 +120,10 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Operator.Should().Be(Operator.And);
 			q.PrefixLength.Should().Be(2);
 			q.Query.Should().Be("querytext");
+			q.MultiTermQueryRewrite.Should().Be(MultiTermQueryRewrite.ConstantScoreBoolean);
+#pragma warning disable 618
 			q.Rewrite.Should().Be(RewriteMultiTerm.ConstantScoreBoolean);
+#pragma warning restore 618
 			q.Slop.Should().Be(2);
 		}
 

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MultiMatchQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/MultiMatchQueryTests.cs
@@ -22,7 +22,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 					.Operator(Operator.Or)
 					.PrefixLength(2)
 					.Query("querytext")
-					.Rewrite(RewriteMultiTerm.TopTermsN)
+					.Rewrite(MultiTermQueryRewrite.TopTerms(10))
 					.Slop(2)
 					.TieBreaker(2.0)
 					.Type(TextQueryType.BestFields)
@@ -38,7 +38,10 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Operator.Should().Be(Operator.Or);
 			q.PrefixLength.Should().Be(2);
 			q.Query.Should().Be("querytext");
+			q.MultiTermQueryRewrite.Should().Be(MultiTermQueryRewrite.TopTerms(10));
+#pragma warning disable 618
 			q.Rewrite.Should().Be(RewriteMultiTerm.TopTermsN);
+#pragma warning restore 618
 			q.Slop.Should().Be(2);
 			q.TieBreaker.Should().Be(2.0);
 			q.Type.Should().Be(TextQueryType.BestFields);

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/PrefixQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/PrefixQueryTests.cs
@@ -14,13 +14,16 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 				f=>f.Prefix(pq=>pq
 					.Boost(2.1)
 					.OnField(p=>p.Name)
-					.Rewrite(RewriteMultiTerm.ConstantScoreBoolean)
+					.Rewrite(MultiTermQueryRewrite.ConstantScoreBoolean)
 					.Value("prefix*")
 					)
 				);
 			q.Boost.Should().Be(2.1);
 			q.Field.Should().Be("name");
+			q.MultiTermQueryRewrite.Should().Be(MultiTermQueryRewrite.ConstantScoreBoolean);
+#pragma warning disable 618
 			q.Rewrite.Should().Be(RewriteMultiTerm.ConstantScoreBoolean);
+#pragma warning restore 618
 			q.Value.Should().Be("prefix*");
 		}
 	}

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/QueryStringQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/QueryStringQueryTests.cs
@@ -28,7 +28,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 					.OnFields(p=>p.Name, p=>p.Origin)
 					.PhraseSlop(2.1)
 					.Query("q")
-					.Rewrite(RewriteMultiTerm.ConstantScoreDefault)
+					.Rewrite(MultiTermQueryRewrite.ConstantScoreDefault)
 					.TieBreaker(4.1)
 					.UseDisMax()
 					)
@@ -49,7 +49,10 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Fields.Should().BeEquivalentTo(new []{"name", "origin"});
 			q.PhraseSlop.Should().Be(2.1);
 			q.Query.Should().Be("q");
+			q.MultiTermQueryRewrite.Should().Be(MultiTermQueryRewrite.ConstantScoreDefault);
+#pragma warning disable 618
 			q.Rewrite.Should().Be(RewriteMultiTerm.ConstantScoreDefault);
+#pragma warning restore 618
 			q.TieBreaker.Should().Be(4.1);
 			q.UseDisMax.Should().BeTrue();
 		}

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/WildCardQueryTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Queries/WildCardQueryTests.cs
@@ -15,7 +15,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 				f => f.Wildcard,
 				f => f.Wildcard(wq => wq
 					.Boost(1.1)
-					.Rewrite(RewriteMultiTerm.ConstantScoreBoolean)
+					.Rewrite(MultiTermQueryRewrite.ConstantScoreBoolean)
 					.OnField(p => p.Name)
 					.Value("wild*")
 					)
@@ -23,7 +23,10 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			q.Boost.Should().Be(1.1);
 			q.Field.Should().Be("name");
 			q.Value.Should().Be("wild*");
+			q.MultiTermQueryRewrite.Should().Be(MultiTermQueryRewrite.ConstantScoreBoolean);
+#pragma warning disable 618
 			q.Rewrite.Should().Be(RewriteMultiTerm.ConstantScoreBoolean);
+#pragma warning restore 618
 		}
 
 		[Test]
@@ -33,7 +36,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 			{
 				Field = "my_prefix_field",
 				Value = "value",
-				Rewrite = RewriteMultiTerm.ConstantScoreBoolean
+				MultiTermQueryRewrite = MultiTermQueryRewrite.ConstantScoreBoolean
 			};
 			var searchRequest = new SearchRequest()
 			{
@@ -54,7 +57,7 @@ namespace Nest.Tests.Unit.QueryParsers.Queries
 				new WildcardQuery<ElasticsearchProject>(p => p.Name)
 				{
 					Value = "value",
-					Rewrite = RewriteMultiTerm.ConstantScoreBoolean
+					MultiTermQueryRewrite = MultiTermQueryRewrite.ConstantScoreBoolean
 				}
 				&& new WildcardQuery
 				{

--- a/src/Tests/Nest.Tests.Unit/Search/InitializerSyntax/InitializerExample.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/InitializerSyntax/InitializerExample.cs
@@ -22,7 +22,7 @@ namespace Nest.Tests.Unit.Search.InitializerSyntax
 			{
 				Field = "prefix_field", 
 				Value = "prefi", 
-				Rewrite = RewriteMultiTerm.ConstantScoreBoolean
+				MultiTermQueryRewrite = MultiTermQueryRewrite.ConstantScoreBoolean
 			};
 
 			var result = _client.Search<ElasticsearchProject>(new SearchRequest

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MatchQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/MatchQueryJson.cs
@@ -18,7 +18,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 						.OnField(f=>f.Name)
 						.Query("this is a test")
 						.MinimumShouldMatch("2<80%")
-						.Rewrite(RewriteMultiTerm.ConstantScoreDefault)
+						.Rewrite(MultiTermQueryRewrite.ConstantScoreDefault)
 					)
 			);
 				
@@ -29,7 +29,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 						name : { 
 							_name: ""named_query"",
 							query : ""this is a test"",
-							rewrite: ""constant_score_default"",
+							rewrite: ""constant_score_auto"",
 							minimum_should_match: ""2<80%""
 						}
 					}
@@ -84,7 +84,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 						.Fuzziness(1.0)
 						.Analyzer("my_analyzer")
 						.CutoffFrequency(0.3)
-						.Rewrite(RewriteMultiTerm.ConstantScoreFilter)
+						.Rewrite(MultiTermQueryRewrite.ConstantScoreFilter)
 						.PrefixLength(2)
 					)
 			);
@@ -122,7 +122,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 						.FuzzyTranspositions()
 						.Analyzer("my_analyzer")
 						.CutoffFrequency(0.3)
-						.Rewrite(RewriteMultiTerm.ConstantScoreFilter)
+						.Rewrite(MultiTermQueryRewrite.ConstantScoreFilter)
 						.PrefixLength(2)
 					)
 			);

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/PrefixQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/PrefixQueryJson.cs
@@ -26,9 +26,11 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 			var s = new SearchDescriptor<ElasticsearchProject>()
 				.From(0)
 				.Size(10)
+#pragma warning disable CS0618
 				.Query(q => q
 					.Prefix(f => f.Name, "el", Boost: 1.2)
 				);
+#pragma warning restore CS0618
 			var json = TestElasticClient.Serialize(s);
 			var expected = @"{ from: 0, size: 10, query : 
 			{ prefix: { name : { value : ""el"", boost: 1.2 } }}}";
@@ -41,12 +43,14 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 			var s = new SearchDescriptor<ElasticsearchProject>()
 				.From(0)
 				.Size(10)
+#pragma warning disable CS0618 // Type or member is obsolete
 				.Query(q => q
 					.Prefix(f => f.Name, "el", 1.2, RewriteMultiTerm.ConstantScoreDefault)
 				);
+#pragma warning restore CS0618 // Type or member is obsolete
 			var json = TestElasticClient.Serialize(s);
 			var expected = @"{ from: 0, size: 10, query : 
-			{ prefix: { name : { value : ""el"", boost: 1.2, rewrite: ""constant_score_default"" } }}}";
+			{ prefix: { name : { value : ""el"", boost: 1.2, rewrite: ""constant_score_auto"" } }}}";
 			Assert.True(json.JsonEquals(expected), json);
 		}
 

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/QueryStringQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/QueryStringQueryJson.cs
@@ -59,7 +59,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 						.MinimumShouldMatchPercentage(20)
 						.UseDisMax(true)
 						.TieBreaker(0.7)
-						.Rewrite(RewriteMultiTerm.TopTermsN)
+						.Rewrite(MultiTermQueryRewrite.TopTerms(10))
 					)
 			);
 
@@ -83,7 +83,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 						minimum_should_match: ""20%"",
 						use_dis_max: true,
 						tie_breaker: 0.7,
-						rewrite: ""top_terms_N""
+						rewrite: ""top_terms_10""
 
 					}
 				}


### PR DESCRIPTION
TopTermsN and TopTermsBoostN require the ability to pass a value for N.

Deprecate the direct usage of RewriteMultiTerm enum in favour of MultiTermQueryRewrite type.

Fixes #2688

(cherry picked from commit 5784bdbf2f78cac40f7695c736df40b17e249fca)