### PR TITLE
Set HttpClientHandler.UseProxy=false to disable automatic proxy detection

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -186,9 +186,10 @@ namespace Elasticsearch.Net
 				}
 				handler.Proxy = proxy;
 			}
-
-			if (requestData.DisableAutomaticProxyDetection)
-				handler.Proxy = null;
+			else if (requestData.DisableAutomaticProxyDetection)
+			{
+				handler.UseProxy = false;
+			}
 
 			var callback = requestData?.ConnectionSettings?.ServerCertificateValidationCallback;
 			if (callback != null && handler.ServerCertificateCustomValidationCallback == null)


### PR DESCRIPTION
With HttpClientHandler.Proxy = null HttClient still tries to detect and use system proxy.
I've fixed this by using HttpClientHandler.UseProxy flag, which prevents HttpClient from using proxy at all.
"Else if" is used to avoid preventing usage of proxy, if client setted ProxyAddress.