### PR TITLE
Doc/contract converters

### DIFF
--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -10,10 +10,13 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
     <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Build" Version="15.1.548" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.2" />
+    <PackageReference Include="Microsoft.Build" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Runtime" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.409" />
     <PackageReference Include="NuDoq" Version="1.2.5" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />

--- a/src/CodeGeneration/DocGenerator/LitUp.cs
+++ b/src/CodeGeneration/DocGenerator/LitUp.cs
@@ -45,8 +45,14 @@ namespace DocGenerator
 
 		public static async Task GoAsync(string[] args)
 		{
+			//.NET core csprojects are not supported all that well.
+			// https://github.com/dotnet/roslyn/issues/21660 :sadpanda:
 
 			var workspace = MSBuildWorkspace.Create();
+			workspace.WorkspaceFailed += (s, e) =>
+			{
+				Console.Error.WriteLine(e.Diagnostic.Message);
+			};
             var testProject = workspace.OpenProjectAsync(GetProjectFile("Tests"));
             var nestProject = workspace.OpenProjectAsync(GetProjectFile("Nest"));
             var elasticSearchNetProject = workspace.OpenProjectAsync(GetProjectFile("Elasticsearch.Net"));

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
@@ -20,7 +20,6 @@ namespace Nest
 		private JsonSerializer _defaultSerializer;
 		private JsonSerializer _indentedSerializer;
 
-
 		protected IConnectionSettingsValues Settings { get; }
 
 		/// <summary>
@@ -35,7 +34,7 @@ namespace Nest
 		/// The size of the buffer to use when writing the serialized request
 		/// to the request stream
 		/// </summary>
-		// Performance tests as part of https://github.com/elastic/elasticsearch-net/issues/1899 indicate this 
+		// Performance tests as part of https://github.com/elastic/elasticsearch-net/issues/1899 indicate this
 		// to be a good compromise buffer size for performance throughput and bytes allocated.
 		protected virtual int BufferSize => 1024;
 

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SerializerFactory.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SerializerFactory.cs
@@ -20,10 +20,7 @@ namespace Nest
 		private Func<IConnectionSettingsValues, IElasticsearchSerializer> _serializerFactoryFunc;
 		private Action<JsonSerializerSettings, IConnectionSettingsValues> _settingsModifier;
 
-		public SerializerFactory()
-		{
-
-		}
+		public SerializerFactory() { }
 		public SerializerFactory(Func<IConnectionSettingsValues, IElasticsearchSerializer> serializerFactoryFunc) : this(serializerFactoryFunc, null) { }
 
 		public SerializerFactory(Action<JsonSerializerSettings, IConnectionSettingsValues> settingsModifier) : this(null, settingsModifier) { }

--- a/src/Tests/ClientConcepts/HighLevel/CovariantHits/CovariantSearchResults.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/CovariantHits/CovariantSearchResults.doc.cs
@@ -225,31 +225,15 @@ namespace Tests.ClientConcepts.HighLevel.CovariantHits
 		[U] public void UsingSubClasses()
 		{
 			/**
-			* ==== Using types
-			* The most straightforward way to search over multiple types is to
-			* type the response to the parent interface or base class
-			* and pass the actual types we want to search over using `.Type()`
+			* Covariance also works over subclasses not just interfaces
 			*/
 			var result = this._client.Search<BaseX>(s => s
 				.Type(Types.Type(typeof(A), typeof(B), typeof(C)))
 				.Size(100)
 			);
-			/**
-			* NEST will translate this to a search over `/index/a,b,c/_search`;
-			* hits that have `"_type" : "a"` will be serialized to `A` and so forth
-			*/
-
-			/**
-			* Here we assume our response is valid and that we received the 100 documents
-			* we are expecting. Remember `result.Documents` is an `IReadOnlyCollection<ISearchResult>`
-			*/
 			result.ShouldBeValid();
 			result.Documents.Count.Should().Be(100);
 
-			/**
-			* To prove the returned result set is covariant we filter the documents based on their
-			* actual type and assert the returned subsets are the expected sizes
-			*/
 			var aDocuments = result.Documents.OfType<A>();
 			var bDocuments = result.Documents.OfType<B>();
 			var cDocuments = result.Documents.OfType<C>();
@@ -258,9 +242,6 @@ namespace Tests.ClientConcepts.HighLevel.CovariantHits
 			bDocuments.Count().Should().Be(25);
 			cDocuments.Count().Should().Be(50);
 
-			/**
-			* and assume that properties that only exist on the subclass itself are properly filled
-			*/
 			aDocuments.Should().OnlyContain(a => a.PropertyOnA > 0);
 			bDocuments.Should().OnlyContain(a => a.PropertyOnB > 0);
 			cDocuments.Should().OnlyContain(a => a.PropertyOnC > 0);

--- a/src/Tests/ClientConcepts/HighLevel/CovariantHits/CovariantSearchResults.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/CovariantHits/CovariantSearchResults.doc.cs
@@ -22,24 +22,26 @@ namespace Tests.ClientConcepts.HighLevel.CovariantHits
 			string Name { get; set; }
 		}
 
+		public abstract class BaseX : ISearchResult
+		{
+			public string Name { get; set; }
+		}
+
 		/**
 		* We have three implementations of `ISearchResult` namely `A`, `B` and `C`
 		*/
-		public class A : ISearchResult
+		public class A : BaseX
 		{
-			public string Name { get; set; }
 			public int PropertyOnA { get; set; }
 		}
 
-		public class B : ISearchResult
+		public class B : BaseX
 		{
-			public string Name { get; set; }
 			public int PropertyOnB { get; set; }
 		}
 
-		public class C : ISearchResult
+		public class C : BaseX
 		{
-			public string Name { get; set; }
 			public int PropertyOnC { get; set; }
 		}
 
@@ -191,6 +193,50 @@ namespace Tests.ClientConcepts.HighLevel.CovariantHits
 			* As before, within the delegate passed to `.ConcreteTypeSelector`
 			* - `d` is the `_source` typed as `dynamic`
 			* - `h` is the encapsulating typed hit
+			*/
+
+			/**
+			* Here we assume our response is valid and that we received the 100 documents
+			* we are expecting. Remember `result.Documents` is an `IReadOnlyCollection<ISearchResult>`
+			*/
+			result.ShouldBeValid();
+			result.Documents.Count.Should().Be(100);
+
+			/**
+			* To prove the returned result set is covariant we filter the documents based on their
+			* actual type and assert the returned subsets are the expected sizes
+			*/
+			var aDocuments = result.Documents.OfType<A>();
+			var bDocuments = result.Documents.OfType<B>();
+			var cDocuments = result.Documents.OfType<C>();
+
+			aDocuments.Count().Should().Be(25);
+			bDocuments.Count().Should().Be(25);
+			cDocuments.Count().Should().Be(50);
+
+			/**
+			* and assume that properties that only exist on the subclass itself are properly filled
+			*/
+			aDocuments.Should().OnlyContain(a => a.PropertyOnA > 0);
+			bDocuments.Should().OnlyContain(a => a.PropertyOnB > 0);
+			cDocuments.Should().OnlyContain(a => a.PropertyOnC > 0);
+		}
+
+		[U] public void UsingSubClasses()
+		{
+			/**
+			* ==== Using types
+			* The most straightforward way to search over multiple types is to
+			* type the response to the parent interface or base class
+			* and pass the actual types we want to search over using `.Type()`
+			*/
+			var result = this._client.Search<BaseX>(s => s
+				.Type(Types.Type(typeof(A), typeof(B), typeof(C)))
+				.Size(100)
+			);
+			/**
+			* NEST will translate this to a search over `/index/a,b,c/_search`;
+			* hits that have `"_type" : "a"` will be serialized to `A` and so forth
 			*/
 
 			/**

--- a/src/Tests/ClientConcepts/HighLevel/Serialization/ModifyingDefaultSerializer.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Serialization/ModifyingDefaultSerializer.doc.cs
@@ -119,7 +119,8 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
          * ====
          */
 
-         /** ==== Adding contract JsonConverters
+         /**
+         * ==== Adding contract JsonConverters
          *
          * If you want to register custom json converters without attributing your classes you can register
          * Functions that given a type return a JsonConverter. This is cached as part of the types json contract so once

--- a/src/Tests/ClientConcepts/HighLevel/Serialization/ModifyingDefaultSerializer.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Serialization/ModifyingDefaultSerializer.doc.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Nest;
 using Newtonsoft.Json;
+using Tests.Framework.MockData;
 
 namespace Tests.ClientConcepts.HighLevel.Serialization
 {
@@ -117,5 +118,34 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
          * from `JsonNetSerializer`.
          * ====
          */
+
+         /** ==== Adding contract JsonConverters
+         *
+         * If you want to register custom json converters without attributing your classes you can register
+         * Functions that given a type return a JsonConverter. This is cached as part of the types json contract so once
+         * Json.NET knows a type has a certain converter it won't ask anymore for the duration of the application.
+         *
+         * Override `ContractConverters` getter property and have it return a list of these functions
+         */
+        public class CustomContractsJsonNetSerializer : CustomJsonNetSerializer
+        {
+            public CustomContractsJsonNetSerializer(IConnectionSettingsValues settings) : base(settings) { }
+            public CustomContractsJsonNetSerializer(IConnectionSettingsValues settings, JsonConverter statefulConverter)
+	            : base(settings, statefulConverter) { }
+
+	        protected override IList<Func<Type, JsonConverter>> ContractConverters { get; } = new List<Func<Type, JsonConverter>>
+	        {
+		        ((t) => t == typeof(Project) ? new MyCustomJsonConverter() : null)
+	        };
+        }
+
+	    public class MyCustomJsonConverter : JsonConverter
+	    {
+		    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) { }
+
+		    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) => null;
+
+		    public override bool CanConvert(Type objectType) => false;
+	    }
     }
 }

