### PR TITLE
Throw an exception when Reindex() produces just enough documents for …

### DIFF
--- a/src/Nest/CommonAbstractions/Reactive/CoordinatedRequestObserverBase.cs
+++ b/src/Nest/CommonAbstractions/Reactive/CoordinatedRequestObserverBase.cs
@@ -4,7 +4,7 @@ namespace Nest
 {
 	internal static class CoordinatedRequestDefaults
 	{
-		public static int BulkAllMaxDegreeOfParallelismDefault = 20;
+		public static int BulkAllMaxDegreeOfParallelismDefault = 4;
 		public static TimeSpan BulkAllBackOffTimeDefault = TimeSpan.FromMinutes(1);
 		public static int BulkAllBackOffRetriesDefault = 0;
 		public static int BulkAllSizeDefault = 1000;

--- a/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
@@ -131,6 +131,13 @@ namespace Nest
 					+ $" which is smaller then the bulkSize:{bulkSize}."
 				);
 
+			var funnelExact = producerBandwidth == bulkSize;
+			if (funnelExact)
+				throw new Exception("The back pressure settings are too conservative it provides enough documents for a single bulk but not enough room to advance "
+					+ $"searchSize:{searchSize} * maxConcurrency:{maxConcurrency} * backPressureFactor:{backPressureFactor} = {producerBandwidth}"
+					+ $" which is exactly the bulkSize:{bulkSize}. Increase the BulkAll max concurrency or the backPressureFactor"
+				);
+
 			var backPressure = new ProducerConsumerBackPressure(backPressureFactor, maxConcurrency);
 			return backPressure;
 		}

--- a/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
@@ -133,7 +133,7 @@ namespace Nest
 
 			var funnelExact = producerBandwidth == bulkSize;
 			if (funnelExact)
-				throw new Exception("The back pressure settings are too conservative it provides enough documents for a single bulk but not enough room to advance "
+				throw new Exception("The back pressure settings are too conservative. They provide enough documents for a single bulk but not enough room to advance "
 					+ $"searchSize:{searchSize} * maxConcurrency:{maxConcurrency} * backPressureFactor:{backPressureFactor} = {producerBandwidth}"
 					+ $" which is exactly the bulkSize:{bulkSize}. Increase the BulkAll max concurrency or the backPressureFactor"
 				);


### PR DESCRIPTION
…a single bulk but leaves no slots to call MoveNext() which would free up an awaiting task. fixes #2771