### PR TITLE
Disable AllowWriteStreamBuffering 

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -222,9 +222,6 @@ namespace Elasticsearch.Net
 			}
 			requestMessage.Headers.Connection.Clear();
 			requestMessage.Headers.ConnectionClose = false;
-			requestMessage.Headers.Connection.Add("Keep-Alive");
-			//requestMessage.Headers.Connection;
-
 			requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(requestData.Accept));
 
 			if (!requestData.RunAs.IsNullOrEmpty())

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -59,9 +59,8 @@ namespace Elasticsearch.Net
 
 			request.Accept = requestData.Accept;
 			request.ContentType = requestData.ContentType;
-
 			request.MaximumResponseHeadersLength = -1;
-
+			request.AllowWriteStreamBuffering = false;
 			request.Pipelined = requestData.Pipelined;
 
 			if (requestData.HttpCompression)


### PR DESCRIPTION
- Disable `AllowWriteStreamBuffering` on HttpWebRequest as requests do not require retrying with buffered content.
- Remove superfluous Keep-Alive header on .NET Core HttpConnection