### PR TITLE
Correctly handle terms include/exclude

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -46,6 +46,11 @@ if not exist build\tools\node_modules\wintersmith\bin\wintersmith (
 SET TARGET="Build"
 SET VERSION=
 
+IF /I "%1"=="skiptests" (
+	set SKIPTESTS="1"
+	SHIFT
+)
+
 IF NOT [%1]==[] (set TARGET="%1")
 
 IF NOT [%2]==[] (set VERSION="%2")

--- a/build/scripts/Building.fsx
+++ b/build/scripts/Building.fsx
@@ -19,6 +19,7 @@ type Build() =
     static let msbuildProperties = [
       ("Configuration","Release"); 
       ("PreBuildEvent","echo");
+      ("Optimize", "True");
     ]
 
     static let moveToBuildOutput (f: DotNetFramework) =

--- a/src/Nest/DSL/Aggregations/SignificantTermsAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/SignificantTermsAggregationDescriptor.cs
@@ -25,11 +25,19 @@ namespace Nest
 		[JsonProperty("execution_hint")]
 		TermsAggregationExecutionHint? ExecutionHint { get; set; }
 
-		[JsonProperty("include")]
+		[JsonIgnore]
+		[Obsolete("Use IncludeTerms")]
 		IDictionary<string, string> Include { get; set; }
 
-		[JsonProperty("exclude")]
+		[JsonProperty("include")]
+		TermsIncludeExclude IncludeTerms { get; set; }
+
+		[JsonIgnore]
+		[Obsolete("Use ExcludeTerms")]
 		IDictionary<string, string> Exclude { get; set; }
+
+		[JsonProperty("exclude")]
+		TermsIncludeExclude ExcludeTerms { get; set; }
 
 		[JsonProperty("mutual_information")]
 		MutualInformationHeuristic MutualInformation { get; set; }
@@ -59,8 +67,12 @@ namespace Nest
 		public int? ShardSize { get; set; }
 		public int? MinimumDocumentCount { get; set; }
 		public TermsAggregationExecutionHint? ExecutionHint { get; set; }
+		[Obsolete("Use IncludeTerms")]
 		public IDictionary<string, string> Include { get; set; }
+		public TermsIncludeExclude IncludeTerms { get; set; }
+		[Obsolete("Use ExcludeTerms")]
 		public IDictionary<string, string> Exclude { get; set; }
+		public TermsIncludeExclude ExcludeTerms { get; set; }
 		public MutualInformationHeuristic MutualInformation { get; set; }
 		public ChiSquareHeuristic ChiSquare { get; set; }
 		public GoogleNormalizedDistanceHeuristic GoogleNormalizedDistance { get; set; }
@@ -83,9 +95,15 @@ namespace Nest
 
 		TermsAggregationExecutionHint? ISignificantTermsAggregator.ExecutionHint { get; set; }
 
+		[Obsolete("Use IncludeTerms")]
 		IDictionary<string, string> ISignificantTermsAggregator.Include { get; set; }
 
+		TermsIncludeExclude ISignificantTermsAggregator.IncludeTerms { get; set; }
+
+		[Obsolete("Use ExcludeTerms")]
 		IDictionary<string, string> ISignificantTermsAggregator.Exclude { get; set; }
+
+		TermsIncludeExclude ISignificantTermsAggregator.ExcludeTerms { get; set; }
 
 		MutualInformationHeuristic ISignificantTermsAggregator.MutualInformation { get; set; }
 
@@ -137,17 +155,33 @@ namespace Nest
 
 		public SignificantTermsAggregationDescriptor<T> Include(string includePattern, string regexFlags = null)
 		{
-			Self.Include = new Dictionary<string, string> { {"pattern", includePattern}};
-			if (!regexFlags.IsNullOrEmpty())
-				Self.Include.Add("pattern", regexFlags);
+			Self.IncludeTerms = includePattern == null 
+				? null 
+				: new TermsIncludeExclude { Pattern = includePattern, Flags = regexFlags }; 
+			return this;
+		}
+
+		public SignificantTermsAggregationDescriptor<T> Include(IEnumerable<string> values)
+		{
+			Self.IncludeTerms = values == null 
+				? null 
+				: new TermsIncludeExclude { Values = values }; 
 			return this;
 		}
 		
 		public SignificantTermsAggregationDescriptor<T> Exclude(string excludePattern, string regexFlags = null)
 		{
-			Self.Exclude = new Dictionary<string, string> { {"pattern", excludePattern}};
-			if (!regexFlags.IsNullOrEmpty())
-				Self.Exclude.Add("pattern", regexFlags);
+			Self.ExcludeTerms = excludePattern == null 
+				? null 
+				: new TermsIncludeExclude { Pattern = excludePattern, Flags = regexFlags };
+			return this;
+		}
+
+		public SignificantTermsAggregationDescriptor<T> Exclude(IEnumerable<string> values)
+		{
+			Self.ExcludeTerms = values == null 
+				? null 
+				: new TermsIncludeExclude { Values = values };
 			return this;
 		}
 

--- a/src/Tests/Nest.Tests.Integration/Aggregations/BucketAggregationTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Aggregations/BucketAggregationTests.cs
@@ -86,6 +86,42 @@ namespace Nest.Tests.Integration.Aggregations
 		}
 
 		[Test]
+		[SkipVersion("0 - 1.4.9", "Filtering by exact terms added in ES 1.5")]
+		public void SignificantTermsWithValues()
+		{
+			var results = this.Client.Search<ElasticsearchProject>(s => s
+				.Size(0)
+				.Aggregations(a => a
+					.SignificantTerms("sig_terms", st => st
+						.Field(p => p.Content)
+						.Include(new [] { "pastrami", "bacon", "turkey" })
+					)
+				)
+			);
+			results.IsValid.Should().BeTrue();
+			var bucket = results.Aggs.SignificantTerms("sig_terms");
+			bucket.Items.Should().NotBeEmpty();
+		}
+
+		[Test]
+		[SkipVersion("0 - 1.1.9", "Filtering by terms pattern added in ES 1.2")]
+		public void SignificantTermsWithPattern()
+		{
+			var results = this.Client.Search<ElasticsearchProject>(s => s
+				.Size(0)
+				.Aggregations(a => a
+					.SignificantTerms("sig_terms", st => st
+						.Field(p => p.Content)
+						.Include("pa.*", "CANON_EQ|CASE_INSENSITIVE")
+					)
+				)
+			);
+			results.IsValid.Should().BeTrue();
+			var bucket = results.Aggs.SignificantTerms("sig_terms");
+			bucket.Items.Should().NotBeEmpty();
+		}
+
+		[Test]
 		public void Histogram()
 		{
 			var results = this.Client.Search<ElasticsearchProject>(s => s


### PR DESCRIPTION
for Significant Terms aggregation
- Deprecate dictionary that was incorrectly used to filter terms. Use TermsIncludeExclude type to represent the available options.

(port of commit a309d38d8e4b5165dc7a00a23e99a118c61b01c7)