### PR TITLE
For Ping(node) method, setting request time out equal to ping timeout

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -253,7 +253,7 @@ namespace Elasticsearch.Net
 			var requestOverrides = new RequestConfiguration
 			{
 				PingTimeout = this.PingTimeout,
-				RequestTimeout = this.RequestTimeout,
+				RequestTimeout = this.PingTimeout,
 				BasicAuthenticationCredentials = this._settings.BasicAuthenticationCredentials,
 				EnableHttpPipelining = this.RequestConfiguration?.EnableHttpPipelining ?? this._settings.HttpPipeliningEnabled,
 				ForceNode = this.RequestConfiguration?.ForceNode


### PR DESCRIPTION
Issue: If a node is down due to some maintenance work. Then sometimes the ES queries take more than 20s to complete. Instead of timing out after 2s (PingTimeout) and retrying on the other client node in the cluster.

Fix: Change the request time out for ping requests to ping timeout.