### PR TITLE
Several fixes related to HttpClient + .NET Core + linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,4 @@ BUILDSCRIPT="build/scripts/Targets.fsx"
 mono .paket/paket.bootstrapper.exe
 if [[ -f .paket.lock ]]; then mono .paket/paket.exe restore; fi
 if [[ ! -f .paket.lock ]]; then mono .paket/paket.exe install; fi
-mono $FAKE $@ --fsiargs -d:MONO $BUILDSCRIPT "cmdline=$@"
+mono $FAKE $BUILDSCRIPT "cmdline=$*" --fsiargs -d:MONO 

--- a/build/Clients.Common.targets
+++ b/build/Clients.Common.targets
@@ -5,7 +5,12 @@
     <CurrentVersion>0.0.0-bad</CurrentVersion>
     <CurrentAssemblyVersion>0.0.0</CurrentAssemblyVersion>
     <CurrentAssemblyFileVersion>0.0.0.0</CurrentAssemblyFileVersion>
-    <DotNetCoreOnly></DotNetCoreOnly>
+    <!-- 'dotnet xunit' does a build but has no way to pass properties or prevent build so we snoop for TRAVIS here
+    Ideally we handle this in the FAKE script (which we do for 'dotnet build')
+    TODO too lazy to write and test a <CHOOSE>
+    -->
+    <DotNetCoreOnly Condition="'$(TRAVIS)'=='true'">1</DotNetCoreOnly>
+    <DotNetCoreOnly Condition="'$(TRAVIS)'==''"></DotNetCoreOnly>
     <DoSourceLink></DoSourceLink>
 
     <!-- Version and Informational reflect actual version -->
@@ -16,20 +21,13 @@
     <!-- File version reflects actual version number without prelease since that not allowed in its struct -->
     <FileVersion>$(CurrentAssemblyFileVersion)</FileVersion>
 
-    <!-- 'dotnet xunit' does a build but has no way to pass properties or prevent build so we snoop for TRAVIS here
-    Ideally we handle this in the FAKE script (which we do for 'dotnet build')
-    TODO too lazy to write and test a <CHOOSE>
-    -->
-    <DotNetCoreOnly Condition="'$(TRAVIS)'=='true'">1</DotNetCoreOnly>
-    <DotNetCoreOnly Condition="'$(TRAVIS)'==''"></DotNetCoreOnly>
-    <DoSourceLink></DoSourceLink>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly Condition="'$(DotNetCoreOnly)'==''">true</SignAssembly>
     <AssemblyOriginatorKeyFile Condition="'$(DotNetCoreOnly)'==''">..\..\build\keys\keypair.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile Condition="'$(DotNetCoreOnly)'==''">true</GenerateDocumentationFile>
     <NoWarn>1591,1572,1571,1573,1587,1570</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
     <DefineConstants Condition="'$(TargetFramework)'=='netstandard1.3' OR '$(DotNetCoreOnly)'=='1'">$(DefineConstants);DOTNETCORE</DefineConstants>
-    <DebugType>embedded</DebugType>
+    <DebugType Condition="'$(DotNetCoreOnly)'==''">embedded</DebugType>
     <SourceLink Condition="'$(DoSourceLink)'!=''">$(BaseIntermediateOutputPath)\sl-$(MsBuildProjectName)-$(TargetFramework).json</SourceLink>
     <RepoUri>https://raw.githubusercontent.com/elastic/elasticsearch-net</RepoUri>
   </PropertyGroup>

--- a/build/scripts/Building.fsx
+++ b/build/scripts/Building.fsx
@@ -24,8 +24,8 @@ module Build =
 
     type private GlobalJson = JsonProvider<"../../global.json">
     let private pinnedSdkVersion = GlobalJson.GetSample().Sdk.Version
-
-    let private buildingOnTravis = getEnvironmentVarAsBool "TRAVIS"
+    if isMono then setProcessEnvironVar "TRAVIS" "true"
+    let private buildingOnTravis = getEnvironmentVarAsBool "TRAVIS" 
 
     let private sln = sprintf "src/Elasticsearch%s.sln" (if buildingOnTravis then ".DotNetCoreOnly" else "")
 

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -86,6 +86,14 @@ module Commandline =
             setBuildParam "clusterfilter" clusterFilter
             setBuildParam "testfilter" testFilter
 
