### PR TITLE
Fix #2725 and #2719

### DIFF
--- a/build/Clients.Common.targets
+++ b/build/Clients.Common.targets
@@ -5,6 +5,8 @@
     <CurrentVersion>0.0.0-bad</CurrentVersion>
     <CurrentAssemblyVersion>0.0.0</CurrentAssemblyVersion>
     <CurrentAssemblyFileVersion>0.0.0.0</CurrentAssemblyFileVersion>
+    <DotNetCoreOnly></DotNetCoreOnly>
+    <DoSourceLink></DoSourceLink>
 
     <!-- Version and Informational reflect actual version -->
     <Version>$(CurrentVersion)</Version>

--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -75,6 +75,8 @@ namespace Elasticsearch.Net
 
 		public IEnumerable<string> DeprecationWarnings { get; internal set; } = Enumerable.Empty<string>();
 
+		internal bool AllowAllStatusCodes { get; }
+
 		/// <summary>
 		/// The response is successful or has a response code between 400-599, the call should not be retried.
 		/// Only on 502,503 and 504 will this return false;
@@ -99,7 +101,8 @@ namespace Elasticsearch.Net
 		public ElasticsearchResponse(int statusCode, IEnumerable<int> allowedStatusCodes)
 		{
 			var statusCodes = allowedStatusCodes as int[] ?? allowedStatusCodes.ToArray();
-			this.Success = statusCode >= 200 && statusCode < 300 || statusCodes.Contains(statusCode) || statusCodes.Contains(-1);
+			this.AllowAllStatusCodes = statusCodes.Contains(-1);
+			this.Success = statusCode >= 200 && statusCode < 300 || statusCodes.Contains(statusCode) || this.AllowAllStatusCodes;
 			this.HttpStatusCode = statusCode;
 		}
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
-using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Purify;
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -66,7 +66,7 @@ namespace Elasticsearch.Net
 		private void SetBody(ElasticsearchResponse<TReturn> response, Stream stream)
 		{
 			byte[] bytes = null;
-			if (NeedsToEagerReadStream())
+			if (NeedsToEagerReadStream(response))
 			{
 				var inMemoryStream = this._requestData.MemoryStreamFactory.Create();
 				stream.CopyTo(inMemoryStream, BufferSize);
@@ -76,29 +76,25 @@ namespace Elasticsearch.Net
 			var needsDispose = typeof(TReturn) != typeof(Stream);
 			using (needsDispose ? stream : EmptyDisposable)
 			{
-				if (response.Success)
+				if (response.Success || response.AllowAllStatusCodes)
 				{
 					if (!SetSpecialTypes(stream, response, bytes))
 					{
 						if (this._requestData.CustomConverter != null) response.Body = this._requestData.CustomConverter(response, stream) as TReturn;
 						else response.Body = this._requestData.ConnectionSettings.Serializer.Deserialize<TReturn>(stream);
 					}
+					if (response.AllowAllStatusCodes) 
+						ReadServerError(response, new MemoryStream(bytes), bytes);
 				}
 				else if (response.HttpStatusCode != null)
-				{
-					ServerError serverError;
-					if (ServerError.TryCreate(stream, out serverError))
-						response.ServerError = serverError;
-					if (_disableDirectStreaming)
-						response.ResponseBodyInBytes = bytes;
-				}
+					ReadServerError(response, stream, bytes);
 			}
 		}
 
 		private async Task SetBodyAsync(ElasticsearchResponse<TReturn> response, Stream stream)
 		{
 			byte[] bytes = null;
-			if (NeedsToEagerReadStream())
+			if (NeedsToEagerReadStream(response))
 			{
 				var inMemoryStream = this._requestData.MemoryStreamFactory.Create();
 				await stream.CopyToAsync(inMemoryStream, BufferSize, this._cancellationToken).ConfigureAwait(false);
@@ -108,21 +104,35 @@ namespace Elasticsearch.Net
 			var needsDispose = typeof(TReturn) != typeof(Stream);
 			using (needsDispose ? stream : EmptyDisposable)
 			{
-				if (response.Success)
+				if (response.Success || response.AllowAllStatusCodes)
 				{
 					if (!SetSpecialTypes(stream, response, bytes))
 					{
 						if (this._requestData.CustomConverter != null) response.Body = this._requestData.CustomConverter(response, stream) as TReturn;
 						else response.Body = await this._requestData.ConnectionSettings.Serializer.DeserializeAsync<TReturn>(stream, this._cancellationToken).ConfigureAwait(false);
 					}
+					if (response.AllowAllStatusCodes)
+						await ReadServerErrorAsync(response, new MemoryStream(bytes), bytes);
 				}
 				else if (response.HttpStatusCode != null)
-				{
-					response.ServerError = await ServerError.TryCreateAsync(stream, this._cancellationToken).ConfigureAwait(false);
-					if (_disableDirectStreaming)
-						response.ResponseBodyInBytes = bytes;
-				}
+					await ReadServerErrorAsync(response, stream, bytes);
 			}
+		}
+
+		private void ReadServerError(ElasticsearchResponse<TReturn> response, Stream stream, byte[] bytes)
+		{
+			ServerError serverError;
+			if (ServerError.TryCreate(stream, out serverError))
+				response.ServerError = serverError;
+			if (_disableDirectStreaming)
+				response.ResponseBodyInBytes = bytes;
+		}
+
+		private async Task ReadServerErrorAsync(ElasticsearchResponse<TReturn> response, Stream stream, byte[] bytes)
+		{
+			response.ServerError = await ServerError.TryCreateAsync(stream, this._cancellationToken).ConfigureAwait(false);
+			if (_disableDirectStreaming)
+				response.ResponseBodyInBytes = bytes;
 		}
 
 		private void Finalize(ElasticsearchResponse<TReturn> response)
@@ -134,8 +144,9 @@ namespace Elasticsearch.Net
 			}
 		}
 
