### PR TITLE
WIP PR for fixing Issue2767

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "1.0.1"
+    "version": "1.0.3"
   },
   "version": "5.4.0"
 }

--- a/src/Elasticsearch.sln
+++ b/src/Elasticsearch.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26403.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nest", "Nest\Nest.csproj", "{072BA7DA-7B60-407D-8B6E-95E3186BE70C}"
 EndProject
@@ -29,11 +29,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiGenerator", "CodeGenerat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elasticsearch.Net", "Elasticsearch.Net\Elasticsearch.Net.csproj", "{E97CCF40-0BA6-43FE-9F2D-58D454134088}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "scripts", "..\build\scripts\scripts.fsproj", "{28328694-2598-44D3-BB25-8B6C3FBDD3EF}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "scripts", "..\build\scripts\scripts.fsproj", "{D6997ADC-E933-418E-831C-DE1A78897493}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{37164C11-88EF-4428-803A-9AA24FB8B44D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocGenerator", "CodeGeneration\DocGenerator\DocGenerator.csproj", "{98400F59-4BA8-4534-9A78-9C7FA0B42901}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elasticsearch.Managed", "Managed\Elasticsearch.Managed.csproj", "{59C288FE-4EF7-45CA-9742-625A59DBC31B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,8 +55,8 @@ Global
 		{E97CCF40-0BA6-43FE-9F2D-58D454134088}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E97CCF40-0BA6-43FE-9F2D-58D454134088}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E97CCF40-0BA6-43FE-9F2D-58D454134088}.Release|Any CPU.Build.0 = Release|Any CPU
