### PR TITLE
`ElasticsearchNode` should use `DesiredPort` from `NodeConfiguration`

### DIFF
--- a/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
@@ -355,7 +355,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 		{
 			get
 			{
-				var es = this.Node.Version > new ElasticsearchVersion("5.0.0-alpha2") ? "" : "es.";
+				var es = this.Node.Version > ElasticsearchVersion.GetOrAdd("5.0.0-alpha2") ? "" : "es.";
 
 				return new[]
 				{

--- a/src/Tests/Document/Multiple/BulkAll/BulkAllApiTests.cs
+++ b/src/Tests/Document/Multiple/BulkAll/BulkAllApiTests.cs
@@ -120,7 +120,7 @@ namespace Tests.Document.Multiple.BulkAll
 			var handle = new ManualResetEvent(false);
 
 			var size = 1000;
-			var pages = 100;
+			var pages = 1000;
 			var seenPages = 0;
 			var numberOfDocuments = size * pages;
 			var documents = this.CreateLazyStreamOfDocuments(numberOfDocuments);
@@ -146,7 +146,7 @@ namespace Tests.Document.Multiple.BulkAll
 			observableBulk.Subscribe(bulkObserver);
 
 			//we wait N seconds to see some bulks
-			handle.WaitOne(TimeSpan.FromSeconds(1));
+			handle.WaitOne(TimeSpan.FromSeconds(3));
 			observableBulk.Dispose();
 			//we wait N seconds to give in flight request a chance to cancel
 			handle.WaitOne(TimeSpan.FromSeconds(3));
@@ -165,7 +165,7 @@ namespace Tests.Document.Multiple.BulkAll
 			var handle = new ManualResetEvent(false);
 
 			var size = 1000;
-			var pages = 100;
+			var pages = 1000;
 			var seenPages = 0;
 			var numberOfDocuments = size * pages;
 			var documents = this.CreateLazyStreamOfDocuments(numberOfDocuments);
@@ -191,7 +191,7 @@ namespace Tests.Document.Multiple.BulkAll
 			observableBulk.Subscribe(bulkObserver);
 
 			//we wait Nseconds to see some bulks
-			handle.WaitOne(TimeSpan.FromSeconds(1));
+			handle.WaitOne(TimeSpan.FromSeconds(3));
 			tokenSource.Cancel();
 			//we wait Nseconds to give in flight request a chance to cancel
 			handle.WaitOne(TimeSpan.FromSeconds(3));

--- a/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
@@ -11,7 +11,7 @@ namespace Tests.Framework.Configuration
 	{
 		public override bool TestAgainstAlreadyRunningElasticsearch { get; protected set; } = false;
 		public override bool ForceReseed { get; protected set; } = true;
-		public override ElasticsearchVersion ElasticsearchVersion { get; protected set; } = new ElasticsearchVersion("5.0.0");
+		public override ElasticsearchVersion ElasticsearchVersion { get; protected set; } = ElasticsearchVersion.GetOrAdd("5.0.0");
 		public override TestMode Mode { get; protected set; } = TestMode.Unit;
 		public override string ClusterFilter { get; protected set; }
 		public override string TestFilter { get; protected set; }
@@ -23,7 +23,7 @@ namespace Tests.Framework.Configuration
 			var version = Environment.GetEnvironmentVariable("NEST_INTEGRATION_VERSION");
 			if (!string.IsNullOrEmpty(version)) Mode = TestMode.Integration;
 
-			this.ElasticsearchVersion = new ElasticsearchVersion(string.IsNullOrWhiteSpace(version) ? "5.0.0" : version);
+			this.ElasticsearchVersion = ElasticsearchVersion.GetOrAdd(string.IsNullOrWhiteSpace(version) ? "5.0.0" : version);
 			this.ClusterFilter = Environment.GetEnvironmentVariable("NEST_INTEGRATION_CLUSTER");
 			this.TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
 		}

--- a/src/Tests/Framework/Configuration/Versions/ElasticsearchVersion.cs
+++ b/src/Tests/Framework/Configuration/Versions/ElasticsearchVersion.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Xml.Linq;
 using Nest;
@@ -15,6 +16,7 @@ namespace Tests.Framework.Versions
 		private static readonly object _lock = new { };
 		private static readonly ConcurrentDictionary<string, string> SnapshotVersions = new ConcurrentDictionary<string, string>();
 		private static readonly string SonaTypeUrl = "https://oss.sonatype.org/content/repositories/snapshots/org/elasticsearch/distribution/zip/elasticsearch";
+		private static readonly ConcurrentDictionary<string, ElasticsearchVersion> Versions = new ConcurrentDictionary<string, ElasticsearchVersion>();
 
 		private string RootUrl => this.IsSnapshot
 			? SonaTypeUrl
@@ -127,5 +129,8 @@ namespace Tests.Framework.Versions
 		public bool IsSnapshot => this.Version?.ToLower().Contains("snapshot") ?? false;
 
 		public override string ToString() => this.Version;
+
+		public static ElasticsearchVersion GetOrAdd(string version) =>
+			Versions.GetOrAdd(version, v => new ElasticsearchVersion(v));
 	}
 }

--- a/src/Tests/Framework/Configuration/YamlConfiguration.cs
+++ b/src/Tests/Framework/Configuration/YamlConfiguration.cs
@@ -23,7 +23,7 @@ namespace Tests.Framework.Configuration
 				.ToDictionary(ConfigName, ConfigValue);
 
 			this.Mode = GetTestMode(config["mode"]);
-			this.ElasticsearchVersion = new ElasticsearchVersion(config["elasticsearch_version"]);
+			this.ElasticsearchVersion = ElasticsearchVersion.GetOrAdd(config["elasticsearch_version"]);
 			this.ForceReseed = bool.Parse(config["force_reseed"]);
 			this.TestAgainstAlreadyRunningElasticsearch = bool.Parse(config["test_against_already_running_elasticsearch"]);
 			this.ClusterFilter = config.ContainsKey("cluster_filter") ? config["cluster_filter"] : null;

--- a/src/Tests/Framework/ManagedElasticsearch/Nodes/ElasticsearchNode.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Nodes/ElasticsearchNode.cs
@@ -26,11 +26,12 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 		private readonly NodeConfiguration _config;
 
 		public ElasticsearchVersion Version => _config.ElasticsearchVersion;
+
 		public NodeFileSystem FileSystem { get; }
 
 		public bool Started { get; private set; }
 
-		public int Port { get; private set; } = 9200;
+		public int Port { get; private set; }
 
 		private bool RunningOnCI { get; }
 
@@ -39,7 +40,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 			this._config = config;
 			this.FileSystem = config.FileSystem;
 			this.RunningOnCI = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION"));
-
+			this.Port = config.DesiredPort;
 			if (this._config.RunIntegrationTests && !this._config.TestAgainstAlreadyRunningElasticsearch) return;
 		}
 
