### PR TITLE
Feature/5.x build output

### DIFF
--- a/build/Elasticsearch.Net.nuspec
+++ b/build/Elasticsearch.Net.nuspec
@@ -30,13 +30,13 @@
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="..\src\Elasticsearch.Net\bin\Release\net45\Elasticsearch.Net.dll" target="lib\net45"/>
-		<file src="..\src\Elasticsearch.Net\bin\Release\net45\Elasticsearch.Net.XML" target="lib\net45"/>
+		<file src="output\Elasticsearch.Net\net45\Elasticsearch.Net.dll" target="lib\net45"/>
+		<file src="output\Elasticsearch.Net\net45\Elasticsearch.Net.XML" target="lib\net45"/>
 
-		<file src="..\src\Elasticsearch.Net\bin\Release\net46\Elasticsearch.Net.dll" target="lib\net46"/>
-		<file src="..\src\Elasticsearch.Net\bin\Release\net46\Elasticsearch.Net.XML" target="lib\net46"/>
+		<file src="output\Elasticsearch.Net\net46\Elasticsearch.Net.dll" target="lib\net46"/>
+		<file src="output\Elasticsearch.Net\net46\Elasticsearch.Net.XML" target="lib\net46"/>
 
-		<file src="..\src\Elasticsearch.Net\bin\Release\netstandard1.3\Elasticsearch.Net.dll" target="lib\netstandard1.3"/>
-		<file src="..\src\Elasticsearch.Net\bin\Release\netstandard1.3\Elasticsearch.Net.xml" target="lib\netstandard1.3"/>
+		<file src="output\Elasticsearch.Net\netstandard1.3\Elasticsearch.Net.dll" target="lib\netstandard1.3"/>
+		<file src="output\Elasticsearch.Net\netstandard1.3\Elasticsearch.Net.xml" target="lib\netstandard1.3"/>
 	</files>
 </package>

--- a/build/NEST.nuspec
+++ b/build/NEST.nuspec
@@ -18,11 +18,11 @@
 		<dependencies>
 			<group targetFramework=".NETFramework4.5">
 				<dependency id="Elasticsearch.Net" version="[$version$, $nextMajorVersion$)" />
-				<dependency id="Newtonsoft.Json" version="[10,11)" />
+				<dependency id="Newtonsoft.Json" version="[$jsonDotNetCurrentVersion$, $jsonDotNetNextVersion$)" />
 			</group>
 			<group targetFramework=".NETFramework4.6">
 				<dependency id="Elasticsearch.Net" version="[$version$, $nextMajorVersion$)" />
-				<dependency id="Newtonsoft.Json" version="[10,11)" />
+				<dependency id="Newtonsoft.Json" version="[$jsonDotNetCurrentVersion$, $jsonDotNetNextVersion$)" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="[1.6.0, )" />
@@ -30,7 +30,7 @@
 				<dependency id="System.Reflection.TypeExtensions" version="[4.3.0, )" />
 				<dependency id="System.Linq.Queryable" version="[4.0.1, )" />
 				<dependency id="Elasticsearch.Net" version="[$version$, $nextMajorVersion$)" />
-				<dependency id="Newtonsoft.Json" version="[10,11)" />
+				<dependency id="Newtonsoft.Json" version="[$jsonDotNetCurrentVersion$, $jsonDotNetNextVersion$)" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/build/NEST.nuspec
+++ b/build/NEST.nuspec
@@ -35,13 +35,13 @@
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="..\src\Nest\bin\Release\net45\Nest.dll" target="lib\net45"/>
-		<file src="..\src\Nest\bin\Release\net45\Nest.XML" target="lib\net45"/>
+		<file src="output\Nest\net45\Nest.dll" target="lib\net45"/>
+		<file src="output\Nest\net45\Nest.XML" target="lib\net45"/>
 
-		<file src="..\src\Nest\bin\Release\net46\Nest.dll" target="lib\net46"/>
-		<file src="..\src\Nest\bin\Release\net46\Nest.XML" target="lib\net46"/>
+		<file src="output\Nest\net46\Nest.dll" target="lib\net46"/>
+		<file src="output\Nest\net46\Nest.XML" target="lib\net46"/>
 
