### PR TITLE
Runnable xunit tests with Resharper

### DIFF
--- a/src/Tests/Program.cs
+++ b/src/Tests/Program.cs
@@ -56,7 +56,7 @@ namespace Tests
 		private static  string SdkPath { get; }
 		private static  string OutputPath { get; }
 
-		public static void Main(string[] args)
+		public static void TestMain(string[] args)
 		{
 			if (args.Length == 0)
 				Console.WriteLine("Must specify at least one argument: TestAssemblyPath, Profile or Benchmark ");

--- a/src/Tests/Program.cs
+++ b/src/Tests/Program.cs
@@ -56,6 +56,9 @@ namespace Tests
 		private static  string SdkPath { get; }
 		private static  string OutputPath { get; }
 
+		// TODO: Renamed this from Main to TestMain because of a bug with Resharper and running unit tests
+		// in Visual Studio with .NET Core: https://youtrack.jetbrains.com/issue/RSRP-464233
+		// Once this is fixed, look at renaming back and removing additional packages. See https://github.com/elastic/elasticsearch-net/pull/2793
 		public static void TestMain(string[] args)
 		{
 			if (args.Length == 0)

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="BenchMarkDotNet" Version="0.10.0" />
     <PackageReference Include="DiffPlex" Version="1.4.1" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <!-- TODO only for Desktop CLR? -->
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <!-- TODO update -->
@@ -30,7 +31,9 @@
   <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp1.1'">
     <PackageReference Include="JetBrains.Profiler.Kernel.Windows.Api" Version="108.0.20170209.151431-eap01" />
     <Reference Include="..\..\build\profiling\JetBrains.Profiler.Windows.SelfApi.dll" />
-    <PackageReference Include="JetBrains.Profiler.Kernel.Windows.Api" Version="108.0.20170209.151431-eap01" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='net45'">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
     <PackageReference Include="System.Net.Http" Version="4.3.0" />


### PR DESCRIPTION
Visual Studio 2017 RTM and Resharper unit test runner are currently broken: https://youtrack.jetbrains.com/issue/RSRP-464233

This fix allows xunit tests to be runnable within Visual Studio by adding references to the following packages:

```
<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
<PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
```

A consequence of doing this is that Microsoft.NET.Test.Sdk defines a Main entry point which means that Tests project cannot define one. Main renamed to TestMain until this is resolved.