--- a/src/Tests/Program.cs
+++ b/src/Tests/Program.cs
@@ -16,9 +16,10 @@ using Tests.Framework.Profiling.Timeline;
 
 namespace Tests
 {
-	public class Program
+	public class Program { }
+	public class BenchmarkProgram
 	{
-		static Program()
+		static BenchmarkProgram()
 		{
 			var currentDirectory = new DirectoryInfo(Directory.GetCurrentDirectory());
 			if ((currentDirectory.Name == "Debug" || currentDirectory.Name == "Release") && currentDirectory.Parent.Name == "bin")

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -9,6 +9,7 @@
     <VersionPrefix>6.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <DefineConstants Condition="'$(TargetFramework)'=='netcoreapp1.1' OR '$(DotNetCoreOnly)'=='1'">$(DefineConstants);DOTNETCORE</DefineConstants>
+    <StartupObject>Tests.BenchmarkProgram</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
     <PackageReference Include="SemanticVersioning" Version="0.7.6" />
     <PackageReference Include="DiffPlex" Version="1.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <!-- TODO only for Desktop CLR? -->
     <PackageReference Include="System.Buffers" Version="4.3.0" />

--- a/src/Tests/tests.default.yaml
+++ b/src/Tests/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
+mode: u
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 5.5.0


### PR DESCRIPTION

Add documentation around ContractConverters.

It took me 1h trying to remember how to pass JsonConverters to ElasticContractResolvers, clearly needed to be documented better :)  Also includes xunit fixes for Rider and additional tests that tests covariance on subclasses as well.

---

Could not get the actual documentation to be generated though, `MSBuildWorkSpace` loads the project just fine but wont discover any files. 

Adding a `WorkspaceFailed` handler shows that

>Msbuild failed when processing the file 'C:\Projects\elastic\net-5\src\Elasticsearch.Net\Elasticsearch.Net.csproj' with message: The SDK 'Microsoft.NET.Sdk' specified could not be found.  C:\Projects\elastic\net-5\src\Elasticsearch.Net\Elasticsearch.Net.csproj
Msbuild failed when processing the file 'C:\Projects\elastic\net-5\src\Tests\Tests.csproj' with message: The SDK 'Microsoft.NET.Sdk' specified could not be found.  C:\Projects\elastic\net-5\src\Tests\Tests.csproj
Msbuild failed when processing the file 'C:\Projects\elastic\net-5\src\Nest\Nest.csproj' with message: The SDK 'Microsoft.NET.Sdk' specified could not be found.  C:\Projects\elastic\net-5\src\Nest\Nest.csproj

Leading the the project being loaded as empty and so we are never picking up on new documentation changes. 

Which explains why https://github.com/elastic/elasticsearch-net/tree/master/docs has not been updated for 5 months too. 

https://github.com/dotnet/roslyn/issues/21660#issuecomment-324314157 leads me to believe that this will be fixed at some point by simply updating Roslyn but not sure I have a full handle on the situation. 

cc @DustinCampbell
