### PR TITLE
Add missing fields on simple query string query

### DIFF
--- a/src/Nest/QueryDsl/FullText/Match/MatchQuery.cs
+++ b/src/Nest/QueryDsl/FullText/Match/MatchQuery.cs
@@ -66,8 +66,8 @@ namespace Nest
 		[Obsolete("Use FuzzyMultiTermQueryRewrite")]
 		public RewriteMultiTerm? FuzzyRewrite
 		{
-			get { return FuzzyMultiTermQueryRewrite?.Rewrite; }
-			set { FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => FuzzyMultiTermQueryRewrite?.Rewrite;
+			set => FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 		public MultiTermQueryRewrite FuzzyMultiTermQueryRewrite { get; set; }
 		public IFuzziness Fuzziness { get; set; }
@@ -99,8 +99,8 @@ namespace Nest
 		MinimumShouldMatch IMatchQuery.MinimumShouldMatch { get; set; }
 		RewriteMultiTerm? IMatchQuery.FuzzyRewrite
 		{
-			get { return Self.FuzzyMultiTermQueryRewrite?.Rewrite; }
-			set { Self.FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => Self.FuzzyMultiTermQueryRewrite?.Rewrite;
+			set => Self.FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 		MultiTermQueryRewrite IMatchQuery.FuzzyMultiTermQueryRewrite { get; set; }
 		IFuzziness IMatchQuery.Fuzziness { get; set; }

--- a/src/Nest/QueryDsl/FullText/MultiMatch/MultiMatchQuery.cs
+++ b/src/Nest/QueryDsl/FullText/MultiMatch/MultiMatchQuery.cs
@@ -77,8 +77,8 @@ namespace Nest
 		[Obsolete("Use FuzzyMultiTermQueryRewrite")]
 		public RewriteMultiTerm? FuzzyRewrite
 		{
-			get { return FuzzyMultiTermQueryRewrite?.Rewrite; }
-			set { FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => FuzzyMultiTermQueryRewrite?.Rewrite;
+			set => FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 		public MultiTermQueryRewrite FuzzyMultiTermQueryRewrite { get; set; }
 
@@ -119,8 +119,8 @@ namespace Nest
 		[Obsolete("Use FuzzyMultiTermQueryRewrite")]
 		RewriteMultiTerm? IMultiMatchQuery.FuzzyRewrite
 		{
-			get { return Self.FuzzyMultiTermQueryRewrite?.Rewrite; }
-			set { Self.FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => Self.FuzzyMultiTermQueryRewrite?.Rewrite;
+			set => Self.FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 		MultiTermQueryRewrite IMultiMatchQuery.FuzzyMultiTermQueryRewrite { get; set; }
 		Fuzziness IMultiMatchQuery.Fuzziness { get; set; }

--- a/src/Nest/QueryDsl/FullText/QueryString/QueryStringQuery.cs
+++ b/src/Nest/QueryDsl/FullText/QueryString/QueryStringQuery.cs
@@ -27,6 +27,7 @@ namespace Nest
 		bool? AllowLeadingWildcard { get; set; }
 
 		[JsonProperty("lowercase_expanded_terms")]
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		bool? LowercaseExpendedTerms { get; set; }
 
 		[JsonProperty("enable_position_increments")]
@@ -60,6 +61,7 @@ namespace Nest
 		bool? Lenient { get; set; }
 
 		[JsonProperty("locale")]
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		string Locale { get; set; }
 
 		[JsonProperty("time_zone")]
@@ -93,6 +95,12 @@ namespace Nest
 
 		[JsonProperty("escape")]
 		bool? Escape { get; set; }
+
+		[JsonProperty("all_fields")]
+		bool? AllFields { get; set; }
+
+		[JsonProperty("split_on_whitespace")]
+		bool? SplitOnWhitespace { get; set; }
 	}
 
 	public class QueryStringQuery : QueryBase, IQueryStringQuery
@@ -101,20 +109,21 @@ namespace Nest
 		public int? FuzzyMaxExpansions { get; set; }
 		public Fuzziness Fuzziness { get; set; }
 		public MinimumShouldMatch MinimumShouldMatch { get; set; }
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		public string Locale { get; set; }
 		[Obsolete("Use MultiTermQueryRewrite")]
 		public RewriteMultiTerm? Rewrite
 		{
-			get { return MultiTermQueryRewrite?.Rewrite; }
-			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => MultiTermQueryRewrite?.Rewrite;
+			set => MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
 
 		[Obsolete("Use FuzzyMultiTermQueryRewrite")]
 		public RewriteMultiTerm? FuzzyRewrite
 		{
-			get { return FuzzyMultiTermQueryRewrite?.Rewrite; }
-			set { FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => FuzzyMultiTermQueryRewrite?.Rewrite;
+			set => FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 		public MultiTermQueryRewrite FuzzyMultiTermQueryRewrite { get; set; }
 		public string QuoteFieldSuffix { get; set; }
@@ -127,6 +136,7 @@ namespace Nest
 		public string Analyzer { get; set; }
 		public string QuoteAnalyzer { get; set; }
 		public bool? AllowLeadingWildcard { get; set; }
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		public bool? LowercaseExpendedTerms { get; set; }
 		public bool? EnablePositionIncrements { get; set; }
 		public int? FuzzyPrefixLength { get; set; }
@@ -137,6 +147,8 @@ namespace Nest
 		public bool? UseDisMax { get; set; }
 		public double? TieBreaker { get; set; }
 		public int? MaximumDeterminizedStates { get; set; }
+		public bool? AllFields { get; set; }
+		public bool? SplitOnWhitespace { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.QueryString = this;
 		internal static bool IsConditionless(IQueryStringQuery q) => q.Query.IsNullOrEmpty();
@@ -150,6 +162,7 @@ namespace Nest
 		protected override bool Conditionless => QueryStringQuery.IsConditionless(this);
 
 		string IQueryStringQuery.Query { get; set; }
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		string IQueryStringQuery.Locale { get; set; }
 		string IQueryStringQuery.Timezone { get; set; }
 		Field IQueryStringQuery.DefaultField { get; set; }
@@ -158,6 +171,7 @@ namespace Nest
 		string IQueryStringQuery.Analyzer { get; set; }
 		string IQueryStringQuery.QuoteAnalyzer { get; set; }
 		bool? IQueryStringQuery.AllowLeadingWildcard { get; set; }
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		bool? IQueryStringQuery.LowercaseExpendedTerms { get; set; }
 		bool? IQueryStringQuery.EnablePositionIncrements { get; set; }
 		int? IQueryStringQuery.FuzzyMaxExpansions { get; set; }
@@ -174,19 +188,21 @@ namespace Nest
 		[Obsolete("Use FuzzyMultiTermQueryRewrite")]
 		RewriteMultiTerm? IQueryStringQuery.FuzzyRewrite
 		{
-			get { return Self.FuzzyMultiTermQueryRewrite?.Rewrite; }
-			set { Self.FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => Self.FuzzyMultiTermQueryRewrite?.Rewrite;
+			set => Self.FuzzyMultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 		MultiTermQueryRewrite IQueryStringQuery.FuzzyMultiTermQueryRewrite { get; set; }
 		[Obsolete("Use MultiTermQueryRewrite")]
 		RewriteMultiTerm? IQueryStringQuery.Rewrite
 		{
-			get { return Self.MultiTermQueryRewrite?.Rewrite; }
-			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => Self.MultiTermQueryRewrite?.Rewrite;
+			set => Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 		MultiTermQueryRewrite IQueryStringQuery.MultiTermQueryRewrite { get; set; }
 		string IQueryStringQuery.QuoteFieldSuffix { get; set; }
 		bool? IQueryStringQuery.Escape { get; set; }
+		bool? IQueryStringQuery.AllFields { get; set; }
+		bool? IQueryStringQuery.SplitOnWhitespace { get; set; }
 
 		public QueryStringQueryDescriptor<T> DefaultField(Field field) => Assign(a => a.DefaultField = field);
 		public QueryStringQueryDescriptor<T> DefaultField(Expression<Func<T, object>> field) => Assign(a => a.DefaultField = field);
@@ -198,6 +214,7 @@ namespace Nest
 
 		public QueryStringQueryDescriptor<T> Query(string query) => Assign(a => a.Query = query);
 
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		public QueryStringQueryDescriptor<T> Locale(string locale) => Assign(a => a.Locale = locale);
 
 		public QueryStringQueryDescriptor<T> Timezone(string timezone) => Assign(a => a.Timezone = timezone);
@@ -211,6 +228,7 @@ namespace Nest
 		public QueryStringQueryDescriptor<T> AllowLeadingWildcard(bool? allowLeadingWildcard = true) =>
 			Assign(a => a.AllowLeadingWildcard = allowLeadingWildcard);
 
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		public QueryStringQueryDescriptor<T> LowercaseExpendedTerms(bool? lowercaseExpendedTerms = true) =>
 			Assign(a => a.LowercaseExpendedTerms = lowercaseExpendedTerms);
 
@@ -260,11 +278,17 @@ namespace Nest
 					: null;
 			});
 
-		public QueryStringQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite) => Assign(a => Self.MultiTermQueryRewrite = rewrite);
+		public QueryStringQueryDescriptor<T> Rewrite(MultiTermQueryRewrite rewrite) => 
+			Assign(a => Self.MultiTermQueryRewrite = rewrite);
 
-		public QueryStringQueryDescriptor<T> QuoteFieldSuffix(string quoteFieldSuffix) => Assign(a => a.QuoteFieldSuffix = quoteFieldSuffix);
+		public QueryStringQueryDescriptor<T> QuoteFieldSuffix(string quoteFieldSuffix) => 
+			Assign(a => a.QuoteFieldSuffix = quoteFieldSuffix);
 
 		public QueryStringQueryDescriptor<T> Escape(bool? escape = true) => Assign(a => a.Escape = escape);
 
+		public QueryStringQueryDescriptor<T> AllFields(bool? allFields = true) => Assign(a => a.AllFields = allFields);
+
+		public QueryStringQueryDescriptor<T> SplitOnWhitespace(bool? splitOnWhitespace = true) => 
+			Assign(a => a.SplitOnWhitespace = splitOnWhitespace);
 	}
 }

--- a/src/Nest/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringQuery.cs
+++ b/src/Nest/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringQuery.cs
@@ -23,9 +23,11 @@ namespace Nest
 		SimpleQueryStringFlags? Flags { get; set; }
 
 		[JsonProperty(PropertyName = "locale")]
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		string Locale { get; set; }
 
 		[JsonProperty(PropertyName = "lowercase_expanded_terms")]
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		bool? LowercaseExpendedTerms { get; set; }
 
 		[JsonProperty(PropertyName = "lenient")]
@@ -36,6 +38,12 @@ namespace Nest
 
 		[JsonProperty("minimum_should_match")]
 		MinimumShouldMatch MinimumShouldMatch { get; set; }
+
+		[JsonProperty("quote_field_suffix")]
+		string QuoteFieldSuffix { get; set; }
+
+		[JsonProperty("all_fields")]
+		bool? AllFields { get; set; }
 	}
 
 	public class SimpleQueryStringQuery : QueryBase, ISimpleQueryStringQuery
@@ -46,11 +54,15 @@ namespace Nest
 		public string Analyzer { get; set; }
 		public Operator? DefaultOperator { get; set; }
 		public SimpleQueryStringFlags? Flags { get; set; }
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		public string Locale { get; set; }
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		public bool? LowercaseExpendedTerms { get; set; }
 		public bool? Lenient { get; set; }
 		public bool? AnalyzeWildcard { get; set; }
 		public MinimumShouldMatch MinimumShouldMatch { get; set; }
+		public string QuoteFieldSuffix { get; set; }
+		public bool? AllFields { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.SimpleQueryString = this;
 		internal static bool IsConditionless(ISimpleQueryStringQuery q) => q.Query.IsNullOrEmpty();
@@ -66,11 +78,15 @@ namespace Nest
 		string ISimpleQueryStringQuery.Analyzer { get; set; }
 		Operator? ISimpleQueryStringQuery.DefaultOperator { get; set; }
 		SimpleQueryStringFlags? ISimpleQueryStringQuery.Flags { get; set; }
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		string ISimpleQueryStringQuery.Locale { get; set; }
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		bool? ISimpleQueryStringQuery.LowercaseExpendedTerms { get; set; }
 		bool? ISimpleQueryStringQuery.AnalyzeWildcard { get; set; }
 		bool? ISimpleQueryStringQuery.Lenient { get; set; }
 		MinimumShouldMatch ISimpleQueryStringQuery.MinimumShouldMatch { get; set; }
+		string ISimpleQueryStringQuery.QuoteFieldSuffix { get; set; }
+		bool? ISimpleQueryStringQuery.AllFields { get; set; }
 
 		public SimpleQueryStringQueryDescriptor<T> Fields(Func<FieldsDescriptor<T>, IPromise<Fields>> fields) =>
 			Assign(a => a.Fields = fields?.Invoke(new FieldsDescriptor<T>())?.Value);
@@ -85,8 +101,10 @@ namespace Nest
 
 		public SimpleQueryStringQueryDescriptor<T> Flags(SimpleQueryStringFlags? flags) => Assign(a => a.Flags = flags);
 
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		public SimpleQueryStringQueryDescriptor<T> Locale(string locale) => Assign(a => a.Locale = locale);
 
+		[Obsolete("Deprecated in Elasticsearch 5.1.1. Can be performed by the analyzer applied")]
 		public SimpleQueryStringQueryDescriptor<T> LowercaseExpendedTerms(bool? lowercaseExpendedTerms = true) =>
 			Assign(a => a.LowercaseExpendedTerms = lowercaseExpendedTerms);
 
@@ -98,5 +116,10 @@ namespace Nest
 		public SimpleQueryStringQueryDescriptor<T> MinimumShouldMatch(MinimumShouldMatch minimumShouldMatch) =>
 			Assign(a => a.MinimumShouldMatch = minimumShouldMatch);
 
-    }
+		public SimpleQueryStringQueryDescriptor<T> QuoteFieldSuffix(string quoteFieldSuffix) => 
+			Assign(a => a.QuoteFieldSuffix = quoteFieldSuffix);
+
+		public SimpleQueryStringQueryDescriptor<T> AllFields(bool? allFields = true) => 
+			Assign(a => a.AllFields = allFields);
+	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Fuzzy/FuzzyQueryBase.cs
+++ b/src/Nest/QueryDsl/TermLevel/Fuzzy/FuzzyQueryBase.cs
@@ -49,8 +49,8 @@ namespace Nest
 		[Obsolete("Use MultiTermQueryRewrite")]
 		public RewriteMultiTerm? Rewrite
 		{
-			get { return MultiTermQueryRewrite?.Rewrite; }
-			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => MultiTermQueryRewrite?.Rewrite;
+			set => MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 
 		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
@@ -78,8 +78,8 @@ namespace Nest
 		[Obsolete("Use MultiTermQueryRewrite")]
 		RewriteMultiTerm? IFuzzyQuery.Rewrite
 		{
-			get { return Self.MultiTermQueryRewrite?.Rewrite; }
-			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => Self.MultiTermQueryRewrite?.Rewrite;
+			set => Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 
 		MultiTermQueryRewrite IFuzzyQuery.MultiTermQueryRewrite { get; set; }

--- a/src/Nest/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
@@ -24,8 +24,8 @@ namespace Nest
 		[Obsolete("Use MultiTermQueryRewrite")]
 		public RewriteMultiTerm? Rewrite
 		{
-			get { return MultiTermQueryRewrite?.Rewrite; }
-			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => MultiTermQueryRewrite?.Rewrite;
+			set => MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 
 		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
@@ -40,8 +40,8 @@ namespace Nest
 
 		RewriteMultiTerm? IPrefixQuery.Rewrite
 		{
-			get { return Self.MultiTermQueryRewrite?.Rewrite; }
-			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => Self.MultiTermQueryRewrite?.Rewrite;
+			set => Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 
 		MultiTermQueryRewrite IPrefixQuery.MultiTermQueryRewrite { get; set; }

--- a/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
@@ -31,8 +31,8 @@ namespace Nest
 		[Obsolete("Use MultiTermQueryRewrite")]
 		public RewriteMultiTerm? Rewrite
 		{
-			get { return MultiTermQueryRewrite?.Rewrite; }
-			set { MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => MultiTermQueryRewrite?.Rewrite;
+			set => MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 
 		public MultiTermQueryRewrite MultiTermQueryRewrite { get; set; }
@@ -48,8 +48,8 @@ namespace Nest
 
 		RewriteMultiTerm? IWildcardQuery.Rewrite
 		{
-			get { return Self.MultiTermQueryRewrite?.Rewrite; }
-			set { Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value); }
+			get => Self.MultiTermQueryRewrite?.Rewrite;
+			set => Self.MultiTermQueryRewrite = value == null ? null : new MultiTermQueryRewrite(value.Value);
 		}
 
 		MultiTermQueryRewrite IWildcardQuery.MultiTermQueryRewrite { get; set; }

--- a/src/Tests/QueryDsl/FullText/QueryString/QueryStringUsageTests.cs
+++ b/src/Tests/QueryDsl/FullText/QueryString/QueryStringUsageTests.cs
@@ -57,7 +57,10 @@ namespace Tests.QueryDsl.FullText.QueryString
 			AllowLeadingWildcard = true,
 			AutoGeneratePhraseQueries = true,
 			MaximumDeterminizedStates = 2,
+#pragma warning disable 618 // usage of lowercase_expanded_terms and locale
 			LowercaseExpendedTerms = true,
+			Locale = "en_US",
+#pragma warning restore 618 // usage of lowercase_expanded_terms and locale
 			EnablePositionIncrements = true,
 			Escape = true,
 			UseDisMax = true,
@@ -70,12 +73,12 @@ namespace Tests.QueryDsl.FullText.QueryString
 			AnalyzeWildcard = true,
 			MinimumShouldMatch = 2,
 			QuoteFieldSuffix = "'",
-			Lenient = true,
-			Locale = "en_US",
+			Lenient = true,			
 			Timezone = "root"
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+#pragma warning disable 618 // usage of lowercase_expanded_terms and locale
 			.QueryString(c => c
 				.Name("named_query")
 				.Boost(1.1)
@@ -105,6 +108,7 @@ namespace Tests.QueryDsl.FullText.QueryString
 				.Locale("en_US")
 				.Timezone("root")
 			);
+#pragma warning restore 618 // usage of lowercase_expanded_terms and locale
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IQueryStringQuery>(a => a.QueryString)
 		{

--- a/src/Tests/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringUsageTests.cs
+++ b/src/Tests/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringUsageTests.cs
@@ -4,6 +4,7 @@ using Tests.Framework.ManagedElasticsearch.Clusters;
 using Tests.Framework.MockData;
 using static Nest.Infer;
 
+
 namespace Tests.QueryDsl.FullText.SimpleQueryString
 {
 	public class SimpleQueryStringUsageTests : QueryDslUsageTestsBase
@@ -38,14 +39,17 @@ namespace Tests.QueryDsl.FullText.SimpleQueryString
 			Analyzer = "standard",
 			DefaultOperator = Operator.Or,
 			Flags = SimpleQueryStringFlags.And|SimpleQueryStringFlags.Near,
+#pragma warning disable 618 // usage of lowercase_expanded_terms and locale
 			Locale = "en_US",
 			LowercaseExpendedTerms = true,
+#pragma warning restore 618
 			Lenient = true,
 			AnalyzeWildcard = true,
 			MinimumShouldMatch = "30%"
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+#pragma warning disable 618 // usage of lowercase_expanded_terms and locale
 			.SimpleQueryString(c => c
 				.Name("named_query")
 				.Boost(1.1)
@@ -60,6 +64,7 @@ namespace Tests.QueryDsl.FullText.SimpleQueryString
 				.AnalyzeWildcard()
 				.MinimumShouldMatch("30%")
 			);
+#pragma warning restore 618
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<ISimpleQueryStringQuery>(a => a.SimpleQueryString)
 		{


### PR DESCRIPTION
Add missing fields on simple query string query
Add `quote_field_suffix` to simple_query_string query
Deprecate `lowercase_expanded_terms` and `locale`: elastic/elasticsearch#20208
Add "all field" execution mode to query_string and simple_query_string query: elastic/elasticsearch#20925

Fixes #2792

Requires porting to `master` (check if `lowercase_expanded_terms` and `locale` should be removed)