### PR TITLE
Improve composing aggregations

### DIFF
--- a/src/Nest/Aggregations/AggregationContainer.cs
+++ b/src/Nest/Aggregations/AggregationContainer.cs
@@ -304,6 +304,16 @@ namespace Nest
 			aggregator.WrapInContainer(container);
 			var bucket = aggregator as BucketAggregationBase;
 			container.Aggregations = bucket?.Aggregations;
+
+			var combinator = aggregator as AggregationCombinator;
+			if (combinator?.Aggregations != null)
+			{
+				var dict = new AggregationDictionary();
+				foreach (var agg in combinator.Aggregations)
+					dict.Add(((IAggregation) agg).Name, agg);
+				container.Aggregations = dict;
+			}
+
 			container.Meta = aggregator.Meta;
 			return container;
 		}
@@ -649,6 +659,10 @@ namespace Nest
 
 		public static AggregationContainerDescriptor<T> operator &(AggregationContainerDescriptor<T> left, AggregationContainerDescriptor<T> right)
 		{
+			if (right == null) return left;
+			if (left == null) return right;
+			if (Equals(left, right)) return left;
+
 			var d = new AggregationContainerDescriptor<T>();
 			var leftAggs = (IDictionary<string, IAggregationContainer>)((IAggregationContainer)left).Aggregations;
 			var rightAggs = (IDictionary<string, IAggregationContainer>)((IAggregationContainer)right).Aggregations;

--- a/src/Nest/Aggregations/Bucket/BucketAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/BucketAggregation.cs
@@ -25,7 +25,7 @@ namespace Nest
 		where TBucketAggregationInterface : class, IBucketAggregation
 	{
 		AggregationDictionary IBucketAggregation.Aggregations { get; set; }
-		
+
 		protected TBucketAggregation Assign(Action<TBucketAggregationInterface> assigner) =>
 			Fluent.Assign(((TBucketAggregation)this), assigner);
 
@@ -37,6 +37,9 @@ namespace Nest
 
 		public TBucketAggregation Aggregations(Func<AggregationContainerDescriptor<T>, IAggregationContainer> selector) =>
 			Assign(a => a.Aggregations = selector?.Invoke(new AggregationContainerDescriptor<T>())?.Aggregations);
+
+		public TBucketAggregation Aggregations(AggregationDictionary aggregations) =>
+			Assign(a => a.Aggregations = aggregations);
 
 		public TBucketAggregation Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector) =>
 			Assign(a => a.Meta = selector?.Invoke(new FluentDictionary<string, object>()));

--- a/src/Nest/Search/Percolator/Percolate/PercolateRequest.cs
+++ b/src/Nest/Search/Percolator/Percolate/PercolateRequest.cs
@@ -93,6 +93,9 @@ namespace Nest
 		public PercolateDescriptor<TDocument> Aggregations(Func<AggregationContainerDescriptor<TDocument>, IAggregationContainer> aggregationsSelector) =>
 			Assign(a => a.Aggregations = aggregationsSelector(new AggregationContainerDescriptor<TDocument>())?.Aggregations);
 
+		public PercolateDescriptor<TDocument> Aggregations(AggregationDictionary aggregations) =>
+			Assign(a => a.Aggregations = aggregations);
+
 		/// <summary>
 		/// Allow to highlight search results on one or more fields.
 		/// </summary>

--- a/src/Nest/Search/Percolator/PercolateCount/PercolateCountRequest.cs
+++ b/src/Nest/Search/Percolator/PercolateCount/PercolateCountRequest.cs
@@ -78,6 +78,9 @@ namespace Nest
 		public PercolateCountDescriptor<TDocument> Aggregations(Func<AggregationContainerDescriptor<TDocument>, IAggregationContainer> aggregationsSelector) =>
 			Assign(a => a.Aggregations = aggregationsSelector(new AggregationContainerDescriptor<TDocument>())?.Aggregations);
 
+		public PercolateCountDescriptor<TDocument> Aggregations(AggregationDictionary aggregations) =>
+			Assign(a => a.Aggregations = aggregations);
+
 		public PercolateCountDescriptor<TDocument> Sort(Func<SortDescriptor<TDocument>, IPromise<IList<ISort>>> selector) => Assign(a => a.Sort = selector?.Invoke(new SortDescriptor<TDocument>())?.Value);
 
 		/// <summary>

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -235,6 +235,9 @@ namespace Nest
 		public SearchDescriptor<T> Aggregations(Func<AggregationContainerDescriptor<T>, IAggregationContainer> aggregationsSelector) =>
 			Assign(a => a.Aggregations = aggregationsSelector(new AggregationContainerDescriptor<T>())?.Aggregations);
 
+		public SearchDescriptor<T> Aggregations(AggregationDictionary aggregations) =>
+			Assign(a => a.Aggregations = aggregations);
+
 		public SearchDescriptor<T> Source(bool enabled = true) => Assign(a => a.Source = enabled);
 
 		public SearchDescriptor<T> Source(Func<SourceFilterDescriptor<T>, ISourceFilter> selector) =>

--- a/src/Tests/Aggregations/WritingAggregations.doc.cs
+++ b/src/Tests/Aggregations/WritingAggregations.doc.cs
@@ -146,7 +146,7 @@ namespace Tests.Aggregations
 		/**[float]
 		* === Mixed usage of object initializer and fluent
 		*
-		* Sometimes its useful to mix and match fluent and object initializer, the fluent Aggregations method therefor
+		* Sometimes its useful to mix and match fluent and object initializer, the fluent Aggregations method therefore
 		* also accepts `AggregationDictionary` directly.
 		*/
 		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s


### PR DESCRIPTION
Firstly this PR allows you to use the ois syntax directly on the fluent
descriptors.

Second, when abstracting to methods e.g .Aggs(s=> Compose()) could lead
to unexpected results if `Compose` returns `AggregationContainer` by
using OIS to compose multiple `AggregationBase`'s. The implicit
conversion from `AggregationBase` to `AggregationContainer` failed if
that `AggregationBase` was off type `AggregationCombinator` in which
case none of the combinator aggregations were lifted. This is a tad
unconvential and undocumented way of generating aggregations but its not
that far fetched + it compiles so should generate the expected output.

Third, you are now allowed to call unary `&&` operator on the same
`AggregationDescriptor` allowing you to write `aggs.Terms() &&
agg.Max()` and abstract to `Terms(aggs) && Max(aggs)` without being forced
to compose both to `Terms(Max(aggs))` which does not always read nicely.