-		<file src="..\src\Nest\bin\Release\netstandard1.3\Nest.dll" target="lib\netstandard1.3"/>
-		<file src="..\src\Nest\bin\Release\netstandard1.3\Nest.xml" target="lib\netstandard1.3"/>
+		<file src="output\Nest\netstandard1.3\Nest.dll" target="lib\netstandard1.3"/>
+		<file src="output\Nest\netstandard1.3\Nest.xml" target="lib\netstandard1.3"/>
 	</files>
 </package>

--- a/build/scripts/Building.fsx
+++ b/build/scripts/Building.fsx
@@ -8,6 +8,7 @@
 #load @"Versioning.fsx"
 
 open System 
+open System.IO
 open Fake 
 open FSharp.Data 
 
@@ -41,6 +42,7 @@ module Build =
                 "CurrentAssemblyFileVersion", (Versioning.CurrentAssemblyFileVersion.ToString());
                 "DoSourceLink", sourceLink;
                 "DotNetCoreOnly", if buildingOnTravis then "1" else "";
+                "OutputPathBaseDir", Path.GetFullPath Paths.BuildOutput;
             ] 
             |> List.map (fun (p,v) -> sprintf "%s=%s" p v)
             |> String.concat ";"
@@ -77,4 +79,4 @@ module Build =
             DotNetCli.RunCommand (fun p -> { p with TimeOut = TimeSpan.FromMinutes(3.) }) "clean src/Elasticsearch.sln -c Release" |> ignore
             DotNetProject.All |> Seq.iter(fun p -> CleanDir(Paths.BinFolder p.Name))
         | (_, _) -> 
-            tracefn "Skiping clean target only run when calling 'release', 'canary', 'clean' as targets directly"
+            tracefn "Skipping clean target only run when calling 'release', 'canary', 'clean' as targets directly"

--- a/build/scripts/Documentation.fsx
+++ b/build/scripts/Documentation.fsx
@@ -14,14 +14,13 @@ open Projects
 module Documentation = 
 
     let Generate() = 
-        let prefix = "CodeGeneration"
-        let generatorFolder = Paths.IncrementalOutputFolderWithPrefix prefix (PrivateProject PrivateProject.DocGenerator) DotNetFramework.Net46
-        let generator = generatorFolder @@ "DocGenerator.exe"
+        let docGenerator = PrivateProject(DocGenerator)
+        let path = Paths.ProjectOutputFolder docGenerator DotNetFramework.Net46
+        let generator = sprintf "%s/%s.exe" path docGenerator.Name
         ExecProcess (fun p ->
-            p.WorkingDirectory <- "src/CodeGeneration/DocGenerator"
+            p.WorkingDirectory <- Paths.Source("CodeGeneration") @@ docGenerator.Name
             p.FileName <- generator
-          ) 
-          (TimeSpan.FromMinutes (1.0)) |> ignore
+        ) (TimeSpan.FromMinutes 1.) |> ignore
 
     // TODO: hook documentation validation into the process
     let Validate() = 

--- a/build/scripts/Paths.fsx
+++ b/build/scripts/Paths.fsx
@@ -21,14 +21,8 @@ module Paths =
     let BuildOutput = sprintf "%s/output" BuildFolder
 
     let ProjectOutputFolder (project:DotNetProject) (framework:DotNetFramework) = 
-        sprintf "%s/%s/%s" BuildOutput framework.Identifier.MSBuild project.Name
-
-    let IncrementalOutputFolder (project:DotNetProject) (framework:DotNetFramework) = 
-        sprintf "src/%s/bin/Release/%s" project.Name framework.Identifier.Nuget
-            
-    let IncrementalOutputFolderWithPrefix prefix (project:DotNetProject) (framework:DotNetFramework) = 
-        sprintf "src/%s/%s/bin/Release/%s" prefix project.Name framework.Identifier.Nuget
-
+        sprintf "%s/%s/%s" BuildOutput project.Name framework.Identifier.Nuget
+  
     let Tool tool = sprintf "packages/build/%s" tool
     let CheckedInToolsFolder = "build/Tools"
     let KeysFolder = sprintf "%s/keys" BuildFolder
@@ -44,6 +38,3 @@ module Paths =
     let BinFolder(folder) = 
         let f = replace @"\" "/" folder
         sprintf "%s/%s/bin/Release" SourceFolder f
-
-    let ProjectJson(projectName) =
-        Source(sprintf "%s/project.json" projectName)

--- a/build/scripts/Releasing.fsx
+++ b/build/scripts/Releasing.fsx
@@ -33,6 +33,11 @@ module Release =
 
             let year = sprintf "%i" DateTime.UtcNow.Year
 