-		private bool NeedsToEagerReadStream() =>
-			_disableDirectStreaming || typeof(TReturn) == typeof(string) || typeof(TReturn) == typeof(byte[]);
+		private bool NeedsToEagerReadStream(ElasticsearchResponse<TReturn> response) =>
+			response.AllowAllStatusCodes //need to double read for error and TReturn
+			|| _disableDirectStreaming || typeof(TReturn) == typeof(string) || typeof(TReturn) == typeof(byte[]);
 
 		private byte[] SwapStreams(ref Stream responseStream, ref MemoryStream ms)
 		{

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerResponse.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerResponse.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
 using System.Linq;
+using Elasticsearch.Net;
 
 namespace Nest
 {

--- a/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
+++ b/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
@@ -48,7 +48,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 
 		protected override bool SupportsDeserialization => false;
 
-		private static string _script = "if (ctx._source.flag == 'bar') {ctx._source.remove('flag')}";
+		protected virtual string PainlessScript { get; } = "if (ctx._source.flag == 'bar') {ctx._source.remove('flag')}";
 
 		protected override Func<ReindexOnServerDescriptor, IReindexOnServerRequest> Fluent => d => d
 			.Source(s => s
@@ -72,7 +72,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 				.VersionType(VersionType.Internal)
 				.Routing(ReindexRouting.Discard)
 			)
-			.Script(ss => ss.Inline(_script).Lang("groovy"))
+			.Script(ss => ss.Inline(PainlessScript).Lang("groovy"))
 			.Conflicts(Conflicts.Proceed)
 			.Refresh();
 
@@ -95,7 +95,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 				VersionType = VersionType.Internal,
 				Routing = ReindexRouting.Discard
 			},
-			Script = new InlineScript(_script) { Lang = "groovy" },
+			Script = new InlineScript(PainlessScript) { Lang = "groovy" },
 			Conflicts = Conflicts.Proceed,
 			Refresh = true,
 		};
@@ -131,7 +131,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 				},
 				script = new
 				{
-					inline = _script,
+					inline = this.PainlessScript,
 					lang = "groovy"
 				},
 				source = new

--- a/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerInvalidApiTests.cs
+++ b/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerInvalidApiTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using Tests.Framework.MockData;
+using Xunit;
+using static Nest.Infer;
+
+namespace Tests.Document.Multiple.ReindexOnServer
+{
+	[SkipVersion("<2.3.0", "")]
+	public class ReindexOnServerInvalidApiTests : ReindexOnServerApiTests
+	{
+		public ReindexOnServerInvalidApiTests(IntrusiveOperationCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override bool ExpectIsValid => false;
+		protected override int ExpectStatusCode => 500;
+
+		//bad painless script
+		protected override string PainlessScript { get; } = "if ctx._source.flag == 'bar') {ctx._source.remove('flag')}";
+
+		protected override void ExpectResponse(IReindexOnServerResponse response)
+		{
+			response.ServerError.Should().NotBeNull();
+			response.ServerError.Status.Should().Be(500);
+			response.ServerError.Error.Should().NotBeNull();
+			response.ServerError.Error.RootCause.Should().NotBeNullOrEmpty();
+			response.ServerError.Error.RootCause.First().Reason.Should().Contain("Error compiling");
+			response.ServerError.Error.RootCause.First().Type.Should().Be("script_exception");
+		}
+
+	}
+}

--- a/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerRemoteApiTests.cs
+++ b/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerRemoteApiTests.cs
@@ -15,7 +15,7 @@ using static Nest.Infer;
 namespace Tests.Document.Multiple.ReindexOnServer
 {
 	[SkipVersion("<2.3.0", "")]
-	public class ReindexOnServerRemoteApiTests : ApiTestBase<ReadOnlyCluster, IReindexOnServerResponse, IReindexOnServerRequest, ReindexOnServerDescriptor, ReindexOnServerRequest>
+	public class ReindexOnServerRemoteApiTests : ApiTestBase<IntrusiveOperationCluster, IReindexOnServerResponse, IReindexOnServerRequest, ReindexOnServerDescriptor, ReindexOnServerRequest>
 	{
 		private readonly Uri _host = new Uri("http://myremoteserver.example:9200");
 		public ReindexOnServerRemoteApiTests(IntrusiveOperationCluster cluster, EndpointUsage usage) : base(cluster, usage) { }


### PR DESCRIPTION
Fixes #2725 and #2719

Do a double read for error for response that are always valid since they return valid object shapes on non 200-300 such as reindex and deletebyquery.

Relates too https://github.com/elastic/elasticsearch/issues/17548

In normal cases we shortcircuit reading `error` in the low level client on invalid http status codes. Some API's still return a response on bad status codes as well (such as Reindex, DeleteByQuery). If these API's **actually** return an `error` we  failed to pick up on these causing `.IsValid` to always be true here.