@@ -91,7 +92,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 				{
 					var subscription = Observable.Using(() => process, p => p.Start())
 						.Select(c => new ElasticsearchConsoleOut(this._config.ElasticsearchVersion, c.Error, c.Data))
-						.Subscribe(s => this.HandleConsoleMessage(s, handle), e => { throw e; }, () => handle.Set());
+						.Subscribe(s => this.HandleConsoleMessage(s, handle), e => throw e, () => handle.Set());
 					this._composite.Add(subscription);
 
 					if (!handle.WaitOne(timeout, true))
@@ -133,7 +134,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 
 			if (this.ProcessId == null && consoleOut.TryParseNodeInfo(out version, out pid))
 			{
-				var startedVersion = new ElasticsearchVersion(version);
+				var startedVersion = ElasticsearchVersion.GetOrAdd(version);
 				this.ProcessId = pid;
 				if (this.Version != startedVersion)
 					throw new Exception($"Booted elasticsearch is version {startedVersion} but the test config dictates {this.Version}");

--- a/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeConfiguration.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeConfiguration.cs
@@ -56,9 +56,9 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 			this.DesiredPort = cluster.DesiredPort;
 
 			var attr = v.Major >= 5 ? "attr." : "";
-			var indexedOrStored = v > new ElasticsearchVersion("5.0.0-alpha1") ? "stored" : "indexed";
-			var shieldOrSecurity = v > new ElasticsearchVersion("5.0.0-alpha1") ? "xpack.security" : "shield";
-			var es = v > new ElasticsearchVersion("5.0.0-alpha2") ? "" : "es.";
+			var indexedOrStored = v > ElasticsearchVersion.GetOrAdd("5.0.0-alpha1") ? "stored" : "indexed";
+			var shieldOrSecurity = v > ElasticsearchVersion.GetOrAdd("5.0.0-alpha1") ? "xpack.security" : "shield";
+			var es = v > ElasticsearchVersion.GetOrAdd("5.0.0-alpha2") ? "" : "es.";
 			var b = this.XPackEnabled.ToString().ToLowerInvariant();
 			var sslEnabled = this.EnableSsl.ToString().ToLowerInvariant();
 			this.DefaultNodeSettings = new List<string>
@@ -78,7 +78,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 				$"{es}{shieldOrSecurity}.authc.realms.pki1.enabled={sslEnabled}",
 
 			};
-			if (v >= new ElasticsearchVersion("5.4.0"))
+			if (v >= ElasticsearchVersion.GetOrAdd("5.4.0"))
 				this.DefaultNodeSettings.Add($"{es}search.remote.connect=true");
 		}
 

