### PR TITLE
Update Releasing.fsx

### DIFF
--- a/build/scripts/Releasing.fsx
+++ b/build/scripts/Releasing.fsx
@@ -34,10 +34,8 @@ module Release =
 
             let year = sprintf "%i" DateTime.UtcNow.Year
 
-            let jsonDotNetVersion = 10
-
-            let jsonDotNetCurrentVersion = sprintf "%i" jsonDotNetVersion
-            let jsonDotNetNextVersion = sprintf "%i" (jsonDotNetVersion + 1)
+            let jsonDotNetCurrentVersion = "10.0.1"
+            let jsonDotNetNextVersion = "11.0"
 
             let properties =
                 let addKeyValue (e:Expr<string>) (builder:StringBuilder) =


### PR DESCRIPTION
Removing the computed properties for the current/next version of Newtonsoft.Json in favour of supplying the strings raw, to allow us to use "10.0.1" as the correct minimum version. I've removed the computation and simply specified the versions as strings.

This resolves issue #2831 by specifying a valid value for the minimum version of Newtonsoft.Json, and thus fixes any NU1603 compiler warnings.