### PR TITLE
Update AggregateJsonConverter.cs

### DIFF
--- a/src/Nest/Aggregations/AggregateJsonConverter.cs
+++ b/src/Nest/Aggregations/AggregateJsonConverter.cs
@@ -561,10 +561,11 @@ namespace Nest
 
 			var scriptedMetric = serializer.Deserialize(reader);
 
+			reader.Read();
+			
 			if (scriptedMetric != null)
 				return new ScriptedMetricAggregate {_Value = scriptedMetric};
 
-			reader.Read();
 			return valueMetric;
 		}
 


### PR DESCRIPTION
If search requests multiple aggregations and there present scripted metric aggregation that returns Map (dictionary), some aggregations absent in Aggregations after json deserializaion

This fixes requires perfrom reader.Read() in any case before this line:
   return new ScriptedMetricAggregate { _Value = scriptedMetric };

So reader state stays correct after current aggregate processing