### PR TITLE
Add ReadSingleOrEnumerableJsonConverter attribute

### DIFF
--- a/src/Nest/Analysis/TokenFilters/CommonGramsTokenFilter.cs
+++ b/src/Nest/Analysis/TokenFilters/CommonGramsTokenFilter.cs
@@ -13,6 +13,7 @@ namespace Nest
 		/// A list of common words to use.
 		/// </summary>
 		[JsonProperty("common_words")]
+		[JsonConverter(typeof(ReadSingleOrEnumerableJsonConverter<string>))]
 		IEnumerable<string> CommonWords { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
Add ReadSingleOrEnumerableJsonConverter attribute to allow single common_words values to be deserialized
Fix for #2886