+        | ["connectionreuse"; esVersions] ->
+            setBuildParam "esversions" esVersions
+            setBuildParam "clusterfilter" "ConnectionReuse"
+        | ["connectionreuse"; esVersions; numberOfConnections] ->
+            setBuildParam "esversions" esVersions
+            setBuildParam "clusterfilter" "ConnectionReuse"
+            setBuildParam "numberOfConnections" numberOfConnections
+            
         | ["canary"; ] -> ignore()
         | ["canary"; apiKey ] ->
             setBuildParam "apiKey" apiKey
@@ -97,5 +105,5 @@ module Commandline =
             traceError usage
             exit 2
 
-        setBuildParam "target" target
+        setBuildParam "target" (if target = "connectionreuse" then "integrate" else target)
         traceHeader target

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -51,8 +51,6 @@ module Commandline =
         | _ -> "build"
 
     let needsFullBuild =
-        printfn "%s, %A" target skipTests
-
         match (target, skipTests) with
         | (_, true) -> true
         //dotnet-xunit needs to a build of its own anyways
@@ -67,6 +65,7 @@ module Commandline =
 
     let parse () =
         setEnvironVar "FAKEBUILD" "1"
+        printfn "%A" arguments
         match arguments with
         | [] | ["build"] | ["test"] | ["clean"] -> ignore()
         | ["release"; version] -> setBuildParam "version" version

--- a/build/scripts/Testing.fsx
+++ b/build/scripts/Testing.fsx
@@ -21,8 +21,10 @@ module Tests =
     let private setLocalEnvVars() = 
         let clusterFilter =  getBuildParamOrDefault "clusterfilter" ""
         let testFilter = getBuildParamOrDefault "testfilter" ""
+        let numberOfConnections = getBuildParamOrDefault "numberOfConnections" ""
         setProcessEnvironVar "NEST_INTEGRATION_CLUSTER" clusterFilter
         setProcessEnvironVar "NEST_TEST_FILTER" testFilter
+        setProcessEnvironVar "NEST_NUMBER_OF_CONNECTIONS" numberOfConnections
 
     let private dotnetTest (target: Commandline.MultiTarget) =
         CreateDir Paths.BuildOutput

--- a/build/scripts/Tooling.fsx
+++ b/build/scripts/Tooling.fsx
@@ -13,6 +13,8 @@ open System.Net
 
 open Fake
 
+Fake.ProcessHelper.redirectOutputToTrace <-true
+    
 module Tooling = 
     open Paths
     open Projects

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -21,10 +21,16 @@ namespace Elasticsearch.Net
 	/// </summary>
 	public class ConnectionConfiguration : ConnectionConfiguration<ConnectionConfiguration>
 	{
+		internal static bool IsCurlHandler { get; } =
+            #if DOTNETCORE
+                typeof(HttpClientHandler).Assembly().GetType("System.Net.Http.CurlHandler") != null;
+            #else
+                 false;
+            #endif
 		public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(1);
 		public static readonly TimeSpan DefaultPingTimeout = TimeSpan.FromSeconds(2);
 		public static readonly TimeSpan DefaultPingTimeoutOnSSL = TimeSpan.FromSeconds(5);
-		public static readonly int DefaultConnectionLimit = 80;
+		public static readonly int DefaultConnectionLimit = IsCurlHandler ? Environment.ProcessorCount : 80;
 
 		/// <summary>
 		/// ConnectionConfiguration allows you to control how ElasticLowLevelClient behaves and where/how it connects

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -268,9 +268,7 @@ namespace Elasticsearch.Net
 
 		void IDisposable.Dispose() => this.DisposeManagedResources();
 
-		protected virtual void DisposeManagedResources()
-		{
-		}
+		protected virtual void DisposeManagedResources() { }
 	}
 }
 #endif

--- a/src/Elasticsearch.Net/CrossPlatform/TypeExtensions.cs
+++ b/src/Elasticsearch.Net/CrossPlatform/TypeExtensions.cs
@@ -25,6 +25,15 @@ namespace Elasticsearch.Net
 			return type.IsAssignableFrom(from);
 #endif
 		}