--- a/src/Tests/Framework/ManagedElasticsearch/Plugins/ElasticsearchPluginCollection.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Plugins/ElasticsearchPluginCollection.cs
@@ -8,12 +8,12 @@ namespace Tests.Framework.ManagedElasticsearch.Plugins
 		public static ElasticsearchPluginCollection Supported { get; } =
 			new ElasticsearchPluginCollection
 			{
-				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.DeleteByQuery, version => version < new ElasticsearchVersion("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.DeleteByQuery, version => version < ElasticsearchVersion.GetOrAdd("5.0.0-alpha3")),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.MapperAttachments),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.MapperMurmer3),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.XPack),
-				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestGeoIp, version => version >= new ElasticsearchVersion("5.0.0-alpha3")),
-				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestAttachment, version => version >= new ElasticsearchVersion("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestGeoIp, version => version >= ElasticsearchVersion.GetOrAdd("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestAttachment, version => version >= ElasticsearchVersion.GetOrAdd("5.0.0-alpha3")),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.AnalysisKuromoji),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.AnalysisIcu)
 			};

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/ValidationTasks/ValidateRunningVersion.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/ValidationTasks/ValidateRunningVersion.cs
@@ -17,8 +17,8 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks.ValidationTasks
 			if (!alreadyUp.IsValid) return;
 			var v = configuration.ElasticsearchVersion;
 
-			var alreadyUpVersion = new ElasticsearchVersion(alreadyUp.Version.Number);
-			var alreadyUpSnapshotVersion = new ElasticsearchVersion(alreadyUp.Version.Number + "-SNAPSHOT");
+			var alreadyUpVersion = ElasticsearchVersion.GetOrAdd(alreadyUp.Version.Number);
+			var alreadyUpSnapshotVersion = ElasticsearchVersion.GetOrAdd(alreadyUp.Version.Number + "-SNAPSHOT");
 			if (v != alreadyUpVersion && v != alreadyUpSnapshotVersion)
 				throw new Exception($"running elasticsearch is version {alreadyUpVersion} but the test config dictates {v}");
 		}

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -96,7 +96,7 @@ namespace Tests.Framework
 				m.Ignore(p => p.Ranges);
 			return m;
 		}
-		public static string PercolatorType => Configuration.ElasticsearchVersion <= new ElasticsearchVersion("5.0.0-alpha1")
+		public static string PercolatorType => Configuration.ElasticsearchVersion <= ElasticsearchVersion.GetOrAdd("5.0.0-alpha1")
 			? ".percolator"
 			: "query";
 

--- a/src/Tests/XPack/Watcher/ExecuteWatch/ExecuteWatchApiTests.cs
+++ b/src/Tests/XPack/Watcher/ExecuteWatch/ExecuteWatchApiTests.cs
@@ -548,6 +548,9 @@ namespace Tests.XPack.Watcher.ExecuteWatch
 						.Body("{}")
 					)
 				)
+			)
+			.RequestConfiguration(r => r
+				.RequestTimeout(TimeSpan.FromMinutes(2))
 			);
 
 		protected override ExecuteWatchRequest Initializer =>
@@ -615,6 +618,10 @@ namespace Tests.XPack.Watcher.ExecuteWatch
 						Method = HttpInputMethod.Post,
 						Body = "{}"
 					}
+				},
+				RequestConfiguration = new RequestConfiguration
+				{
+					RequestTimeout = TimeSpan.FromMinutes(2)
 				}
 			};
 


### PR DESCRIPTION
- Share `ElasticsearchVersion` instances created.
- Allow more time for flaky integration tests
    
    These were failing consistently locally for me so I've increased the doc count and wait time to allow some indexing to take place.

Needs porting to `master`