### PR TITLE
Set Transfer-Encoding: chunked when a POST/PUT with body

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -65,7 +65,6 @@ namespace Elasticsearch.Net
 			if (requestData.HttpCompression)
 			{
 				request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-				request.Headers.Add("Accept-Encoding", "gzip,deflate");
 				request.Headers.Add("Content-Encoding", "gzip");
 			}
 			if (!requestData.RunAs.IsNullOrEmpty())
@@ -79,12 +78,18 @@ namespace Elasticsearch.Net
 			request.ReadWriteTimeout = timeout;
 
 			//WebRequest won't send Content-Length: 0 for empty bodies
-			//which goes against RFC's and might break i.e IIS hen used as a proxy.
-			//see: https://github.com/elasticsearch/elasticsearch-net/issues/562
-			var m = requestData.Method.GetStringValue();
-			request.Method = m;
-			if (m != "HEAD" && m != "GET" && (requestData.PostData == null))
-				request.ContentLength = 0;
+			//which goes against RFC's and might break i.e IIS when used as a proxy.
+			//see: https://github.com/elasticsearch/elasticsearch-net/issues/562.
+			//Transfer-Encoding: chunked must be set for POST and PUT where there is a body.
+			var method = requestData.Method.GetStringValue();
+			request.Method = method;
+			if (method != "HEAD" && method != "GET")
+			{
+				if (requestData.PostData == null)
+					request.ContentLength = 0;
+				else
+					request.SendChunked = true;
+			}
 
 			return request;
 		}

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -60,6 +60,7 @@ namespace Elasticsearch.Net
 			request.Accept = requestData.Accept;
 			request.ContentType = requestData.ContentType;
 			request.MaximumResponseHeadersLength = -1;
+			request.AllowWriteStreamBuffering = false;
 			request.Pipelined = requestData.Pipelined;
 
 			if (requestData.HttpCompression)


### PR DESCRIPTION
AllowWriteStreamBuffering = false means the request is not buffered before wirting to the request stream. As a consequence, the .NET Framework does not calculate a Content-Length value for the request, so it either needs to be calculated upfront and set, or the request should use chunked transfer encoding by setting SendChunked = true. This commit adds the latter.

Fixes #2908