### PR TITLE
Resolve JSON.Net version and next major version from Nest.csproj

### DIFF
--- a/build/scripts/Paths.fsx
+++ b/build/scripts/Paths.fsx
@@ -34,6 +34,15 @@ module Paths =
     let Output(folder) = sprintf "%s/%s" BuildOutput folder
     let Source(folder) = sprintf "%s/%s" SourceFolder folder
     let Build(folder) = sprintf "%s/%s" BuildFolder folder
+    
+    let ProjFile(project:DotNetProject) =
+        match project with 
+        | Project p -> sprintf "%s/%s/%s.csproj" SourceFolder project.Name project.Name
+        | PrivateProject p ->
+            match p with
+            | Tests -> sprintf "%s/%s/%s.csproj" SourceFolder project.Name project.Name
+            | DocGenerator -> sprintf "%s/CodeGeneration/%s/%s.csproj" SourceFolder project.Name project.Name
+            
 
     let BinFolder(folder) = 
         let f = replace @"\" "/" folder

--- a/build/scripts/Releasing.fsx
+++ b/build/scripts/Releasing.fsx
@@ -34,10 +34,8 @@ module Release =
 
             let year = sprintf "%i" DateTime.UtcNow.Year
 
-            let jsonDotNetVersion = 10
-
-            let jsonDotNetCurrentVersion = sprintf "%i" jsonDotNetVersion
-            let jsonDotNetNextVersion = sprintf "%i" (jsonDotNetVersion + 1)
+            let jsonDotNetCurrentVersion = "10.0.1"
+            let jsonDotNetNextVersion = "11.0"
 
             let properties =
                 let addKeyValue (e:Expr<string>) (builder:StringBuilder) =


### PR DESCRIPTION
Supercedes #2862 

Resolve the version of JSON.Net from the version referenced in Nest.csproj and calculate the next major version from this.

Closes #2831 