+		
+		internal static Assembly Assembly(this Type type)
+		{
+#if DOTNETCORE
+			return type.GetTypeInfo().Assembly;
+#else
+			return type.Assembly;
+#endif
+		}
 
 		internal static bool IsValue(this Type type)
 		{

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\Clients.Common.targets" />
   <PropertyGroup>
     <TargetFrameworks Condition="'$(DotNetCoreOnly)'==''">net45;net46;netstandard1.3</TargetFrameworks>

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\Clients.Common.targets" />
   <PropertyGroup>
     <TargetFrameworks Condition="'$(DotNetCoreOnly)'==''">net45;net46;netstandard1.3</TargetFrameworks>

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -7,8 +7,9 @@ using System.Threading.Tasks;
 
 namespace Elasticsearch.Net
 {
-	public class ResponseBuilder<TReturn>
+	public class ResponseBuilder<TReturn> 
 		where TReturn : class
+		
 	{
 		private const int BufferSize = 81920;
 		private static readonly VoidResponse Void = new VoidResponse();

--- a/src/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
+++ b/src/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
@@ -36,7 +36,7 @@ namespace Tests.ClientConcepts.Troubleshooting
 			 * We'll use a Sniffing connection pool here since it sniffs on startup and pings before
 			 * first usage, so we can get an audit trail with a few events out
 			 */
-			var pool = new SniffingConnectionPool(new []{ new Uri($"http://localhost:{_cluster.Node.Port}") });
+			var pool = new SniffingConnectionPool(new []{ new Uri($"http://{TestClient.DefaultHost}:9200") });
 		    var connectionSettings = new ConnectionSettings(pool)
 				.InferMappingFor<Project>(i => i
 					.IndexName("project")

--- a/src/Tests/Framework/ManagedElasticsearch/Nodes/ElasticsearchNode.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Nodes/ElasticsearchNode.cs
@@ -111,10 +111,12 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 
 		private void HandleConsoleMessage(ElasticsearchConsoleOut consoleOut, XplatManualResetEvent handle)
 		{
+			Console.WriteLine(consoleOut.Data);
 			//no need to snoop for metadata if we already started
 			if (!this._config.RunIntegrationTests || this.Started) return;
 
-			if (consoleOut.Error && !this.Started) throw new Exception(consoleOut.Data);
+			if (consoleOut.Error && !this.Started && !string.IsNullOrWhiteSpace(consoleOut.Data)) 
+				throw new Exception("Error out:" + consoleOut.Data);
 
 			string version;
 			int? pid;

--- a/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeFileSystem.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeFileSystem.cs
@@ -13,9 +13,11 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 		private readonly string _clusterName;
 
 		public string ElasticsearchHome { get; }
-		public string Binary => Path.Combine(this.ElasticsearchHome, "bin", "elasticsearch") + ".bat";
+		private static bool IsMono { get; } = Type.GetType("Mono.Runtime") == null;
+		public string BinarySuffix => IsMono || Path.PathSeparator == '/' ? "" : ".bat";
+		public string Binary => Path.Combine(this.ElasticsearchHome, "bin", "elasticsearch") + BinarySuffix;
 		public string PluginBinary =>
-			Path.Combine(this.ElasticsearchHome, "bin", (this._version.Major >= 5 ? "elasticsearch-" : "" ) +"plugin") + ".bat";
+			Path.Combine(this.ElasticsearchHome, "bin", (this._version.Major >= 5 ? "elasticsearch-" : "" ) +"plugin") + BinarySuffix;
 		public string ConfigPath => Path.Combine(ElasticsearchHome, "config");
 		public string DataPath => Path.Combine(ElasticsearchHome, "data", this._clusterName);
 		public string LogsPath => Path.Combine(ElasticsearchHome, "logs");
@@ -28,7 +30,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 
 
 		//certificates
-		public string CertGenBinary => Path.Combine(this.ElasticsearchHome, "bin", "x-pack", "certgen") + ".bat";
+		public string CertGenBinary => Path.Combine(this.ElasticsearchHome, "bin", "x-pack", "certgen") + BinarySuffix;
 
 		public string CertificateFolderName => "node-certificates";
 		public string CertificateNodeName => "node01";

--- a/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeFileSystem.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeFileSystem.cs
@@ -13,7 +13,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 		private readonly string _clusterName;
 
 		public string ElasticsearchHome { get; }
-		private static bool IsMono { get; } = Type.GetType("Mono.Runtime") == null;
+		private static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
 		public string BinarySuffix => IsMono || Path.PathSeparator == '/' ? "" : ".bat";
 		public string Binary => Path.Combine(this.ElasticsearchHome, "bin", "elasticsearch") + BinarySuffix;
 		public string PluginBinary =>

--- a/src/Tests/Framework/ManagedElasticsearch/Process/ElasticsearchConsoleOut.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Process/ElasticsearchConsoleOut.cs
@@ -61,8 +61,8 @@ namespace Tests.Framework.ManagedElasticsearch.Process
 		private static readonly Regex InfoParser =
 			new Regex(@"version\[(?<version>.*)\], pid\[(?<pid>.*)\], build\[(?<build>.+)\]");
 
-		public bool InNodeSection => this.Section != "o.e.n.Node" || this.Section != "node";
-		public bool InHttpSection => this.Section != "o.e.h.HttpServer" || this.Section != "http";
+		public bool InNodeSection => this.Section == "o.e.n.Node" || this.Section == "node";
+		public bool InHttpSection => this.Section == "o.e.h.HttpServer" || this.Section == "http";
 
 		public bool TryParseNodeInfo(out string version, out int? pid)
 		{
@@ -81,7 +81,7 @@ namespace Tests.Framework.ManagedElasticsearch.Process
 		public bool TryGetStartedConfirmation()
 		{
 			if (!this.InNodeSection) return false;
-			return this.Message == "started";
+			return this.Message.Trim() == "started";
 		}
 
 		private static readonly Regex PortParser =

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/EnsureSecurityUsersInDefaultRealmAreAdded.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/EnsureSecurityUsersInDefaultRealmAreAdded.cs
@@ -14,7 +14,7 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks.InstallationTasks
 			var folder = v.Major >= 5 ? "x-pack" : "shield";
 			var plugin = v.Major >= 5 ? "users" : "esusers";
 
-			var pluginBat = Path.Combine(fileSystem.ElasticsearchHome, "bin", folder, plugin) + ".bat";
+			var pluginBat = Path.Combine(fileSystem.ElasticsearchHome, "bin", folder, plugin) + BinarySuffix;
 			foreach (var cred in ShieldInformation.AllUsers)
 				this.ExecuteBinary(pluginBat, $"adding user {cred.Username}",$"useradd {cred.Username} -p {cred.Password} -r {cred.Role}");
 		}

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/InstallationTaskBase.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/InstallationTaskBase.cs
@@ -15,6 +15,9 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks.InstallationTasks
 	public abstract class InstallationTaskBase
 	{
 		public abstract void Run(NodeConfiguration config, NodeFileSystem fileSystem);
+		
+		private static bool IsMono { get; } = Type.GetType("Mono.Runtime") == null;
+		protected string BinarySuffix => IsMono || Path.PathSeparator == '/' ? "" : ".bat";
 
 		protected void DownloadFile(string from, string to)
 		{

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/InstallationTaskBase.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/InstallationTaskBase.cs
@@ -16,7 +16,7 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks.InstallationTasks
 	{
 		public abstract void Run(NodeConfiguration config, NodeFileSystem fileSystem);
 		
-		private static bool IsMono { get; } = Type.GetType("Mono.Runtime") == null;
+		private static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
 		protected string BinarySuffix => IsMono || Path.PathSeparator == '/' ? "" : ".bat";
 
 		protected void DownloadFile(string from, string to)

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -27,7 +27,8 @@ namespace Tests.Framework
 		public static Uri CreateUri(int port = 9200, bool forceSsl = false) =>
 			new UriBuilder(forceSsl ? "https" : "http", Host, port).Uri;
 
-		public static string Host => (RunningFiddler) ? "ipv4.fiddler" : "localhost";
+		public static string DefaultHost => "localhost";
+		public static string Host => (RunningFiddler) ? "ipv4.fiddler" : DefaultHost;
 
 		private static ITestConfiguration LoadConfiguration()
 		{
@@ -74,6 +75,8 @@ namespace Tests.Framework
 				.IndexName("queries")
 				.TypeName(PercolatorType)
 			)
+			//.ConnectionLimit(4)
+			//.Proxy(new Uri("http://127.0.0.1:8888"), "", "")
 			//.EnableTcpKeepAlive(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2))
 			//.PrettyJson()
 			//TODO make this random

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -57,7 +57,12 @@ namespace Tests.Framework
 
 			throw new Exception($"Tried to load a yaml file from {yamlConfigurationPath} but it does not exist : pwd:{directoryInfo.FullName}");
 		}
-
+		
+		private static int ConnectionLimitDefault => 
+			int.TryParse(Environment.GetEnvironmentVariable("NEST_NUMBER_OF_CONNECTIONS"), out int x) 
+			? x
+			: ConnectionConfiguration.DefaultConnectionLimit;
+		
 		private static ConnectionSettings DefaultSettings(ConnectionSettings settings) => settings
 			.DefaultIndex("default-index")
 			.PrettyJson()
@@ -75,7 +80,7 @@ namespace Tests.Framework
 				.IndexName("queries")
 				.TypeName(PercolatorType)
 			)
-			//.ConnectionLimit(4)
+			.ConnectionLimit(ConnectionLimitDefault)
 			//.Proxy(new Uri("http://127.0.0.1:8888"), "", "")
 			//.EnableTcpKeepAlive(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2))
 			//.PrettyJson()

--- a/src/Tests/Reproduce/ConnectionReuseAndBalancing.cs
+++ b/src/Tests/Reproduce/ConnectionReuseAndBalancing.cs
@@ -1,27 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Tests.Framework;
-using Tests.Framework.Integration;
 using Tests.Framework.MockData;
 using Xunit;
-
 using Elasticsearch.Net;
 using Nest;
 using FluentAssertions;
 using System.Threading;
 using System.Reactive.Linq;
-using Tests.Framework.ManagedElasticsearch;
 using Tests.Framework.ManagedElasticsearch.Clusters;
 using static Nest.Infer;
 
 namespace Tests.Reproduce
 {
 	public class ConnectionReuseCluster : ClusterBase { }
+
 	public class ConnectionReuseAndBalancing : IClusterFixture<ConnectionReuseCluster>
 	{
+		
+		private static bool IsCurlHandler { get; } =
+            #if DOTNETCORE
+                typeof(HttpClientHandler).Assembly().GetType("System.Net.Http.CurlHandler") != null;
+            #else
+                 false;
+            #endif
+
 		private readonly ConnectionReuseCluster _cluster;
 
 		public ConnectionReuseAndBalancing(ConnectionReuseCluster cluster)
@@ -32,50 +38,82 @@ namespace Tests.Reproduce
 		public IEnumerable<Project> MockDataGenerator(int numDocuments)
 		{
 			foreach (var i in Enumerable.Range(0, numDocuments))
-				yield return new Project { Name = $"project-{i}" };
+				yield return new Project {Name = $"project-{i}"};
 		}
 
 		[I] public async Task IndexAndSearchABunch()
 		{
-			var tokenSource = new CancellationTokenSource();
+			const int requestsPerIteration = 1000;
 			var client = _cluster.Client;
 
-			await client.DeleteIndexAsync(Index<Project>());
-			var observableBulk = client.BulkAll(this.MockDataGenerator(100000), f => f
-				.MaxDegreeOfParallelism(10)
-				.BackOffTime(TimeSpan.FromSeconds(10))
-				.BackOffRetries(2)
-				.Size(1000)
-				.RefreshOnCompleted()
-			, tokenSource.Token);
-			await observableBulk.ForEachAsync(x => { }, tokenSource.Token);
-			var statsRequest = new NodesStatsRequest(NodesStatsMetric.Http);
-			var nodeStats = await client.NodesStatsAsync(statsRequest);
-			this.AssertHttpStats(nodeStats);
-			for (var i = 0; i < 10; i++)
-			{
-				var taskList = new Task[1000];
-				for (var t=0;t<1000;t++)
-				{
-					taskList[t] = client.SearchAsync<Project>();
-				}
-				//Parallel.For(0, 1000, c => client.Search<Project>(s => s));
-				Task.WaitAll(taskList);
+			await IndexMockData(client, requestsPerIteration);
 
-				nodeStats = await client.NodesStatsAsync(statsRequest);
-				this.AssertHttpStats(nodeStats);
+			var statsRequest = new NodesStatsRequest(NodesStatsMetric.Http);
+			for (var i = 0; i < 20; i++)
+			{
+				Task[] tasks = Enumerable.Range(0, requestsPerIteration)
+					.Select(async (r) => await client.SearchAsync<Project>())
+					.ToArray();
+				Task.WaitAll(tasks);
+
+				var nodeStats = await client.NodesStatsAsync(statsRequest);
+				AssertHttpStats(client, nodeStats, i, requestsPerIteration);
 			}
 		}
 
-		private void AssertHttpStats(INodesStatsResponse response)
+		private static void AssertHttpStats(IElasticClient c, INodesStatsResponse r, int i, int requestsPerIteration)
 		{
-			foreach(var node in response.Nodes.Values)
-			{
-				node.Http.TotalOpened.Should().BeGreaterThan(2);
-				node.Http.TotalOpened.Should().BeLessThan(100);
-				node.Http.CurrentOpen.Should().BeLessThan(100);
-			}
+			const int leeWay = 10;
+			var connectionLimit = c.ConnectionSettings.ConnectionLimit;
+			var maxCurrent = connectionLimit;
 
+			foreach (var node in r.Nodes.Values) //in our cluster we only have 1 node
+			{
+				node.Http.TotalOpened.Should().BeGreaterThan(2, "We want to see some concurrency");
+				var h = node.Http;
+				node.Http.CurrentOpen.Should().BeLessOrEqualTo(maxCurrent, $"CurrentOpen exceed our connection limit {maxCurrent}");
+
+				string errorMessage;
+				int iterationMax;
+
+				if (!IsCurlHandler)
+				{
+					//on non curl connections we expect full connection reuse 
+					//we allow some leeway on the maxOpened because of connections setup and teared down
+					//during the initial bootstrap procudure from the test framework getting the cluster up.
+					iterationMax = maxCurrent + leeWay;
+					errorMessage = $"Total openend exceeded {maxCurrent} + leighway factor {leeWay}";
+				}
+				else
+				{
+					var m = Math.Max(2, i + 1) + 1;
+					iterationMax = ((maxCurrent * m) / 2) + leeWay;
+					errorMessage =
+						$"Expected some socket bleeding but iteration {i} exceeded iteration specific max {iterationMax} = (({maxCurrent} * {m}) / 2) + {leeWay}";
+				}
+				node.Http.TotalOpened.Should().BeLessOrEqualTo(iterationMax, errorMessage);
+				if (i == -1) return;
+
+				Console.WriteLine(
+					$"Current Open: {h.CurrentOpen}, Total Opened: {h.TotalOpened}, Iteration Max = {iterationMax}, Iteration: {i}, Total Searches {(i + 1) * requestsPerIteration}");
+			}
+		}
+
+		private async Task IndexMockData(IElasticClient c, int requestsPerIteration) 
+		{
+			var tokenSource = new CancellationTokenSource();
+			await c.DeleteIndexAsync(Index<Project>(), cancellationToken: tokenSource.Token);
+			var observableBulk = c.BulkAll(this.MockDataGenerator(100000), f => f
+					.MaxDegreeOfParallelism(10)
+					.BackOffTime(TimeSpan.FromSeconds(10))
+					.BackOffRetries(2)
+					.Size(1000)
+					.RefreshOnCompleted()
+				, tokenSource.Token);
+			await observableBulk.ForEachAsync(x => { }, tokenSource.Token);
+			var statsRequest = new NodesStatsRequest(NodesStatsMetric.Http);
+			var nodeStats = await c.NodesStatsAsync(statsRequest, tokenSource.Token);
+			AssertHttpStats(c, nodeStats, -1, requestsPerIteration);
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes several issues:

* [x] fixes the build on linux machines that are not TRAVIS..
* [x] Can now run the integration test framework on linux too.
* [x] Lowers the default concurrent connection limit when we find that HttpClient runs with `CurlHandler`, this to minimize TCP connections bleeding.
* [x] `CurlHandler` needs `response` explicitly disposed.


While on Desktop CLR we still use WebRequest where the following holds true as per: http://msdn.microsoft.com/en-us/library/system.net.httpwebresponse.getresponsestream.aspx

> You must call either the Stream.Close or the HttpWebResponse.Close method to close the stream and release the connection for reuse. It is not necessary to call both Stream.Close and HttpWebResponse.Close, but doing so does not cause an error. Failure to close the stream will cause your application to run out of connections.

The same is not necessarily true for all `HttpMessageHandler` implementations on CoreFX as @icanhasjonas reported on #2784.

While fixing that and running our connection reuse integration test I noticed that even with the fix in place this test always failed. Some TCP bleeding always happens UNLESS you set the ConnectionLimit to number of physical CPU cores (`lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l`). In fact i saw the same numbers of bleedage with and without the dispose fix although i am certain the fix will behave much better in longer running applications.

I *suspect* this property is at play in combination with thread preempting:

https://github.com/dotnet/corefx/blob/bffef76f6af208e2042a2f27bc081ee908bb390b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs#L32

But will open an issue on corefx https://github.com/dotnet/corefx/ to make sure these findings are correct.

In either case using `Stream` as `TReturn` on the client will now throw when `CurlHandler` is found and we should consider removing support for this in 6.0.

The default `ConnectionLimit` remains `80` for `net45/6` targets but for `netstandard` if we see `CurlHandler` the default is now `Environment.ProcessorCount`.

To easily test the connection reuse you can now call:

```
./build.sh connectionreuse <version> [number_of_connections]
```

with the latter optional 

e.g

```
./build.sh connectionreuse 6.0.0-alpha1 80
```