+            let jsonDotNetVersion = 10
+
+            let jsonDotNetCurrentVersion = sprintf "%i" jsonDotNetVersion
+            let jsonDotNetNextVersion = sprintf "%i" (jsonDotNetVersion + 1)
+
             let properties =
                 let addKeyValue (e:Expr<string>) (builder:StringBuilder) =
                     // the binding for this tuple looks like key/value should 
@@ -46,6 +51,8 @@ module Release =
                 new StringBuilder()
                 |> addKeyValue <@nextMajorVersion@>
                 |> addKeyValue <@year@>
+                |> addKeyValue <@jsonDotNetCurrentVersion@>
+                |> addKeyValue <@jsonDotNetNextVersion@>
                 |> toText
             
             Tooling.Nuget.Exec [ "pack"; nuspec; 

--- a/build/scripts/Signing.fsx
+++ b/build/scripts/Signing.fsx
@@ -42,7 +42,7 @@ module StrongName =
         for p in DotNetProject.AllPublishable do
             for f in DotNetFramework.All do 
                 let name = p.Name
-                let folder = Paths.IncrementalOutputFolder p f
+                let folder = Paths.ProjectOutputFolder p f
                 let dll = sprintf "%s/%s.dll" folder name
                 match fileExists dll with
                 | true -> validate dll name 

--- a/build/scripts/Versioning.fsx
+++ b/build/scripts/Versioning.fsx
@@ -43,12 +43,13 @@ module Versioning =
         let bv = getBuildParam "version"
         let buildVersion = if (isNullOrEmpty bv) then None else Some(parse(bv)) 
         match (getBuildParam "target", buildVersion) with
-        | ("release", None) -> failwithf "can not run release because no explicit version number was passed on the command line"
+        | ("release", None) -> failwithf "cannot run release because no explicit version number was passed on the command line"
         | ("release", Some v) -> 
-            if (currentVersion >= v) then failwithf "tried to create release %s but current version is already at %s" (v.ToString()) (currentVersion.ToString())
+            // Warn if version is same as current version
+            if (currentVersion >= v) then traceImportant (sprintf "creating release %s when current version is already at %s" (v.ToString()) (currentVersion.ToString()))
             writeVersionIntoGlobalJson v
             v
-        | ("canary", Some v) -> failwithf "can not run canary release, expected no version number to specified but received %s" (v.ToString())
+        | ("canary", Some v) -> failwithf "cannot run canary release, expected no version number to specified but received %s" (v.ToString())
         | ("canary", None) -> 
             let timestampedVersion = (sprintf "ci%s" (DateTime.UtcNow.ToString("MMddHHmmss")))
             tracefn "Canary suffix %s " timestampedVersion

--- a/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
+++ b/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
@@ -6,7 +6,6 @@
     <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Nest\Nest.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="RazorMachine" Version="2.6.1" />
     <!-- TODO the following packages prevent us to jump to netcoreapp1.0 -->
@@ -17,4 +16,5 @@
     <Folder Include="RestSpecification\XPack\Info" />
     <Folder Include="RestSpecification\XPack\MachineLearning" />
   </ItemGroup>
+  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -18,4 +18,5 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
+  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -16,4 +16,5 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
+  <Import Project="..\outputpath.props" />
 </Project>

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -18,5 +18,5 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />
   </ItemGroup>
-  <!--<Import Project="..\..\.paket\Paket.Restore.targets" />-->
+  <Import Project="..\outputpath.props" />
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -44,4 +44,5 @@
   <ItemGroup>
     <EmbeddedResource Include="Document\Single\Attachment\Attachment_Test_Document.pdf" />
   </ItemGroup>
+  <Import Project="..\outputpath.props" />
 </Project>

--- a/src/outputpath.props
+++ b/src/outputpath.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <OutputPath Condition="'$(OutputPathBaseDir)' != ''">$(OutputPathBaseDir)\$(TargetFrameworkVersion)\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPathBaseDir)' != ''">$(OutputPathBaseDir)\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR is a return to outputting the build for all projects from the command line to `build/output`. All projects build there with the following dir structure `build/output/<Project>/<TFM>`

- package nuget packages from `build/output`
- remove superfluous properties from `Paths` module
- specify Json.NET version dependency in one place and parameterize in nuspec file.

