### PR TITLE
drop class constrain in promise for linq support

### DIFF
--- a/src/Nest/CommonAbstractions/Fluent/Promise/DescriptorPromiseBase.cs
+++ b/src/Nest/CommonAbstractions/Fluent/Promise/DescriptorPromiseBase.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 namespace Nest
 {
-	public interface IPromise<out TValue> where TValue : class
+	public interface IPromise<out TValue>
 	{
 		TValue Value { get; }
 	}


### PR DESCRIPTION
#2522 

Started with first place. If you fine checkin one by one, please let me know. Will sign agreement then. My research have shown that it is fine one by one, as all childs do drug constraint with them, so changes on parent has ZERO effect on existing code.