### PR TITLE
ExtendedBounds property of the DateHistogramAggregation to use DateMath

### DIFF
--- a/src/Nest/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
@@ -37,7 +37,7 @@ namespace Nest
 		HistogramOrder Order { get; set; }
 
 		[JsonProperty("extended_bounds")]
-		ExtendedBounds<DateTime> ExtendedBounds { get; set; }
+		ExtendedBounds<DateMath> ExtendedBounds { get; set; }
 
 		[JsonProperty("missing")]
 		DateTime? Missing { get; set; }
@@ -68,7 +68,7 @@ namespace Nest
 		public string TimeZone { get; set; }
 		public string Offset { get; set; }
 		public HistogramOrder Order { get; set; }
-		public ExtendedBounds<DateTime> ExtendedBounds { get; set; }
+		public ExtendedBounds<DateMath> ExtendedBounds { get; set; }
 		public DateTime? Missing { get; set; }
 
 		internal DateHistogramAggregation() { }
@@ -113,7 +113,7 @@ namespace Nest
 
 		HistogramOrder IDateHistogramAggregation.Order { get; set; }
 
-		ExtendedBounds<DateTime> IDateHistogramAggregation.ExtendedBounds { get; set; }
+		ExtendedBounds<DateMath> IDateHistogramAggregation.ExtendedBounds { get; set; }
 
 		DateTime? IDateHistogramAggregation.Missing { get; set; }
 
@@ -148,8 +148,8 @@ namespace Nest
 		public DateHistogramAggregationDescriptor<T> OrderDescending(string key) =>
 			Assign(a => a.Order = new HistogramOrder { Key = key, Order = SortOrder.Descending });
 
-		public DateHistogramAggregationDescriptor<T> ExtendedBounds(DateTime min, DateTime max) =>
-			Assign(a=>a.ExtendedBounds = new ExtendedBounds<DateTime> { Minimum = min, Maximum = max });
+		public DateHistogramAggregationDescriptor<T> ExtendedBounds(DateMath min, DateMath max) =>
+			Assign(a=>a.ExtendedBounds = new ExtendedBounds<DateMath> { Minimum = min, Maximum = max });
 
 		public DateHistogramAggregationDescriptor<T> Missing(DateTime missing) => Assign(a => a.Missing = missing);
 	}

--- a/src/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
@@ -99,7 +99,7 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 					Interval = DateInterval.Month,
 					MinimumDocumentCount = 2,
 					Format = "yyyy-MM-dd'T'HH:mm:ss",
-					ExtendedBounds = new ExtendedBounds<DateTime>
+					ExtendedBounds = new ExtendedBounds<DateMath>
 					{
 						Minimum = FixedDate.AddYears(-1),
 						Maximum = FixedDate.AddYears(1),


### PR DESCRIPTION
Make the ExtendedBounds property of the DateHistogramAggregation to use DateMath instead of DateTime.
See Issue #2828 

