### PR TITLE
Fix fielddata for upgraded string field types

### DIFF
--- a/src/Nest/Mapping/Types/Core/String/StringAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/String/StringAttribute.cs
@@ -18,7 +18,11 @@ namespace Nest
 		bool? IStringProperty.IncludeInAll { get; set; }
 		int? IStringProperty.IgnoreAbove { get; set; }
 		int? IStringProperty.PositionIncrementGap { get; set; }
+		[Obsolete("Use FielddataUpgrade")]
 		IStringFielddata IStringProperty.Fielddata { get; set; }
+		bool? IStringProperty.FielddataUpgrade { get; set; }
+		IFielddataFrequencyFilter IStringProperty.FielddataFrequencyFilter { get; set; }
+		bool? IStringProperty.EagerGlobalOrdinals { get; set; }
 
 		public string Analyzer { get { return Self.Analyzer; } set { Self.Analyzer = value; } }
 		public double Boost { get { return Self.Boost.GetValueOrDefault(); } set { Self.Boost = value; } }
@@ -31,6 +35,8 @@ namespace Nest
 		public string SearchAnalyzer { get { return Self.SearchAnalyzer; } set { Self.SearchAnalyzer = value; } }
 		public TermVectorOption TermVector { get { return Self.TermVector.GetValueOrDefault(); } set { Self.TermVector = value; } }
 		public bool Norms { get { return Self.Norms.GetValueOrDefault(true); } set { Self.Norms = value; } }
+		public bool Fielddata { get { return Self.FielddataUpgrade.GetValueOrDefault(true); } set { Self.FielddataUpgrade = value; } }
+		public bool EagerGlobalOrdinals { get { return Self.EagerGlobalOrdinals.GetValueOrDefault(true); } set { Self.EagerGlobalOrdinals = value; } }
 
 		[Obsolete("Only valid for indices created before Elasticsearch 5.0 and will be removed in the next major version.  For newly created indices, use Text or Keyword attribute instead.")]
 		public StringAttribute() : base("string") { }

--- a/src/Nest/Mapping/Types/Core/String/StringProperty.cs
+++ b/src/Nest/Mapping/Types/Core/String/StringProperty.cs
@@ -42,8 +42,18 @@ namespace Nest
 		[JsonProperty("position_increment_gap")]
 		int? PositionIncrementGap { get; set; }
 
+		[JsonIgnore]
+		[Obsolete("Use FielddataUpgrade")]
+		IStringFielddata Fielddata{ get; set; }
+
 		[JsonProperty("fielddata")]
-		IStringFielddata Fielddata { get; set; }
+		bool? FielddataUpgrade { get; set; }
+
+		[JsonProperty("fielddata_frequency_filter")]
+		IFielddataFrequencyFilter FielddataFrequencyFilter { get; set; }
+
+		[JsonProperty("eager_global_ordinals")]
+		bool? EagerGlobalOrdinals { get; set; }
 	}
 
 	[Obsolete("Only valid for indices created before Elasticsearch 5.0 and will be removed in the next major version.  For newly created indices, use `text` or `keyword` instead.")]
@@ -64,7 +74,11 @@ namespace Nest
 		public bool? IncludeInAll { get; set; }
 		public int? IgnoreAbove { get; set; }
 		public int? PositionIncrementGap { get; set; }
+		[Obsolete("Use FielddataUpgrade")]
 		public IStringFielddata Fielddata { get; set; }
+		public bool? FielddataUpgrade { get; set; }
+		public IFielddataFrequencyFilter FielddataFrequencyFilter { get; set; }
+		public bool? EagerGlobalOrdinals { get; set; }
 	}
 
 	[Obsolete("Only valid for indices created before Elasticsearch 5.0 and will be removed in the next major version.  For newly created indices, use `text` or `keyword` instead.")]
@@ -84,7 +98,11 @@ namespace Nest
 		bool? IStringProperty.IncludeInAll { get; set; }
 		int? IStringProperty.IgnoreAbove { get; set; }
 		int? IStringProperty.PositionIncrementGap { get; set; }
+		[Obsolete("Use FielddataUpgrade")]
 		IStringFielddata IStringProperty.Fielddata { get; set; }
+		bool? IStringProperty.FielddataUpgrade { get; set; }
+		IFielddataFrequencyFilter IStringProperty.FielddataFrequencyFilter { get; set; }
+		bool? IStringProperty.EagerGlobalOrdinals { get; set; }
 
 		public StringPropertyDescriptor() : base("string") { }
 
@@ -116,7 +134,15 @@ namespace Nest
 
 		public StringPropertyDescriptor<T> PositionIncrementGap(int positionIncrementGap) => Assign(a => a.PositionIncrementGap = positionIncrementGap);
 
+		[Obsolete("Use Fielddata that takes a bool argument")]
 		public StringPropertyDescriptor<T> Fielddata(Func<StringFielddataDescriptor, IStringFielddata> selector) =>
 			Assign(a => a.Fielddata = selector?.Invoke(new StringFielddataDescriptor()));
+
+		public StringPropertyDescriptor<T> EagerGlobalOrdinals(bool eagerGlobalOrdinals = true) => Assign(a => a.EagerGlobalOrdinals = eagerGlobalOrdinals);
+
+		public StringPropertyDescriptor<T> Fielddata(bool fielddata = true) => Assign(a => a.FielddataUpgrade = fielddata);
+
+		public StringPropertyDescriptor<T> FielddataFrequencyFilter(Func<FielddataFrequencyFilterDescriptor, IFielddataFrequencyFilter> selector) =>
+			Assign(a => a.FielddataFrequencyFilter = selector?.Invoke(new FielddataFrequencyFilterDescriptor()));
 	}
 }

--- a/src/Nest/Modules/Indices/Fielddata/String/StringFielddata.cs
+++ b/src/Nest/Modules/Indices/Fielddata/String/StringFielddata.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Nest
 {

--- a/src/Tests/Mapping/Types/Core/String/StringAttributeTests.cs
+++ b/src/Tests/Mapping/Types/Core/String/StringAttributeTests.cs
@@ -19,7 +19,9 @@ namespace Tests.Mapping.Types.Core.String
 			SearchAnalyzer = "mysearchanalyzer",
 			Similarity = "BM25",
 			Store = true,
-			TermVector = TermVectorOption.WithPositionsOffsets)]
+			TermVector = TermVectorOption.WithPositionsOffsets,
+			Fielddata = false,
+			EagerGlobalOrdinals = true)]
 		public string Full { get; set; }
 
 		[String]
@@ -53,7 +55,9 @@ namespace Tests.Mapping.Types.Core.String
 					search_analyzer = "mysearchanalyzer",
 					similarity = "BM25",
 					store = true,
-					term_vector = "with_positions_offsets"
+					term_vector = "with_positions_offsets",
+					fielddata = false,
+					eager_global_ordinals = true
 				},
 				minimal = new
 				{


### PR DESCRIPTION
fielddata is upgraded to a boolean flag and the filter and loading properties are used to set the fielddata_frequency_filter and eager_global_ordinals properties : https://github.com/elastic/elasticsearch/blob/9946abf479bfaa791e0b87904e088823430e47b4/core/src/main/java/org/elasticsearch/index/mapper/StringFieldMapper.java#L241-L259

Deprecate `Fielddata` property on `StringProperty` type and add `FielddataUpgrade`, `EagerGlobalOrdinals ` and `FielddataFrequencyFilter` properties

Closes #2721