-		{28328694-2598-44D3-BB25-8B6C3FBDD3EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{28328694-2598-44D3-BB25-8B6C3FBDD3EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6997ADC-E933-418E-831C-DE1A78897493}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6997ADC-E933-418E-831C-DE1A78897493}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{37164C11-88EF-4428-803A-9AA24FB8B44D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{37164C11-88EF-4428-803A-9AA24FB8B44D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{37164C11-88EF-4428-803A-9AA24FB8B44D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -63,13 +65,17 @@ Global
 		{98400F59-4BA8-4534-9A78-9C7FA0B42901}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{98400F59-4BA8-4534-9A78-9C7FA0B42901}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98400F59-4BA8-4534-9A78-9C7FA0B42901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59C288FE-4EF7-45CA-9742-625A59DBC31B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59C288FE-4EF7-45CA-9742-625A59DBC31B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59C288FE-4EF7-45CA-9742-625A59DBC31B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59C288FE-4EF7-45CA-9742-625A59DBC31B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{56A87048-9065-459B-826D-3DF68B409845} = {93331BEE-0AA0-47B7-B1D2-BD5BD31634D1}
-		{28328694-2598-44D3-BB25-8B6C3FBDD3EF} = {432D5575-2347-4D3C-BF8C-3E38410C46CA}
+		{D6997ADC-E933-418E-831C-DE1A78897493} = {432D5575-2347-4D3C-BF8C-3E38410C46CA}
 		{98400F59-4BA8-4534-9A78-9C7FA0B42901} = {93331BEE-0AA0-47B7-B1D2-BD5BD31634D1}
 	EndGlobalSection
 EndGlobal

--- a/src/Managed/Elasticsearch.Managed.csproj
+++ b/src/Managed/Elasticsearch.Managed.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nest\Nest.csproj" />
+    <PackageReference Include="SemanticVersioning" Version="0.7.6" />
+    <Folder Include="Versions\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Managed/Plugins/ElasticsearchPlugin.cs
+++ b/src/Managed/Plugins/ElasticsearchPlugin.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+
+namespace Elasticsearch.Managed.Plugins
+{
+	public enum ElasticsearchPlugin
+	{
+		[Moniker("delete-by-query")] DeleteByQuery,
+		[Moniker("cloud-azure")] CloudAzure,
+		[Moniker("mapper-attachments")] MapperAttachments,
+		[Moniker("mapper-murmur3")] MapperMurmer3,
+		[Moniker("x-pack")] XPack,
+		[Moniker("ingest-geoip")] IngestGeoIp,
+		[Moniker("ingest-attachment")] IngestAttachment,
+		[Moniker("analysis-kuromoji")] AnalysisKuromoji,
+		[Moniker("analysis-icu")] AnalysisIcu
+	}
+}
+

--- a/src/Managed/Plugins/ElasticsearchPluginCollection.cs
+++ b/src/Managed/Plugins/ElasticsearchPluginCollection.cs
@@ -1,0 +1,23 @@
+using System.Collections.ObjectModel;
+using Elasticsearch.Managed.Versions;
+
+namespace Elasticsearch.Managed.Plugins
+{
+	public class ElasticsearchPluginCollection : KeyedCollection<ElasticsearchPlugin, ElasticsearchPluginConfiguration>
+	{
+		public static ElasticsearchPluginCollection Supported { get; } =
+			new ElasticsearchPluginCollection
+			{
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.DeleteByQuery, version => version < new ElasticsearchVersion("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.MapperAttachments),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.MapperMurmer3),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.XPack),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestGeoIp, version => version >= new ElasticsearchVersion("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestAttachment, version => version >= new ElasticsearchVersion("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.AnalysisKuromoji),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.AnalysisIcu)
+			};
+
+		protected override ElasticsearchPlugin GetKeyForItem(ElasticsearchPluginConfiguration item) => item.Plugin;
+	}
+}

--- a/src/Managed/Plugins/ElasticsearchPluginConfiguration.cs
+++ b/src/Managed/Plugins/ElasticsearchPluginConfiguration.cs
@@ -1,0 +1,39 @@
+using System;
+using Elasticsearch.Managed.Versions;
+
+namespace Elasticsearch.Managed.Plugins
+{
+	public class ElasticsearchPluginConfiguration
+	{
+		private readonly Func<ElasticsearchVersion, bool> _isValid;
+
+		public ElasticsearchPlugin Plugin { get; }
+
+		/// <summary>
+		/// The moniker the plugin is known by in Elasticsearch e.g what /_cat/plugins will return for it
+		/// </summary>
+		public string Moniker { get; internal set; }
+
+		/// <summary>
+		/// The folder name under /plugins, defaults to moniker
+		/// </summary>
+		public string FolderName { get; internal set; }
+
+		public ElasticsearchPluginConfiguration(ElasticsearchPlugin plugin) : this(plugin, null) { }
+
+		public ElasticsearchPluginConfiguration(ElasticsearchPlugin plugin, Func<ElasticsearchVersion, bool> isValid)
+		{
+			Plugin = plugin;
+			Moniker = plugin.Moniker();
+			FolderName = plugin.Moniker();
+			_isValid = isValid ?? (v => true);
+		}
+
+		public bool IsValid(ElasticsearchVersion version) => _isValid(version);
+
+		public string SnapshotDownloadUrl(ElasticsearchVersion version)  =>
+			$"https://snapshots.elastic.co/downloads/elasticsearch-plugins/{Moniker}/{SnapshotZip(version)}";
+
+		public string SnapshotZip(ElasticsearchVersion version) => $"{Moniker}-{version.Version}.zip";
+	}
+}

--- a/src/Managed/Plugins/MonikerAttribute.cs
+++ b/src/Managed/Plugins/MonikerAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Reflection;
+
+namespace Elasticsearch.Managed.Plugins
+{
+	[AttributeUsage(AttributeTargets.Field)]
+	public class MonikerAttribute : Attribute
+	{
+		public string Moniker { get; }
+
+		public MonikerAttribute(string moniker)
+		{
+			if (moniker == null) throw new ArgumentNullException(nameof(moniker));
+			if (moniker.Length == 0) throw new ArgumentException("must have a value");
+			Moniker = moniker;
+		}
+	}
+	public static class ElasticsearchPluginExtensions
+	{
+		public static string Moniker(this ElasticsearchPlugin plugin)
+		{
+			var info = typeof(ElasticsearchPlugin).GetField(plugin.ToString());
+			var da = info.GetCustomAttribute<MonikerAttribute>();
+
+			if (da == null) throw new InvalidOperationException($"{plugin} plugin must have a {nameof(MonikerAttribute)}");
+			return da.Moniker;
+		}
+	}
+}

--- a/src/Managed/Versions/ElasticsearchVersion.cs
+++ b/src/Managed/Versions/ElasticsearchVersion.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Xml.Linq;
+using Version = SemVer.Version;
+
+namespace Elasticsearch.Managed.Versions
+{
+	public class ElasticsearchVersion : Version
+	{
+		private static readonly Lazy<string> LatestVersion = new Lazy<string>(ResolveLatestVersion, LazyThreadSafetyMode.ExecutionAndPublication);
+		private static readonly Lazy<string> LatestSnapshot = new Lazy<string>(ResolveLatestSnapshot, LazyThreadSafetyMode.ExecutionAndPublication);
+		private static readonly object _lock = new { };
+		private static readonly ConcurrentDictionary<string, string> SnapshotVersions = new ConcurrentDictionary<string, string>();
+		private static readonly string SonaTypeUrl = "https://oss.sonatype.org/content/repositories/snapshots/org/elasticsearch/distribution/zip/elasticsearch";
+		private bool VersionSatisfiedBy(string range)
+		{
+			var versionRange = new SemVer.Range(range);
+			var satisfied = versionRange.IsSatisfied(Version);
+			if (!IsSnapshot || satisfied) return satisfied;
+			//Semver can only match snapshot version with ranges on the same major and minor
+			//anything else fails but we want to know e.g 2.4.5-SNAPSHOT satisfied by <5.0.0;
+			var wholeVersion = $"{Major}.{Minor}.{Patch}";
+			return versionRange.IsSatisfied(wholeVersion);
+
+		}
+
+		private string RootUrl => this.IsSnapshot
+			? SonaTypeUrl
+			: VersionSatisfiedBy("<5.0.0")
+				? "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch"
+				: "https://artifacts.elastic.co/downloads/elasticsearch";
+
+		private static string ResolveLatestSnapshot()
+		{
+			var version = LatestVersion.Value;
+			return ResolveLatestSnapshotFor(version);
+		}
+
+		private static string ResolveLatestSnapshotFor(string version)
+		{
+			var url = $"{SonaTypeUrl}/{version}/maven-metadata.xml";
+			try
+			{
+				var mavenMetadata = XElement.Load(url);
+				var snapshot = mavenMetadata.Descendants("versioning").Descendants("snapshot").FirstOrDefault();
+				var snapshotTimestamp = snapshot.Descendants("timestamp").FirstOrDefault().Value;
+				var snapshotBuildNumber = snapshot.Descendants("buildNumber").FirstOrDefault().Value;
+				var identifier = $"{snapshotTimestamp}-{snapshotBuildNumber}";
+				var zip = $"elasticsearch-{version.Replace("SNAPSHOT", "")}{identifier}.zip";
+				return zip;
+
+			}
+			catch (Exception e)
+			{
+				throw new Exception($"Can not download maven data from {url}", e);
+			}
+		}
+
+		private static string ResolveLatestVersion()
+		{
+			var url = $"{SonaTypeUrl}/maven-metadata.xml";
+			try
+			{
+                var versions = XElement.Load(url)
+                    .Descendants("version")
+                    .Select(n => new Version(n.Value))
+                    .OrderByDescending(n => n);
+                return versions.First().ToString();
+			}
+			catch (Exception e)
+			{
+				throw new Exception($"Can not download maven data from {url}", e);
+			}
+		}
+
+		private static string TranslateConfigVersion(string configMoniker) => configMoniker == "latest" ? LatestVersion.Value : configMoniker;
+
+		public ElasticsearchVersion(string version) : base(TranslateConfigVersion(version))
+		{
+			this.Version = version;
+			if (this.Version.Equals("latest", StringComparison.OrdinalIgnoreCase))
+			{
+				this.Version = LatestVersion.Value;
+				this.Zip = LatestSnapshot.Value;
+			}
+			else if (this.IsSnapshot)
+			{
+				lock (_lock)
+				{
+					string zipLocation;
+					if (SnapshotVersions.TryGetValue(version, out zipLocation))
+						this.Zip = zipLocation;
+					else
+					{
+						zipLocation = ResolveLatestSnapshotFor(version);
+						SnapshotVersions.TryAdd(version, zipLocation);
+						this.Zip = zipLocation;
+					}
+				}
+			}
+
+			this.Zip = this.Zip ?? $"elasticsearch-{this.Version}.zip";
+		}
+
+		private string _downloadUrl;
+		public string DownloadUrl
+		{
+			get
+			{
+				if (!string.IsNullOrWhiteSpace(this._downloadUrl)) return this._downloadUrl;
+                this._downloadUrl = this.IsSnapshot
+	                ? $"{this.RootUrl}/{this.Version}/{this.Zip}"
+	                : $"{this.RootUrl}/{this.Zip}";
+				return this._downloadUrl;
+
+			}
+		}
+		public string Zip { get; }
+		public string Version { get; }
+
+		/// <summary>
+		/// Returns the version in elasticsearch-{version} format, for SNAPSHOTS this includes a
+		/// datetime suffix
+		/// </summary>
+		public string FullyQualifiedVersion => this.Zip?.Replace(".zip", "").Replace("elasticsearch-", "");
+
+		/// <summary>
+		/// The folder name to expect to be in the zip distribution
+		/// </summary>
+		public string FolderInZip => $"elasticsearch-{this.Version}";
+
+		/// <summary>
+		/// Whether this version is a snapshot or officicially released distribution
+		/// </summary>
+		public bool IsSnapshot => this.Version?.ToLower().Contains("snapshot") ?? false;
+
+		public override string ToString() => this.Version;
+	}
+}


### PR DESCRIPTION
This PR extracts the required code in the tests/framework folder to allow anyone to run ElasticSearch nodes without relying on the test project. It currently targets .net standard 1.4, but this can be changed.
I'm anticipating adding this to the v6 milestone, due to the fact that I think certain API's will changed, notably the API's around the NodeFileSystem and how we access things through .ne standard.