### PR TITLE
Prevent boxing on PostData<object>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ solution: src/Elasticsearch.sln
 script: ./build.sh test
 dist: trusty
 mono: 4.6.2
-dotnet: 1.0.1
+dotnet: 2.0.3
 env:
   global:     
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/src/CodeGeneration/ApiGenerator/Domain/ApiEndpoint.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/ApiEndpoint.cs
@@ -158,7 +158,7 @@ namespace ApiGenerator.Domain
 							parts.Add(new ApiUrlPart
 							{
 								Name = "body",
-								Type = "PostData<object>",
+								Type = "PostData",
 								Description = this.Body.Description
 							});
 						}

--- a/src/CodeGeneration/ApiGenerator/Views/_LowLevelDispatch.Generated.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/_LowLevelDispatch.Generated.cshtml
@@ -1,4 +1,5 @@
 @using System.Linq
+@using System.Text.RegularExpressions
 @using ApiGenerator.Domain
 @using ApiGenerator
 using System;
@@ -32,13 +33,19 @@ namespace Nest
 			<text>//NO METHOD FOR @endpoint.Url.Path</text>
 			continue;
 		}
+		var isGeneric = peek.InterfaceType.Contains("<");
+		var genericTypes = !isGeneric ? new string[] {} : Regex.Replace(peek.InterfaceType, @"^.+<(.+)>$", "$1").Split(',').Select(s => s.Trim()).ToArray();
+
+		var dispatchGeneric = !isGeneric ? "<T>" : ("<T," + string.Join(",", genericTypes) + ">");
+		var methodConstraints = "where T : class" + (string.Join("", genericTypes.Select(s => " where " + s + " : class")));
+		
 		var generate = new [] {
-			new { Name = endpoint.CsharpMethodName + "Dispatch<T>", Returns = "ElasticsearchResponse<T>" , Async = false},
-			new { Name = endpoint.CsharpMethodName + "DispatchAsync<T>", Returns = "Task<ElasticsearchResponse<T>>", Async = true },
+			new { Name = endpoint.CsharpMethodName + "Dispatch" + dispatchGeneric, Returns = "ElasticsearchResponse<T>" , Async = false},
+			new { Name = endpoint.CsharpMethodName + "DispatchAsync" + dispatchGeneric, Returns = "Task<ElasticsearchResponse<T>>", Async = true },
 		};
 		foreach(var gen in generate)
 		{
-		<text>internal @Raw(gen.Returns) @(Raw(gen.Name))(IRequest<@peek.QueryStringParamName> p @if (endpoint.Body != null) {<text>, @(Raw("PostData<object>")) body</text>}@(gen.Async ? ", CancellationToken cancellationToken" : string.Empty)) where T : class
+		<text>internal @Raw(gen.Returns) @(Raw(gen.Name))(IRequest<@peek.QueryStringParamName> p@{if (endpoint.Body != null) {<text>,@(Raw("SerializableData<"))@(Raw(peek.InterfaceType))@(Raw(">")) body</text>}}@(gen.Async ? ", CancellationToken ct" : string.Empty)) @methodConstraints
 		{
 			switch(p.HttpMethod)
 			{
@@ -60,7 +67,7 @@ namespace Nest
 						name += "Async<T>";
 						methodArguments = methodArguments.Concat(new[]
 						{
-							"cancellationToken"
+							"ct"
 						});
 					}
 					else

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
@@ -31,7 +31,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Bulk<T>(PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Bulk<T>(PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_bulk"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_bulk
@@ -45,7 +45,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> BulkAsync<T>(PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> BulkAsync<T>(PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_bulk"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_bulk
@@ -60,7 +60,7 @@ namespace Elasticsearch.Net
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Bulk<T>(string index, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Bulk<T>(string index, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_bulk"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_bulk
@@ -75,7 +75,7 @@ namespace Elasticsearch.Net
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> BulkAsync<T>(string index, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> BulkAsync<T>(string index, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_bulk"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_bulk
@@ -91,7 +91,7 @@ namespace Elasticsearch.Net
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Bulk<T>(string index, string type, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Bulk<T>(string index, string type, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_bulk"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_bulk
@@ -107,7 +107,7 @@ namespace Elasticsearch.Net
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> BulkAsync<T>(string index, string type, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> BulkAsync<T>(string index, string type, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_bulk"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_bulk
@@ -121,7 +121,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> BulkPut<T>(PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> BulkPut<T>(PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_bulk"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_bulk
@@ -135,7 +135,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> BulkPutAsync<T>(PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> BulkPutAsync<T>(PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_bulk"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/_bulk
@@ -150,7 +150,7 @@ namespace Elasticsearch.Net
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> BulkPut<T>(string index, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> BulkPut<T>(string index, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/_bulk"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/_bulk
@@ -165,7 +165,7 @@ namespace Elasticsearch.Net
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> BulkPutAsync<T>(string index, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> BulkPutAsync<T>(string index, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/_bulk"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}/_bulk
@@ -181,7 +181,7 @@ namespace Elasticsearch.Net
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> BulkPut<T>(string index, string type, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> BulkPut<T>(string index, string type, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_bulk"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}/_bulk
@@ -197,7 +197,7 @@ namespace Elasticsearch.Net
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> BulkPutAsync<T>(string index, string type, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> BulkPutAsync<T>(string index, string type, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_bulk"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_cat/aliases
@@ -1039,7 +1039,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> ClearScroll<T>(PostData<object> body, Func<ClearScrollRequestParameters, ClearScrollRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> ClearScroll<T>(PostData body, Func<ClearScrollRequestParameters, ClearScrollRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(DELETE, Url($"_search/scroll"), body, _params(requestParameters));
 		
 		///<summary>Represents a DELETE on /_search/scroll
@@ -1053,7 +1053,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> ClearScrollAsync<T>(PostData<object> body, Func<ClearScrollRequestParameters, ClearScrollRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> ClearScrollAsync<T>(PostData body, Func<ClearScrollRequestParameters, ClearScrollRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(DELETE, Url($"_search/scroll"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_cluster/allocation/explain
@@ -1093,7 +1093,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The index, shard, and primary flag to explain. Empty means &#39;explain the first unassigned shard&#39;</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> ClusterAllocationExplain<T>(PostData<object> body, Func<ClusterAllocationExplainRequestParameters, ClusterAllocationExplainRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> ClusterAllocationExplain<T>(PostData body, Func<ClusterAllocationExplainRequestParameters, ClusterAllocationExplainRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_cluster/allocation/explain"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_cluster/allocation/explain
@@ -1107,7 +1107,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The index, shard, and primary flag to explain. Empty means &#39;explain the first unassigned shard&#39;</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> ClusterAllocationExplainAsync<T>(PostData<object> body, Func<ClusterAllocationExplainRequestParameters, ClusterAllocationExplainRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> ClusterAllocationExplainAsync<T>(PostData body, Func<ClusterAllocationExplainRequestParameters, ClusterAllocationExplainRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_cluster/allocation/explain"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_cluster/settings
@@ -1227,7 +1227,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> ClusterPutSettings<T>(PostData<object> body, Func<ClusterPutSettingsRequestParameters, ClusterPutSettingsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> ClusterPutSettings<T>(PostData body, Func<ClusterPutSettingsRequestParameters, ClusterPutSettingsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_cluster/settings"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_cluster/settings
@@ -1241,7 +1241,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> ClusterPutSettingsAsync<T>(PostData<object> body, Func<ClusterPutSettingsRequestParameters, ClusterPutSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> ClusterPutSettingsAsync<T>(PostData body, Func<ClusterPutSettingsRequestParameters, ClusterPutSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_cluster/settings"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_remote/info
@@ -1281,7 +1281,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> ClusterReroute<T>(PostData<object> body, Func<ClusterRerouteRequestParameters, ClusterRerouteRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> ClusterReroute<T>(PostData body, Func<ClusterRerouteRequestParameters, ClusterRerouteRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_cluster/reroute"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_cluster/reroute
@@ -1295,7 +1295,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> ClusterRerouteAsync<T>(PostData<object> body, Func<ClusterRerouteRequestParameters, ClusterRerouteRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> ClusterRerouteAsync<T>(PostData body, Func<ClusterRerouteRequestParameters, ClusterRerouteRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_cluster/reroute"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_cluster/state
@@ -1447,7 +1447,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Count<T>(PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Count<T>(PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_count"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_count
@@ -1461,7 +1461,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> CountAsync<T>(PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> CountAsync<T>(PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_count"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_count
@@ -1476,7 +1476,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Count<T>(string index, PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Count<T>(string index, PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_count"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_count
@@ -1491,7 +1491,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> CountAsync<T>(string index, PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> CountAsync<T>(string index, PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_count"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_count
@@ -1507,7 +1507,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of types to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Count<T>(string index, string type, PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Count<T>(string index, string type, PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_count"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_count
@@ -1523,7 +1523,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of types to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> CountAsync<T>(string index, string type, PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> CountAsync<T>(string index, string type, PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_count"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_count
@@ -1624,7 +1624,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Create<T>(string index, string type, string id, PostData<object> body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Create<T>(string index, string type, string id, PostData body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_create"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}/{id}/_create
@@ -1641,7 +1641,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> CreateAsync<T>(string index, string type, string id, PostData<object> body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> CreateAsync<T>(string index, string type, string id, PostData body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_create"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_create
@@ -1658,7 +1658,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> CreatePost<T>(string index, string type, string id, PostData<object> body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> CreatePost<T>(string index, string type, string id, PostData body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_create"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_create
@@ -1675,7 +1675,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> CreatePostAsync<T>(string index, string type, string id, PostData<object> body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> CreatePostAsync<T>(string index, string type, string id, PostData body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_create"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a DELETE on /{index}/{type}/{id}
@@ -1722,7 +1722,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> DeleteByQuery<T>(string index, PostData<object> body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> DeleteByQuery<T>(string index, PostData body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_delete_by_query"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_delete_by_query
@@ -1737,7 +1737,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> DeleteByQueryAsync<T>(string index, PostData<object> body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> DeleteByQueryAsync<T>(string index, PostData body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_delete_by_query"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_delete_by_query
@@ -1753,7 +1753,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> DeleteByQuery<T>(string index, string type, PostData<object> body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> DeleteByQuery<T>(string index, string type, PostData body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_delete_by_query"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_delete_by_query
@@ -1769,7 +1769,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> DeleteByQueryAsync<T>(string index, string type, PostData<object> body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> DeleteByQueryAsync<T>(string index, string type, PostData body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_delete_by_query"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a DELETE on /_scripts/{id}
@@ -1910,7 +1910,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The document ID</param>
 		///<param name="body">The query definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Explain<T>(string index, string type, string id, PostData<object> body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Explain<T>(string index, string type, string id, PostData body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_explain"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_explain
@@ -1927,7 +1927,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The document ID</param>
 		///<param name="body">The query definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> ExplainAsync<T>(string index, string type, string id, PostData<object> body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> ExplainAsync<T>(string index, string type, string id, PostData body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_explain"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_field_caps
@@ -1995,7 +1995,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Field json objects containing an array of field names</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> FieldCaps<T>(PostData<object> body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> FieldCaps<T>(PostData body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_field_caps"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_field_caps
@@ -2009,7 +2009,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Field json objects containing an array of field names</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> FieldCapsAsync<T>(PostData<object> body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> FieldCapsAsync<T>(PostData body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_field_caps"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_field_caps
@@ -2024,7 +2024,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">Field json objects containing an array of field names</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> FieldCaps<T>(string index, PostData<object> body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> FieldCaps<T>(string index, PostData body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_field_caps"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_field_caps
@@ -2039,7 +2039,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">Field json objects containing an array of field names</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> FieldCapsAsync<T>(string index, PostData<object> body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> FieldCapsAsync<T>(string index, PostData body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_field_caps"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /{index}/{type}/{id}
@@ -2147,7 +2147,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Index<T>(string index, string type, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Index<T>(string index, string type, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}
@@ -2163,7 +2163,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndexAsync<T>(string index, string type, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndexAsync<T>(string index, string type, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}
@@ -2180,7 +2180,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Index<T>(string index, string type, string id, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Index<T>(string index, string type, string id, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}
@@ -2197,7 +2197,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndexAsync<T>(string index, string type, string id, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndexAsync<T>(string index, string type, string id, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}
@@ -2213,7 +2213,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndexPut<T>(string index, string type, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndexPut<T>(string index, string type, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}
@@ -2229,7 +2229,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndexPutAsync<T>(string index, string type, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndexPutAsync<T>(string index, string type, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}/{id}
@@ -2246,7 +2246,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndexPut<T>(string index, string type, string id, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndexPut<T>(string index, string type, string id, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}/{id}
@@ -2263,7 +2263,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndexPutAsync<T>(string index, string type, string id, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndexPutAsync<T>(string index, string type, string id, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_analyze
@@ -2331,7 +2331,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Define analyzer/tokenizer parameters and the text on which the analysis should be performed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesAnalyzeForAll<T>(PostData<object> body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesAnalyzeForAll<T>(PostData body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_analyze"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_analyze
@@ -2345,7 +2345,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Define analyzer/tokenizer parameters and the text on which the analysis should be performed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesAnalyzeForAllAsync<T>(PostData<object> body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesAnalyzeForAllAsync<T>(PostData body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_analyze"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_analyze
@@ -2360,7 +2360,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">Define analyzer/tokenizer parameters and the text on which the analysis should be performed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesAnalyze<T>(string index, PostData<object> body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesAnalyze<T>(string index, PostData body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_analyze"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_analyze
@@ -2375,7 +2375,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">Define analyzer/tokenizer parameters and the text on which the analysis should be performed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesAnalyzeAsync<T>(string index, PostData<object> body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesAnalyzeAsync<T>(string index, PostData body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_analyze"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_cache/clear
@@ -2526,7 +2526,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesCreate<T>(string index, PostData<object> body, Func<CreateIndexRequestParameters, CreateIndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesCreate<T>(string index, PostData body, Func<CreateIndexRequestParameters, CreateIndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}
@@ -2541,7 +2541,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesCreateAsync<T>(string index, PostData<object> body, Func<CreateIndexRequestParameters, CreateIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesCreateAsync<T>(string index, PostData body, Func<CreateIndexRequestParameters, CreateIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a DELETE on /{index}
@@ -3677,7 +3677,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the alias to be created or updated</param>
 		///<param name="body">The settings for the alias, such as `routing` or `filter`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutAlias<T>(string index, string name, PostData<object> body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutAlias<T>(string index, string name, PostData body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/_alias/{name.NotNull("name")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/_alias/{name}
@@ -3693,7 +3693,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the alias to be created or updated</param>
 		///<param name="body">The settings for the alias, such as `routing` or `filter`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutAliasAsync<T>(string index, string name, PostData<object> body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutAliasAsync<T>(string index, string name, PostData body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/_alias/{name.NotNull("name")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_alias/{name}
@@ -3709,7 +3709,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the alias to be created or updated</param>
 		///<param name="body">The settings for the alias, such as `routing` or `filter`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutAliasPost<T>(string index, string name, PostData<object> body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutAliasPost<T>(string index, string name, PostData body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_alias/{name.NotNull("name")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_alias/{name}
@@ -3725,7 +3725,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the alias to be created or updated</param>
 		///<param name="body">The settings for the alias, such as `routing` or `filter`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutAliasPostAsync<T>(string index, string name, PostData<object> body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutAliasPostAsync<T>(string index, string name, PostData body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_alias/{name.NotNull("name")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}/_mapping
@@ -3741,7 +3741,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutMapping<T>(string index, string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutMapping<T>(string index, string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_mapping"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/{type}/_mapping
@@ -3757,7 +3757,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutMappingAsync<T>(string index, string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutMappingAsync<T>(string index, string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_mapping"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_mapping/{type}
@@ -3772,7 +3772,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutMappingForAll<T>(string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutMappingForAll<T>(string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_mapping/{type.NotNull("type")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_mapping/{type}
@@ -3787,7 +3787,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutMappingForAllAsync<T>(string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutMappingForAllAsync<T>(string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_mapping/{type.NotNull("type")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_mapping
@@ -3803,7 +3803,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutMappingPost<T>(string index, string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutMappingPost<T>(string index, string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_mapping"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_mapping
@@ -3819,7 +3819,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutMappingPostAsync<T>(string index, string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutMappingPostAsync<T>(string index, string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_mapping"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_mapping/{type}
@@ -3834,7 +3834,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutMappingPostForAll<T>(string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutMappingPostForAll<T>(string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_mapping/{type.NotNull("type")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_mapping/{type}
@@ -3849,7 +3849,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutMappingPostForAllAsync<T>(string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutMappingPostForAllAsync<T>(string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_mapping/{type.NotNull("type")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_settings
@@ -3863,7 +3863,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutSettingsForAll<T>(PostData<object> body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutSettingsForAll<T>(PostData body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_settings"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_settings
@@ -3877,7 +3877,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutSettingsForAllAsync<T>(PostData<object> body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutSettingsForAllAsync<T>(PostData body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_settings"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/_settings
@@ -3892,7 +3892,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutSettings<T>(string index, PostData<object> body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutSettings<T>(string index, PostData body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/_settings"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/_settings
@@ -3907,7 +3907,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutSettingsAsync<T>(string index, PostData<object> body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutSettingsAsync<T>(string index, PostData body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/_settings"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_template/{name}
@@ -3922,7 +3922,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutTemplateForAll<T>(string name, PostData<object> body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutTemplateForAll<T>(string name, PostData body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_template/{name.NotNull("name")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_template/{name}
@@ -3937,7 +3937,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutTemplateForAllAsync<T>(string name, PostData<object> body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutTemplateForAllAsync<T>(string name, PostData body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_template/{name.NotNull("name")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_template/{name}
@@ -3952,7 +3952,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesPutTemplatePostForAll<T>(string name, PostData<object> body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesPutTemplatePostForAll<T>(string name, PostData body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_template/{name.NotNull("name")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_template/{name}
@@ -3967,7 +3967,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesPutTemplatePostForAllAsync<T>(string name, PostData<object> body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesPutTemplatePostForAllAsync<T>(string name, PostData body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_template/{name.NotNull("name")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_recovery
@@ -4144,7 +4144,7 @@ namespace Elasticsearch.Net
 		///<param name="alias">The name of the alias to rollover</param>
 		///<param name="body">The conditions that needs to be met for executing rollover</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesRolloverForAll<T>(string alias, PostData<object> body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesRolloverForAll<T>(string alias, PostData body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{alias.NotNull("alias")}/_rollover"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{alias}/_rollover
@@ -4159,7 +4159,7 @@ namespace Elasticsearch.Net
 		///<param name="alias">The name of the alias to rollover</param>
 		///<param name="body">The conditions that needs to be met for executing rollover</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesRolloverForAllAsync<T>(string alias, PostData<object> body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesRolloverForAllAsync<T>(string alias, PostData body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{alias.NotNull("alias")}/_rollover"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{alias}/_rollover/{new_index}
@@ -4175,7 +4175,7 @@ namespace Elasticsearch.Net
 		///<param name="new_index">The name of the rollover index</param>
 		///<param name="body">The conditions that needs to be met for executing rollover</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesRolloverForAll<T>(string alias, string new_index, PostData<object> body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesRolloverForAll<T>(string alias, string new_index, PostData body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{alias.NotNull("alias")}/_rollover/{new_index.NotNull("new_index")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{alias}/_rollover/{new_index}
@@ -4191,7 +4191,7 @@ namespace Elasticsearch.Net
 		///<param name="new_index">The name of the rollover index</param>
 		///<param name="body">The conditions that needs to be met for executing rollover</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesRolloverForAllAsync<T>(string alias, string new_index, PostData<object> body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesRolloverForAllAsync<T>(string alias, string new_index, PostData body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{alias.NotNull("alias")}/_rollover/{new_index.NotNull("new_index")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_segments
@@ -4315,7 +4315,7 @@ namespace Elasticsearch.Net
 		///<param name="target">The name of the target index to shrink into</param>
 		///<param name="body">The configuration for the target index (`settings` and `aliases`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesShrink<T>(string index, string target, PostData<object> body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesShrink<T>(string index, string target, PostData body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"{index.NotNull("index")}/_shrink/{target.NotNull("target")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /{index}/_shrink/{target}
@@ -4331,7 +4331,7 @@ namespace Elasticsearch.Net
 		///<param name="target">The name of the target index to shrink into</param>
 		///<param name="body">The configuration for the target index (`settings` and `aliases`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesShrinkAsync<T>(string index, string target, PostData<object> body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesShrinkAsync<T>(string index, string target, PostData body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"{index.NotNull("index")}/_shrink/{target.NotNull("target")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_shrink/{target}
@@ -4347,7 +4347,7 @@ namespace Elasticsearch.Net
 		///<param name="target">The name of the target index to shrink into</param>
 		///<param name="body">The configuration for the target index (`settings` and `aliases`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesShrinkPost<T>(string index, string target, PostData<object> body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesShrinkPost<T>(string index, string target, PostData body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_shrink/{target.NotNull("target")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_shrink/{target}
@@ -4363,7 +4363,7 @@ namespace Elasticsearch.Net
 		///<param name="target">The name of the target index to shrink into</param>
 		///<param name="body">The configuration for the target index (`settings` and `aliases`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesShrinkPostAsync<T>(string index, string target, PostData<object> body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesShrinkPostAsync<T>(string index, string target, PostData body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_shrink/{target.NotNull("target")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_stats
@@ -4489,7 +4489,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesUpdateAliasesForAll<T>(PostData<object> body, Func<BulkAliasRequestParameters, BulkAliasRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesUpdateAliasesForAll<T>(PostData body, Func<BulkAliasRequestParameters, BulkAliasRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_aliases"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_aliases
@@ -4503,7 +4503,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesUpdateAliasesForAllAsync<T>(PostData<object> body, Func<BulkAliasRequestParameters, BulkAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesUpdateAliasesForAllAsync<T>(PostData body, Func<BulkAliasRequestParameters, BulkAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_aliases"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_upgrade
@@ -4655,7 +4655,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesValidateQueryForAll<T>(PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesValidateQueryForAll<T>(PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_validate/query"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_validate/query
@@ -4669,7 +4669,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesValidateQueryForAllAsync<T>(PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesValidateQueryForAllAsync<T>(PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_validate/query"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_validate/query
@@ -4684,7 +4684,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to restrict the operation; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesValidateQuery<T>(string index, PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesValidateQuery<T>(string index, PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_validate/query"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_validate/query
@@ -4699,7 +4699,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to restrict the operation; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesValidateQueryAsync<T>(string index, PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesValidateQueryAsync<T>(string index, PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_validate/query"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_validate/query
@@ -4715,7 +4715,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IndicesValidateQuery<T>(string index, string type, PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IndicesValidateQuery<T>(string index, string type, PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_validate/query"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_validate/query
@@ -4731,7 +4731,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IndicesValidateQueryAsync<T>(string index, string type, PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IndicesValidateQueryAsync<T>(string index, string type, PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_validate/query"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /
@@ -4880,7 +4880,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Pipeline ID</param>
 		///<param name="body">The ingest definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IngestPutPipeline<T>(string id, PostData<object> body, Func<PutPipelineRequestParameters, PutPipelineRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IngestPutPipeline<T>(string id, PostData body, Func<PutPipelineRequestParameters, PutPipelineRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_ingest/pipeline/{id.NotNull("id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_ingest/pipeline/{id}
@@ -4895,7 +4895,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Pipeline ID</param>
 		///<param name="body">The ingest definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IngestPutPipelineAsync<T>(string id, PostData<object> body, Func<PutPipelineRequestParameters, PutPipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IngestPutPipelineAsync<T>(string id, PostData body, Func<PutPipelineRequestParameters, PutPipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_ingest/pipeline/{id.NotNull("id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_ingest/pipeline/_simulate
@@ -4963,7 +4963,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The simulate definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IngestSimulate<T>(PostData<object> body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IngestSimulate<T>(PostData body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_ingest/pipeline/_simulate"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_ingest/pipeline/_simulate
@@ -4977,7 +4977,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The simulate definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IngestSimulateAsync<T>(PostData<object> body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IngestSimulateAsync<T>(PostData body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_ingest/pipeline/_simulate"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_ingest/pipeline/{id}/_simulate
@@ -4992,7 +4992,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Pipeline ID</param>
 		///<param name="body">The simulate definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> IngestSimulate<T>(string id, PostData<object> body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> IngestSimulate<T>(string id, PostData body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_ingest/pipeline/{id.NotNull("id")}/_simulate"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_ingest/pipeline/{id}/_simulate
@@ -5007,7 +5007,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Pipeline ID</param>
 		///<param name="body">The simulate definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> IngestSimulateAsync<T>(string id, PostData<object> body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> IngestSimulateAsync<T>(string id, PostData body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_ingest/pipeline/{id.NotNull("id")}/_simulate"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_mget
@@ -5105,7 +5105,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Mget<T>(PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Mget<T>(PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_mget"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_mget
@@ -5119,7 +5119,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MgetAsync<T>(PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MgetAsync<T>(PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_mget"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_mget
@@ -5134,7 +5134,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Mget<T>(string index, PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Mget<T>(string index, PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_mget"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_mget
@@ -5149,7 +5149,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MgetAsync<T>(string index, PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MgetAsync<T>(string index, PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_mget"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_mget
@@ -5165,7 +5165,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Mget<T>(string index, string type, PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Mget<T>(string index, string type, PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_mget"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_mget
@@ -5181,7 +5181,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MgetAsync<T>(string index, string type, PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MgetAsync<T>(string index, string type, PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_mget"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_msearch
@@ -5279,7 +5279,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Msearch<T>(PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Msearch<T>(PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_msearch"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_msearch
@@ -5293,7 +5293,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MsearchAsync<T>(PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MsearchAsync<T>(PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_msearch"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_msearch
@@ -5308,7 +5308,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Msearch<T>(string index, PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Msearch<T>(string index, PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_msearch"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_msearch
@@ -5323,7 +5323,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MsearchAsync<T>(string index, PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MsearchAsync<T>(string index, PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_msearch"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_msearch
@@ -5339,7 +5339,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Msearch<T>(string index, string type, PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Msearch<T>(string index, string type, PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_msearch"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_msearch
@@ -5355,7 +5355,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MsearchAsync<T>(string index, string type, PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MsearchAsync<T>(string index, string type, PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_msearch"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_msearch/template
@@ -5453,7 +5453,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> MsearchTemplate<T>(PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> MsearchTemplate<T>(PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_msearch/template"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_msearch/template
@@ -5467,7 +5467,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_msearch/template"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_msearch/template
@@ -5482,7 +5482,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> MsearchTemplate<T>(string index, PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> MsearchTemplate<T>(string index, PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_msearch/template"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_msearch/template
@@ -5497,7 +5497,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(string index, PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(string index, PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_msearch/template"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_msearch/template
@@ -5513,7 +5513,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> MsearchTemplate<T>(string index, string type, PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> MsearchTemplate<T>(string index, string type, PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_msearch/template"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_msearch/template
@@ -5529,7 +5529,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(string index, string type, PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(string index, string type, PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_msearch/template"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_mtermvectors
@@ -5627,7 +5627,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Mtermvectors<T>(PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Mtermvectors<T>(PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_mtermvectors"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_mtermvectors
@@ -5641,7 +5641,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_mtermvectors"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_mtermvectors
@@ -5656,7 +5656,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Mtermvectors<T>(string index, PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Mtermvectors<T>(string index, PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_mtermvectors"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_mtermvectors
@@ -5671,7 +5671,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(string index, PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(string index, PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_mtermvectors"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_mtermvectors
@@ -5687,7 +5687,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document.</param>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Mtermvectors<T>(string index, string type, PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Mtermvectors<T>(string index, string type, PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_mtermvectors"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_mtermvectors
@@ -5703,7 +5703,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document.</param>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(string index, string type, PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(string index, string type, PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_mtermvectors"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_cluster/nodes/hotthreads
@@ -6196,7 +6196,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Script ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> PutScript<T>(string id, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> PutScript<T>(string id, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_scripts/{id.NotNull("id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_scripts/{id}
@@ -6211,7 +6211,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Script ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> PutScriptAsync<T>(string id, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> PutScriptAsync<T>(string id, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_scripts/{id.NotNull("id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_scripts/{id}/{context}
@@ -6227,7 +6227,7 @@ namespace Elasticsearch.Net
 		///<param name="context">Script context</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> PutScript<T>(string id, string context, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> PutScript<T>(string id, string context, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_scripts/{id.NotNull("id")}/{context.NotNull("context")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_scripts/{id}/{context}
@@ -6243,7 +6243,7 @@ namespace Elasticsearch.Net
 		///<param name="context">Script context</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> PutScriptAsync<T>(string id, string context, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> PutScriptAsync<T>(string id, string context, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_scripts/{id.NotNull("id")}/{context.NotNull("context")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_scripts/{id}
@@ -6258,7 +6258,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Script ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> PutScriptPost<T>(string id, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> PutScriptPost<T>(string id, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_scripts/{id.NotNull("id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_scripts/{id}
@@ -6273,7 +6273,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Script ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> PutScriptPostAsync<T>(string id, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> PutScriptPostAsync<T>(string id, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_scripts/{id.NotNull("id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_scripts/{id}/{context}
@@ -6289,7 +6289,7 @@ namespace Elasticsearch.Net
 		///<param name="context">Script context</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> PutScriptPost<T>(string id, string context, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> PutScriptPost<T>(string id, string context, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_scripts/{id.NotNull("id")}/{context.NotNull("context")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_scripts/{id}/{context}
@@ -6305,7 +6305,7 @@ namespace Elasticsearch.Net
 		///<param name="context">Script context</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> PutScriptPostAsync<T>(string id, string context, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> PutScriptPostAsync<T>(string id, string context, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_scripts/{id.NotNull("id")}/{context.NotNull("context")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_reindex
@@ -6319,7 +6319,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Reindex<T>(PostData<object> body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Reindex<T>(PostData body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_reindex"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_reindex
@@ -6333,7 +6333,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData<object> body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_reindex"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_reindex/{task_id}/_rethrottle
@@ -6429,7 +6429,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> RenderSearchTemplate<T>(PostData<object> body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> RenderSearchTemplate<T>(PostData body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_render/template"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_render/template
@@ -6443,7 +6443,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> RenderSearchTemplateAsync<T>(PostData<object> body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> RenderSearchTemplateAsync<T>(PostData body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_render/template"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_render/template/{id}
@@ -6458,7 +6458,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The id of the stored search template</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> RenderSearchTemplate<T>(string id, PostData<object> body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> RenderSearchTemplate<T>(string id, PostData body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_render/template/{id.NotNull("id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_render/template/{id}
@@ -6473,7 +6473,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The id of the stored search template</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> RenderSearchTemplateAsync<T>(string id, PostData<object> body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> RenderSearchTemplateAsync<T>(string id, PostData body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_render/template/{id.NotNull("id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_search/scroll
@@ -6513,7 +6513,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Scroll<T>(PostData<object> body, Func<ScrollRequestParameters, ScrollRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Scroll<T>(PostData body, Func<ScrollRequestParameters, ScrollRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_search/scroll"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_search/scroll
@@ -6527,7 +6527,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> ScrollAsync<T>(PostData<object> body, Func<ScrollRequestParameters, ScrollRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> ScrollAsync<T>(PostData body, Func<ScrollRequestParameters, ScrollRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_search/scroll"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_search
@@ -6625,7 +6625,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Search<T>(PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Search<T>(PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_search"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_search
@@ -6639,7 +6639,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SearchAsync<T>(PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SearchAsync<T>(PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_search"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_search
@@ -6654,7 +6654,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Search<T>(string index, PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Search<T>(string index, PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_search"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_search
@@ -6669,7 +6669,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_search"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_search
@@ -6685,7 +6685,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Search<T>(string index, string type, PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Search<T>(string index, string type, PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_search"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_search
@@ -6701,7 +6701,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, string type, PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, string type, PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_search"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_search_shards
@@ -6907,7 +6907,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> SearchTemplate<T>(PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SearchTemplate<T>(PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_search/template"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_search/template
@@ -6921,7 +6921,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_search/template"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_search/template
@@ -6936,7 +6936,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> SearchTemplate<T>(string index, PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SearchTemplate<T>(string index, PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_search/template"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_search/template
@@ -6951,7 +6951,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(string index, PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(string index, PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_search/template"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_search/template
@@ -6967,7 +6967,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> SearchTemplate<T>(string index, string type, PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SearchTemplate<T>(string index, string type, PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_search/template"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_search/template
@@ -6983,7 +6983,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(string index, string type, PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(string index, string type, PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_search/template"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_snapshot/{repository}/{snapshot}
@@ -6999,7 +6999,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">The snapshot definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> SnapshotCreate<T>(string repository, string snapshot, PostData<object> body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SnapshotCreate<T>(string repository, string snapshot, PostData body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_snapshot/{repository.NotNull("repository")}/{snapshot.NotNull("snapshot")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_snapshot/{repository}/{snapshot}
@@ -7015,7 +7015,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">The snapshot definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SnapshotCreateAsync<T>(string repository, string snapshot, PostData<object> body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SnapshotCreateAsync<T>(string repository, string snapshot, PostData body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_snapshot/{repository.NotNull("repository")}/{snapshot.NotNull("snapshot")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_snapshot/{repository}/{snapshot}
@@ -7031,7 +7031,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">The snapshot definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> SnapshotCreatePost<T>(string repository, string snapshot, PostData<object> body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SnapshotCreatePost<T>(string repository, string snapshot, PostData body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_snapshot/{repository.NotNull("repository")}/{snapshot.NotNull("snapshot")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_snapshot/{repository}/{snapshot}
@@ -7047,7 +7047,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">The snapshot definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SnapshotCreatePostAsync<T>(string repository, string snapshot, PostData<object> body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SnapshotCreatePostAsync<T>(string repository, string snapshot, PostData body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_snapshot/{repository.NotNull("repository")}/{snapshot.NotNull("snapshot")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_snapshot/{repository}
@@ -7062,7 +7062,7 @@ namespace Elasticsearch.Net
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> SnapshotCreateRepository<T>(string repository, PostData<object> body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SnapshotCreateRepository<T>(string repository, PostData body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_snapshot/{repository.NotNull("repository")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_snapshot/{repository}
@@ -7077,7 +7077,7 @@ namespace Elasticsearch.Net
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryAsync<T>(string repository, PostData<object> body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryAsync<T>(string repository, PostData body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_snapshot/{repository.NotNull("repository")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_snapshot/{repository}
@@ -7092,7 +7092,7 @@ namespace Elasticsearch.Net
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> SnapshotCreateRepositoryPost<T>(string repository, PostData<object> body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SnapshotCreateRepositoryPost<T>(string repository, PostData body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_snapshot/{repository.NotNull("repository")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_snapshot/{repository}
@@ -7107,7 +7107,7 @@ namespace Elasticsearch.Net
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryPostAsync<T>(string repository, PostData<object> body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryPostAsync<T>(string repository, PostData body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_snapshot/{repository.NotNull("repository")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a DELETE on /_snapshot/{repository}/{snapshot}
@@ -7265,7 +7265,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">Details of what to restore</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> SnapshotRestore<T>(string repository, string snapshot, PostData<object> body, Func<RestoreRequestParameters, RestoreRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> SnapshotRestore<T>(string repository, string snapshot, PostData body, Func<RestoreRequestParameters, RestoreRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_snapshot/{repository.NotNull("repository")}/{snapshot.NotNull("snapshot")}/_restore"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_snapshot/{repository}/{snapshot}/_restore
@@ -7281,7 +7281,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">Details of what to restore</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> SnapshotRestoreAsync<T>(string repository, string snapshot, PostData<object> body, Func<RestoreRequestParameters, RestoreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> SnapshotRestoreAsync<T>(string repository, string snapshot, PostData body, Func<RestoreRequestParameters, RestoreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_snapshot/{repository.NotNull("repository")}/{snapshot.NotNull("snapshot")}/_restore"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_snapshot/_status
@@ -7579,7 +7579,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document.</param>
 		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Termvectors<T>(string index, string type, PostData<object> body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Termvectors<T>(string index, string type, PostData body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_termvectors"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_termvectors
@@ -7595,7 +7595,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document.</param>
 		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> TermvectorsAsync<T>(string index, string type, PostData<object> body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> TermvectorsAsync<T>(string index, string type, PostData body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_termvectors"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_termvectors
@@ -7612,7 +7612,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Termvectors<T>(string index, string type, string id, PostData<object> body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Termvectors<T>(string index, string type, string id, PostData body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_termvectors"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_termvectors
@@ -7629,7 +7629,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> TermvectorsAsync<T>(string index, string type, string id, PostData<object> body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> TermvectorsAsync<T>(string index, string type, string id, PostData body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_termvectors"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_update
@@ -7646,7 +7646,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The request definition using either `script` or partial `doc`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> Update<T>(string index, string type, string id, PostData<object> body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> Update<T>(string index, string type, string id, PostData body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_update"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_update
@@ -7663,7 +7663,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The request definition using either `script` or partial `doc`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> UpdateAsync<T>(string index, string type, string id, PostData<object> body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> UpdateAsync<T>(string index, string type, string id, PostData body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/{id.NotNull("id")}/_update"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_update_by_query
@@ -7678,7 +7678,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> UpdateByQuery<T>(string index, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> UpdateByQuery<T>(string index, PostData body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_update_by_query"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_update_by_query
@@ -7693,7 +7693,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, PostData body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_update_by_query"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_update_by_query
@@ -7709,7 +7709,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> UpdateByQuery<T>(string index, string type, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> UpdateByQuery<T>(string index, string type, PostData body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_update_by_query"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_update_by_query
@@ -7725,7 +7725,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, string type, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, string type, PostData body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_update_by_query"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /{index}/_xpack/graph/_explore
@@ -7798,7 +7798,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">Graph Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackGraphExplore<T>(string index, PostData<object> body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackGraphExplore<T>(string index, PostData body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/_xpack/graph/_explore"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/_xpack/graph/_explore
@@ -7813,7 +7813,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">Graph Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackGraphExploreAsync<T>(string index, PostData<object> body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackGraphExploreAsync<T>(string index, PostData body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/_xpack/graph/_explore"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_xpack/graph/_explore
@@ -7829,7 +7829,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">Graph Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackGraphExplore<T>(string index, string type, PostData<object> body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackGraphExplore<T>(string index, string type, PostData body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_xpack/graph/_explore"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /{index}/{type}/_xpack/graph/_explore
@@ -7845,7 +7845,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">Graph Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackGraphExploreAsync<T>(string index, string type, PostData<object> body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackGraphExploreAsync<T>(string index, string type, PostData body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"{index.NotNull("index")}/{type.NotNull("type")}/_xpack/graph/_explore"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/migration/deprecations
@@ -8017,7 +8017,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">licenses to be installed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackLicensePost<T>(PostData<object> body, Func<PostLicenseRequestParameters, PostLicenseRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackLicensePost<T>(PostData body, Func<PostLicenseRequestParameters, PostLicenseRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/license"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/license
@@ -8031,7 +8031,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">licenses to be installed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackLicensePostAsync<T>(PostData<object> body, Func<PostLicenseRequestParameters, PostLicenseRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackLicensePostAsync<T>(PostData body, Func<PostLicenseRequestParameters, PostLicenseRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/license"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_close
@@ -8186,7 +8186,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job to flush</param>
 		///<param name="body">Flush parameters</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlFlushJob<T>(string job_id, PostData<object> body, Func<FlushJobRequestParameters, FlushJobRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlFlushJob<T>(string job_id, PostData body, Func<FlushJobRequestParameters, FlushJobRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_flush"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_flush
@@ -8201,7 +8201,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job to flush</param>
 		///<param name="body">Flush parameters</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlFlushJobAsync<T>(string job_id, PostData<object> body, Func<FlushJobRequestParameters, FlushJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlFlushJobAsync<T>(string job_id, PostData body, Func<FlushJobRequestParameters, FlushJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_flush"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/ml/anomaly_detectors/{job_id}/results/buckets
@@ -8244,7 +8244,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">ID of the job to get bucket results from</param>
 		///<param name="body">Bucket selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlGetBuckets<T>(string job_id, PostData<object> body, Func<GetBucketsRequestParameters, GetBucketsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlGetBuckets<T>(string job_id, PostData body, Func<GetBucketsRequestParameters, GetBucketsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/buckets"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/buckets
@@ -8259,7 +8259,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">ID of the job to get bucket results from</param>
 		///<param name="body">Bucket selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlGetBucketsAsync<T>(string job_id, PostData<object> body, Func<GetBucketsRequestParameters, GetBucketsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlGetBucketsAsync<T>(string job_id, PostData body, Func<GetBucketsRequestParameters, GetBucketsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/buckets"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/ml/anomaly_detectors/{job_id}/results/categories/{category_id}
@@ -8333,7 +8333,7 @@ namespace Elasticsearch.Net
 		///<param name="category_id">The identifier of the category definition of interest</param>
 		///<param name="body">Category selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlGetCategories<T>(string job_id, long category_id, PostData<object> body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlGetCategories<T>(string job_id, long category_id, PostData body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/categories/{category_id}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/categories/{category_id}
@@ -8349,7 +8349,7 @@ namespace Elasticsearch.Net
 		///<param name="category_id">The identifier of the category definition of interest</param>
 		///<param name="body">Category selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlGetCategoriesAsync<T>(string job_id, long category_id, PostData<object> body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlGetCategoriesAsync<T>(string job_id, long category_id, PostData body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/categories/{category_id}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/categories/
@@ -8364,7 +8364,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job</param>
 		///<param name="body">Category selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlGetCategories<T>(string job_id, PostData<object> body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlGetCategories<T>(string job_id, PostData body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/categories/"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/categories/
@@ -8379,7 +8379,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job</param>
 		///<param name="body">Category selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlGetCategoriesAsync<T>(string job_id, PostData<object> body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlGetCategoriesAsync<T>(string job_id, PostData body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/categories/"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/ml/datafeeds/{datafeed_id}
@@ -8530,7 +8530,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id"></param>
 		///<param name="body">Influencer selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlGetInfluencers<T>(string job_id, PostData<object> body, Func<GetInfluencersRequestParameters, GetInfluencersRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlGetInfluencers<T>(string job_id, PostData body, Func<GetInfluencersRequestParameters, GetInfluencersRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/influencers"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/influencers
@@ -8545,7 +8545,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id"></param>
 		///<param name="body">Influencer selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlGetInfluencersAsync<T>(string job_id, PostData<object> body, Func<GetInfluencersRequestParameters, GetInfluencersRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlGetInfluencersAsync<T>(string job_id, PostData body, Func<GetInfluencersRequestParameters, GetInfluencersRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/influencers"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/ml/anomaly_detectors/{job_id}
@@ -8727,7 +8727,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to fetch</param>
 		///<param name="body">Model snapshot selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlGetModelSnapshots<T>(string job_id, string snapshot_id, PostData<object> body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlGetModelSnapshots<T>(string job_id, string snapshot_id, PostData body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/model_snapshots/{snapshot_id.NotNull("snapshot_id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}
@@ -8743,7 +8743,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to fetch</param>
 		///<param name="body">Model snapshot selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsAsync<T>(string job_id, string snapshot_id, PostData<object> body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsAsync<T>(string job_id, string snapshot_id, PostData body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/model_snapshots/{snapshot_id.NotNull("snapshot_id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots
@@ -8758,7 +8758,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to fetch</param>
 		///<param name="body">Model snapshot selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlGetModelSnapshots<T>(string job_id, PostData<object> body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlGetModelSnapshots<T>(string job_id, PostData body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/model_snapshots"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots
@@ -8773,7 +8773,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to fetch</param>
 		///<param name="body">Model snapshot selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsAsync<T>(string job_id, PostData<object> body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsAsync<T>(string job_id, PostData body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/model_snapshots"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/ml/anomaly_detectors/{job_id}/results/records
@@ -8816,7 +8816,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id"></param>
 		///<param name="body">Record selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlGetRecords<T>(string job_id, PostData<object> body, Func<GetAnomalyRecordsRequestParameters, GetAnomalyRecordsRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlGetRecords<T>(string job_id, PostData body, Func<GetAnomalyRecordsRequestParameters, GetAnomalyRecordsRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/records"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/records
@@ -8831,7 +8831,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id"></param>
 		///<param name="body">Record selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlGetRecordsAsync<T>(string job_id, PostData<object> body, Func<GetAnomalyRecordsRequestParameters, GetAnomalyRecordsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlGetRecordsAsync<T>(string job_id, PostData body, Func<GetAnomalyRecordsRequestParameters, GetAnomalyRecordsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/results/records"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_open
@@ -8874,7 +8874,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job receiving the data</param>
 		///<param name="body">The data to process</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlPostData<T>(string job_id, PostData<object> body, Func<PostJobDataRequestParameters, PostJobDataRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlPostData<T>(string job_id, PostData body, Func<PostJobDataRequestParameters, PostJobDataRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_data"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_data
@@ -8889,7 +8889,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job receiving the data</param>
 		///<param name="body">The data to process</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlPostDataAsync<T>(string job_id, PostData<object> body, Func<PostJobDataRequestParameters, PostJobDataRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlPostDataAsync<T>(string job_id, PostData body, Func<PostJobDataRequestParameters, PostJobDataRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_data"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/ml/datafeeds/{datafeed_id}/_preview
@@ -8932,7 +8932,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to create</param>
 		///<param name="body">The datafeed config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlPutDatafeed<T>(string datafeed_id, PostData<object> body, Func<PutDatafeedRequestParameters, PutDatafeedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlPutDatafeed<T>(string datafeed_id, PostData body, Func<PutDatafeedRequestParameters, PutDatafeedRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/ml/datafeeds/{datafeed_id.NotNull("datafeed_id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/ml/datafeeds/{datafeed_id}
@@ -8947,7 +8947,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to create</param>
 		///<param name="body">The datafeed config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlPutDatafeedAsync<T>(string datafeed_id, PostData<object> body, Func<PutDatafeedRequestParameters, PutDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlPutDatafeedAsync<T>(string datafeed_id, PostData body, Func<PutDatafeedRequestParameters, PutDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/ml/datafeeds/{datafeed_id.NotNull("datafeed_id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/ml/anomaly_detectors/{job_id}
@@ -8962,7 +8962,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlPutJob<T>(string job_id, PostData<object> body, Func<PutJobRequestParameters, PutJobRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlPutJob<T>(string job_id, PostData body, Func<PutJobRequestParameters, PutJobRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/ml/anomaly_detectors/{job_id}
@@ -8977,7 +8977,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlPutJobAsync<T>(string job_id, PostData<object> body, Func<PutJobRequestParameters, PutJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlPutJobAsync<T>(string job_id, PostData body, Func<PutJobRequestParameters, PutJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_revert
@@ -8993,7 +8993,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to revert to</param>
 		///<param name="body">Reversion options</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlRevertModelSnapshot<T>(string job_id, string snapshot_id, PostData<object> body, Func<RevertModelSnapshotRequestParameters, RevertModelSnapshotRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlRevertModelSnapshot<T>(string job_id, string snapshot_id, PostData body, Func<RevertModelSnapshotRequestParameters, RevertModelSnapshotRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/model_snapshots/{snapshot_id.NotNull("snapshot_id")}/_revert"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_revert
@@ -9009,7 +9009,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to revert to</param>
 		///<param name="body">Reversion options</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlRevertModelSnapshotAsync<T>(string job_id, string snapshot_id, PostData<object> body, Func<RevertModelSnapshotRequestParameters, RevertModelSnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlRevertModelSnapshotAsync<T>(string job_id, string snapshot_id, PostData body, Func<RevertModelSnapshotRequestParameters, RevertModelSnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/model_snapshots/{snapshot_id.NotNull("snapshot_id")}/_revert"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/datafeeds/{datafeed_id}/_start
@@ -9024,7 +9024,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to start</param>
 		///<param name="body">The start datafeed parameters</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlStartDatafeed<T>(string datafeed_id, PostData<object> body, Func<StartDatafeedRequestParameters, StartDatafeedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlStartDatafeed<T>(string datafeed_id, PostData body, Func<StartDatafeedRequestParameters, StartDatafeedRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/datafeeds/{datafeed_id.NotNull("datafeed_id")}/_start"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/datafeeds/{datafeed_id}/_start
@@ -9039,7 +9039,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to start</param>
 		///<param name="body">The start datafeed parameters</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlStartDatafeedAsync<T>(string datafeed_id, PostData<object> body, Func<StartDatafeedRequestParameters, StartDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlStartDatafeedAsync<T>(string datafeed_id, PostData body, Func<StartDatafeedRequestParameters, StartDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/datafeeds/{datafeed_id.NotNull("datafeed_id")}/_start"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/datafeeds/{datafeed_id}/_stop
@@ -9082,7 +9082,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to update</param>
 		///<param name="body">The datafeed update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlUpdateDatafeed<T>(string datafeed_id, PostData<object> body, Func<UpdateDatafeedRequestParameters, UpdateDatafeedRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlUpdateDatafeed<T>(string datafeed_id, PostData body, Func<UpdateDatafeedRequestParameters, UpdateDatafeedRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/datafeeds/{datafeed_id.NotNull("datafeed_id")}/_update"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/datafeeds/{datafeed_id}/_update
@@ -9097,7 +9097,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to update</param>
 		///<param name="body">The datafeed update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlUpdateDatafeedAsync<T>(string datafeed_id, PostData<object> body, Func<UpdateDatafeedRequestParameters, UpdateDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlUpdateDatafeedAsync<T>(string datafeed_id, PostData body, Func<UpdateDatafeedRequestParameters, UpdateDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/datafeeds/{datafeed_id.NotNull("datafeed_id")}/_update"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_update
@@ -9112,7 +9112,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlUpdateJob<T>(string job_id, PostData<object> body, Func<UpdateJobRequestParameters, UpdateJobRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlUpdateJob<T>(string job_id, PostData body, Func<UpdateJobRequestParameters, UpdateJobRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_update"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_update
@@ -9127,7 +9127,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlUpdateJobAsync<T>(string job_id, PostData<object> body, Func<UpdateJobRequestParameters, UpdateJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlUpdateJobAsync<T>(string job_id, PostData body, Func<UpdateJobRequestParameters, UpdateJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_update"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_update
@@ -9143,7 +9143,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to update</param>
 		///<param name="body">The model snapshot properties to update</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlUpdateModelSnapshot<T>(string job_id, string snapshot_id, PostData<object> body, Func<UpdateModelSnapshotRequestParameters, UpdateModelSnapshotRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlUpdateModelSnapshot<T>(string job_id, string snapshot_id, PostData body, Func<UpdateModelSnapshotRequestParameters, UpdateModelSnapshotRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/model_snapshots/{snapshot_id.NotNull("snapshot_id")}/_update"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_update
@@ -9159,7 +9159,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to update</param>
 		///<param name="body">The model snapshot properties to update</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlUpdateModelSnapshotAsync<T>(string job_id, string snapshot_id, PostData<object> body, Func<UpdateModelSnapshotRequestParameters, UpdateModelSnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlUpdateModelSnapshotAsync<T>(string job_id, string snapshot_id, PostData body, Func<UpdateModelSnapshotRequestParameters, UpdateModelSnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/model_snapshots/{snapshot_id.NotNull("snapshot_id")}/_update"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/_validate
@@ -9173,7 +9173,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The job config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlValidate<T>(PostData<object> body, Func<ValidateJobRequestParameters, ValidateJobRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlValidate<T>(PostData body, Func<ValidateJobRequestParameters, ValidateJobRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/_validate"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/_validate
@@ -9187,7 +9187,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The job config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlValidateAsync<T>(PostData<object> body, Func<ValidateJobRequestParameters, ValidateJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlValidateAsync<T>(PostData body, Func<ValidateJobRequestParameters, ValidateJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/_validate"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/_validate/detector
@@ -9201,7 +9201,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The detector</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackMlValidateDetector<T>(PostData<object> body, Func<ValidateDetectorRequestParameters, ValidateDetectorRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackMlValidateDetector<T>(PostData body, Func<ValidateDetectorRequestParameters, ValidateDetectorRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/ml/anomaly_detectors/_validate/detector"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/_validate/detector
@@ -9215,7 +9215,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The detector</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackMlValidateDetectorAsync<T>(PostData<object> body, Func<ValidateDetectorRequestParameters, ValidateDetectorRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackMlValidateDetectorAsync<T>(PostData body, Func<ValidateDetectorRequestParameters, ValidateDetectorRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/ml/anomaly_detectors/_validate/detector"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/security/_authenticate
@@ -9256,7 +9256,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the user to change the password for</param>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityChangePassword<T>(string username, PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityChangePassword<T>(string username, PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/security/user/{username.NotNull("username")}/_password"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/user/{username}/_password
@@ -9271,7 +9271,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the user to change the password for</param>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordAsync<T>(string username, PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordAsync<T>(string username, PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/security/user/{username.NotNull("username")}/_password"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/user/_password
@@ -9285,7 +9285,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityChangePassword<T>(PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityChangePassword<T>(PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/security/user/_password"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/user/_password
@@ -9299,7 +9299,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordAsync<T>(PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordAsync<T>(PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/security/user/_password"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/user/{username}/_password
@@ -9314,7 +9314,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the user to change the password for</param>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityChangePasswordPost<T>(string username, PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityChangePasswordPost<T>(string username, PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/security/user/{username.NotNull("username")}/_password"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/user/{username}/_password
@@ -9329,7 +9329,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the user to change the password for</param>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordPostAsync<T>(string username, PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordPostAsync<T>(string username, PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/security/user/{username.NotNull("username")}/_password"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/user/_password
@@ -9343,7 +9343,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityChangePasswordPost<T>(PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityChangePasswordPost<T>(PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/security/user/_password"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/user/_password
@@ -9357,7 +9357,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordPostAsync<T>(PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordPostAsync<T>(PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/security/user/_password"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/realm/{realms}/_clear_cache
@@ -9731,7 +9731,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The token request to get</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityGetToken<T>(PostData<object> body, Func<GetUserAccessTokenRequestParameters, GetUserAccessTokenRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityGetToken<T>(PostData body, Func<GetUserAccessTokenRequestParameters, GetUserAccessTokenRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/security/oauth2/token"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/oauth2/token
@@ -9745,7 +9745,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The token request to get</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityGetTokenAsync<T>(PostData<object> body, Func<GetUserAccessTokenRequestParameters, GetUserAccessTokenRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityGetTokenAsync<T>(PostData body, Func<GetUserAccessTokenRequestParameters, GetUserAccessTokenRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/security/oauth2/token"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/security/user/{username}
@@ -9813,7 +9813,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The token to invalidate</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityInvalidateToken<T>(PostData<object> body, Func<InvalidateUserAccessTokenRequestParameters, InvalidateUserAccessTokenRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityInvalidateToken<T>(PostData body, Func<InvalidateUserAccessTokenRequestParameters, InvalidateUserAccessTokenRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(DELETE, Url($"_xpack/security/oauth2/token"), body, _params(requestParameters));
 		
 		///<summary>Represents a DELETE on /_xpack/security/oauth2/token
@@ -9827,7 +9827,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">The token to invalidate</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityInvalidateTokenAsync<T>(PostData<object> body, Func<InvalidateUserAccessTokenRequestParameters, InvalidateUserAccessTokenRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityInvalidateTokenAsync<T>(PostData body, Func<InvalidateUserAccessTokenRequestParameters, InvalidateUserAccessTokenRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(DELETE, Url($"_xpack/security/oauth2/token"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/role/{name}
@@ -9842,7 +9842,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityPutRole<T>(string name, PostData<object> body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityPutRole<T>(string name, PostData body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/security/role/{name.NotNull("name")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/role/{name}
@@ -9857,7 +9857,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityPutRoleAsync<T>(string name, PostData<object> body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityPutRoleAsync<T>(string name, PostData body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/security/role/{name.NotNull("name")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/role/{name}
@@ -9872,7 +9872,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityPutRolePost<T>(string name, PostData<object> body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityPutRolePost<T>(string name, PostData body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/security/role/{name.NotNull("name")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/role/{name}
@@ -9887,7 +9887,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityPutRolePostAsync<T>(string name, PostData<object> body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityPutRolePostAsync<T>(string name, PostData body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/security/role/{name.NotNull("name")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/role_mapping/{name}
@@ -9902,7 +9902,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role-mapping name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityPutRoleMapping<T>(string name, PostData<object> body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityPutRoleMapping<T>(string name, PostData body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/security/role_mapping/{name.NotNull("name")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/role_mapping/{name}
@@ -9917,7 +9917,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role-mapping name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingAsync<T>(string name, PostData<object> body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingAsync<T>(string name, PostData body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/security/role_mapping/{name.NotNull("name")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/role_mapping/{name}
@@ -9932,7 +9932,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role-mapping name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityPutRoleMappingPost<T>(string name, PostData<object> body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityPutRoleMappingPost<T>(string name, PostData body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/security/role_mapping/{name.NotNull("name")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/role_mapping/{name}
@@ -9947,7 +9947,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role-mapping name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingPostAsync<T>(string name, PostData<object> body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingPostAsync<T>(string name, PostData body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/security/role_mapping/{name.NotNull("name")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/user/{username}
@@ -9962,7 +9962,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the User</param>
 		///<param name="body">The user to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityPutUser<T>(string username, PostData<object> body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityPutUser<T>(string username, PostData body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/security/user/{username.NotNull("username")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/security/user/{username}
@@ -9977,7 +9977,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the User</param>
 		///<param name="body">The user to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityPutUserAsync<T>(string username, PostData<object> body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityPutUserAsync<T>(string username, PostData body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/security/user/{username.NotNull("username")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/user/{username}
@@ -9992,7 +9992,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the User</param>
 		///<param name="body">The user to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackSecurityPutUserPost<T>(string username, PostData<object> body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackSecurityPutUserPost<T>(string username, PostData body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/security/user/{username.NotNull("username")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/security/user/{username}
@@ -10007,7 +10007,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the User</param>
 		///<param name="body">The user to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackSecurityPutUserPostAsync<T>(string username, PostData<object> body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackSecurityPutUserPostAsync<T>(string username, PostData body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/security/user/{username.NotNull("username")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/{watch_id}/_ack
@@ -10278,7 +10278,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackWatcherExecuteWatch<T>(string id, PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackWatcherExecuteWatch<T>(string id, PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/watcher/watch/{id.NotNull("id")}/_execute"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/{id}/_execute
@@ -10293,7 +10293,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchAsync<T>(string id, PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchAsync<T>(string id, PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/watcher/watch/{id.NotNull("id")}/_execute"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/_execute
@@ -10307,7 +10307,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackWatcherExecuteWatch<T>(PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackWatcherExecuteWatch<T>(PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/watcher/watch/_execute"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/_execute
@@ -10321,7 +10321,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchAsync<T>(PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchAsync<T>(PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/watcher/watch/_execute"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/{id}/_execute
@@ -10336,7 +10336,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackWatcherExecuteWatchPost<T>(string id, PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackWatcherExecuteWatchPost<T>(string id, PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/watcher/watch/{id.NotNull("id")}/_execute"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/{id}/_execute
@@ -10351,7 +10351,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchPostAsync<T>(string id, PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchPostAsync<T>(string id, PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/watcher/watch/{id.NotNull("id")}/_execute"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/_execute
@@ -10365,7 +10365,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackWatcherExecuteWatchPost<T>(PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackWatcherExecuteWatchPost<T>(PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/watcher/watch/_execute"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/_execute
@@ -10379,7 +10379,7 @@ namespace Elasticsearch.Net
 	    ///</summary>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchPostAsync<T>(PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchPostAsync<T>(PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/watcher/watch/_execute"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a GET on /_xpack/watcher/watch/{id}
@@ -10422,7 +10422,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">The watch</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackWatcherPutWatch<T>(string id, PostData<object> body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackWatcherPutWatch<T>(string id, PostData body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(PUT, Url($"_xpack/watcher/watch/{id.NotNull("id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/{id}
@@ -10437,7 +10437,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">The watch</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackWatcherPutWatchAsync<T>(string id, PostData<object> body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackWatcherPutWatchAsync<T>(string id, PostData body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(PUT, Url($"_xpack/watcher/watch/{id.NotNull("id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/{id}
@@ -10452,7 +10452,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">The watch</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public ElasticsearchResponse<T> XpackWatcherPutWatchPost<T>(string id, PostData<object> body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null)
+		public ElasticsearchResponse<T> XpackWatcherPutWatchPost<T>(string id, PostData body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null)
 			where T : class => this.DoRequest<T>(POST, Url($"_xpack/watcher/watch/{id.NotNull("id")}"), body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/{id}
@@ -10467,7 +10467,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">The watch</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<ElasticsearchResponse<T>> XpackWatcherPutWatchPostAsync<T>(string id, PostData<object> body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
+		public Task<ElasticsearchResponse<T>> XpackWatcherPutWatchPostAsync<T>(string id, PostData body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class => this.DoRequestAsync<T>(POST, Url($"_xpack/watcher/watch/{id.NotNull("id")}"), cancellationToken, body, _params(requestParameters));
 		
 		///<summary>Represents a POST on /_xpack/watcher/_restart

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.cs
@@ -56,11 +56,11 @@ namespace Elasticsearch.Net
 			return requestParams;
 		}
 
-		public ElasticsearchResponse<T> DoRequest<T>(HttpMethod method, string path, PostData<object> data = null, IRequestParameters requestParameters = null)
+		public ElasticsearchResponse<T> DoRequest<T>(HttpMethod method, string path, PostData data = null, IRequestParameters requestParameters = null)
 			where T : class =>
 			this.Transport.Request<T>(method, path, data, requestParameters);
 
-		public Task<ElasticsearchResponse<T>> DoRequestAsync<T>(HttpMethod method, string path, CancellationToken cancellationToken, PostData<object> data = null, IRequestParameters requestParameters = null)
+		public Task<ElasticsearchResponse<T>> DoRequestAsync<T>(HttpMethod method, string path, CancellationToken cancellationToken, PostData data = null, IRequestParameters requestParameters = null)
 			where T : class =>
 			this.Transport.RequestAsync<T>(method, path, cancellationToken, data, requestParameters);
 	}

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
@@ -38,7 +38,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Bulk<T>(PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Bulk<T>(PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_bulk
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -51,7 +51,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> BulkAsync<T>(PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> BulkAsync<T>(PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_bulk
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -65,7 +65,7 @@ namespace Elasticsearch.Net
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Bulk<T>(string index, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Bulk<T>(string index, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_bulk
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -79,7 +79,7 @@ namespace Elasticsearch.Net
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> BulkAsync<T>(string index, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> BulkAsync<T>(string index, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_bulk
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -94,7 +94,7 @@ namespace Elasticsearch.Net
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Bulk<T>(string index, string type, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Bulk<T>(string index, string type, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_bulk
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -109,7 +109,7 @@ namespace Elasticsearch.Net
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> BulkAsync<T>(string index, string type, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> BulkAsync<T>(string index, string type, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_bulk
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -122,7 +122,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> BulkPut<T>(PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> BulkPut<T>(PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_bulk
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -135,7 +135,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> BulkPutAsync<T>(PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> BulkPutAsync<T>(PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/_bulk
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -149,7 +149,7 @@ namespace Elasticsearch.Net
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> BulkPut<T>(string index, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> BulkPut<T>(string index, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/_bulk
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -163,7 +163,7 @@ namespace Elasticsearch.Net
 		///<param name="index">Default index for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> BulkPutAsync<T>(string index, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> BulkPutAsync<T>(string index, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}/_bulk
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -178,7 +178,7 @@ namespace Elasticsearch.Net
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> BulkPut<T>(string index, string type, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> BulkPut<T>(string index, string type, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}/_bulk
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -193,7 +193,7 @@ namespace Elasticsearch.Net
 		///<param name="type">Default document type for items which don&#39;t provide one</param>
 		///<param name="body">The operation definition and data (action-data pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> BulkPutAsync<T>(string index, string type, PostData<object> body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> BulkPutAsync<T>(string index, string type, PostData body, Func<BulkRequestParameters, BulkRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_cat/aliases
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -972,7 +972,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> ClearScroll<T>(PostData<object> body, Func<ClearScrollRequestParameters, ClearScrollRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> ClearScroll<T>(PostData body, Func<ClearScrollRequestParameters, ClearScrollRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a DELETE on /_search/scroll
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -985,7 +985,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> ClearScrollAsync<T>(PostData<object> body, Func<ClearScrollRequestParameters, ClearScrollRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> ClearScrollAsync<T>(PostData body, Func<ClearScrollRequestParameters, ClearScrollRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_cluster/allocation/explain
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1022,7 +1022,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The index, shard, and primary flag to explain. Empty means &#39;explain the first unassigned shard&#39;</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> ClusterAllocationExplain<T>(PostData<object> body, Func<ClusterAllocationExplainRequestParameters, ClusterAllocationExplainRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> ClusterAllocationExplain<T>(PostData body, Func<ClusterAllocationExplainRequestParameters, ClusterAllocationExplainRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_cluster/allocation/explain
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1035,7 +1035,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The index, shard, and primary flag to explain. Empty means &#39;explain the first unassigned shard&#39;</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> ClusterAllocationExplainAsync<T>(PostData<object> body, Func<ClusterAllocationExplainRequestParameters, ClusterAllocationExplainRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> ClusterAllocationExplainAsync<T>(PostData body, Func<ClusterAllocationExplainRequestParameters, ClusterAllocationExplainRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_cluster/settings
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1146,7 +1146,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> ClusterPutSettings<T>(PostData<object> body, Func<ClusterPutSettingsRequestParameters, ClusterPutSettingsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> ClusterPutSettings<T>(PostData body, Func<ClusterPutSettingsRequestParameters, ClusterPutSettingsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_cluster/settings
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1159,7 +1159,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> ClusterPutSettingsAsync<T>(PostData<object> body, Func<ClusterPutSettingsRequestParameters, ClusterPutSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> ClusterPutSettingsAsync<T>(PostData body, Func<ClusterPutSettingsRequestParameters, ClusterPutSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_remote/info
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1196,7 +1196,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> ClusterReroute<T>(PostData<object> body, Func<ClusterRerouteRequestParameters, ClusterRerouteRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> ClusterReroute<T>(PostData body, Func<ClusterRerouteRequestParameters, ClusterRerouteRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_cluster/reroute
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1209,7 +1209,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The definition of `commands` to perform (`move`, `cancel`, `allocate`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> ClusterRerouteAsync<T>(PostData<object> body, Func<ClusterRerouteRequestParameters, ClusterRerouteRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> ClusterRerouteAsync<T>(PostData body, Func<ClusterRerouteRequestParameters, ClusterRerouteRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_cluster/state
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1350,7 +1350,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Count<T>(PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Count<T>(PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_count
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1363,7 +1363,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> CountAsync<T>(PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> CountAsync<T>(PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_count
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1377,7 +1377,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Count<T>(string index, PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Count<T>(string index, PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_count
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1391,7 +1391,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of indices to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> CountAsync<T>(string index, PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> CountAsync<T>(string index, PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_count
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1406,7 +1406,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of types to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Count<T>(string index, string type, PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Count<T>(string index, string type, PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_count
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1421,7 +1421,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of types to restrict the results</param>
 		///<param name="body">A query to restrict the results specified with the Query DSL (optional)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> CountAsync<T>(string index, string type, PostData<object> body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> CountAsync<T>(string index, string type, PostData body, Func<CountRequestParameters, CountRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_count
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1515,7 +1515,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Create<T>(string index, string type, string id, PostData<object> body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Create<T>(string index, string type, string id, PostData body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}/{id}/_create
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1531,7 +1531,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> CreateAsync<T>(string index, string type, string id, PostData<object> body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> CreateAsync<T>(string index, string type, string id, PostData body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_create
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1547,7 +1547,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> CreatePost<T>(string index, string type, string id, PostData<object> body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> CreatePost<T>(string index, string type, string id, PostData body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_create
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1563,7 +1563,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> CreatePostAsync<T>(string index, string type, string id, PostData<object> body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> CreatePostAsync<T>(string index, string type, string id, PostData body, Func<CreateRequestParameters, CreateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a DELETE on /{index}/{type}/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1607,7 +1607,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> DeleteByQuery<T>(string index, PostData<object> body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> DeleteByQuery<T>(string index, PostData body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_delete_by_query
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1621,7 +1621,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> DeleteByQueryAsync<T>(string index, PostData<object> body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> DeleteByQueryAsync<T>(string index, PostData body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_delete_by_query
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1636,7 +1636,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> DeleteByQuery<T>(string index, string type, PostData<object> body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> DeleteByQuery<T>(string index, string type, PostData body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_delete_by_query
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1651,7 +1651,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> DeleteByQueryAsync<T>(string index, string type, PostData<object> body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> DeleteByQueryAsync<T>(string index, string type, PostData body, Func<DeleteByQueryRequestParameters, DeleteByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a DELETE on /_scripts/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1783,7 +1783,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The document ID</param>
 		///<param name="body">The query definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Explain<T>(string index, string type, string id, PostData<object> body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Explain<T>(string index, string type, string id, PostData body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_explain
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1799,7 +1799,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The document ID</param>
 		///<param name="body">The query definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> ExplainAsync<T>(string index, string type, string id, PostData<object> body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> ExplainAsync<T>(string index, string type, string id, PostData body, Func<ExplainRequestParameters, ExplainRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_field_caps
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1862,7 +1862,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Field json objects containing an array of field names</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> FieldCaps<T>(PostData<object> body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> FieldCaps<T>(PostData body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_field_caps
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1875,7 +1875,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Field json objects containing an array of field names</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> FieldCapsAsync<T>(PostData<object> body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> FieldCapsAsync<T>(PostData body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_field_caps
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -1889,7 +1889,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">Field json objects containing an array of field names</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> FieldCaps<T>(string index, PostData<object> body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> FieldCaps<T>(string index, PostData body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_field_caps
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -1903,7 +1903,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">Field json objects containing an array of field names</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> FieldCapsAsync<T>(string index, PostData<object> body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> FieldCapsAsync<T>(string index, PostData body, Func<FieldCapabilitiesRequestParameters, FieldCapabilitiesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /{index}/{type}/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -2004,7 +2004,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Index<T>(string index, string type, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Index<T>(string index, string type, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -2019,7 +2019,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndexAsync<T>(string index, string type, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndexAsync<T>(string index, string type, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -2035,7 +2035,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Index<T>(string index, string type, string id, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Index<T>(string index, string type, string id, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -2051,7 +2051,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndexAsync<T>(string index, string type, string id, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndexAsync<T>(string index, string type, string id, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -2066,7 +2066,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndexPut<T>(string index, string type, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndexPut<T>(string index, string type, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -2081,7 +2081,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndexPutAsync<T>(string index, string type, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndexPutAsync<T>(string index, string type, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -2097,7 +2097,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndexPut<T>(string index, string type, string id, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndexPut<T>(string index, string type, string id, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}/{id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -2113,7 +2113,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndexPutAsync<T>(string index, string type, string id, PostData<object> body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndexPutAsync<T>(string index, string type, string id, PostData body, Func<IndexRequestParameters, IndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_analyze
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -2176,7 +2176,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Define analyzer/tokenizer parameters and the text on which the analysis should be performed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesAnalyzeForAll<T>(PostData<object> body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesAnalyzeForAll<T>(PostData body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_analyze
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -2189,7 +2189,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Define analyzer/tokenizer parameters and the text on which the analysis should be performed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesAnalyzeForAllAsync<T>(PostData<object> body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesAnalyzeForAllAsync<T>(PostData body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_analyze
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -2203,7 +2203,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">Define analyzer/tokenizer parameters and the text on which the analysis should be performed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesAnalyze<T>(string index, PostData<object> body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesAnalyze<T>(string index, PostData body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_analyze
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -2217,7 +2217,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index to scope the operation</param>
 		///<param name="body">Define analyzer/tokenizer parameters and the text on which the analysis should be performed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesAnalyzeAsync<T>(string index, PostData<object> body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesAnalyzeAsync<T>(string index, PostData body, Func<AnalyzeRequestParameters, AnalyzeRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_cache/clear
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -2357,7 +2357,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesCreate<T>(string index, PostData<object> body, Func<CreateIndexRequestParameters, CreateIndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesCreate<T>(string index, PostData body, Func<CreateIndexRequestParameters, CreateIndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -2371,7 +2371,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index</param>
 		///<param name="body">The configuration for the index (`settings` and `mappings`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesCreateAsync<T>(string index, PostData<object> body, Func<CreateIndexRequestParameters, CreateIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesCreateAsync<T>(string index, PostData body, Func<CreateIndexRequestParameters, CreateIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a DELETE on /{index}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3426,7 +3426,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the alias to be created or updated</param>
 		///<param name="body">The settings for the alias, such as `routing` or `filter`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutAlias<T>(string index, string name, PostData<object> body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutAlias<T>(string index, string name, PostData body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/_alias/{name}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3441,7 +3441,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the alias to be created or updated</param>
 		///<param name="body">The settings for the alias, such as `routing` or `filter`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutAliasAsync<T>(string index, string name, PostData<object> body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutAliasAsync<T>(string index, string name, PostData body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_alias/{name}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3456,7 +3456,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the alias to be created or updated</param>
 		///<param name="body">The settings for the alias, such as `routing` or `filter`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutAliasPost<T>(string index, string name, PostData<object> body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutAliasPost<T>(string index, string name, PostData body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_alias/{name}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3471,7 +3471,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the alias to be created or updated</param>
 		///<param name="body">The settings for the alias, such as `routing` or `filter`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutAliasPostAsync<T>(string index, string name, PostData<object> body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutAliasPostAsync<T>(string index, string name, PostData body, Func<PutAliasRequestParameters, PutAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}/_mapping
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3486,7 +3486,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutMapping<T>(string index, string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutMapping<T>(string index, string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/{type}/_mapping
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3501,7 +3501,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutMappingAsync<T>(string index, string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutMappingAsync<T>(string index, string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_mapping/{type}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3515,7 +3515,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutMappingForAll<T>(string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutMappingForAll<T>(string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_mapping/{type}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3529,7 +3529,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutMappingForAllAsync<T>(string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutMappingForAllAsync<T>(string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_mapping
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3544,7 +3544,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutMappingPost<T>(string index, string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutMappingPost<T>(string index, string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_mapping
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3559,7 +3559,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutMappingPostAsync<T>(string index, string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutMappingPostAsync<T>(string index, string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_mapping/{type}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3573,7 +3573,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutMappingPostForAll<T>(string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutMappingPostForAll<T>(string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_mapping/{type}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3587,7 +3587,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The name of the document type</param>
 		///<param name="body">The mapping definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutMappingPostForAllAsync<T>(string type, PostData<object> body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutMappingPostForAllAsync<T>(string type, PostData body, Func<PutMappingRequestParameters, PutMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_settings
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3600,7 +3600,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutSettingsForAll<T>(PostData<object> body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutSettingsForAll<T>(PostData body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_settings
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3613,7 +3613,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutSettingsForAllAsync<T>(PostData<object> body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutSettingsForAllAsync<T>(PostData body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/_settings
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3627,7 +3627,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutSettings<T>(string index, PostData<object> body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutSettings<T>(string index, PostData body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/_settings
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3641,7 +3641,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The index settings to be updated</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutSettingsAsync<T>(string index, PostData<object> body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutSettingsAsync<T>(string index, PostData body, Func<UpdateIndexSettingsRequestParameters, UpdateIndexSettingsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_template/{name}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3655,7 +3655,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutTemplateForAll<T>(string name, PostData<object> body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutTemplateForAll<T>(string name, PostData body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_template/{name}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3669,7 +3669,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutTemplateForAllAsync<T>(string name, PostData<object> body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutTemplateForAllAsync<T>(string name, PostData body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_template/{name}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3683,7 +3683,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesPutTemplatePostForAll<T>(string name, PostData<object> body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesPutTemplatePostForAll<T>(string name, PostData body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_template/{name}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3697,7 +3697,7 @@ namespace Elasticsearch.Net
 		///<param name="name">The name of the template</param>
 		///<param name="body">The template definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesPutTemplatePostForAllAsync<T>(string name, PostData<object> body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesPutTemplatePostForAllAsync<T>(string name, PostData body, Func<PutIndexTemplateRequestParameters, PutIndexTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_recovery
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3861,7 +3861,7 @@ namespace Elasticsearch.Net
 		///<param name="alias">The name of the alias to rollover</param>
 		///<param name="body">The conditions that needs to be met for executing rollover</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesRolloverForAll<T>(string alias, PostData<object> body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesRolloverForAll<T>(string alias, PostData body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{alias}/_rollover
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3875,7 +3875,7 @@ namespace Elasticsearch.Net
 		///<param name="alias">The name of the alias to rollover</param>
 		///<param name="body">The conditions that needs to be met for executing rollover</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesRolloverForAllAsync<T>(string alias, PostData<object> body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesRolloverForAllAsync<T>(string alias, PostData body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{alias}/_rollover/{new_index}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -3890,7 +3890,7 @@ namespace Elasticsearch.Net
 		///<param name="new_index">The name of the rollover index</param>
 		///<param name="body">The conditions that needs to be met for executing rollover</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesRolloverForAll<T>(string alias, string new_index, PostData<object> body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesRolloverForAll<T>(string alias, string new_index, PostData body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{alias}/_rollover/{new_index}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -3905,7 +3905,7 @@ namespace Elasticsearch.Net
 		///<param name="new_index">The name of the rollover index</param>
 		///<param name="body">The conditions that needs to be met for executing rollover</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesRolloverForAllAsync<T>(string alias, string new_index, PostData<object> body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesRolloverForAllAsync<T>(string alias, string new_index, PostData body, Func<RolloverIndexRequestParameters, RolloverIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_segments
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4020,7 +4020,7 @@ namespace Elasticsearch.Net
 		///<param name="target">The name of the target index to shrink into</param>
 		///<param name="body">The configuration for the target index (`settings` and `aliases`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesShrink<T>(string index, string target, PostData<object> body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesShrink<T>(string index, string target, PostData body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /{index}/_shrink/{target}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4035,7 +4035,7 @@ namespace Elasticsearch.Net
 		///<param name="target">The name of the target index to shrink into</param>
 		///<param name="body">The configuration for the target index (`settings` and `aliases`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesShrinkAsync<T>(string index, string target, PostData<object> body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesShrinkAsync<T>(string index, string target, PostData body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_shrink/{target}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4050,7 +4050,7 @@ namespace Elasticsearch.Net
 		///<param name="target">The name of the target index to shrink into</param>
 		///<param name="body">The configuration for the target index (`settings` and `aliases`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesShrinkPost<T>(string index, string target, PostData<object> body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesShrinkPost<T>(string index, string target, PostData body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_shrink/{target}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4065,7 +4065,7 @@ namespace Elasticsearch.Net
 		///<param name="target">The name of the target index to shrink into</param>
 		///<param name="body">The configuration for the target index (`settings` and `aliases`)</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesShrinkPostAsync<T>(string index, string target, PostData<object> body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesShrinkPostAsync<T>(string index, string target, PostData body, Func<ShrinkIndexRequestParameters, ShrinkIndexRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_stats
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4182,7 +4182,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesUpdateAliasesForAll<T>(PostData<object> body, Func<BulkAliasRequestParameters, BulkAliasRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesUpdateAliasesForAll<T>(PostData body, Func<BulkAliasRequestParameters, BulkAliasRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_aliases
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4195,7 +4195,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The definition of `actions` to perform</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesUpdateAliasesForAllAsync<T>(PostData<object> body, Func<BulkAliasRequestParameters, BulkAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesUpdateAliasesForAllAsync<T>(PostData body, Func<BulkAliasRequestParameters, BulkAliasRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_upgrade
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4336,7 +4336,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesValidateQueryForAll<T>(PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesValidateQueryForAll<T>(PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_validate/query
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4349,7 +4349,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesValidateQueryForAllAsync<T>(PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesValidateQueryForAllAsync<T>(PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_validate/query
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4363,7 +4363,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to restrict the operation; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesValidateQuery<T>(string index, PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesValidateQuery<T>(string index, PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_validate/query
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4377,7 +4377,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to restrict the operation; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesValidateQueryAsync<T>(string index, PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesValidateQueryAsync<T>(string index, PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_validate/query
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4392,7 +4392,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IndicesValidateQuery<T>(string index, string type, PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IndicesValidateQuery<T>(string index, string type, PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_validate/query
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4407,7 +4407,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types</param>
 		///<param name="body">The query definition specified with the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IndicesValidateQueryAsync<T>(string index, string type, PostData<object> body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IndicesValidateQueryAsync<T>(string index, string type, PostData body, Func<ValidateQueryRequestParameters, ValidateQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4545,7 +4545,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Pipeline ID</param>
 		///<param name="body">The ingest definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IngestPutPipeline<T>(string id, PostData<object> body, Func<PutPipelineRequestParameters, PutPipelineRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IngestPutPipeline<T>(string id, PostData body, Func<PutPipelineRequestParameters, PutPipelineRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_ingest/pipeline/{id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4559,7 +4559,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Pipeline ID</param>
 		///<param name="body">The ingest definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IngestPutPipelineAsync<T>(string id, PostData<object> body, Func<PutPipelineRequestParameters, PutPipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IngestPutPipelineAsync<T>(string id, PostData body, Func<PutPipelineRequestParameters, PutPipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_ingest/pipeline/_simulate
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4622,7 +4622,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The simulate definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IngestSimulate<T>(PostData<object> body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IngestSimulate<T>(PostData body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_ingest/pipeline/_simulate
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4635,7 +4635,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The simulate definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IngestSimulateAsync<T>(PostData<object> body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IngestSimulateAsync<T>(PostData body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_ingest/pipeline/{id}/_simulate
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4649,7 +4649,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Pipeline ID</param>
 		///<param name="body">The simulate definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> IngestSimulate<T>(string id, PostData<object> body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> IngestSimulate<T>(string id, PostData body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_ingest/pipeline/{id}/_simulate
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4663,7 +4663,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Pipeline ID</param>
 		///<param name="body">The simulate definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> IngestSimulateAsync<T>(string id, PostData<object> body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> IngestSimulateAsync<T>(string id, PostData body, Func<SimulatePipelineRequestParameters, SimulatePipelineRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_mget
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4754,7 +4754,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Mget<T>(PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Mget<T>(PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_mget
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4767,7 +4767,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MgetAsync<T>(PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MgetAsync<T>(PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_mget
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4781,7 +4781,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Mget<T>(string index, PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Mget<T>(string index, PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_mget
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4795,7 +4795,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The name of the index</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MgetAsync<T>(string index, PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MgetAsync<T>(string index, PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_mget
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4810,7 +4810,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Mget<T>(string index, string type, PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Mget<T>(string index, string type, PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_mget
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4825,7 +4825,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document</param>
 		///<param name="body">Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MgetAsync<T>(string index, string type, PostData<object> body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MgetAsync<T>(string index, string type, PostData body, Func<MultiGetRequestParameters, MultiGetRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_msearch
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4916,7 +4916,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Msearch<T>(PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Msearch<T>(PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_msearch
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4929,7 +4929,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MsearchAsync<T>(PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MsearchAsync<T>(PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_msearch
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4943,7 +4943,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Msearch<T>(string index, PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Msearch<T>(string index, PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_msearch
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4957,7 +4957,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MsearchAsync<T>(string index, PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MsearchAsync<T>(string index, PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_msearch
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -4972,7 +4972,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Msearch<T>(string index, string type, PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Msearch<T>(string index, string type, PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_msearch
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -4987,7 +4987,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MsearchAsync<T>(string index, string type, PostData<object> body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MsearchAsync<T>(string index, string type, PostData body, Func<MultiSearchRequestParameters, MultiSearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_msearch/template
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5078,7 +5078,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> MsearchTemplate<T>(PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> MsearchTemplate<T>(PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_msearch/template
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5091,7 +5091,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_msearch/template
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5105,7 +5105,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> MsearchTemplate<T>(string index, PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> MsearchTemplate<T>(string index, PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_msearch/template
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5119,7 +5119,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(string index, PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(string index, PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_msearch/template
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5134,7 +5134,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> MsearchTemplate<T>(string index, string type, PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> MsearchTemplate<T>(string index, string type, PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_msearch/template
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5149,7 +5149,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to use as default</param>
 		///<param name="body">The request definitions (metadata-search request definition pairs), separated by newlines</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(string index, string type, PostData<object> body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MsearchTemplateAsync<T>(string index, string type, PostData body, Func<MultiSearchTemplateRequestParameters, MultiSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_mtermvectors
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5240,7 +5240,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Mtermvectors<T>(PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Mtermvectors<T>(PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_mtermvectors
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5253,7 +5253,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_mtermvectors
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5267,7 +5267,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Mtermvectors<T>(string index, PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Mtermvectors<T>(string index, PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_mtermvectors
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5281,7 +5281,7 @@ namespace Elasticsearch.Net
 		///<param name="index">The index in which the document resides.</param>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(string index, PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(string index, PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_mtermvectors
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5296,7 +5296,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document.</param>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Mtermvectors<T>(string index, string type, PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Mtermvectors<T>(string index, string type, PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_mtermvectors
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5311,7 +5311,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document.</param>
 		///<param name="body">Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(string index, string type, PostData<object> body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> MtermvectorsAsync<T>(string index, string type, PostData body, Func<MultiTermVectorsRequestParameters, MultiTermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_cluster/nodes/hotthreads
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5769,7 +5769,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Script ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> PutScript<T>(string id, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> PutScript<T>(string id, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_scripts/{id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5783,7 +5783,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Script ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> PutScriptAsync<T>(string id, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> PutScriptAsync<T>(string id, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_scripts/{id}/{context}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5798,7 +5798,7 @@ namespace Elasticsearch.Net
 		///<param name="context">Script context</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> PutScript<T>(string id, string context, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> PutScript<T>(string id, string context, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_scripts/{id}/{context}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5813,7 +5813,7 @@ namespace Elasticsearch.Net
 		///<param name="context">Script context</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> PutScriptAsync<T>(string id, string context, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> PutScriptAsync<T>(string id, string context, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_scripts/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5827,7 +5827,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Script ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> PutScriptPost<T>(string id, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> PutScriptPost<T>(string id, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_scripts/{id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5841,7 +5841,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Script ID</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> PutScriptPostAsync<T>(string id, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> PutScriptPostAsync<T>(string id, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_scripts/{id}/{context}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5856,7 +5856,7 @@ namespace Elasticsearch.Net
 		///<param name="context">Script context</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> PutScriptPost<T>(string id, string context, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> PutScriptPost<T>(string id, string context, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_scripts/{id}/{context}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5871,7 +5871,7 @@ namespace Elasticsearch.Net
 		///<param name="context">Script context</param>
 		///<param name="body">The document</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> PutScriptPostAsync<T>(string id, string context, PostData<object> body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> PutScriptPostAsync<T>(string id, string context, PostData body, Func<PutScriptRequestParameters, PutScriptRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_reindex
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5884,7 +5884,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Reindex<T>(PostData<object> body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Reindex<T>(PostData body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_reindex
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5897,7 +5897,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition using the Query DSL and the prototype for the index request.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData<object> body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> ReindexAsync<T>(PostData body, Func<ReindexOnServerRequestParameters, ReindexOnServerRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_reindex/{task_id}/_rethrottle
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -5986,7 +5986,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> RenderSearchTemplate<T>(PostData<object> body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> RenderSearchTemplate<T>(PostData body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_render/template
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -5999,7 +5999,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> RenderSearchTemplateAsync<T>(PostData<object> body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> RenderSearchTemplateAsync<T>(PostData body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_render/template/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6013,7 +6013,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The id of the stored search template</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> RenderSearchTemplate<T>(string id, PostData<object> body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> RenderSearchTemplate<T>(string id, PostData body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_render/template/{id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6027,7 +6027,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The id of the stored search template</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> RenderSearchTemplateAsync<T>(string id, PostData<object> body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> RenderSearchTemplateAsync<T>(string id, PostData body, Func<RenderSearchTemplateRequestParameters, RenderSearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_search/scroll
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6064,7 +6064,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Scroll<T>(PostData<object> body, Func<ScrollRequestParameters, ScrollRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Scroll<T>(PostData body, Func<ScrollRequestParameters, ScrollRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_search/scroll
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6077,7 +6077,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The scroll ID if not passed by URL or query parameter.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> ScrollAsync<T>(PostData<object> body, Func<ScrollRequestParameters, ScrollRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> ScrollAsync<T>(PostData body, Func<ScrollRequestParameters, ScrollRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6168,7 +6168,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Search<T>(PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Search<T>(PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_search
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6181,7 +6181,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SearchAsync<T>(PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SearchAsync<T>(PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6195,7 +6195,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Search<T>(string index, PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Search<T>(string index, PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_search
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6209,7 +6209,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_search
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6224,7 +6224,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Search<T>(string index, string type, PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Search<T>(string index, string type, PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_search
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6239,7 +6239,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, string type, PostData<object> body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SearchAsync<T>(string index, string type, PostData body, Func<SearchRequestParameters, SearchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_search_shards
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6430,7 +6430,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> SearchTemplate<T>(PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> SearchTemplate<T>(PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_search/template
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6443,7 +6443,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_search/template
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6457,7 +6457,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> SearchTemplate<T>(string index, PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> SearchTemplate<T>(string index, PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_search/template
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6471,7 +6471,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(string index, PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(string index, PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_search/template
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6486,7 +6486,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> SearchTemplate<T>(string index, string type, PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> SearchTemplate<T>(string index, string type, PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_search/template
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6501,7 +6501,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition template and its params</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(string index, string type, PostData<object> body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SearchTemplateAsync<T>(string index, string type, PostData body, Func<SearchTemplateRequestParameters, SearchTemplateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_snapshot/{repository}/{snapshot}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6516,7 +6516,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">The snapshot definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> SnapshotCreate<T>(string repository, string snapshot, PostData<object> body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> SnapshotCreate<T>(string repository, string snapshot, PostData body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_snapshot/{repository}/{snapshot}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6531,7 +6531,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">The snapshot definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SnapshotCreateAsync<T>(string repository, string snapshot, PostData<object> body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SnapshotCreateAsync<T>(string repository, string snapshot, PostData body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_snapshot/{repository}/{snapshot}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6546,7 +6546,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">The snapshot definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> SnapshotCreatePost<T>(string repository, string snapshot, PostData<object> body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> SnapshotCreatePost<T>(string repository, string snapshot, PostData body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_snapshot/{repository}/{snapshot}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6561,7 +6561,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">The snapshot definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SnapshotCreatePostAsync<T>(string repository, string snapshot, PostData<object> body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SnapshotCreatePostAsync<T>(string repository, string snapshot, PostData body, Func<SnapshotRequestParameters, SnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_snapshot/{repository}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6575,7 +6575,7 @@ namespace Elasticsearch.Net
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> SnapshotCreateRepository<T>(string repository, PostData<object> body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> SnapshotCreateRepository<T>(string repository, PostData body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_snapshot/{repository}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6589,7 +6589,7 @@ namespace Elasticsearch.Net
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryAsync<T>(string repository, PostData<object> body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryAsync<T>(string repository, PostData body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_snapshot/{repository}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6603,7 +6603,7 @@ namespace Elasticsearch.Net
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> SnapshotCreateRepositoryPost<T>(string repository, PostData<object> body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> SnapshotCreateRepositoryPost<T>(string repository, PostData body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_snapshot/{repository}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6617,7 +6617,7 @@ namespace Elasticsearch.Net
 		///<param name="repository">A repository name</param>
 		///<param name="body">The repository definition</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryPostAsync<T>(string repository, PostData<object> body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryPostAsync<T>(string repository, PostData body, Func<CreateRepositoryRequestParameters, CreateRepositoryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a DELETE on /_snapshot/{repository}/{snapshot}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -6764,7 +6764,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">Details of what to restore</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> SnapshotRestore<T>(string repository, string snapshot, PostData<object> body, Func<RestoreRequestParameters, RestoreRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> SnapshotRestore<T>(string repository, string snapshot, PostData body, Func<RestoreRequestParameters, RestoreRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_snapshot/{repository}/{snapshot}/_restore
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -6779,7 +6779,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot">A snapshot name</param>
 		///<param name="body">Details of what to restore</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> SnapshotRestoreAsync<T>(string repository, string snapshot, PostData<object> body, Func<RestoreRequestParameters, RestoreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> SnapshotRestoreAsync<T>(string repository, string snapshot, PostData body, Func<RestoreRequestParameters, RestoreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_snapshot/_status
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7056,7 +7056,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document.</param>
 		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Termvectors<T>(string index, string type, PostData<object> body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Termvectors<T>(string index, string type, PostData body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_termvectors
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7071,7 +7071,7 @@ namespace Elasticsearch.Net
 		///<param name="type">The type of the document.</param>
 		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> TermvectorsAsync<T>(string index, string type, PostData<object> body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> TermvectorsAsync<T>(string index, string type, PostData body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_termvectors
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7087,7 +7087,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Termvectors<T>(string index, string type, string id, PostData<object> body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Termvectors<T>(string index, string type, string id, PostData body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_termvectors
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7103,7 +7103,7 @@ namespace Elasticsearch.Net
 		///<param name="id">The id of the document, when not specified a doc param should be supplied.</param>
 		///<param name="body">Define parameters and or supply a document to get termvectors for. See documentation.</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> TermvectorsAsync<T>(string index, string type, string id, PostData<object> body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> TermvectorsAsync<T>(string index, string type, string id, PostData body, Func<TermVectorsRequestParameters, TermVectorsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_update
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7119,7 +7119,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The request definition using either `script` or partial `doc`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> Update<T>(string index, string type, string id, PostData<object> body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> Update<T>(string index, string type, string id, PostData body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/{id}/_update
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7135,7 +7135,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Document ID</param>
 		///<param name="body">The request definition using either `script` or partial `doc`</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> UpdateAsync<T>(string index, string type, string id, PostData<object> body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> UpdateAsync<T>(string index, string type, string id, PostData body, Func<UpdateRequestParameters, UpdateRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_update_by_query
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7149,7 +7149,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> UpdateByQuery<T>(string index, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> UpdateByQuery<T>(string index, PostData body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_update_by_query
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7163,7 +7163,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, PostData body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_update_by_query
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7178,7 +7178,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> UpdateByQuery<T>(string index, string type, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> UpdateByQuery<T>(string index, string type, PostData body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_update_by_query
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7193,7 +7193,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">The search definition using the Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, string type, PostData<object> body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> UpdateByQueryAsync<T>(string index, string type, PostData body, Func<UpdateByQueryRequestParameters, UpdateByQueryRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /{index}/_xpack/graph/_explore
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7261,7 +7261,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">Graph Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackGraphExplore<T>(string index, PostData<object> body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackGraphExplore<T>(string index, PostData body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/_xpack/graph/_explore
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7275,7 +7275,7 @@ namespace Elasticsearch.Net
 		///<param name="index">A comma-separated list of index names to search; use the special string `_all` or Indices.All to perform the operation on all indices</param>
 		///<param name="body">Graph Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackGraphExploreAsync<T>(string index, PostData<object> body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackGraphExploreAsync<T>(string index, PostData body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_xpack/graph/_explore
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7290,7 +7290,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">Graph Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackGraphExplore<T>(string index, string type, PostData<object> body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackGraphExplore<T>(string index, string type, PostData body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /{index}/{type}/_xpack/graph/_explore
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7305,7 +7305,7 @@ namespace Elasticsearch.Net
 		///<param name="type">A comma-separated list of document types to search; leave empty to perform the operation on all types</param>
 		///<param name="body">Graph Query DSL</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackGraphExploreAsync<T>(string index, string type, PostData<object> body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackGraphExploreAsync<T>(string index, string type, PostData body, Func<GraphExploreRequestParameters, GraphExploreRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/migration/deprecations
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7464,7 +7464,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">licenses to be installed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackLicensePost<T>(PostData<object> body, Func<PostLicenseRequestParameters, PostLicenseRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackLicensePost<T>(PostData body, Func<PostLicenseRequestParameters, PostLicenseRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/license
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7477,7 +7477,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">licenses to be installed</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackLicensePostAsync<T>(PostData<object> body, Func<PostLicenseRequestParameters, PostLicenseRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackLicensePostAsync<T>(PostData body, Func<PostLicenseRequestParameters, PostLicenseRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_close
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7621,7 +7621,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job to flush</param>
 		///<param name="body">Flush parameters</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlFlushJob<T>(string job_id, PostData<object> body, Func<FlushJobRequestParameters, FlushJobRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlFlushJob<T>(string job_id, PostData body, Func<FlushJobRequestParameters, FlushJobRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_flush
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7635,7 +7635,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job to flush</param>
 		///<param name="body">Flush parameters</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlFlushJobAsync<T>(string job_id, PostData<object> body, Func<FlushJobRequestParameters, FlushJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlFlushJobAsync<T>(string job_id, PostData body, Func<FlushJobRequestParameters, FlushJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/ml/anomaly_detectors/{job_id}/results/buckets
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7675,7 +7675,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">ID of the job to get bucket results from</param>
 		///<param name="body">Bucket selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlGetBuckets<T>(string job_id, PostData<object> body, Func<GetBucketsRequestParameters, GetBucketsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlGetBuckets<T>(string job_id, PostData body, Func<GetBucketsRequestParameters, GetBucketsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/buckets
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7689,7 +7689,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">ID of the job to get bucket results from</param>
 		///<param name="body">Bucket selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlGetBucketsAsync<T>(string job_id, PostData<object> body, Func<GetBucketsRequestParameters, GetBucketsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlGetBucketsAsync<T>(string job_id, PostData body, Func<GetBucketsRequestParameters, GetBucketsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/ml/anomaly_detectors/{job_id}/results/categories/{category_id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7758,7 +7758,7 @@ namespace Elasticsearch.Net
 		///<param name="category_id">The identifier of the category definition of interest</param>
 		///<param name="body">Category selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlGetCategories<T>(string job_id, long category_id, PostData<object> body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlGetCategories<T>(string job_id, long category_id, PostData body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/categories/{category_id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7773,7 +7773,7 @@ namespace Elasticsearch.Net
 		///<param name="category_id">The identifier of the category definition of interest</param>
 		///<param name="body">Category selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlGetCategoriesAsync<T>(string job_id, long category_id, PostData<object> body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlGetCategoriesAsync<T>(string job_id, long category_id, PostData body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/categories/
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7787,7 +7787,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job</param>
 		///<param name="body">Category selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlGetCategories<T>(string job_id, PostData<object> body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlGetCategories<T>(string job_id, PostData body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/categories/
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7801,7 +7801,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job</param>
 		///<param name="body">Category selection details if not provided in URI</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlGetCategoriesAsync<T>(string job_id, PostData<object> body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlGetCategoriesAsync<T>(string job_id, PostData body, Func<GetCategoriesRequestParameters, GetCategoriesRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/ml/datafeeds/{datafeed_id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -7941,7 +7941,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id"></param>
 		///<param name="body">Influencer selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlGetInfluencers<T>(string job_id, PostData<object> body, Func<GetInfluencersRequestParameters, GetInfluencersRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlGetInfluencers<T>(string job_id, PostData body, Func<GetInfluencersRequestParameters, GetInfluencersRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/influencers
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -7955,7 +7955,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id"></param>
 		///<param name="body">Influencer selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlGetInfluencersAsync<T>(string job_id, PostData<object> body, Func<GetInfluencersRequestParameters, GetInfluencersRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlGetInfluencersAsync<T>(string job_id, PostData body, Func<GetInfluencersRequestParameters, GetInfluencersRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/ml/anomaly_detectors/{job_id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8124,7 +8124,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to fetch</param>
 		///<param name="body">Model snapshot selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlGetModelSnapshots<T>(string job_id, string snapshot_id, PostData<object> body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlGetModelSnapshots<T>(string job_id, string snapshot_id, PostData body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8139,7 +8139,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to fetch</param>
 		///<param name="body">Model snapshot selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsAsync<T>(string job_id, string snapshot_id, PostData<object> body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsAsync<T>(string job_id, string snapshot_id, PostData body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8153,7 +8153,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to fetch</param>
 		///<param name="body">Model snapshot selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlGetModelSnapshots<T>(string job_id, PostData<object> body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlGetModelSnapshots<T>(string job_id, PostData body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8167,7 +8167,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to fetch</param>
 		///<param name="body">Model snapshot selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsAsync<T>(string job_id, PostData<object> body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsAsync<T>(string job_id, PostData body, Func<GetModelSnapshotsRequestParameters, GetModelSnapshotsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/ml/anomaly_detectors/{job_id}/results/records
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8207,7 +8207,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id"></param>
 		///<param name="body">Record selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlGetRecords<T>(string job_id, PostData<object> body, Func<GetAnomalyRecordsRequestParameters, GetAnomalyRecordsRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlGetRecords<T>(string job_id, PostData body, Func<GetAnomalyRecordsRequestParameters, GetAnomalyRecordsRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/results/records
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8221,7 +8221,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id"></param>
 		///<param name="body">Record selection criteria</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlGetRecordsAsync<T>(string job_id, PostData<object> body, Func<GetAnomalyRecordsRequestParameters, GetAnomalyRecordsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlGetRecordsAsync<T>(string job_id, PostData body, Func<GetAnomalyRecordsRequestParameters, GetAnomalyRecordsRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_open
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8261,7 +8261,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job receiving the data</param>
 		///<param name="body">The data to process</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlPostData<T>(string job_id, PostData<object> body, Func<PostJobDataRequestParameters, PostJobDataRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlPostData<T>(string job_id, PostData body, Func<PostJobDataRequestParameters, PostJobDataRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_data
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8275,7 +8275,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The name of the job receiving the data</param>
 		///<param name="body">The data to process</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlPostDataAsync<T>(string job_id, PostData<object> body, Func<PostJobDataRequestParameters, PostJobDataRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlPostDataAsync<T>(string job_id, PostData body, Func<PostJobDataRequestParameters, PostJobDataRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/ml/datafeeds/{datafeed_id}/_preview
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8315,7 +8315,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to create</param>
 		///<param name="body">The datafeed config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlPutDatafeed<T>(string datafeed_id, PostData<object> body, Func<PutDatafeedRequestParameters, PutDatafeedRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlPutDatafeed<T>(string datafeed_id, PostData body, Func<PutDatafeedRequestParameters, PutDatafeedRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/ml/datafeeds/{datafeed_id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8329,7 +8329,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to create</param>
 		///<param name="body">The datafeed config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlPutDatafeedAsync<T>(string datafeed_id, PostData<object> body, Func<PutDatafeedRequestParameters, PutDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlPutDatafeedAsync<T>(string datafeed_id, PostData body, Func<PutDatafeedRequestParameters, PutDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/ml/anomaly_detectors/{job_id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8343,7 +8343,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlPutJob<T>(string job_id, PostData<object> body, Func<PutJobRequestParameters, PutJobRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlPutJob<T>(string job_id, PostData body, Func<PutJobRequestParameters, PutJobRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/ml/anomaly_detectors/{job_id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8357,7 +8357,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlPutJobAsync<T>(string job_id, PostData<object> body, Func<PutJobRequestParameters, PutJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlPutJobAsync<T>(string job_id, PostData body, Func<PutJobRequestParameters, PutJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_revert
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8372,7 +8372,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to revert to</param>
 		///<param name="body">Reversion options</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlRevertModelSnapshot<T>(string job_id, string snapshot_id, PostData<object> body, Func<RevertModelSnapshotRequestParameters, RevertModelSnapshotRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlRevertModelSnapshot<T>(string job_id, string snapshot_id, PostData body, Func<RevertModelSnapshotRequestParameters, RevertModelSnapshotRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_revert
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8387,7 +8387,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to revert to</param>
 		///<param name="body">Reversion options</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlRevertModelSnapshotAsync<T>(string job_id, string snapshot_id, PostData<object> body, Func<RevertModelSnapshotRequestParameters, RevertModelSnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlRevertModelSnapshotAsync<T>(string job_id, string snapshot_id, PostData body, Func<RevertModelSnapshotRequestParameters, RevertModelSnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/datafeeds/{datafeed_id}/_start
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8401,7 +8401,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to start</param>
 		///<param name="body">The start datafeed parameters</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlStartDatafeed<T>(string datafeed_id, PostData<object> body, Func<StartDatafeedRequestParameters, StartDatafeedRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlStartDatafeed<T>(string datafeed_id, PostData body, Func<StartDatafeedRequestParameters, StartDatafeedRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/datafeeds/{datafeed_id}/_start
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8415,7 +8415,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to start</param>
 		///<param name="body">The start datafeed parameters</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlStartDatafeedAsync<T>(string datafeed_id, PostData<object> body, Func<StartDatafeedRequestParameters, StartDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlStartDatafeedAsync<T>(string datafeed_id, PostData body, Func<StartDatafeedRequestParameters, StartDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/datafeeds/{datafeed_id}/_stop
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8455,7 +8455,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to update</param>
 		///<param name="body">The datafeed update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlUpdateDatafeed<T>(string datafeed_id, PostData<object> body, Func<UpdateDatafeedRequestParameters, UpdateDatafeedRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlUpdateDatafeed<T>(string datafeed_id, PostData body, Func<UpdateDatafeedRequestParameters, UpdateDatafeedRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/datafeeds/{datafeed_id}/_update
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8469,7 +8469,7 @@ namespace Elasticsearch.Net
 		///<param name="datafeed_id">The ID of the datafeed to update</param>
 		///<param name="body">The datafeed update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlUpdateDatafeedAsync<T>(string datafeed_id, PostData<object> body, Func<UpdateDatafeedRequestParameters, UpdateDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlUpdateDatafeedAsync<T>(string datafeed_id, PostData body, Func<UpdateDatafeedRequestParameters, UpdateDatafeedRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_update
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8483,7 +8483,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlUpdateJob<T>(string job_id, PostData<object> body, Func<UpdateJobRequestParameters, UpdateJobRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlUpdateJob<T>(string job_id, PostData body, Func<UpdateJobRequestParameters, UpdateJobRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/_update
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8497,7 +8497,7 @@ namespace Elasticsearch.Net
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlUpdateJobAsync<T>(string job_id, PostData<object> body, Func<UpdateJobRequestParameters, UpdateJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlUpdateJobAsync<T>(string job_id, PostData body, Func<UpdateJobRequestParameters, UpdateJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_update
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8512,7 +8512,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to update</param>
 		///<param name="body">The model snapshot properties to update</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlUpdateModelSnapshot<T>(string job_id, string snapshot_id, PostData<object> body, Func<UpdateModelSnapshotRequestParameters, UpdateModelSnapshotRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlUpdateModelSnapshot<T>(string job_id, string snapshot_id, PostData body, Func<UpdateModelSnapshotRequestParameters, UpdateModelSnapshotRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_update
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8527,7 +8527,7 @@ namespace Elasticsearch.Net
 		///<param name="snapshot_id">The ID of the snapshot to update</param>
 		///<param name="body">The model snapshot properties to update</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlUpdateModelSnapshotAsync<T>(string job_id, string snapshot_id, PostData<object> body, Func<UpdateModelSnapshotRequestParameters, UpdateModelSnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlUpdateModelSnapshotAsync<T>(string job_id, string snapshot_id, PostData body, Func<UpdateModelSnapshotRequestParameters, UpdateModelSnapshotRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/_validate
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8540,7 +8540,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The job config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlValidate<T>(PostData<object> body, Func<ValidateJobRequestParameters, ValidateJobRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlValidate<T>(PostData body, Func<ValidateJobRequestParameters, ValidateJobRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/_validate
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8553,7 +8553,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The job config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlValidateAsync<T>(PostData<object> body, Func<ValidateJobRequestParameters, ValidateJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlValidateAsync<T>(PostData body, Func<ValidateJobRequestParameters, ValidateJobRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/_validate/detector
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8566,7 +8566,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The detector</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackMlValidateDetector<T>(PostData<object> body, Func<ValidateDetectorRequestParameters, ValidateDetectorRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackMlValidateDetector<T>(PostData body, Func<ValidateDetectorRequestParameters, ValidateDetectorRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/ml/anomaly_detectors/_validate/detector
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8579,7 +8579,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The detector</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackMlValidateDetectorAsync<T>(PostData<object> body, Func<ValidateDetectorRequestParameters, ValidateDetectorRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackMlValidateDetectorAsync<T>(PostData body, Func<ValidateDetectorRequestParameters, ValidateDetectorRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/security/_authenticate
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8617,7 +8617,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the user to change the password for</param>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityChangePassword<T>(string username, PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityChangePassword<T>(string username, PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/user/{username}/_password
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8631,7 +8631,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the user to change the password for</param>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordAsync<T>(string username, PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordAsync<T>(string username, PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/user/_password
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8644,7 +8644,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityChangePassword<T>(PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityChangePassword<T>(PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/user/_password
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8657,7 +8657,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordAsync<T>(PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordAsync<T>(PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/user/{username}/_password
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8671,7 +8671,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the user to change the password for</param>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityChangePasswordPost<T>(string username, PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityChangePasswordPost<T>(string username, PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/user/{username}/_password
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8685,7 +8685,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the user to change the password for</param>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordPostAsync<T>(string username, PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordPostAsync<T>(string username, PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/user/_password
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -8698,7 +8698,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityChangePasswordPost<T>(PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityChangePasswordPost<T>(PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/user/_password
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -8711,7 +8711,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">the new password for the user</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordPostAsync<T>(PostData<object> body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordPostAsync<T>(PostData body, Func<ChangePasswordRequestParameters, ChangePasswordRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/realm/{realms}/_clear_cache
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9058,7 +9058,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The token request to get</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityGetToken<T>(PostData<object> body, Func<GetUserAccessTokenRequestParameters, GetUserAccessTokenRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityGetToken<T>(PostData body, Func<GetUserAccessTokenRequestParameters, GetUserAccessTokenRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/oauth2/token
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9071,7 +9071,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The token request to get</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityGetTokenAsync<T>(PostData<object> body, Func<GetUserAccessTokenRequestParameters, GetUserAccessTokenRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityGetTokenAsync<T>(PostData body, Func<GetUserAccessTokenRequestParameters, GetUserAccessTokenRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/security/user/{username}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9134,7 +9134,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The token to invalidate</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityInvalidateToken<T>(PostData<object> body, Func<InvalidateUserAccessTokenRequestParameters, InvalidateUserAccessTokenRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityInvalidateToken<T>(PostData body, Func<InvalidateUserAccessTokenRequestParameters, InvalidateUserAccessTokenRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a DELETE on /_xpack/security/oauth2/token
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9147,7 +9147,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">The token to invalidate</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityInvalidateTokenAsync<T>(PostData<object> body, Func<InvalidateUserAccessTokenRequestParameters, InvalidateUserAccessTokenRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityInvalidateTokenAsync<T>(PostData body, Func<InvalidateUserAccessTokenRequestParameters, InvalidateUserAccessTokenRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/role/{name}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9161,7 +9161,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityPutRole<T>(string name, PostData<object> body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityPutRole<T>(string name, PostData body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/role/{name}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9175,7 +9175,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityPutRoleAsync<T>(string name, PostData<object> body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityPutRoleAsync<T>(string name, PostData body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/role/{name}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9189,7 +9189,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityPutRolePost<T>(string name, PostData<object> body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityPutRolePost<T>(string name, PostData body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/role/{name}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9203,7 +9203,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityPutRolePostAsync<T>(string name, PostData<object> body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityPutRolePostAsync<T>(string name, PostData body, Func<PutRoleRequestParameters, PutRoleRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/role_mapping/{name}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9217,7 +9217,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role-mapping name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityPutRoleMapping<T>(string name, PostData<object> body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityPutRoleMapping<T>(string name, PostData body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/role_mapping/{name}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9231,7 +9231,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role-mapping name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingAsync<T>(string name, PostData<object> body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingAsync<T>(string name, PostData body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/role_mapping/{name}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9245,7 +9245,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role-mapping name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityPutRoleMappingPost<T>(string name, PostData<object> body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityPutRoleMappingPost<T>(string name, PostData body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/role_mapping/{name}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9259,7 +9259,7 @@ namespace Elasticsearch.Net
 		///<param name="name">Role-mapping name</param>
 		///<param name="body">The role to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingPostAsync<T>(string name, PostData<object> body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingPostAsync<T>(string name, PostData body, Func<PutRoleMappingRequestParameters, PutRoleMappingRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/user/{username}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9273,7 +9273,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the User</param>
 		///<param name="body">The user to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityPutUser<T>(string username, PostData<object> body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityPutUser<T>(string username, PostData body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/security/user/{username}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9287,7 +9287,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the User</param>
 		///<param name="body">The user to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityPutUserAsync<T>(string username, PostData<object> body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityPutUserAsync<T>(string username, PostData body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/user/{username}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9301,7 +9301,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the User</param>
 		///<param name="body">The user to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackSecurityPutUserPost<T>(string username, PostData<object> body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackSecurityPutUserPost<T>(string username, PostData body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/security/user/{username}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9315,7 +9315,7 @@ namespace Elasticsearch.Net
 		///<param name="username">The username of the User</param>
 		///<param name="body">The user to add</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackSecurityPutUserPostAsync<T>(string username, PostData<object> body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackSecurityPutUserPostAsync<T>(string username, PostData body, Func<PutUserRequestParameters, PutUserRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/{watch_id}/_ack
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9567,7 +9567,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackWatcherExecuteWatch<T>(string id, PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackWatcherExecuteWatch<T>(string id, PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/{id}/_execute
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9581,7 +9581,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchAsync<T>(string id, PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchAsync<T>(string id, PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/_execute
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9594,7 +9594,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackWatcherExecuteWatch<T>(PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackWatcherExecuteWatch<T>(PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/_execute
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9607,7 +9607,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchAsync<T>(PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchAsync<T>(PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/{id}/_execute
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9621,7 +9621,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackWatcherExecuteWatchPost<T>(string id, PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackWatcherExecuteWatchPost<T>(string id, PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/{id}/_execute
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9635,7 +9635,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchPostAsync<T>(string id, PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchPostAsync<T>(string id, PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/_execute
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9648,7 +9648,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackWatcherExecuteWatchPost<T>(PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackWatcherExecuteWatchPost<T>(PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/_execute
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9661,7 +9661,7 @@ namespace Elasticsearch.Net
 		///</summary>
 		///<param name="body">Execution control</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchPostAsync<T>(PostData<object> body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchPostAsync<T>(PostData body, Func<ExecuteWatchRequestParameters, ExecuteWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a GET on /_xpack/watcher/watch/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9701,7 +9701,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">The watch</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackWatcherPutWatch<T>(string id, PostData<object> body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackWatcherPutWatch<T>(string id, PostData body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a PUT on /_xpack/watcher/watch/{id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9715,7 +9715,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">The watch</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackWatcherPutWatchAsync<T>(string id, PostData<object> body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackWatcherPutWatchAsync<T>(string id, PostData body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/{id}
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:
@@ -9729,7 +9729,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">The watch</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		ElasticsearchResponse<T> XpackWatcherPutWatchPost<T>(string id, PostData<object> body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null) where T : class;
+		ElasticsearchResponse<T> XpackWatcherPutWatchPost<T>(string id, PostData body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/watcher/watch/{id}
 		///<para></para>Returns: A task of ElasticsearchResponse&lt;T&gt; where the behaviour depends on the type of T:
@@ -9743,7 +9743,7 @@ namespace Elasticsearch.Net
 		///<param name="id">Watch ID</param>
 		///<param name="body">The watch</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<ElasticsearchResponse<T>> XpackWatcherPutWatchPostAsync<T>(string id, PostData<object> body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
+		Task<ElasticsearchResponse<T>> XpackWatcherPutWatchPostAsync<T>(string id, PostData body, Func<PutWatchRequestParameters, PutWatchRequestParameters> requestParameters = null, CancellationToken cancellationToken = default(CancellationToken)) where T : class;
 		
 		///<summary>Represents a POST on /_xpack/watcher/_restart
 		///<para></para>Returns: ElasticsearchResponse&lt;T&gt; where the behavior depends on the type of T:

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.cs
@@ -14,7 +14,7 @@ namespace Elasticsearch.Net
 		/// <param name="data">The body of the request, string and byte[] are posted as is other types will be serialized to JSON</param>
 		/// <param name="requestParameters">Optionally configure request specific timeouts, headers</param>
 		/// <returns>An ElasticsearchResponse of T where T represents the JSON response body</returns>
-		ElasticsearchResponse<T> DoRequest<T>(HttpMethod method, string path, PostData<object> data = null, IRequestParameters requestParameters = null)
+		ElasticsearchResponse<T> DoRequest<T>(HttpMethod method, string path, PostData data = null, IRequestParameters requestParameters = null)
 			where T : class;
 
 		/// <summary>
@@ -26,7 +26,7 @@ namespace Elasticsearch.Net
 		/// <param name="data">The body of the request, string and byte[] are posted as is other types will be serialized to JSON</param>
 		/// <param name="requestParameters">Optionally configure request specific timeouts, headers</param>
 		/// <returns>A task of ElasticsearchResponse of T where T represents the JSON response body</returns>
-		Task<ElasticsearchResponse<T>> DoRequestAsync<T>(HttpMethod method, string path, CancellationToken cancellationToken, PostData<object> data = null, IRequestParameters requestParameters = null)
+		Task<ElasticsearchResponse<T>> DoRequestAsync<T>(HttpMethod method, string path, CancellationToken cancellationToken, PostData data = null, IRequestParameters requestParameters = null)
 			where T : class;
 	}
 }

--- a/src/Elasticsearch.Net/Serialization/IElasticsearchSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/IElasticsearchSerializer.cs
@@ -8,20 +8,17 @@ namespace Elasticsearch.Net
 {
 	public interface IElasticsearchSerializer
 	{
+		object Deserialize(Type type, Stream stream);
 		T Deserialize<T>(Stream stream);
 
-		object Deserialize(Type type, Stream stream);
-
+		Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default(CancellationToken));
 		Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default(CancellationToken));
 
-		Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default(CancellationToken));
+		void Serialize<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented);
 
-		void Serialize(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented);
-
-		Task SerializeAsync(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
+		Task SerializeAsync<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
 			CancellationToken cancellationToken = default(CancellationToken));
 	}
-
 
 	public static class ElasticsearchSerializerExtensions
 	{

--- a/src/Elasticsearch.Net/Serialization/IElasticsearchSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/IElasticsearchSerializer.cs
@@ -18,6 +18,8 @@ namespace Elasticsearch.Net
 
 		void Serialize(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented);
 
+		Task SerializeAsync(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
+			CancellationToken cancellationToken = default(CancellationToken));
 	}
 
 

--- a/src/Elasticsearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
@@ -62,6 +62,17 @@ namespace Elasticsearch.Net
 			}
 		}
 
+		public async Task SerializeAsync(object data, Stream writableStream, SerializationFormatting formatting,
+			CancellationToken cancellationToken = default(CancellationToken))
+		{
+			var serialized = SimpleJson.SerializeObject(data, Strategy);
+			if (formatting == SerializationFormatting.None) serialized = RemoveNewLinesAndTabs(serialized);
+			using (var ms = new MemoryStream(serialized.Utf8Bytes()))
+			{
+				await ms.CopyToAsync(writableStream);
+			}
+		}
+
 		private static string RemoveNewLinesAndTabs(string input)
 		{
 			return new string(input

--- a/src/Elasticsearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
@@ -52,7 +52,7 @@ namespace Elasticsearch.Net
 			return (T) o;
 		}
 
-		public void Serialize(object data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.Indented)
+		public void Serialize<T>(T data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.Indented)
 		{
 			var serialized = SimpleJson.SerializeObject(data, Strategy);
 			if (formatting == SerializationFormatting.None) serialized = RemoveNewLinesAndTabs(serialized);
@@ -62,7 +62,7 @@ namespace Elasticsearch.Net
 			}
 		}
 
-		public async Task SerializeAsync(object data, Stream writableStream, SerializationFormatting formatting,
+		public async Task SerializeAsync<T>(T data, Stream writableStream, SerializationFormatting formatting,
 			CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var serialized = SimpleJson.SerializeObject(data, Strategy);

--- a/src/Elasticsearch.Net/Transport/ITransport.cs
+++ b/src/Elasticsearch.Net/Transport/ITransport.cs
@@ -9,9 +9,9 @@ namespace Elasticsearch.Net
 	{
 		TConnectionSettings Settings { get; }
 
-		ElasticsearchResponse<T> Request<T>(HttpMethod method, string path, PostData<object> data = null, IRequestParameters requestParameters = null)
+		ElasticsearchResponse<T> Request<T>(HttpMethod method, string path, PostData data = null, IRequestParameters requestParameters = null)
 			where T : class;
-		Task<ElasticsearchResponse<T>> RequestAsync<T>(HttpMethod method, string path, CancellationToken cancellationToken, PostData<object> data = null, IRequestParameters requestParameters = null)
+		Task<ElasticsearchResponse<T>> RequestAsync<T>(HttpMethod method, string path, CancellationToken cancellationToken, PostData data = null, IRequestParameters requestParameters = null)
 			where T : class;
 	}
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -17,7 +17,7 @@ namespace Elasticsearch.Net
 
 		public HttpMethod Method { get; private set; }
 		public string Path { get; }
-		public PostData<object> PostData { get; }
+		public PostData PostData { get; }
 		public bool MadeItToResponse { get; set;}
 		public AuditEvent OnFailureAuditEvent => this.MadeItToResponse ? AuditEvent.BadResponse : AuditEvent.BadRequest;
 		public PipelineFailure OnFailurePipelineFailure => this.MadeItToResponse ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;
@@ -48,7 +48,7 @@ namespace Elasticsearch.Net
 
 		public X509CertificateCollection ClientCertificates { get; set; }
 
-		public RequestData(HttpMethod method, string path, PostData<object> data, IConnectionConfigurationValues global, IRequestParameters local, IMemoryStreamFactory memoryStreamFactory)
+		public RequestData(HttpMethod method, string path, PostData data, IConnectionConfigurationValues global, IRequestParameters local, IMemoryStreamFactory memoryStreamFactory)
 			: this(method, path, data, global, local?.RequestConfiguration, memoryStreamFactory)
 		{
 			this.CustomConverter = local?.DeserializationOverride;
@@ -58,7 +58,7 @@ namespace Elasticsearch.Net
 		private RequestData(
 			HttpMethod method,
 			string path,
-			PostData<object> data,
+			PostData data,
 			IConnectionConfigurationValues global,
 			IRequestConfiguration local,
 			IMemoryStreamFactory memoryStreamFactory)

--- a/src/Elasticsearch.Net/Transport/PostData.cs
+++ b/src/Elasticsearch.Net/Transport/PostData.cs
@@ -70,13 +70,13 @@ namespace Elasticsearch.Net
 			Stream stream = null;
 			switch (Type)
 			{
-				case PostType.ByteArray: 
+				case PostType.ByteArray:
 					ms = new MemoryStream(WrittenBytes);
 					break;
 				case PostType.LiteralString:
 					ms = !string.IsNullOrEmpty(_literalString) ? new MemoryStream(_literalString?.Utf8Bytes()) : null;
 					break;
-				case PostType.EnumerableOfString: 
+				case PostType.EnumerableOfString:
 					ms = _enumurabeOfStrings.HasAny() ? new MemoryStream((string.Join(NewLineString, _enumurabeOfStrings) + NewLineString).Utf8Bytes()) : null;
 					break;
 				case PostType.EnumerableOfObject:
@@ -94,7 +94,7 @@ namespace Elasticsearch.Net
 						stream.Write(NewLineByteArray, 0, 1);
 					}
 					break;
-				case PostType.Serializable: 
+				case PostType.Serializable:
 					stream = writableStream;
 					if (this.DisableDirectStreaming ?? settings.DisableDirectStreaming)
 					{
@@ -119,13 +119,13 @@ namespace Elasticsearch.Net
 			MemoryStream ms = null; Stream stream = null;
 			switch (Type)
 			{
-				case PostType.ByteArray: 
+				case PostType.ByteArray:
 					ms = new MemoryStream(WrittenBytes);
 					break;
-				case PostType.LiteralString: 
+				case PostType.LiteralString:
 					ms = !string.IsNullOrEmpty(_literalString) ? new MemoryStream(_literalString.Utf8Bytes()) : null;
 					break;
-				case PostType.EnumerableOfString: 
+				case PostType.EnumerableOfString:
 					ms = _enumurabeOfStrings.HasAny() ? new MemoryStream((string.Join(NewLineString, _enumurabeOfStrings) + NewLineString).Utf8Bytes()) : null;
 					break;
 				case PostType.EnumerableOfObject:
@@ -138,18 +138,18 @@ namespace Elasticsearch.Net
 					else stream = writableStream;
 					foreach (var o in _enumerableOfObject)
 					{
-						settings.RequestResponseSerializer.Serialize(o, stream, SerializationFormatting.None);
+						await settings.RequestResponseSerializer.SerializeAsync(o, stream, SerializationFormatting.None, cancellationToken);
 						await stream.WriteAsync(NewLineByteArray, 0, 1, cancellationToken).ConfigureAwait(false);
 					}
 					break;
-				case PostType.Serializable: 
+				case PostType.Serializable:
 					stream = writableStream;
 					if (this.DisableDirectStreaming ?? settings.DisableDirectStreaming)
 					{
 						ms = new MemoryStream();
 						stream = ms;
 					}
-					settings.RequestResponseSerializer.Serialize(this._serializable, stream, indent);
+					await settings.RequestResponseSerializer.SerializeAsync(this._serializable, stream, indent, cancellationToken);
 					break;
 			}
 			if (ms != null)

--- a/src/Elasticsearch.Net/Transport/SerializableData.cs
+++ b/src/Elasticsearch.Net/Transport/SerializableData.cs
@@ -1,0 +1,58 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elasticsearch.Net
+{
+	public class SerializableData<T> : PostData, IPostData<T>
+	{
+		private readonly T _serializable;
+
+		public SerializableData(T item)
+		{
+			Type = PostType.Serializable;
+			_serializable = item;
+		}
+		public static implicit operator SerializableData<T>(T serialiableData) => new SerializableData<T>(serialiableData);
+
+		public override void Write(Stream writableStream, IConnectionConfigurationValues settings)
+		{
+			var indent = settings.PrettyJson ? SerializationFormatting.Indented : SerializationFormatting.None;
+			var stream = writableStream;
+			MemoryStream ms = null;
+			if (this.DisableDirectStreaming ?? settings.DisableDirectStreaming)
+			{
+				ms = new MemoryStream();
+				stream = ms;
+			}
+			settings.RequestResponseSerializer.Serialize(this._serializable, stream, indent);
+			if (ms != null)
+			{
+				ms.Position = 0;
+				ms.CopyTo(writableStream, BufferSize);
+			}
+			if (this.Type != 0)
+				this.WrittenBytes = ms?.ToArray();
+		}
+
+		public override async Task WriteAsync(Stream writableStream, IConnectionConfigurationValues settings, CancellationToken cancellationToken)
+		{
+			var indent = settings.PrettyJson ? SerializationFormatting.Indented : SerializationFormatting.None;
+			var stream = writableStream;
+			MemoryStream ms = null;
+			if (this.DisableDirectStreaming ?? settings.DisableDirectStreaming)
+			{
+				ms = new MemoryStream();
+				stream = ms;
+			}
+			await settings.RequestResponseSerializer.SerializeAsync(this._serializable, stream, indent, cancellationToken);
+			if (ms != null)
+			{
+				ms.Position = 0;
+				await ms.CopyToAsync(writableStream, BufferSize, cancellationToken).ConfigureAwait(false);
+			}
+			if (this.Type != 0)
+				this.WrittenBytes = ms?.ToArray();
+		}
+	}
+}

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -47,7 +47,7 @@ namespace Elasticsearch.Net
 			this.MemoryStreamFactory = memoryStreamFactory ?? new MemoryStreamFactory();
 		}
 
-		public ElasticsearchResponse<TReturn> Request<TReturn>(HttpMethod method, string path, PostData<object> data = null, IRequestParameters requestParameters = null)
+		public ElasticsearchResponse<TReturn> Request<TReturn>(HttpMethod method, string path, PostData data = null, IRequestParameters requestParameters = null)
 			where TReturn : class
 		{
 			using (var pipeline = this.PipelineProvider.Create(this.Settings, this.DateTimeProvider, this.MemoryStreamFactory, requestParameters))
@@ -109,7 +109,7 @@ namespace Elasticsearch.Net
 			}
 		}
 
-		public async Task<ElasticsearchResponse<TReturn>> RequestAsync<TReturn>(HttpMethod method, string path, CancellationToken cancellationToken, PostData<object> data = null, IRequestParameters requestParameters = null)
+		public async Task<ElasticsearchResponse<TReturn>> RequestAsync<TReturn>(HttpMethod method, string path, CancellationToken cancellationToken, PostData data = null, IRequestParameters requestParameters = null)
 			where TReturn : class
 		{
 			using (var pipeline = this.PipelineProvider.Create(this.Settings, this.DateTimeProvider, this.MemoryStreamFactory, requestParameters))

--- a/src/Nest/CommonAbstractions/LowLevelDispatch/IHighLevelToLowLevelDispatcher.cs
+++ b/src/Nest/CommonAbstractions/LowLevelDispatch/IHighLevelToLowLevelDispatcher.cs
@@ -10,7 +10,7 @@ namespace Nest
 	{
 		TResponse Dispatch<TRequest, TQueryString, TResponse>(
 			TRequest descriptor,
-			Func<TRequest, PostData<object>, ElasticsearchResponse<TResponse>> dispatch
+			Func<TRequest, SerializableData<TRequest>, ElasticsearchResponse<TResponse>> dispatch
 		)
 			where TQueryString : FluentRequestParameters<TQueryString>, new()
 			where TRequest : IRequest<TQueryString>
@@ -19,7 +19,7 @@ namespace Nest
 		TResponse Dispatch<TRequest, TQueryString, TResponse>(
 			TRequest descriptor,
 			Func<IApiCallDetails, Stream, TResponse> responseGenerator,
-			Func<TRequest, PostData<object>, ElasticsearchResponse<TResponse>> dispatch
+			Func<TRequest, SerializableData<TRequest>, ElasticsearchResponse<TResponse>> dispatch
 			)
 			where TQueryString : FluentRequestParameters<TQueryString>, new()
 			where TRequest : IRequest<TQueryString>
@@ -28,7 +28,7 @@ namespace Nest
 		Task<TResponseInterface> DispatchAsync<TRequest, TQueryString, TResponse, TResponseInterface>(
 			TRequest descriptor,
 			CancellationToken cancellationToken,
-			Func<TRequest, PostData<object>, CancellationToken, Task<ElasticsearchResponse<TResponse>>> dispatch
+			Func<TRequest, SerializableData<TRequest>, CancellationToken, Task<ElasticsearchResponse<TResponse>>> dispatch
 			)
 			where TQueryString : FluentRequestParameters<TQueryString>, new()
 			where TRequest : IRequest<TQueryString>
@@ -39,7 +39,7 @@ namespace Nest
 			TRequest descriptor,
 			CancellationToken cancellationToken,
 			Func<IApiCallDetails, Stream, TResponse> responseGenerator,
-			Func<TRequest, PostData<object>, CancellationToken, Task<ElasticsearchResponse<TResponse>>> dispatch
+			Func<TRequest, SerializableData<TRequest>, CancellationToken, Task<ElasticsearchResponse<TResponse>>> dispatch
 		)
 			where TQueryString : FluentRequestParameters<TQueryString>, new()
 			where TRequest : IRequest<TQueryString>

--- a/src/Nest/CommonAbstractions/Request/RequestBase.cs
+++ b/src/Nest/CommonAbstractions/Request/RequestBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.IO;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
@@ -23,14 +24,11 @@ namespace Nest
 	}
 
 	/// <summary>
-	/// A request that has an untyped document property
+	/// A request that that does not necessarily (de)serializes itself
 	/// </summary>
-	public interface IUntypedDocumentRequest : IRequest
+	public interface IProxyRequest : IRequest
 	{
-		/// <summary>
-		/// The untyped document
-		/// </summary>
-		object UntypedDocument { get; }
+		void WriteJson(IElasticsearchSerializer sourceSerializer, Stream s, SerializationFormatting serializationFormatting);
 	}
 
 	public abstract class RequestBase<TParameters> : IRequest<TParameters>

--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/GenericProxyRequestConverterBase.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/GenericProxyRequestConverterBase.cs
@@ -3,17 +3,16 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 using Newtonsoft.Json;
-using Elasticsearch.Net;
 using Newtonsoft.Json.Linq;
 using static Elasticsearch.Net.SerializationFormatting;
 
 namespace Nest
 {
-	internal abstract class DocumentJsonConverterBase<TRequest> : JsonConverter where TRequest : IUntypedDocumentRequest
+	internal abstract class GenericProxyRequestConverterBase : JsonConverter
 	{
 		private readonly Type _genericRequestType;
 
-		protected DocumentJsonConverterBase(Type genericRequestType)
+		protected GenericProxyRequestConverterBase(Type genericRequestType)
 		{
 			_genericRequestType = genericRequestType;
 		}
@@ -35,17 +34,18 @@ namespace Nest
                 var x = _genericRequestType.CreateGenericInstance(genericType, path, null, null, null);
                 return x;
 			}
-
 		}
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
-			var untypedDocumentRequest = (IUntypedDocumentRequest)value;
-			var o = untypedDocumentRequest.UntypedDocument;
+			var untypedDocumentRequest = (IProxyRequest)value;
 			var f = writer.Formatting == Formatting.Indented ? Indented : None;
-			var v = serializer.GetConnectionSettings().SourceSerializer.SerializeToString(o, f);
-			writer.WriteRawValue(v);
-
+			using (var ms = new MemoryStream())
+			{
+				untypedDocumentRequest.WriteJson(serializer.GetConnectionSettings().SourceSerializer, ms, f);
+				var v = Encoding.UTF8.GetString(ms.ToArray());
+				writer.WriteRawValue(v);
+			}
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonNetSerializer.cs
@@ -55,7 +55,7 @@ namespace Nest
 			this._indentedSerializer = JsonSerializer.Create(indented);
 		}
 
-		public virtual void Serialize(object data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.Indented)
+		public virtual void Serialize<T>(T data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.Indented)
 		{
 			var serializer = formatting == SerializationFormatting.Indented
 				? _indentedSerializer
@@ -75,7 +75,7 @@ namespace Nest
 
 		//we still support net45 so Task.Completed is not available
 		private static readonly Task CompletedTask = Task.FromResult(false);
-		public Task SerializeAsync(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
+		public Task SerializeAsync<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
 			CancellationToken cancellationToken = default(CancellationToken))
 		{
 			//This makes no sense now but we need the async method on the interface in 6.x so we can start swapping this out

--- a/src/Nest/Document/Single/Create/CreateJsonConverter.cs
+++ b/src/Nest/Document/Single/Create/CreateJsonConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nest
 {
-	internal class CreateJsonConverter : DocumentJsonConverterBase<ICreateRequest>
+	internal class CreateJsonConverter : GenericProxyRequestConverterBase
 	{
 		public CreateJsonConverter() : base(typeof(CreateRequest<>)) { }
 	}

--- a/src/Nest/Document/Single/Create/CreateRequest.cs
+++ b/src/Nest/Document/Single/Create/CreateRequest.cs
@@ -1,33 +1,35 @@
-﻿using Elasticsearch.Net;
+﻿using System.IO;
+using Elasticsearch.Net;
 using Newtonsoft.Json;
 
 namespace Nest
 {
 	[ContractJsonConverter(typeof(CreateJsonConverter))]
-	public interface ICreateRequest : IRequest<CreateRequestParameters>, IUntypedDocumentRequest {}
-
-	public partial interface ICreateRequest<TDocument> : ICreateRequest where TDocument : class
+	public partial interface ICreateRequest<TDocument> : IProxyRequest where TDocument : class
 	{
 		TDocument Document { get; set; }
 	}
 
 	public partial class CreateRequest<TDocument> where TDocument : class
 	{
+		public TDocument Document { get; set; }
+
 		partial void DocumentFromPath(TDocument document) => this.Document = document;
 
-		object IUntypedDocumentRequest.UntypedDocument => this.Document;
+		void IProxyRequest.WriteJson(IElasticsearchSerializer sourceSerializer, Stream stream, SerializationFormatting formatting) =>
+			sourceSerializer.Serialize(this.Document, stream, formatting);
 
-		public TDocument Document { get; set; }
 	}
 
 	[DescriptorFor("Create")]
 	public partial class CreateDescriptor<TDocument> where TDocument : class
 	{
+		TDocument ICreateRequest<TDocument>.Document { get; set; }
+
 		partial void DocumentFromPath(TDocument document) => Assign(a => a.Document = document);
 
-		object IUntypedDocumentRequest.UntypedDocument => Self.Document;
-
-		TDocument ICreateRequest<TDocument>.Document { get; set; }
+		void IProxyRequest.WriteJson(IElasticsearchSerializer sourceSerializer, Stream stream, SerializationFormatting formatting) =>
+			sourceSerializer.Serialize(Self.Document, stream, formatting);
 
 		/// <summary>
 		/// Sets the id for the document. Overrides the id that may be inferred from the document.

--- a/src/Nest/Document/Single/Create/ElasticClient-Create.cs
+++ b/src/Nest/Document/Single/Create/ElasticClient-Create.cs
@@ -11,58 +11,72 @@ namespace Nest
 		/// Creates a new typed document in a specific index. If a document with the same index, type and id already exists,
 		/// A 409 Conflict HTTP response status code and error will be returned.
 		/// </summary>
-		/// <typeparam name="T">The document type used to infer the default index, type and id</typeparam>
+		/// <typeparam name="TDocument">The document type used to infer the default index, type and id</typeparam>
 		/// <param name="document">The document to be created. Id will be inferred from (in order):
-		/// <para>1. Id property set up on <see cref="ConnectionSettings"/> for <typeparamref name="T"/></para> 
-		/// <para>2. <see cref="ElasticsearchTypeAttribute.IdProperty"/> property on <see cref="ElasticsearchTypeAttribute"/> applied to <typeparamref name="T"/></para> 
-		/// <para>3. A property named Id on <typeparamref name="T"/></para> 
+		/// <para>1. Id property set up on <see cref="ConnectionSettings"/> for <typeparamref name="TDocument"/></para>
+		/// <para>2. <see cref="ElasticsearchTypeAttribute.IdProperty"/> property on <see cref="ElasticsearchTypeAttribute"/> applied to <typeparamref name="TDocument"/></para>
+		/// <para>3. A property named Id on <typeparamref name="TDocument"/></para>
 		/// </param>
 		/// <param name="selector">Optionally further describe the create operation i.e override type/index/id</param>
-		ICreateResponse Create<T>(T document, Func<CreateDescriptor<T>, ICreateRequest> selector = null) where T : class;
+		ICreateResponse CreateDocument<TDocument>(TDocument document) where TDocument : class;
+		ICreateResponse Create<TDocument>(TDocument document, Func<CreateDescriptor<TDocument>, ICreateRequest<TDocument>> selector)
+			where TDocument : class;
 
 		/// <inheritdoc/>
-		ICreateResponse Create(ICreateRequest request);
+		ICreateResponse Create<TDocument>(ICreateRequest<TDocument> request) where TDocument : class;
 
 		/// <inheritdoc/>
-		Task<ICreateResponse> CreateAsync<T>(
-			T document, Func<CreateDescriptor<T>, ICreateRequest> selector = null,
+		Task<ICreateResponse> CreateDocumentAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default(CancellationToken))
+			where TDocument : class;
+
+		Task<ICreateResponse> CreateAsync<TDocument>(
+			TDocument document, Func<CreateDescriptor<TDocument>, ICreateRequest<TDocument>> selector,
 			CancellationToken cancellationToken = default(CancellationToken)
-		) where T : class;
+		) where TDocument : class;
 
 		/// <inheritdoc/>
-		Task<ICreateResponse> CreateAsync(ICreateRequest request, CancellationToken cancellationToken = default(CancellationToken));
+		Task<ICreateResponse> CreateAsync<TDocument>(ICreateRequest<TDocument> request, CancellationToken cancellationToken = default(CancellationToken))
+			where TDocument : class;
 	}
 
 	public partial class ElasticClient
 	{
 		/// <inheritdoc/>
-		public ICreateResponse Create<T>(T document, Func<CreateDescriptor<T>, ICreateRequest> selector = null) where T : class
-		{
-			var request = document as ICreateRequest;
-			return this.Create(request ?? selector.InvokeOrDefault(new CreateDescriptor<T>(document)));
-		}
+		public ICreateResponse CreateDocument<TDocument>(TDocument document) where TDocument : class => this.Create(document, s => s);
+
+		public ICreateResponse Create<TDocument>(TDocument document, Func<CreateDescriptor<TDocument>, ICreateRequest<TDocument>> selector)
+			where TDocument :
+			class => this.Create(selector?.InvokeOrDefault(new CreateDescriptor<TDocument>(document)));
 
 		/// <inheritdoc/>
-		public ICreateResponse Create(ICreateRequest request) =>
-			this.Dispatcher.Dispatch<ICreateRequest, CreateRequestParameters, CreateResponse>(
+		public ICreateResponse Create<TDocument>(ICreateRequest<TDocument> request) where TDocument : class =>
+			this.Dispatcher.Dispatch<ICreateRequest<TDocument>, CreateRequestParameters, CreateResponse>(
 				request,
-				this.LowLevelDispatch.CreateDispatch<CreateResponse>
+				this.LowLevelDispatch.CreateDispatch<CreateResponse, TDocument>
 			);
 
 		/// <inheritdoc/>
-		public Task<ICreateResponse> CreateAsync<T>(T document, Func<CreateDescriptor<T>, ICreateRequest> selector = null, CancellationToken cancellationToken = default(CancellationToken)
-		) where T : class
-		{
-			var request = document as ICreateRequest;
-			return this.CreateAsync(request ?? selector.InvokeOrDefault(new CreateDescriptor<T>(document)), cancellationToken);
-		}
+		public Task<ICreateResponse> CreateDocumentAsync<TDocument>(
+			TDocument document,
+			CancellationToken cancellationToken = default(CancellationToken)
+		) where TDocument : class =>
+			this.CreateAsync(document, s => s, cancellationToken);
 
 		/// <inheritdoc/>
-		public Task<ICreateResponse> CreateAsync(ICreateRequest request, CancellationToken cancellationToken = default(CancellationToken)) =>
-			this.Dispatcher.DispatchAsync<ICreateRequest, CreateRequestParameters, CreateResponse, ICreateResponse>(
+		public Task<ICreateResponse> CreateAsync<TDocument>(
+			TDocument document,
+			Func<CreateDescriptor<TDocument>, ICreateRequest<TDocument>> selector,
+			CancellationToken cancellationToken = default(CancellationToken)
+		) where TDocument : class =>
+			this.CreateAsync(selector?.InvokeOrDefault(new CreateDescriptor<TDocument>(document)), cancellationToken);
+
+		/// <inheritdoc/>
+		public Task<ICreateResponse> CreateAsync<TDocument>(ICreateRequest<TDocument> request, CancellationToken cancellationToken = default(CancellationToken))
+			where TDocument : class =>
+			this.Dispatcher.DispatchAsync<ICreateRequest<TDocument>, CreateRequestParameters, CreateResponse, ICreateResponse>(
 				request,
 				cancellationToken,
-				this.LowLevelDispatch.CreateDispatchAsync<CreateResponse>
+				this.LowLevelDispatch.CreateDispatchAsync<CreateResponse, TDocument>
 			);
 	}
 }

--- a/src/Nest/Document/Single/Index/ElasticClient-Index.cs
+++ b/src/Nest/Document/Single/Index/ElasticClient-Index.cs
@@ -13,58 +13,66 @@ namespace Nest
 		/// </summary>
 		/// <typeparam name="T">The document type used to infer the default index, type and id</typeparam>
 		/// <param name="document">The document to be indexed. Id will be inferred from (in order):
-		/// <para>1. Id property set up on <see cref="ConnectionSettings"/> for <typeparamref name="T"/></para> 
-		/// <para>2. <see cref="ElasticsearchTypeAttribute.IdProperty"/> property on <see cref="ElasticsearchTypeAttribute"/> applied to <typeparamref name="T"/></para> 
-		/// <para>3. A property named Id on <typeparamref name="T"/></para> 
+		/// <para>1. Id property set up on <see cref="ConnectionSettings"/> for <typeparamref name="T"/></para>
+		/// <para>2. <see cref="ElasticsearchTypeAttribute.IdProperty"/> property on <see cref="ElasticsearchTypeAttribute"/> applied to <typeparamref name="T"/></para>
+		/// <para>3. A property named Id on <typeparamref name="T"/></para>
 		/// </param>
 		/// <param name="selector">Optionally further describe the index operation i.e override type, index, id</param>
-		IIndexResponse Index<T>(T document, Func<IndexDescriptor<T>, IIndexRequest> selector = null) where T : class;
+		IIndexResponse IndexDocument<T>(T document) where T : class;
+		IIndexResponse Index<T>(T document, Func<IndexDescriptor<T>, IIndexRequest<T>> selector) where T : class;
 
 		/// <inheritdoc/>
-		IIndexResponse Index(IIndexRequest request);
+		IIndexResponse Index<T>(IIndexRequest<T> request) where T : class;
+
+		Task<IIndexResponse> IndexDocumentAsync<T>(T document, CancellationToken cancellationToken = default(CancellationToken))
+			where T : class;
 
 		/// <inheritdoc/>
 		Task<IIndexResponse> IndexAsync<T>(
 			T document,
-			Func<IndexDescriptor<T>, IIndexRequest> selector = null,
+			Func<IndexDescriptor<T>, IIndexRequest<T>> selector,
 			CancellationToken cancellationToken = default(CancellationToken)
 		) where T : class;
 
 		/// <inheritdoc/>
-		Task<IIndexResponse> IndexAsync(IIndexRequest request, CancellationToken cancellationToken = default(CancellationToken));
+		Task<IIndexResponse> IndexAsync<T>(IIndexRequest<T> request, CancellationToken cancellationToken = default(CancellationToken))
+			where T : class;
 
 	}
 
 	public partial class ElasticClient
 	{
 		/// <inheritdoc/>
-		public IIndexResponse Index<T>(T document, Func<IndexDescriptor<T>, IIndexRequest> selector = null)
-			where T : class
-		{
-			var request = document as IIndexRequest;
-			return this.Index(request ?? selector.InvokeOrDefault(new IndexDescriptor<T>(document)));
-		}
+		public IIndexResponse IndexDocument<T>(T document) where T : class => this.Index(document, s => s);
 
 		/// <inheritdoc/>
-		public IIndexResponse Index(IIndexRequest request) =>
-			this.Dispatcher.Dispatch<IIndexRequest, IndexRequestParameters, IndexResponse>(
+		public IIndexResponse Index<T>(T document, Func<IndexDescriptor<T>, IIndexRequest<T>> selector)
+			where T : class =>
+			this.Index(selector?.InvokeOrDefault(new IndexDescriptor<T>(document)));
+
+		/// <inheritdoc/>
+		public IIndexResponse Index<T>(IIndexRequest<T> request) where T : class=>
+			this.Dispatcher.Dispatch<IIndexRequest<T>, IndexRequestParameters, IndexResponse>(
 				request,
-				this.LowLevelDispatch.IndexDispatch<IndexResponse>
+				this.LowLevelDispatch.IndexDispatch<IndexResponse, T>
 			);
 
 		/// <inheritdoc/>
-		public Task<IIndexResponse> IndexAsync<T>(T document, Func<IndexDescriptor<T>, IIndexRequest> selector = null,
-			CancellationToken cancellationToken = default(CancellationToken))
-			where T : class
-		{
-			var request = document as IIndexRequest;
-			return this.IndexAsync(request ?? selector.InvokeOrDefault(new IndexDescriptor<T>(document)), cancellationToken);
-		}
+		public Task<IIndexResponse> IndexDocumentAsync<T>(T document, CancellationToken cancellationToken = default(CancellationToken))
+			where T : class =>
+			this.IndexAsync(document, s => s, cancellationToken);
 
 		/// <inheritdoc/>
-		public Task<IIndexResponse> IndexAsync(IIndexRequest request, CancellationToken cancellationToken = default(CancellationToken)) =>
-			this.Dispatcher.DispatchAsync<IIndexRequest, IndexRequestParameters, IndexResponse, IIndexResponse>(
-				request, cancellationToken, this.LowLevelDispatch.IndexDispatchAsync<IndexResponse>
+		public Task<IIndexResponse> IndexAsync<T>(T document, Func<IndexDescriptor<T>, IIndexRequest<T>> selector,
+			CancellationToken cancellationToken = default(CancellationToken))
+			where T : class =>
+			this.IndexAsync(selector?.InvokeOrDefault(new IndexDescriptor<T>(document)), cancellationToken);
+
+		/// <inheritdoc/>
+		public Task<IIndexResponse> IndexAsync<T>(IIndexRequest<T> request, CancellationToken cancellationToken = default(CancellationToken))
+			where T : class =>
+			this.Dispatcher.DispatchAsync<IIndexRequest<T>, IndexRequestParameters, IndexResponse, IIndexResponse>(
+				request, cancellationToken, this.LowLevelDispatch.IndexDispatchAsync<IndexResponse, T>
 			);
 	}
 }

--- a/src/Nest/Document/Single/Index/IndexJsonConverter.cs
+++ b/src/Nest/Document/Single/Index/IndexJsonConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nest
 {
-	internal class IndexJsonConverter : DocumentJsonConverterBase<IIndexRequest>
+	internal class IndexJsonConverter : GenericProxyRequestConverterBase
 	{
 		public IndexJsonConverter() : base(typeof(IndexRequest<>)) { }
 	}

--- a/src/Nest/Document/Single/TermVectors/ElasticClient-TermVectors.cs
+++ b/src/Nest/Document/Single/TermVectors/ElasticClient-TermVectors.cs
@@ -43,7 +43,7 @@ namespace Nest
 		{
 			return this.Dispatcher.Dispatch<ITermVectorsRequest<T>, TermVectorsRequestParameters, TermVectorsResponse>(
 				request,
-				this.LowLevelDispatch.TermvectorsDispatch<TermVectorsResponse>
+				this.LowLevelDispatch.TermvectorsDispatch<TermVectorsResponse, T>
 			);
 		}
 
@@ -58,7 +58,7 @@ namespace Nest
 			this.Dispatcher.DispatchAsync<ITermVectorsRequest<T>, TermVectorsRequestParameters, TermVectorsResponse, ITermVectorsResponse>(
 				request,
 				cancellationToken,
-				this.LowLevelDispatch.TermvectorsDispatchAsync<TermVectorsResponse>
+				this.LowLevelDispatch.TermvectorsDispatchAsync<TermVectorsResponse, T>
 			);
 	}
 }

--- a/src/Nest/Document/Single/Update/ElasticClient-Update.cs
+++ b/src/Nest/Document/Single/Update/ElasticClient-Update.cs
@@ -84,7 +84,7 @@ namespace Nest
 			where TPartialDocument : class =>
 			this.Dispatcher.Dispatch<IUpdateRequest<TDocument, TPartialDocument>, UpdateRequestParameters, UpdateResponse<TDocument>>(
 				request,
-				(p, d) => this.LowLevelDispatch.UpdateDispatch<UpdateResponse<TDocument>>(p, d)
+				this.LowLevelDispatch.UpdateDispatch<UpdateResponse<TDocument>, TDocument, TPartialDocument>
 			);
 
 		/// <inheritdoc/>
@@ -119,7 +119,7 @@ namespace Nest
 			this.Dispatcher.DispatchAsync<IUpdateRequest<TDocument, TPartialDocument>, UpdateRequestParameters, UpdateResponse<TDocument>, IUpdateResponse<TDocument>>(
 				request,
 				cancellationToken,
-				this.LowLevelDispatch.UpdateDispatchAsync<UpdateResponse<TDocument>>
+				this.LowLevelDispatch.UpdateDispatchAsync<UpdateResponse<TDocument>, TDocument, TPartialDocument>
 			);
 	}
 }

--- a/src/Nest/ElasticClient.cs
+++ b/src/Nest/ElasticClient.cs
@@ -43,13 +43,13 @@ namespace Nest
 
 		TResponse IHighLevelToLowLevelDispatcher.Dispatch<TRequest, TQueryString, TResponse>(
 			TRequest request,
-			Func<TRequest, PostData<object>,
+			Func<TRequest, SerializableData<TRequest>,
 			ElasticsearchResponse<TResponse>> dispatch
 			) => this.Dispatcher.Dispatch<TRequest,TQueryString,TResponse>(request, null, dispatch);
 
 		TResponse IHighLevelToLowLevelDispatcher.Dispatch<TRequest, TQueryString, TResponse>(
 			TRequest request, Func<IApiCallDetails, Stream, TResponse> responseGenerator,
-			Func<TRequest, PostData<object>, ElasticsearchResponse<TResponse>> dispatch
+			Func<TRequest, SerializableData<TRequest>, ElasticsearchResponse<TResponse>> dispatch
 			)
 		{
 			request.RouteValues.Resolve(this.ConnectionSettings);
@@ -62,14 +62,14 @@ namespace Nest
 		Task<TResponseInterface> IHighLevelToLowLevelDispatcher.DispatchAsync<TRequest, TQueryString, TResponse, TResponseInterface>(
 			TRequest descriptor,
 			CancellationToken cancellationToken,
-			Func<TRequest, PostData<object>, CancellationToken, Task<ElasticsearchResponse<TResponse>>> dispatch
+			Func<TRequest, SerializableData<TRequest>, CancellationToken, Task<ElasticsearchResponse<TResponse>>> dispatch
 			) => this.Dispatcher.DispatchAsync<TRequest,TQueryString,TResponse,TResponseInterface>(descriptor, cancellationToken, null, dispatch);
 
 		async Task<TResponseInterface> IHighLevelToLowLevelDispatcher.DispatchAsync<TRequest, TQueryString, TResponse, TResponseInterface>(
 			TRequest request,
 			CancellationToken cancellationToken,
 			Func<IApiCallDetails, Stream, TResponse> responseGenerator,
-			Func<TRequest, PostData<object>, CancellationToken, Task<ElasticsearchResponse<TResponse>>> dispatch
+			Func<TRequest, SerializableData<TRequest>, CancellationToken, Task<ElasticsearchResponse<TResponse>>> dispatch
 			)
 		{
 			request.RouteValues.Resolve(this.ConnectionSettings);

--- a/src/Nest/Search/Explain/ElasticClient-Explain.cs
+++ b/src/Nest/Search/Explain/ElasticClient-Explain.cs
@@ -12,50 +12,50 @@ namespace Nest
 		/// This can give useful feedback whether a document matches or didn’t match a specific query.
 		/// <para> </para><a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html</a>
 		/// </summary>
-		IExplainResponse<T> Explain<T>(DocumentPath<T> document, Func<ExplainDescriptor<T>, IExplainRequest<T>> selector)
-			where T : class;
+		IExplainResponse<TDocument> Explain<TDocument>(DocumentPath<TDocument> document, Func<ExplainDescriptor<TDocument>, IExplainRequest<TDocument>> selector)
+			where TDocument : class;
 
 		/// <inheritdoc/>
-		IExplainResponse<T> Explain<T>(IExplainRequest<T> request)
-			where T : class;
+		IExplainResponse<TDocument> Explain<TDocument>(IExplainRequest<TDocument> request)
+			where TDocument : class;
 
 		/// <inheritdoc/>
-		Task<IExplainResponse<T>> ExplainAsync<T>(DocumentPath<T> document,Func<ExplainDescriptor<T>, IExplainRequest<T>> selector, CancellationToken cancellationToken = default(CancellationToken))
-			where T : class;
+		Task<IExplainResponse<TDocument>> ExplainAsync<TDocument>(DocumentPath<TDocument> document,Func<ExplainDescriptor<TDocument>, IExplainRequest<TDocument>> selector, CancellationToken cancellationToken = default(CancellationToken))
+			where TDocument : class;
 
 		/// <inheritdoc/>
-		Task<IExplainResponse<T>> ExplainAsync<T>(IExplainRequest<T> request, CancellationToken cancellationToken = default(CancellationToken))
-			where T : class;
+		Task<IExplainResponse<TDocument>> ExplainAsync<TDocument>(IExplainRequest<TDocument> request, CancellationToken cancellationToken = default(CancellationToken))
+			where TDocument : class;
 
 	}
 
 	public partial class ElasticClient
 	{
 		/// <inheritdoc/>
-		public IExplainResponse<T> Explain<T>(DocumentPath<T> document, Func<ExplainDescriptor<T>, IExplainRequest<T>> selector)
-			where T : class =>
-			this.Explain<T>(selector?.Invoke(new ExplainDescriptor<T>(document.Self.Index, document.Self.Type, document.Self.Id)));
+		public IExplainResponse<TDocument> Explain<TDocument>(DocumentPath<TDocument> document, Func<ExplainDescriptor<TDocument>, IExplainRequest<TDocument>> selector)
+			where TDocument : class =>
+			this.Explain<TDocument>(selector?.Invoke(new ExplainDescriptor<TDocument>(document.Self.Index, document.Self.Type, document.Self.Id)));
 
 		/// <inheritdoc/>
-		public IExplainResponse<T> Explain<T>(IExplainRequest<T> request)
-			where T : class =>
-			this.Dispatcher.Dispatch<IExplainRequest<T>, ExplainRequestParameters, ExplainResponse<T>>(
+		public IExplainResponse<TDocument> Explain<TDocument>(IExplainRequest<TDocument> request)
+			where TDocument : class =>
+			this.Dispatcher.Dispatch<IExplainRequest<TDocument>, ExplainRequestParameters, ExplainResponse<TDocument>>(
 				request,
-				this.LowLevelDispatch.ExplainDispatch<ExplainResponse<T>>
+				this.LowLevelDispatch.ExplainDispatch<ExplainResponse<TDocument>, TDocument>
 			);
 
 		/// <inheritdoc/>
-		public Task<IExplainResponse<T>> ExplainAsync<T>(DocumentPath<T> document, Func<ExplainDescriptor<T>, IExplainRequest<T>> selector, CancellationToken cancellationToken = default(CancellationToken))
-			where T : class =>
-			this.ExplainAsync<T>(selector?.Invoke(new ExplainDescriptor<T>(document.Self.Index, document.Self.Type, document.Self.Id)), cancellationToken);
+		public Task<IExplainResponse<TDocument>> ExplainAsync<TDocument>(DocumentPath<TDocument> document, Func<ExplainDescriptor<TDocument>, IExplainRequest<TDocument>> selector, CancellationToken cancellationToken = default(CancellationToken))
+			where TDocument : class =>
+			this.ExplainAsync<TDocument>(selector?.Invoke(new ExplainDescriptor<TDocument>(document.Self.Index, document.Self.Type, document.Self.Id)), cancellationToken);
 
 		/// <inheritdoc/>
-		public Task<IExplainResponse<T>> ExplainAsync<T>(IExplainRequest<T> request, CancellationToken cancellationToken = default(CancellationToken))
-			where T : class =>
-			this.Dispatcher.DispatchAsync<IExplainRequest<T>, ExplainRequestParameters, ExplainResponse<T>, IExplainResponse<T>>(
+		public Task<IExplainResponse<TDocument>> ExplainAsync<TDocument>(IExplainRequest<TDocument> request, CancellationToken cancellationToken = default(CancellationToken))
+			where TDocument : class =>
+			this.Dispatcher.DispatchAsync<IExplainRequest<TDocument>, ExplainRequestParameters, ExplainResponse<TDocument>, IExplainResponse<TDocument>>(
 				request,
 				cancellationToken,
-				this.LowLevelDispatch.ExplainDispatchAsync<ExplainResponse<T>>
+				this.LowLevelDispatch.ExplainDispatchAsync<ExplainResponse<TDocument>, TDocument>
 			);
 	}
 }

--- a/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
+++ b/src/Nest/Search/MultiSearch/ElasticClient-MultiSearch.cs
@@ -45,7 +45,7 @@ namespace Nest
 					var serializer = this.ConnectionSettings.CreateStateful(converter);
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);
-					return this.LowLevelDispatch.MsearchDispatch<MultiSearchResponse>(p, (object)p);
+					return this.LowLevelDispatch.MsearchDispatch<MultiSearchResponse>(p, new SerializableData<IMultiSearchRequest>(p));
 				}
 			);
 		}
@@ -67,7 +67,7 @@ namespace Nest
 					var serializer = this.ConnectionSettings.CreateStateful(converter);
 					var creator = new MultiSearchCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);
-					return this.LowLevelDispatch.MsearchDispatchAsync<MultiSearchResponse>(p, (object)p, c);
+					return this.LowLevelDispatch.MsearchDispatchAsync<MultiSearchResponse>(p, new SerializableData<IMultiSearchRequest>(p), c);
 				}
 			);
 		}

--- a/src/Nest/Search/MultiSearchTemplate/ElasticClient-MultiSearchTemplate.cs
+++ b/src/Nest/Search/MultiSearchTemplate/ElasticClient-MultiSearchTemplate.cs
@@ -45,7 +45,7 @@ namespace Nest
 					var serializer = this.ConnectionSettings.CreateStateful(converter);
 					var creator = new MultiSearchTemplateCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);
-					return this.LowLevelDispatch.MsearchTemplateDispatch<MultiSearchResponse>(p, (object)p);
+					return this.LowLevelDispatch.MsearchTemplateDispatch<MultiSearchResponse>(p, new SerializableData<IMultiSearchTemplateRequest>(p));
 				}
 			);
 		}
@@ -67,7 +67,7 @@ namespace Nest
 					var serializer = this.ConnectionSettings.CreateStateful(converter);
 					var creator = new MultiSearchTemplateCreator((r, s) => serializer.Deserialize<MultiSearchResponse>(s));
 					request.RequestParameters.DeserializationOverride(creator);
-					return this.LowLevelDispatch.MsearchTemplateDispatchAsync<MultiSearchResponse>(p, (object)p, c);
+					return this.LowLevelDispatch.MsearchTemplateDispatchAsync<MultiSearchResponse>(p, new SerializableData<IMultiSearchTemplateRequest>(p), c);
 				}
 			);
 		}

--- a/src/Nest/_Generated/_LowLevelDispatch.generated.cs
+++ b/src/Nest/_Generated/_LowLevelDispatch.generated.cs
@@ -18,7 +18,7 @@ namespace Nest
 	internal partial class LowLevelDispatch
 	{
 
-		internal ElasticsearchResponse<T> BulkDispatch<T>(IRequest<BulkRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> BulkDispatch<T>(IRequest<BulkRequestParameters> p,SerializableData<IBulkRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -36,25 +36,25 @@ namespace Nest
 			throw InvalidDispatch("Bulk", p, new [] { POST, PUT }, "/_bulk", "/{index}/_bulk", "/{index}/{type}/_bulk");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> BulkDispatchAsync<T>(IRequest<BulkRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> BulkDispatchAsync<T>(IRequest<BulkRequestParameters> p,SerializableData<IBulkRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.BulkAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.BulkAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.BulkAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.BulkAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.BulkAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.BulkAsync<T>(body,u => p.RequestParameters,ct);
 
 				case PUT:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.BulkPutAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.BulkPutAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.BulkPutAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.BulkPutAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.BulkPutAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.BulkPutAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Bulk", p, new [] { POST, PUT }, "/_bulk", "/{index}/_bulk", "/{index}/{type}/_bulk");
 		}
 		
-		internal ElasticsearchResponse<T> CatAliasesDispatch<T>(IRequest<CatAliasesRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatAliasesDispatch<T>(IRequest<CatAliasesRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -66,19 +66,19 @@ namespace Nest
 			throw InvalidDispatch("CatAliases", p, new [] { GET }, "/_cat/aliases", "/_cat/aliases/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatAliasesDispatchAsync<T>(IRequest<CatAliasesRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatAliasesDispatchAsync<T>(IRequest<CatAliasesRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Name)) return _lowLevel.CatAliasesAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatAliasesAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Name)) return _lowLevel.CatAliasesAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
+					return _lowLevel.CatAliasesAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatAliases", p, new [] { GET }, "/_cat/aliases", "/_cat/aliases/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> CatAllocationDispatch<T>(IRequest<CatAllocationRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatAllocationDispatch<T>(IRequest<CatAllocationRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -90,19 +90,19 @@ namespace Nest
 			throw InvalidDispatch("CatAllocation", p, new [] { GET }, "/_cat/allocation", "/_cat/allocation/{node_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatAllocationDispatchAsync<T>(IRequest<CatAllocationRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatAllocationDispatchAsync<T>(IRequest<CatAllocationRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.CatAllocationAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatAllocationAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.CatAllocationAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,ct);
+					return _lowLevel.CatAllocationAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatAllocation", p, new [] { GET }, "/_cat/allocation", "/_cat/allocation/{node_id}");
 		}
 		
-		internal ElasticsearchResponse<T> CatCountDispatch<T>(IRequest<CatCountRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatCountDispatch<T>(IRequest<CatCountRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -114,19 +114,19 @@ namespace Nest
 			throw InvalidDispatch("CatCount", p, new [] { GET }, "/_cat/count", "/_cat/count/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatCountDispatchAsync<T>(IRequest<CatCountRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatCountDispatchAsync<T>(IRequest<CatCountRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatCountAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatCountAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatCountAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.CatCountAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatCount", p, new [] { GET }, "/_cat/count", "/_cat/count/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> CatFielddataDispatch<T>(IRequest<CatFielddataRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatFielddataDispatch<T>(IRequest<CatFielddataRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -138,19 +138,19 @@ namespace Nest
 			throw InvalidDispatch("CatFielddata", p, new [] { GET }, "/_cat/fielddata", "/_cat/fielddata/{fields}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatFielddataDispatchAsync<T>(IRequest<CatFielddataRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatFielddataDispatchAsync<T>(IRequest<CatFielddataRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Fields)) return _lowLevel.CatFielddataAsync<T>(p.RouteValues.Fields,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatFielddataAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Fields)) return _lowLevel.CatFielddataAsync<T>(p.RouteValues.Fields,u => p.RequestParameters,ct);
+					return _lowLevel.CatFielddataAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatFielddata", p, new [] { GET }, "/_cat/fielddata", "/_cat/fielddata/{fields}");
 		}
 		
-		internal ElasticsearchResponse<T> CatHealthDispatch<T>(IRequest<CatHealthRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatHealthDispatch<T>(IRequest<CatHealthRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -161,18 +161,18 @@ namespace Nest
 			throw InvalidDispatch("CatHealth", p, new [] { GET }, "/_cat/health");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatHealthDispatchAsync<T>(IRequest<CatHealthRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatHealthDispatchAsync<T>(IRequest<CatHealthRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatHealthAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatHealthAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatHealth", p, new [] { GET }, "/_cat/health");
 		}
 		
-		internal ElasticsearchResponse<T> CatHelpDispatch<T>(IRequest<CatHelpRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatHelpDispatch<T>(IRequest<CatHelpRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -183,18 +183,18 @@ namespace Nest
 			throw InvalidDispatch("CatHelp", p, new [] { GET }, "/_cat");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatHelpDispatchAsync<T>(IRequest<CatHelpRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatHelpDispatchAsync<T>(IRequest<CatHelpRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatHelpAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatHelpAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatHelp", p, new [] { GET }, "/_cat");
 		}
 		
-		internal ElasticsearchResponse<T> CatIndicesDispatch<T>(IRequest<CatIndicesRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatIndicesDispatch<T>(IRequest<CatIndicesRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -206,19 +206,19 @@ namespace Nest
 			throw InvalidDispatch("CatIndices", p, new [] { GET }, "/_cat/indices", "/_cat/indices/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatIndicesDispatchAsync<T>(IRequest<CatIndicesRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatIndicesDispatchAsync<T>(IRequest<CatIndicesRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatIndicesAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatIndicesAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatIndicesAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.CatIndicesAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatIndices", p, new [] { GET }, "/_cat/indices", "/_cat/indices/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> CatMasterDispatch<T>(IRequest<CatMasterRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatMasterDispatch<T>(IRequest<CatMasterRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -229,18 +229,18 @@ namespace Nest
 			throw InvalidDispatch("CatMaster", p, new [] { GET }, "/_cat/master");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatMasterDispatchAsync<T>(IRequest<CatMasterRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatMasterDispatchAsync<T>(IRequest<CatMasterRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatMasterAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatMasterAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatMaster", p, new [] { GET }, "/_cat/master");
 		}
 		
-		internal ElasticsearchResponse<T> CatNodeattrsDispatch<T>(IRequest<CatNodeAttributesRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatNodeattrsDispatch<T>(IRequest<CatNodeAttributesRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -251,18 +251,18 @@ namespace Nest
 			throw InvalidDispatch("CatNodeattrs", p, new [] { GET }, "/_cat/nodeattrs");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatNodeattrsDispatchAsync<T>(IRequest<CatNodeAttributesRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatNodeattrsDispatchAsync<T>(IRequest<CatNodeAttributesRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatNodeattrsAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatNodeattrsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatNodeattrs", p, new [] { GET }, "/_cat/nodeattrs");
 		}
 		
-		internal ElasticsearchResponse<T> CatNodesDispatch<T>(IRequest<CatNodesRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatNodesDispatch<T>(IRequest<CatNodesRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -273,18 +273,18 @@ namespace Nest
 			throw InvalidDispatch("CatNodes", p, new [] { GET }, "/_cat/nodes");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatNodesDispatchAsync<T>(IRequest<CatNodesRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatNodesDispatchAsync<T>(IRequest<CatNodesRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatNodesAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatNodesAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatNodes", p, new [] { GET }, "/_cat/nodes");
 		}
 		
-		internal ElasticsearchResponse<T> CatPendingTasksDispatch<T>(IRequest<CatPendingTasksRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatPendingTasksDispatch<T>(IRequest<CatPendingTasksRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -295,18 +295,18 @@ namespace Nest
 			throw InvalidDispatch("CatPendingTasks", p, new [] { GET }, "/_cat/pending_tasks");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatPendingTasksDispatchAsync<T>(IRequest<CatPendingTasksRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatPendingTasksDispatchAsync<T>(IRequest<CatPendingTasksRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatPendingTasksAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatPendingTasksAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatPendingTasks", p, new [] { GET }, "/_cat/pending_tasks");
 		}
 		
-		internal ElasticsearchResponse<T> CatPluginsDispatch<T>(IRequest<CatPluginsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatPluginsDispatch<T>(IRequest<CatPluginsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -317,18 +317,18 @@ namespace Nest
 			throw InvalidDispatch("CatPlugins", p, new [] { GET }, "/_cat/plugins");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatPluginsDispatchAsync<T>(IRequest<CatPluginsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatPluginsDispatchAsync<T>(IRequest<CatPluginsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatPluginsAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatPluginsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatPlugins", p, new [] { GET }, "/_cat/plugins");
 		}
 		
-		internal ElasticsearchResponse<T> CatRecoveryDispatch<T>(IRequest<CatRecoveryRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatRecoveryDispatch<T>(IRequest<CatRecoveryRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -340,19 +340,19 @@ namespace Nest
 			throw InvalidDispatch("CatRecovery", p, new [] { GET }, "/_cat/recovery", "/_cat/recovery/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatRecoveryDispatchAsync<T>(IRequest<CatRecoveryRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatRecoveryDispatchAsync<T>(IRequest<CatRecoveryRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatRecoveryAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatRecoveryAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatRecoveryAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.CatRecoveryAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatRecovery", p, new [] { GET }, "/_cat/recovery", "/_cat/recovery/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> CatRepositoriesDispatch<T>(IRequest<CatRepositoriesRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatRepositoriesDispatch<T>(IRequest<CatRepositoriesRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -363,18 +363,18 @@ namespace Nest
 			throw InvalidDispatch("CatRepositories", p, new [] { GET }, "/_cat/repositories");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatRepositoriesDispatchAsync<T>(IRequest<CatRepositoriesRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatRepositoriesDispatchAsync<T>(IRequest<CatRepositoriesRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatRepositoriesAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatRepositoriesAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatRepositories", p, new [] { GET }, "/_cat/repositories");
 		}
 		
-		internal ElasticsearchResponse<T> CatSegmentsDispatch<T>(IRequest<CatSegmentsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatSegmentsDispatch<T>(IRequest<CatSegmentsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -386,19 +386,19 @@ namespace Nest
 			throw InvalidDispatch("CatSegments", p, new [] { GET }, "/_cat/segments", "/_cat/segments/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatSegmentsDispatchAsync<T>(IRequest<CatSegmentsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatSegmentsDispatchAsync<T>(IRequest<CatSegmentsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatSegmentsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatSegmentsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatSegmentsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.CatSegmentsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatSegments", p, new [] { GET }, "/_cat/segments", "/_cat/segments/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> CatShardsDispatch<T>(IRequest<CatShardsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatShardsDispatch<T>(IRequest<CatShardsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -410,19 +410,19 @@ namespace Nest
 			throw InvalidDispatch("CatShards", p, new [] { GET }, "/_cat/shards", "/_cat/shards/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatShardsDispatchAsync<T>(IRequest<CatShardsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatShardsDispatchAsync<T>(IRequest<CatShardsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatShardsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatShardsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.CatShardsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.CatShardsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatShards", p, new [] { GET }, "/_cat/shards", "/_cat/shards/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> CatSnapshotsDispatch<T>(IRequest<CatSnapshotsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatSnapshotsDispatch<T>(IRequest<CatSnapshotsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -434,19 +434,19 @@ namespace Nest
 			throw InvalidDispatch("CatSnapshots", p, new [] { GET }, "/_cat/snapshots", "/_cat/snapshots/{repository}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatSnapshotsDispatchAsync<T>(IRequest<CatSnapshotsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatSnapshotsDispatchAsync<T>(IRequest<CatSnapshotsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Repository)) return _lowLevel.CatSnapshotsAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatSnapshotsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Repository)) return _lowLevel.CatSnapshotsAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,ct);
+					return _lowLevel.CatSnapshotsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatSnapshots", p, new [] { GET }, "/_cat/snapshots", "/_cat/snapshots/{repository}");
 		}
 		
-		internal ElasticsearchResponse<T> CatTasksDispatch<T>(IRequest<CatTasksRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatTasksDispatch<T>(IRequest<CatTasksRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -457,18 +457,18 @@ namespace Nest
 			throw InvalidDispatch("CatTasks", p, new [] { GET }, "/_cat/tasks");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatTasksDispatchAsync<T>(IRequest<CatTasksRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatTasksDispatchAsync<T>(IRequest<CatTasksRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.CatTasksAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.CatTasksAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatTasks", p, new [] { GET }, "/_cat/tasks");
 		}
 		
-		internal ElasticsearchResponse<T> CatTemplatesDispatch<T>(IRequest<CatTemplatesRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatTemplatesDispatch<T>(IRequest<CatTemplatesRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -480,19 +480,19 @@ namespace Nest
 			throw InvalidDispatch("CatTemplates", p, new [] { GET }, "/_cat/templates", "/_cat/templates/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatTemplatesDispatchAsync<T>(IRequest<CatTemplatesRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatTemplatesDispatchAsync<T>(IRequest<CatTemplatesRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Name)) return _lowLevel.CatTemplatesAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatTemplatesAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Name)) return _lowLevel.CatTemplatesAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
+					return _lowLevel.CatTemplatesAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatTemplates", p, new [] { GET }, "/_cat/templates", "/_cat/templates/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> CatThreadPoolDispatch<T>(IRequest<CatThreadPoolRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> CatThreadPoolDispatch<T>(IRequest<CatThreadPoolRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -504,19 +504,19 @@ namespace Nest
 			throw InvalidDispatch("CatThreadPool", p, new [] { GET }, "/_cat/thread_pool", "/_cat/thread_pool/{thread_pool_patterns}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CatThreadPoolDispatchAsync<T>(IRequest<CatThreadPoolRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CatThreadPoolDispatchAsync<T>(IRequest<CatThreadPoolRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.ThreadPoolPatterns)) return _lowLevel.CatThreadPoolAsync<T>(p.RouteValues.ThreadPoolPatterns,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CatThreadPoolAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.ThreadPoolPatterns)) return _lowLevel.CatThreadPoolAsync<T>(p.RouteValues.ThreadPoolPatterns,u => p.RequestParameters,ct);
+					return _lowLevel.CatThreadPoolAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("CatThreadPool", p, new [] { GET }, "/_cat/thread_pool", "/_cat/thread_pool/{thread_pool_patterns}");
 		}
 		
-		internal ElasticsearchResponse<T> ClearScrollDispatch<T>(IRequest<ClearScrollRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> ClearScrollDispatch<T>(IRequest<ClearScrollRequestParameters> p,SerializableData<IClearScrollRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -527,18 +527,18 @@ namespace Nest
 			throw InvalidDispatch("ClearScroll", p, new [] { DELETE }, "/_search/scroll");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClearScrollDispatchAsync<T>(IRequest<ClearScrollRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClearScrollDispatchAsync<T>(IRequest<ClearScrollRequestParameters> p,SerializableData<IClearScrollRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					return _lowLevel.ClearScrollAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ClearScrollAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClearScroll", p, new [] { DELETE }, "/_search/scroll");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterAllocationExplainDispatch<T>(IRequest<ClusterAllocationExplainRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> ClusterAllocationExplainDispatch<T>(IRequest<ClusterAllocationExplainRequestParameters> p,SerializableData<IClusterAllocationExplainRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -552,21 +552,21 @@ namespace Nest
 			throw InvalidDispatch("ClusterAllocationExplain", p, new [] { GET, POST }, "/_cluster/allocation/explain");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterAllocationExplainDispatchAsync<T>(IRequest<ClusterAllocationExplainRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterAllocationExplainDispatchAsync<T>(IRequest<ClusterAllocationExplainRequestParameters> p,SerializableData<IClusterAllocationExplainRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.ClusterAllocationExplainGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ClusterAllocationExplainGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					return _lowLevel.ClusterAllocationExplainAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ClusterAllocationExplainAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterAllocationExplain", p, new [] { GET, POST }, "/_cluster/allocation/explain");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterGetSettingsDispatch<T>(IRequest<ClusterGetSettingsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ClusterGetSettingsDispatch<T>(IRequest<ClusterGetSettingsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -577,18 +577,18 @@ namespace Nest
 			throw InvalidDispatch("ClusterGetSettings", p, new [] { GET }, "/_cluster/settings");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterGetSettingsDispatchAsync<T>(IRequest<ClusterGetSettingsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterGetSettingsDispatchAsync<T>(IRequest<ClusterGetSettingsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.ClusterGetSettingsAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ClusterGetSettingsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterGetSettings", p, new [] { GET }, "/_cluster/settings");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterHealthDispatch<T>(IRequest<ClusterHealthRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ClusterHealthDispatch<T>(IRequest<ClusterHealthRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -600,19 +600,19 @@ namespace Nest
 			throw InvalidDispatch("ClusterHealth", p, new [] { GET }, "/_cluster/health", "/_cluster/health/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterHealthDispatchAsync<T>(IRequest<ClusterHealthRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterHealthDispatchAsync<T>(IRequest<ClusterHealthRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.ClusterHealthAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.ClusterHealthAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.ClusterHealthAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.ClusterHealthAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterHealth", p, new [] { GET }, "/_cluster/health", "/_cluster/health/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterPendingTasksDispatch<T>(IRequest<ClusterPendingTasksRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ClusterPendingTasksDispatch<T>(IRequest<ClusterPendingTasksRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -623,18 +623,18 @@ namespace Nest
 			throw InvalidDispatch("ClusterPendingTasks", p, new [] { GET }, "/_cluster/pending_tasks");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterPendingTasksDispatchAsync<T>(IRequest<ClusterPendingTasksRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterPendingTasksDispatchAsync<T>(IRequest<ClusterPendingTasksRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.ClusterPendingTasksAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ClusterPendingTasksAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterPendingTasks", p, new [] { GET }, "/_cluster/pending_tasks");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterPutSettingsDispatch<T>(IRequest<ClusterPutSettingsRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> ClusterPutSettingsDispatch<T>(IRequest<ClusterPutSettingsRequestParameters> p,SerializableData<IClusterPutSettingsRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -645,18 +645,18 @@ namespace Nest
 			throw InvalidDispatch("ClusterPutSettings", p, new [] { PUT }, "/_cluster/settings");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterPutSettingsDispatchAsync<T>(IRequest<ClusterPutSettingsRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterPutSettingsDispatchAsync<T>(IRequest<ClusterPutSettingsRequestParameters> p,SerializableData<IClusterPutSettingsRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					return _lowLevel.ClusterPutSettingsAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ClusterPutSettingsAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterPutSettings", p, new [] { PUT }, "/_cluster/settings");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterRemoteInfoDispatch<T>(IRequest<RemoteInfoRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ClusterRemoteInfoDispatch<T>(IRequest<RemoteInfoRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -667,18 +667,18 @@ namespace Nest
 			throw InvalidDispatch("ClusterRemoteInfo", p, new [] { GET }, "/_remote/info");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterRemoteInfoDispatchAsync<T>(IRequest<RemoteInfoRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterRemoteInfoDispatchAsync<T>(IRequest<RemoteInfoRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.ClusterRemoteInfoAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ClusterRemoteInfoAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterRemoteInfo", p, new [] { GET }, "/_remote/info");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterRerouteDispatch<T>(IRequest<ClusterRerouteRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> ClusterRerouteDispatch<T>(IRequest<ClusterRerouteRequestParameters> p,SerializableData<IClusterRerouteRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -689,18 +689,18 @@ namespace Nest
 			throw InvalidDispatch("ClusterReroute", p, new [] { POST }, "/_cluster/reroute");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterRerouteDispatchAsync<T>(IRequest<ClusterRerouteRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterRerouteDispatchAsync<T>(IRequest<ClusterRerouteRequestParameters> p,SerializableData<IClusterRerouteRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.ClusterRerouteAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ClusterRerouteAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterReroute", p, new [] { POST }, "/_cluster/reroute");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterStateDispatch<T>(IRequest<ClusterStateRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ClusterStateDispatch<T>(IRequest<ClusterStateRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -713,20 +713,20 @@ namespace Nest
 			throw InvalidDispatch("ClusterState", p, new [] { GET }, "/_cluster/state", "/_cluster/state/{metric}", "/_cluster/state/{metric}/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterStateDispatchAsync<T>(IRequest<ClusterStateRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterStateDispatchAsync<T>(IRequest<ClusterStateRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Metric, p.RouteValues.Index)) return _lowLevel.ClusterStateAsync<T>(p.RouteValues.Metric,p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Metric)) return _lowLevel.ClusterStateAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.ClusterStateAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Metric, p.RouteValues.Index)) return _lowLevel.ClusterStateAsync<T>(p.RouteValues.Metric,p.RouteValues.Index,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Metric)) return _lowLevel.ClusterStateAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,ct);
+					return _lowLevel.ClusterStateAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterState", p, new [] { GET }, "/_cluster/state", "/_cluster/state/{metric}", "/_cluster/state/{metric}/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> ClusterStatsDispatch<T>(IRequest<ClusterStatsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ClusterStatsDispatch<T>(IRequest<ClusterStatsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -738,19 +738,19 @@ namespace Nest
 			throw InvalidDispatch("ClusterStats", p, new [] { GET }, "/_cluster/stats", "/_cluster/stats/nodes/{node_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ClusterStatsDispatchAsync<T>(IRequest<ClusterStatsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ClusterStatsDispatchAsync<T>(IRequest<ClusterStatsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.ClusterStatsAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.ClusterStatsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.ClusterStatsAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,ct);
+					return _lowLevel.ClusterStatsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("ClusterStats", p, new [] { GET }, "/_cluster/stats", "/_cluster/stats/nodes/{node_id}");
 		}
 		
-		internal ElasticsearchResponse<T> CountDispatch<T>(IRequest<CountRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> CountDispatch<T>(IRequest<CountRequestParameters> p,SerializableData<ICountRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -768,25 +768,25 @@ namespace Nest
 			throw InvalidDispatch("Count", p, new [] { POST, GET }, "/_count", "/{index}/_count", "/{index}/{type}/_count");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CountDispatchAsync<T>(IRequest<CountRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CountDispatchAsync<T>(IRequest<CountRequestParameters> p,SerializableData<ICountRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.CountAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.CountAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CountAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.CountAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.CountAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.CountAsync<T>(body,u => p.RequestParameters,ct);
 
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.CountGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.CountGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.CountGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.CountGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.CountGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.CountGetAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Count", p, new [] { POST, GET }, "/_count", "/{index}/_count", "/{index}/{type}/_count");
 		}
 		
-		internal ElasticsearchResponse<T> CreateDispatch<T>(IRequest<CreateRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> CreateDispatch<T,TDocument>(IRequest<CreateRequestParameters> p,SerializableData<ICreateRequest<TDocument>> body) where T : class where TDocument : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -802,23 +802,23 @@ namespace Nest
 			throw InvalidDispatch("Create", p, new [] { PUT, POST }, "/{index}/{type}/{id}/_create");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> CreateDispatchAsync<T>(IRequest<CreateRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> CreateDispatchAsync<T,TDocument>(IRequest<CreateRequestParameters> p,SerializableData<ICreateRequest<TDocument>> body, CancellationToken ct) where T : class where TDocument : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.CreateAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.CreateAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.CreatePostAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.CreatePostAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("Create", p, new [] { PUT, POST }, "/{index}/{type}/{id}/_create");
 		}
 		
-		internal ElasticsearchResponse<T> DeleteDispatch<T>(IRequest<DeleteRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> DeleteDispatch<T>(IRequest<DeleteRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -830,19 +830,19 @@ namespace Nest
 			throw InvalidDispatch("Delete", p, new [] { DELETE }, "/{index}/{type}/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> DeleteDispatchAsync<T>(IRequest<DeleteRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> DeleteDispatchAsync<T>(IRequest<DeleteRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.DeleteAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.DeleteAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("Delete", p, new [] { DELETE }, "/{index}/{type}/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> DeleteByQueryDispatch<T>(IRequest<DeleteByQueryRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> DeleteByQueryDispatch<T>(IRequest<DeleteByQueryRequestParameters> p,SerializableData<IDeleteByQueryRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -855,20 +855,20 @@ namespace Nest
 			throw InvalidDispatch("DeleteByQuery", p, new [] { POST }, "/{index}/_delete_by_query", "/{index}/{type}/_delete_by_query");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> DeleteByQueryDispatchAsync<T>(IRequest<DeleteByQueryRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> DeleteByQueryDispatchAsync<T>(IRequest<DeleteByQueryRequestParameters> p,SerializableData<IDeleteByQueryRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.DeleteByQueryAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.DeleteByQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.DeleteByQueryAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.DeleteByQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("DeleteByQuery", p, new [] { POST }, "/{index}/_delete_by_query", "/{index}/{type}/_delete_by_query");
 		}
 		
-		internal ElasticsearchResponse<T> DeleteScriptDispatch<T>(IRequest<DeleteScriptRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> DeleteScriptDispatch<T>(IRequest<DeleteScriptRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -880,19 +880,19 @@ namespace Nest
 			throw InvalidDispatch("DeleteScript", p, new [] { DELETE }, "/_scripts/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> DeleteScriptDispatchAsync<T>(IRequest<DeleteScriptRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> DeleteScriptDispatchAsync<T>(IRequest<DeleteScriptRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.DeleteScriptAsync<T>(p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.DeleteScriptAsync<T>(p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("DeleteScript", p, new [] { DELETE }, "/_scripts/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> ExistsDispatch<T>(IRequest<DocumentExistsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ExistsDispatch<T>(IRequest<DocumentExistsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -904,19 +904,19 @@ namespace Nest
 			throw InvalidDispatch("Exists", p, new [] { HEAD }, "/{index}/{type}/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ExistsDispatchAsync<T>(IRequest<DocumentExistsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ExistsDispatchAsync<T>(IRequest<DocumentExistsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case HEAD:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.ExistsAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.ExistsAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("Exists", p, new [] { HEAD }, "/{index}/{type}/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> ExistsSourceDispatch<T>(IRequest<SourceExistsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ExistsSourceDispatch<T>(IRequest<SourceExistsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -928,19 +928,19 @@ namespace Nest
 			throw InvalidDispatch("ExistsSource", p, new [] { HEAD }, "/{index}/{type}/{id}/_source");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ExistsSourceDispatchAsync<T>(IRequest<SourceExistsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ExistsSourceDispatchAsync<T>(IRequest<SourceExistsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case HEAD:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.ExistsSourceAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.ExistsSourceAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("ExistsSource", p, new [] { HEAD }, "/{index}/{type}/{id}/_source");
 		}
 		
-		internal ElasticsearchResponse<T> ExplainDispatch<T>(IRequest<ExplainRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> ExplainDispatch<T,TDocument>(IRequest<ExplainRequestParameters> p,SerializableData<IExplainRequest<TDocument>> body) where T : class where TDocument : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -956,23 +956,23 @@ namespace Nest
 			throw InvalidDispatch("Explain", p, new [] { GET, POST }, "/{index}/{type}/{id}/_explain");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ExplainDispatchAsync<T>(IRequest<ExplainRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ExplainDispatchAsync<T,TDocument>(IRequest<ExplainRequestParameters> p,SerializableData<IExplainRequest<TDocument>> body, CancellationToken ct) where T : class where TDocument : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.ExplainGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.ExplainGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.ExplainAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.ExplainAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("Explain", p, new [] { GET, POST }, "/{index}/{type}/{id}/_explain");
 		}
 		
-		internal ElasticsearchResponse<T> FieldCapsDispatch<T>(IRequest<FieldCapabilitiesRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> FieldCapsDispatch<T>(IRequest<FieldCapabilitiesRequestParameters> p,SerializableData<IFieldCapabilitiesRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -988,23 +988,23 @@ namespace Nest
 			throw InvalidDispatch("FieldCaps", p, new [] { GET, POST }, "/_field_caps", "/{index}/_field_caps");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> FieldCapsDispatchAsync<T>(IRequest<FieldCapabilitiesRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> FieldCapsDispatchAsync<T>(IRequest<FieldCapabilitiesRequestParameters> p,SerializableData<IFieldCapabilitiesRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.FieldCapsGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.FieldCapsGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.FieldCapsGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.FieldCapsGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.FieldCapsAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.FieldCapsAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.FieldCapsAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.FieldCapsAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("FieldCaps", p, new [] { GET, POST }, "/_field_caps", "/{index}/_field_caps");
 		}
 		
-		internal ElasticsearchResponse<T> GetDispatch<T>(IRequest<GetRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> GetDispatch<T>(IRequest<GetRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1016,19 +1016,19 @@ namespace Nest
 			throw InvalidDispatch("Get", p, new [] { GET }, "/{index}/{type}/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> GetDispatchAsync<T>(IRequest<GetRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> GetDispatchAsync<T>(IRequest<GetRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.GetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.GetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("Get", p, new [] { GET }, "/{index}/{type}/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> GetScriptDispatch<T>(IRequest<GetScriptRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> GetScriptDispatch<T>(IRequest<GetScriptRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1040,19 +1040,19 @@ namespace Nest
 			throw InvalidDispatch("GetScript", p, new [] { GET }, "/_scripts/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> GetScriptDispatchAsync<T>(IRequest<GetScriptRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> GetScriptDispatchAsync<T>(IRequest<GetScriptRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.GetScriptAsync<T>(p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.GetScriptAsync<T>(p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("GetScript", p, new [] { GET }, "/_scripts/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> GetSourceDispatch<T>(IRequest<SourceRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> GetSourceDispatch<T>(IRequest<SourceRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1064,19 +1064,19 @@ namespace Nest
 			throw InvalidDispatch("GetSource", p, new [] { GET }, "/{index}/{type}/{id}/_source");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> GetSourceDispatchAsync<T>(IRequest<SourceRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> GetSourceDispatchAsync<T>(IRequest<SourceRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.GetSourceAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.GetSourceAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("GetSource", p, new [] { GET }, "/{index}/{type}/{id}/_source");
 		}
 		
-		internal ElasticsearchResponse<T> IndexDispatch<T>(IRequest<IndexRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndexDispatch<T,TDocument>(IRequest<IndexRequestParameters> p,SerializableData<IIndexRequest<TDocument>> body) where T : class where TDocument : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1094,25 +1094,25 @@ namespace Nest
 			throw InvalidDispatch("Index", p, new [] { POST, PUT }, "/{index}/{type}", "/{index}/{type}/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndexDispatchAsync<T>(IRequest<IndexRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndexDispatchAsync<T,TDocument>(IRequest<IndexRequestParameters> p,SerializableData<IIndexRequest<TDocument>> body, CancellationToken ct) where T : class where TDocument : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.IndexAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndexAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.IndexAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndexAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
 					break;
 
 				case PUT:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.IndexPutAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndexPutAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.IndexPutAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndexPutAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("Index", p, new [] { POST, PUT }, "/{index}/{type}", "/{index}/{type}/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesAnalyzeDispatch<T>(IRequest<AnalyzeRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesAnalyzeDispatch<T>(IRequest<AnalyzeRequestParameters> p,SerializableData<IAnalyzeRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1128,23 +1128,23 @@ namespace Nest
 			throw InvalidDispatch("IndicesAnalyze", p, new [] { GET, POST }, "/_analyze", "/{index}/_analyze");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesAnalyzeDispatchAsync<T>(IRequest<AnalyzeRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesAnalyzeDispatchAsync<T>(IRequest<AnalyzeRequestParameters> p,SerializableData<IAnalyzeRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesAnalyzeGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesAnalyzeGetForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesAnalyzeGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesAnalyzeGetForAllAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesAnalyzeAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesAnalyzeForAllAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesAnalyzeAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesAnalyzeForAllAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesAnalyze", p, new [] { GET, POST }, "/_analyze", "/{index}/_analyze");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesClearCacheDispatch<T>(IRequest<ClearCacheRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesClearCacheDispatch<T>(IRequest<ClearCacheRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1160,23 +1160,23 @@ namespace Nest
 			throw InvalidDispatch("IndicesClearCache", p, new [] { POST, GET }, "/_cache/clear", "/{index}/_cache/clear");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesClearCacheDispatchAsync<T>(IRequest<ClearCacheRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesClearCacheDispatchAsync<T>(IRequest<ClearCacheRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesClearCacheAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesClearCacheForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesClearCacheAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesClearCacheForAllAsync<T>(u => p.RequestParameters,ct);
 
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesClearCacheGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesClearCacheGetForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesClearCacheGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesClearCacheGetForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesClearCache", p, new [] { POST, GET }, "/_cache/clear", "/{index}/_cache/clear");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesCloseDispatch<T>(IRequest<CloseIndexRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesCloseDispatch<T>(IRequest<CloseIndexRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1188,19 +1188,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesClose", p, new [] { POST }, "/{index}/_close");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesCloseDispatchAsync<T>(IRequest<CloseIndexRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesCloseDispatchAsync<T>(IRequest<CloseIndexRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesCloseAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesCloseAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesClose", p, new [] { POST }, "/{index}/_close");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesCreateDispatch<T>(IRequest<CreateIndexRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesCreateDispatch<T>(IRequest<CreateIndexRequestParameters> p,SerializableData<ICreateIndexRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1212,19 +1212,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesCreate", p, new [] { PUT }, "/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesCreateDispatchAsync<T>(IRequest<CreateIndexRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesCreateDispatchAsync<T>(IRequest<CreateIndexRequestParameters> p,SerializableData<ICreateIndexRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesCreateAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesCreateAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesCreate", p, new [] { PUT }, "/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesDeleteDispatch<T>(IRequest<DeleteIndexRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesDeleteDispatch<T>(IRequest<DeleteIndexRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1236,19 +1236,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesDelete", p, new [] { DELETE }, "/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesDeleteDispatchAsync<T>(IRequest<DeleteIndexRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesDeleteDispatchAsync<T>(IRequest<DeleteIndexRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesDeleteAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesDeleteAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesDelete", p, new [] { DELETE }, "/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesDeleteAliasDispatch<T>(IRequest<DeleteAliasRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesDeleteAliasDispatch<T>(IRequest<DeleteAliasRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1260,19 +1260,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesDeleteAlias", p, new [] { DELETE }, "/{index}/_alias/{name}", "/{index}/_aliases/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesDeleteAliasDispatchAsync<T>(IRequest<DeleteAliasRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesDeleteAliasDispatchAsync<T>(IRequest<DeleteAliasRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesDeleteAliasAsync<T>(p.RouteValues.Index,p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesDeleteAliasAsync<T>(p.RouteValues.Index,p.RouteValues.Name,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesDeleteAlias", p, new [] { DELETE }, "/{index}/_alias/{name}", "/{index}/_aliases/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesDeleteTemplateDispatch<T>(IRequest<DeleteIndexTemplateRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesDeleteTemplateDispatch<T>(IRequest<DeleteIndexTemplateRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1284,19 +1284,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesDeleteTemplate", p, new [] { DELETE }, "/_template/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesDeleteTemplateDispatchAsync<T>(IRequest<DeleteIndexTemplateRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesDeleteTemplateDispatchAsync<T>(IRequest<DeleteIndexTemplateRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.IndicesDeleteTemplateForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.IndicesDeleteTemplateForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesDeleteTemplate", p, new [] { DELETE }, "/_template/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesExistsDispatch<T>(IRequest<IndexExistsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesExistsDispatch<T>(IRequest<IndexExistsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1308,19 +1308,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesExists", p, new [] { HEAD }, "/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesExistsDispatchAsync<T>(IRequest<IndexExistsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesExistsDispatchAsync<T>(IRequest<IndexExistsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case HEAD:
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesExistsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesExistsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesExists", p, new [] { HEAD }, "/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesExistsAliasDispatch<T>(IRequest<AliasExistsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesExistsAliasDispatch<T>(IRequest<AliasExistsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1333,20 +1333,20 @@ namespace Nest
 			throw InvalidDispatch("IndicesExistsAlias", p, new [] { HEAD }, "/_alias/{name}", "/{index}/_alias/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesExistsAliasDispatchAsync<T>(IRequest<AliasExistsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesExistsAliasDispatchAsync<T>(IRequest<AliasExistsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case HEAD:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesExistsAliasAsync<T>(p.RouteValues.Index,p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Name)) return _lowLevel.IndicesExistsAliasForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesExistsAliasAsync<T>(p.RouteValues.Index,p.RouteValues.Name,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Name)) return _lowLevel.IndicesExistsAliasForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesExistsAlias", p, new [] { HEAD }, "/_alias/{name}", "/{index}/_alias/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesExistsTemplateDispatch<T>(IRequest<IndexTemplateExistsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesExistsTemplateDispatch<T>(IRequest<IndexTemplateExistsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1358,19 +1358,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesExistsTemplate", p, new [] { HEAD }, "/_template/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesExistsTemplateDispatchAsync<T>(IRequest<IndexTemplateExistsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesExistsTemplateDispatchAsync<T>(IRequest<IndexTemplateExistsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case HEAD:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.IndicesExistsTemplateForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.IndicesExistsTemplateForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesExistsTemplate", p, new [] { HEAD }, "/_template/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesExistsTypeDispatch<T>(IRequest<TypeExistsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesExistsTypeDispatch<T>(IRequest<TypeExistsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1382,19 +1382,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesExistsType", p, new [] { HEAD }, "/{index}/_mapping/{type}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesExistsTypeDispatchAsync<T>(IRequest<TypeExistsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesExistsTypeDispatchAsync<T>(IRequest<TypeExistsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case HEAD:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesExistsTypeAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesExistsTypeAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesExistsType", p, new [] { HEAD }, "/{index}/_mapping/{type}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesFlushDispatch<T>(IRequest<FlushRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesFlushDispatch<T>(IRequest<FlushRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1410,23 +1410,23 @@ namespace Nest
 			throw InvalidDispatch("IndicesFlush", p, new [] { POST, GET }, "/_flush", "/{index}/_flush");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesFlushDispatchAsync<T>(IRequest<FlushRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesFlushDispatchAsync<T>(IRequest<FlushRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesFlushAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesFlushForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesFlushAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesFlushForAllAsync<T>(u => p.RequestParameters,ct);
 
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesFlushGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesFlushGetForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesFlushGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesFlushGetForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesFlush", p, new [] { POST, GET }, "/_flush", "/{index}/_flush");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesFlushSyncedDispatch<T>(IRequest<SyncedFlushRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesFlushSyncedDispatch<T>(IRequest<SyncedFlushRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1442,23 +1442,23 @@ namespace Nest
 			throw InvalidDispatch("IndicesFlushSynced", p, new [] { POST, GET }, "/_flush/synced", "/{index}/_flush/synced");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesFlushSyncedDispatchAsync<T>(IRequest<SyncedFlushRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesFlushSyncedDispatchAsync<T>(IRequest<SyncedFlushRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesFlushSyncedAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesFlushSyncedForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesFlushSyncedAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesFlushSyncedForAllAsync<T>(u => p.RequestParameters,ct);
 
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesFlushSyncedGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesFlushSyncedGetForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesFlushSyncedGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesFlushSyncedGetForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesFlushSynced", p, new [] { POST, GET }, "/_flush/synced", "/{index}/_flush/synced");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesForcemergeDispatch<T>(IRequest<ForceMergeRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesForcemergeDispatch<T>(IRequest<ForceMergeRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1470,19 +1470,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesForcemerge", p, new [] { POST }, "/_forcemerge", "/{index}/_forcemerge");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesForcemergeDispatchAsync<T>(IRequest<ForceMergeRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesForcemergeDispatchAsync<T>(IRequest<ForceMergeRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesForcemergeAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesForcemergeForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesForcemergeAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesForcemergeForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesForcemerge", p, new [] { POST }, "/_forcemerge", "/{index}/_forcemerge");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesGetDispatch<T>(IRequest<GetIndexRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesGetDispatch<T>(IRequest<GetIndexRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1494,19 +1494,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesGet", p, new [] { GET }, "/{index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesGetDispatchAsync<T>(IRequest<GetIndexRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesGetDispatchAsync<T>(IRequest<GetIndexRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesGet", p, new [] { GET }, "/{index}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesGetAliasDispatch<T>(IRequest<GetAliasRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesGetAliasDispatch<T>(IRequest<GetAliasRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1520,21 +1520,21 @@ namespace Nest
 			throw InvalidDispatch("IndicesGetAlias", p, new [] { GET }, "/_alias", "/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesGetAliasDispatchAsync<T>(IRequest<GetAliasRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesGetAliasDispatchAsync<T>(IRequest<GetAliasRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesGetAliasAsync<T>(p.RouteValues.Index,p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Name)) return _lowLevel.IndicesGetAliasForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesGetAliasAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesGetAliasForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesGetAliasAsync<T>(p.RouteValues.Index,p.RouteValues.Name,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Name)) return _lowLevel.IndicesGetAliasForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesGetAliasAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesGetAliasForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesGetAlias", p, new [] { GET }, "/_alias", "/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesGetFieldMappingDispatch<T>(IRequest<GetFieldMappingRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesGetFieldMappingDispatch<T>(IRequest<GetFieldMappingRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1549,22 +1549,22 @@ namespace Nest
 			throw InvalidDispatch("IndicesGetFieldMapping", p, new [] { GET }, "/_mapping/field/{fields}", "/{index}/_mapping/field/{fields}", "/_mapping/{type}/field/{fields}", "/{index}/_mapping/{type}/field/{fields}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesGetFieldMappingDispatchAsync<T>(IRequest<GetFieldMappingRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesGetFieldMappingDispatchAsync<T>(IRequest<GetFieldMappingRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Fields)) return _lowLevel.IndicesGetFieldMappingAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Fields,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Fields)) return _lowLevel.IndicesGetFieldMappingAsync<T>(p.RouteValues.Index,p.RouteValues.Fields,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Type, p.RouteValues.Fields)) return _lowLevel.IndicesGetFieldMappingForAllAsync<T>(p.RouteValues.Type,p.RouteValues.Fields,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Fields)) return _lowLevel.IndicesGetFieldMappingForAllAsync<T>(p.RouteValues.Fields,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Fields)) return _lowLevel.IndicesGetFieldMappingAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Fields,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Fields)) return _lowLevel.IndicesGetFieldMappingAsync<T>(p.RouteValues.Index,p.RouteValues.Fields,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Type, p.RouteValues.Fields)) return _lowLevel.IndicesGetFieldMappingForAllAsync<T>(p.RouteValues.Type,p.RouteValues.Fields,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Fields)) return _lowLevel.IndicesGetFieldMappingForAllAsync<T>(p.RouteValues.Fields,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesGetFieldMapping", p, new [] { GET }, "/_mapping/field/{fields}", "/{index}/_mapping/field/{fields}", "/_mapping/{type}/field/{fields}", "/{index}/_mapping/{type}/field/{fields}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesGetMappingDispatch<T>(IRequest<GetMappingRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesGetMappingDispatch<T>(IRequest<GetMappingRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1578,21 +1578,21 @@ namespace Nest
 			throw InvalidDispatch("IndicesGetMapping", p, new [] { GET }, "/_mapping", "/{index}/_mapping", "/_mapping/{type}", "/{index}/_mapping/{type}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesGetMappingDispatchAsync<T>(IRequest<GetMappingRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesGetMappingDispatchAsync<T>(IRequest<GetMappingRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesGetMappingAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesGetMappingAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Type)) return _lowLevel.IndicesGetMappingForAllAsync<T>(p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesGetMappingForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesGetMappingAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesGetMappingAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Type)) return _lowLevel.IndicesGetMappingForAllAsync<T>(p.RouteValues.Type,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesGetMappingForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesGetMapping", p, new [] { GET }, "/_mapping", "/{index}/_mapping", "/_mapping/{type}", "/{index}/_mapping/{type}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesGetSettingsDispatch<T>(IRequest<GetIndexSettingsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesGetSettingsDispatch<T>(IRequest<GetIndexSettingsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1606,21 +1606,21 @@ namespace Nest
 			throw InvalidDispatch("IndicesGetSettings", p, new [] { GET }, "/_settings", "/{index}/_settings", "/{index}/_settings/{name}", "/_settings/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesGetSettingsDispatchAsync<T>(IRequest<GetIndexSettingsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesGetSettingsDispatchAsync<T>(IRequest<GetIndexSettingsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesGetSettingsAsync<T>(p.RouteValues.Index,p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesGetSettingsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Name)) return _lowLevel.IndicesGetSettingsForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesGetSettingsForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesGetSettingsAsync<T>(p.RouteValues.Index,p.RouteValues.Name,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesGetSettingsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Name)) return _lowLevel.IndicesGetSettingsForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesGetSettingsForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesGetSettings", p, new [] { GET }, "/_settings", "/{index}/_settings", "/{index}/_settings/{name}", "/_settings/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesGetTemplateDispatch<T>(IRequest<GetIndexTemplateRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesGetTemplateDispatch<T>(IRequest<GetIndexTemplateRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1632,19 +1632,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesGetTemplate", p, new [] { GET }, "/_template", "/_template/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesGetTemplateDispatchAsync<T>(IRequest<GetIndexTemplateRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesGetTemplateDispatchAsync<T>(IRequest<GetIndexTemplateRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Name)) return _lowLevel.IndicesGetTemplateForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesGetTemplateForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Name)) return _lowLevel.IndicesGetTemplateForAllAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesGetTemplateForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesGetTemplate", p, new [] { GET }, "/_template", "/_template/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesGetUpgradeDispatch<T>(IRequest<UpgradeStatusRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesGetUpgradeDispatch<T>(IRequest<UpgradeStatusRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1656,19 +1656,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesGetUpgrade", p, new [] { GET }, "/_upgrade", "/{index}/_upgrade");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesGetUpgradeDispatchAsync<T>(IRequest<UpgradeStatusRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesGetUpgradeDispatchAsync<T>(IRequest<UpgradeStatusRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesGetUpgradeAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesGetUpgradeForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesGetUpgradeAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesGetUpgradeForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesGetUpgrade", p, new [] { GET }, "/_upgrade", "/{index}/_upgrade");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesOpenDispatch<T>(IRequest<OpenIndexRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesOpenDispatch<T>(IRequest<OpenIndexRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1680,19 +1680,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesOpen", p, new [] { POST }, "/{index}/_open");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesOpenDispatchAsync<T>(IRequest<OpenIndexRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesOpenDispatchAsync<T>(IRequest<OpenIndexRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesOpenAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.IndicesOpenAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesOpen", p, new [] { POST }, "/{index}/_open");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesPutAliasDispatch<T>(IRequest<PutAliasRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesPutAliasDispatch<T>(IRequest<PutAliasRequestParameters> p,SerializableData<IPutAliasRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1708,23 +1708,23 @@ namespace Nest
 			throw InvalidDispatch("IndicesPutAlias", p, new [] { PUT, POST }, "/{index}/_alias/{name}", "/{index}/_aliases/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesPutAliasDispatchAsync<T>(IRequest<PutAliasRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesPutAliasDispatchAsync<T>(IRequest<PutAliasRequestParameters> p,SerializableData<IPutAliasRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesPutAliasAsync<T>(p.RouteValues.Index,p.RouteValues.Name,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesPutAliasAsync<T>(p.RouteValues.Index,p.RouteValues.Name,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesPutAliasPostAsync<T>(p.RouteValues.Index,p.RouteValues.Name,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Name)) return _lowLevel.IndicesPutAliasPostAsync<T>(p.RouteValues.Index,p.RouteValues.Name,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesPutAlias", p, new [] { PUT, POST }, "/{index}/_alias/{name}", "/{index}/_aliases/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesPutMappingDispatch<T>(IRequest<PutMappingRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesPutMappingDispatch<T>(IRequest<PutMappingRequestParameters> p,SerializableData<IPutMappingRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1742,25 +1742,25 @@ namespace Nest
 			throw InvalidDispatch("IndicesPutMapping", p, new [] { PUT, POST }, "/{index}/{type}/_mapping", "/{index}/_mapping/{type}", "/_mapping/{type}", "/{index}/{type}/_mappings", "/{index}/_mappings/{type}", "/_mappings/{type}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesPutMappingDispatchAsync<T>(IRequest<PutMappingRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesPutMappingDispatchAsync<T>(IRequest<PutMappingRequestParameters> p,SerializableData<IPutMappingRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesPutMappingAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Type)) return _lowLevel.IndicesPutMappingForAllAsync<T>(p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesPutMappingAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Type)) return _lowLevel.IndicesPutMappingForAllAsync<T>(p.RouteValues.Type,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesPutMappingPostAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Type)) return _lowLevel.IndicesPutMappingPostForAllAsync<T>(p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesPutMappingPostAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Type)) return _lowLevel.IndicesPutMappingPostForAllAsync<T>(p.RouteValues.Type,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesPutMapping", p, new [] { PUT, POST }, "/{index}/{type}/_mapping", "/{index}/_mapping/{type}", "/_mapping/{type}", "/{index}/{type}/_mappings", "/{index}/_mappings/{type}", "/_mappings/{type}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesPutSettingsDispatch<T>(IRequest<UpdateIndexSettingsRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesPutSettingsDispatch<T>(IRequest<UpdateIndexSettingsRequestParameters> p,SerializableData<IUpdateIndexSettingsRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1772,19 +1772,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesPutSettings", p, new [] { PUT }, "/_settings", "/{index}/_settings");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesPutSettingsDispatchAsync<T>(IRequest<UpdateIndexSettingsRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesPutSettingsDispatchAsync<T>(IRequest<UpdateIndexSettingsRequestParameters> p,SerializableData<IUpdateIndexSettingsRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesPutSettingsAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesPutSettingsForAllAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesPutSettingsAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesPutSettingsForAllAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesPutSettings", p, new [] { PUT }, "/_settings", "/{index}/_settings");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesPutTemplateDispatch<T>(IRequest<PutIndexTemplateRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesPutTemplateDispatch<T>(IRequest<PutIndexTemplateRequestParameters> p,SerializableData<IPutIndexTemplateRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1800,23 +1800,23 @@ namespace Nest
 			throw InvalidDispatch("IndicesPutTemplate", p, new [] { PUT, POST }, "/_template/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesPutTemplateDispatchAsync<T>(IRequest<PutIndexTemplateRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesPutTemplateDispatchAsync<T>(IRequest<PutIndexTemplateRequestParameters> p,SerializableData<IPutIndexTemplateRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.IndicesPutTemplateForAllAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.IndicesPutTemplateForAllAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.IndicesPutTemplatePostForAllAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.IndicesPutTemplatePostForAllAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesPutTemplate", p, new [] { PUT, POST }, "/_template/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesRecoveryDispatch<T>(IRequest<RecoveryStatusRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesRecoveryDispatch<T>(IRequest<RecoveryStatusRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1828,19 +1828,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesRecovery", p, new [] { GET }, "/_recovery", "/{index}/_recovery");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesRecoveryDispatchAsync<T>(IRequest<RecoveryStatusRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesRecoveryDispatchAsync<T>(IRequest<RecoveryStatusRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesRecoveryAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesRecoveryForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesRecoveryAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesRecoveryForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesRecovery", p, new [] { GET }, "/_recovery", "/{index}/_recovery");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesRefreshDispatch<T>(IRequest<RefreshRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesRefreshDispatch<T>(IRequest<RefreshRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1856,23 +1856,23 @@ namespace Nest
 			throw InvalidDispatch("IndicesRefresh", p, new [] { POST, GET }, "/_refresh", "/{index}/_refresh");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesRefreshDispatchAsync<T>(IRequest<RefreshRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesRefreshDispatchAsync<T>(IRequest<RefreshRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesRefreshAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesRefreshForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesRefreshAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesRefreshForAllAsync<T>(u => p.RequestParameters,ct);
 
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesRefreshGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesRefreshGetForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesRefreshGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesRefreshGetForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesRefresh", p, new [] { POST, GET }, "/_refresh", "/{index}/_refresh");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesRolloverDispatch<T>(IRequest<RolloverIndexRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesRolloverDispatch<T>(IRequest<RolloverIndexRequestParameters> p,SerializableData<IRolloverIndexRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1885,20 +1885,20 @@ namespace Nest
 			throw InvalidDispatch("IndicesRollover", p, new [] { POST }, "/{alias}/_rollover", "/{alias}/_rollover/{new_index}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesRolloverDispatchAsync<T>(IRequest<RolloverIndexRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesRolloverDispatchAsync<T>(IRequest<RolloverIndexRequestParameters> p,SerializableData<IRolloverIndexRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Alias, p.RouteValues.NewIndex)) return _lowLevel.IndicesRolloverForAllAsync<T>(p.RouteValues.Alias,p.RouteValues.NewIndex,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Alias)) return _lowLevel.IndicesRolloverForAllAsync<T>(p.RouteValues.Alias,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Alias, p.RouteValues.NewIndex)) return _lowLevel.IndicesRolloverForAllAsync<T>(p.RouteValues.Alias,p.RouteValues.NewIndex,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Alias)) return _lowLevel.IndicesRolloverForAllAsync<T>(p.RouteValues.Alias,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesRollover", p, new [] { POST }, "/{alias}/_rollover", "/{alias}/_rollover/{new_index}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesSegmentsDispatch<T>(IRequest<SegmentsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesSegmentsDispatch<T>(IRequest<SegmentsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1910,19 +1910,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesSegments", p, new [] { GET }, "/_segments", "/{index}/_segments");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesSegmentsDispatchAsync<T>(IRequest<SegmentsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesSegmentsDispatchAsync<T>(IRequest<SegmentsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesSegmentsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesSegmentsForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesSegmentsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesSegmentsForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesSegments", p, new [] { GET }, "/_segments", "/{index}/_segments");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesShardStoresDispatch<T>(IRequest<IndicesShardStoresRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesShardStoresDispatch<T>(IRequest<IndicesShardStoresRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1934,19 +1934,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesShardStores", p, new [] { GET }, "/_shard_stores", "/{index}/_shard_stores");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesShardStoresDispatchAsync<T>(IRequest<IndicesShardStoresRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesShardStoresDispatchAsync<T>(IRequest<IndicesShardStoresRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesShardStoresAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesShardStoresForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesShardStoresAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesShardStoresForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesShardStores", p, new [] { GET }, "/_shard_stores", "/{index}/_shard_stores");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesShrinkDispatch<T>(IRequest<ShrinkIndexRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesShrinkDispatch<T>(IRequest<ShrinkIndexRequestParameters> p,SerializableData<IShrinkIndexRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1962,23 +1962,23 @@ namespace Nest
 			throw InvalidDispatch("IndicesShrink", p, new [] { PUT, POST }, "/{index}/_shrink/{target}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesShrinkDispatchAsync<T>(IRequest<ShrinkIndexRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesShrinkDispatchAsync<T>(IRequest<ShrinkIndexRequestParameters> p,SerializableData<IShrinkIndexRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Target)) return _lowLevel.IndicesShrinkAsync<T>(p.RouteValues.Index,p.RouteValues.Target,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Target)) return _lowLevel.IndicesShrinkAsync<T>(p.RouteValues.Index,p.RouteValues.Target,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Target)) return _lowLevel.IndicesShrinkPostAsync<T>(p.RouteValues.Index,p.RouteValues.Target,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Target)) return _lowLevel.IndicesShrinkPostAsync<T>(p.RouteValues.Index,p.RouteValues.Target,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IndicesShrink", p, new [] { PUT, POST }, "/{index}/_shrink/{target}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesStatsDispatch<T>(IRequest<IndicesStatsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesStatsDispatch<T>(IRequest<IndicesStatsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -1992,21 +1992,21 @@ namespace Nest
 			throw InvalidDispatch("IndicesStats", p, new [] { GET }, "/_stats", "/_stats/{metric}", "/{index}/_stats", "/{index}/_stats/{metric}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesStatsDispatchAsync<T>(IRequest<IndicesStatsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesStatsDispatchAsync<T>(IRequest<IndicesStatsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Metric)) return _lowLevel.IndicesStatsAsync<T>(p.RouteValues.Index,p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Metric)) return _lowLevel.IndicesStatsForAllAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesStatsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesStatsForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Metric)) return _lowLevel.IndicesStatsAsync<T>(p.RouteValues.Index,p.RouteValues.Metric,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Metric)) return _lowLevel.IndicesStatsForAllAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesStatsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesStatsForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesStats", p, new [] { GET }, "/_stats", "/_stats/{metric}", "/{index}/_stats", "/{index}/_stats/{metric}");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesUpdateAliasesDispatch<T>(IRequest<BulkAliasRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesUpdateAliasesDispatch<T>(IRequest<BulkAliasRequestParameters> p,SerializableData<IBulkAliasRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2017,18 +2017,18 @@ namespace Nest
 			throw InvalidDispatch("IndicesUpdateAliases", p, new [] { POST }, "/_aliases");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesUpdateAliasesDispatchAsync<T>(IRequest<BulkAliasRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesUpdateAliasesDispatchAsync<T>(IRequest<BulkAliasRequestParameters> p,SerializableData<IBulkAliasRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.IndicesUpdateAliasesForAllAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.IndicesUpdateAliasesForAllAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesUpdateAliases", p, new [] { POST }, "/_aliases");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesUpgradeDispatch<T>(IRequest<UpgradeRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IndicesUpgradeDispatch<T>(IRequest<UpgradeRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2040,19 +2040,19 @@ namespace Nest
 			throw InvalidDispatch("IndicesUpgrade", p, new [] { POST }, "/_upgrade", "/{index}/_upgrade");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesUpgradeDispatchAsync<T>(IRequest<UpgradeRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesUpgradeDispatchAsync<T>(IRequest<UpgradeRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesUpgradeAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesUpgradeForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesUpgradeAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesUpgradeForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesUpgrade", p, new [] { POST }, "/_upgrade", "/{index}/_upgrade");
 		}
 		
-		internal ElasticsearchResponse<T> IndicesValidateQueryDispatch<T>(IRequest<ValidateQueryRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IndicesValidateQueryDispatch<T>(IRequest<ValidateQueryRequestParameters> p,SerializableData<IValidateQueryRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2070,25 +2070,25 @@ namespace Nest
 			throw InvalidDispatch("IndicesValidateQuery", p, new [] { GET, POST }, "/_validate/query", "/{index}/_validate/query", "/{index}/{type}/_validate/query");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IndicesValidateQueryDispatchAsync<T>(IRequest<ValidateQueryRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IndicesValidateQueryDispatchAsync<T>(IRequest<ValidateQueryRequestParameters> p,SerializableData<IValidateQueryRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesValidateQueryGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesValidateQueryGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesValidateQueryGetForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesValidateQueryGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesValidateQueryGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesValidateQueryGetForAllAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesValidateQueryAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesValidateQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IndicesValidateQueryForAllAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.IndicesValidateQueryAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.IndicesValidateQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.IndicesValidateQueryForAllAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IndicesValidateQuery", p, new [] { GET, POST }, "/_validate/query", "/{index}/_validate/query", "/{index}/{type}/_validate/query");
 		}
 		
-		internal ElasticsearchResponse<T> InfoDispatch<T>(IRequest<RootNodeInfoRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> InfoDispatch<T>(IRequest<RootNodeInfoRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2099,18 +2099,18 @@ namespace Nest
 			throw InvalidDispatch("Info", p, new [] { GET }, "/");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> InfoDispatchAsync<T>(IRequest<RootNodeInfoRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> InfoDispatchAsync<T>(IRequest<RootNodeInfoRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.InfoAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.InfoAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Info", p, new [] { GET }, "/");
 		}
 		
-		internal ElasticsearchResponse<T> IngestDeletePipelineDispatch<T>(IRequest<DeletePipelineRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IngestDeletePipelineDispatch<T>(IRequest<DeletePipelineRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2122,19 +2122,19 @@ namespace Nest
 			throw InvalidDispatch("IngestDeletePipeline", p, new [] { DELETE }, "/_ingest/pipeline/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IngestDeletePipelineDispatchAsync<T>(IRequest<DeletePipelineRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IngestDeletePipelineDispatchAsync<T>(IRequest<DeletePipelineRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.IngestDeletePipelineAsync<T>(p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.IngestDeletePipelineAsync<T>(p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IngestDeletePipeline", p, new [] { DELETE }, "/_ingest/pipeline/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> IngestGetPipelineDispatch<T>(IRequest<GetPipelineRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IngestGetPipelineDispatch<T>(IRequest<GetPipelineRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2146,19 +2146,19 @@ namespace Nest
 			throw InvalidDispatch("IngestGetPipeline", p, new [] { GET }, "/_ingest/pipeline", "/_ingest/pipeline/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IngestGetPipelineDispatchAsync<T>(IRequest<GetPipelineRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IngestGetPipelineDispatchAsync<T>(IRequest<GetPipelineRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Id)) return _lowLevel.IngestGetPipelineAsync<T>(p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IngestGetPipelineAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id)) return _lowLevel.IngestGetPipelineAsync<T>(p.RouteValues.Id,u => p.RequestParameters,ct);
+					return _lowLevel.IngestGetPipelineAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IngestGetPipeline", p, new [] { GET }, "/_ingest/pipeline", "/_ingest/pipeline/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> IngestProcessorGrokDispatch<T>(IRequest<GrokProcessorPatternsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> IngestProcessorGrokDispatch<T>(IRequest<GrokProcessorPatternsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2169,18 +2169,18 @@ namespace Nest
 			throw InvalidDispatch("IngestProcessorGrok", p, new [] { GET }, "/_ingest/processor/grok");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IngestProcessorGrokDispatchAsync<T>(IRequest<GrokProcessorPatternsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IngestProcessorGrokDispatchAsync<T>(IRequest<GrokProcessorPatternsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.IngestProcessorGrokAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.IngestProcessorGrokAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IngestProcessorGrok", p, new [] { GET }, "/_ingest/processor/grok");
 		}
 		
-		internal ElasticsearchResponse<T> IngestPutPipelineDispatch<T>(IRequest<PutPipelineRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IngestPutPipelineDispatch<T>(IRequest<PutPipelineRequestParameters> p,SerializableData<IPutPipelineRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2192,19 +2192,19 @@ namespace Nest
 			throw InvalidDispatch("IngestPutPipeline", p, new [] { PUT }, "/_ingest/pipeline/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IngestPutPipelineDispatchAsync<T>(IRequest<PutPipelineRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IngestPutPipelineDispatchAsync<T>(IRequest<PutPipelineRequestParameters> p,SerializableData<IPutPipelineRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.IngestPutPipelineAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.IngestPutPipelineAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("IngestPutPipeline", p, new [] { PUT }, "/_ingest/pipeline/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> IngestSimulateDispatch<T>(IRequest<SimulatePipelineRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> IngestSimulateDispatch<T>(IRequest<SimulatePipelineRequestParameters> p,SerializableData<ISimulatePipelineRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2220,23 +2220,23 @@ namespace Nest
 			throw InvalidDispatch("IngestSimulate", p, new [] { GET, POST }, "/_ingest/pipeline/_simulate", "/_ingest/pipeline/{id}/_simulate");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> IngestSimulateDispatchAsync<T>(IRequest<SimulatePipelineRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> IngestSimulateDispatchAsync<T>(IRequest<SimulatePipelineRequestParameters> p,SerializableData<ISimulatePipelineRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Id)) return _lowLevel.IngestSimulateGetAsync<T>(p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IngestSimulateGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id)) return _lowLevel.IngestSimulateGetAsync<T>(p.RouteValues.Id,u => p.RequestParameters,ct);
+					return _lowLevel.IngestSimulateGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Id)) return _lowLevel.IngestSimulateAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.IngestSimulateAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id)) return _lowLevel.IngestSimulateAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
+					return _lowLevel.IngestSimulateAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("IngestSimulate", p, new [] { GET, POST }, "/_ingest/pipeline/_simulate", "/_ingest/pipeline/{id}/_simulate");
 		}
 		
-		internal ElasticsearchResponse<T> MgetDispatch<T>(IRequest<MultiGetRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> MgetDispatch<T>(IRequest<MultiGetRequestParameters> p,SerializableData<IMultiGetRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2254,25 +2254,25 @@ namespace Nest
 			throw InvalidDispatch("Mget", p, new [] { GET, POST }, "/_mget", "/{index}/_mget", "/{index}/{type}/_mget");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> MgetDispatchAsync<T>(IRequest<MultiGetRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> MgetDispatchAsync<T>(IRequest<MultiGetRequestParameters> p,SerializableData<IMultiGetRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MgetGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.MgetGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.MgetGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MgetGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.MgetGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.MgetGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MgetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.MgetAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.MgetAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MgetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.MgetAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.MgetAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Mget", p, new [] { GET, POST }, "/_mget", "/{index}/_mget", "/{index}/{type}/_mget");
 		}
 		
-		internal ElasticsearchResponse<T> MsearchDispatch<T>(IRequest<MultiSearchRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> MsearchDispatch<T>(IRequest<MultiSearchRequestParameters> p,SerializableData<IMultiSearchRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2290,25 +2290,25 @@ namespace Nest
 			throw InvalidDispatch("Msearch", p, new [] { GET, POST }, "/_msearch", "/{index}/_msearch", "/{index}/{type}/_msearch");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> MsearchDispatchAsync<T>(IRequest<MultiSearchRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> MsearchDispatchAsync<T>(IRequest<MultiSearchRequestParameters> p,SerializableData<IMultiSearchRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MsearchGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.MsearchGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.MsearchGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MsearchGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.MsearchGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.MsearchGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MsearchAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.MsearchAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.MsearchAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MsearchAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.MsearchAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.MsearchAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Msearch", p, new [] { GET, POST }, "/_msearch", "/{index}/_msearch", "/{index}/{type}/_msearch");
 		}
 		
-		internal ElasticsearchResponse<T> MsearchTemplateDispatch<T>(IRequest<MultiSearchTemplateRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> MsearchTemplateDispatch<T>(IRequest<MultiSearchTemplateRequestParameters> p,SerializableData<IMultiSearchTemplateRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2326,25 +2326,25 @@ namespace Nest
 			throw InvalidDispatch("MsearchTemplate", p, new [] { GET, POST }, "/_msearch/template", "/{index}/_msearch/template", "/{index}/{type}/_msearch/template");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> MsearchTemplateDispatchAsync<T>(IRequest<MultiSearchTemplateRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> MsearchTemplateDispatchAsync<T>(IRequest<MultiSearchTemplateRequestParameters> p,SerializableData<IMultiSearchTemplateRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MsearchTemplateGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.MsearchTemplateGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.MsearchTemplateGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MsearchTemplateGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.MsearchTemplateGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.MsearchTemplateGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MsearchTemplateAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.MsearchTemplateAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.MsearchTemplateAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MsearchTemplateAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.MsearchTemplateAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.MsearchTemplateAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("MsearchTemplate", p, new [] { GET, POST }, "/_msearch/template", "/{index}/_msearch/template", "/{index}/{type}/_msearch/template");
 		}
 		
-		internal ElasticsearchResponse<T> MtermvectorsDispatch<T>(IRequest<MultiTermVectorsRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> MtermvectorsDispatch<T>(IRequest<MultiTermVectorsRequestParameters> p,SerializableData<IMultiTermVectorsRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2362,25 +2362,25 @@ namespace Nest
 			throw InvalidDispatch("Mtermvectors", p, new [] { GET, POST }, "/_mtermvectors", "/{index}/_mtermvectors", "/{index}/{type}/_mtermvectors");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> MtermvectorsDispatchAsync<T>(IRequest<MultiTermVectorsRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> MtermvectorsDispatchAsync<T>(IRequest<MultiTermVectorsRequestParameters> p,SerializableData<IMultiTermVectorsRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MtermvectorsGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.MtermvectorsGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.MtermvectorsGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MtermvectorsGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.MtermvectorsGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.MtermvectorsGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MtermvectorsAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.MtermvectorsAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.MtermvectorsAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.MtermvectorsAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.MtermvectorsAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.MtermvectorsAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Mtermvectors", p, new [] { GET, POST }, "/_mtermvectors", "/{index}/_mtermvectors", "/{index}/{type}/_mtermvectors");
 		}
 		
-		internal ElasticsearchResponse<T> NodesHotThreadsDispatch<T>(IRequest<NodesHotThreadsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> NodesHotThreadsDispatch<T>(IRequest<NodesHotThreadsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2392,19 +2392,19 @@ namespace Nest
 			throw InvalidDispatch("NodesHotThreads", p, new [] { GET }, "/_cluster/nodes/hotthreads", "/_cluster/nodes/hot_threads", "/_cluster/nodes/{node_id}/hotthreads", "/_cluster/nodes/{node_id}/hot_threads", "/_nodes/hotthreads", "/_nodes/hot_threads", "/_nodes/{node_id}/hotthreads", "/_nodes/{node_id}/hot_threads");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> NodesHotThreadsDispatchAsync<T>(IRequest<NodesHotThreadsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> NodesHotThreadsDispatchAsync<T>(IRequest<NodesHotThreadsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.NodesHotThreadsAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.NodesHotThreadsForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.NodesHotThreadsAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,ct);
+					return _lowLevel.NodesHotThreadsForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("NodesHotThreads", p, new [] { GET }, "/_cluster/nodes/hotthreads", "/_cluster/nodes/hot_threads", "/_cluster/nodes/{node_id}/hotthreads", "/_cluster/nodes/{node_id}/hot_threads", "/_nodes/hotthreads", "/_nodes/hot_threads", "/_nodes/{node_id}/hotthreads", "/_nodes/{node_id}/hot_threads");
 		}
 		
-		internal ElasticsearchResponse<T> NodesInfoDispatch<T>(IRequest<NodesInfoRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> NodesInfoDispatch<T>(IRequest<NodesInfoRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2418,21 +2418,21 @@ namespace Nest
 			throw InvalidDispatch("NodesInfo", p, new [] { GET }, "/_nodes", "/_nodes/{node_id}", "/_nodes/{metric}", "/_nodes/{node_id}/{metric}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> NodesInfoDispatchAsync<T>(IRequest<NodesInfoRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> NodesInfoDispatchAsync<T>(IRequest<NodesInfoRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.NodeId, p.RouteValues.Metric)) return _lowLevel.NodesInfoAsync<T>(p.RouteValues.NodeId,p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.NodesInfoAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Metric)) return _lowLevel.NodesInfoForAllAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.NodesInfoForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.NodeId, p.RouteValues.Metric)) return _lowLevel.NodesInfoAsync<T>(p.RouteValues.NodeId,p.RouteValues.Metric,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.NodesInfoAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Metric)) return _lowLevel.NodesInfoForAllAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,ct);
+					return _lowLevel.NodesInfoForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("NodesInfo", p, new [] { GET }, "/_nodes", "/_nodes/{node_id}", "/_nodes/{metric}", "/_nodes/{node_id}/{metric}");
 		}
 		
-		internal ElasticsearchResponse<T> NodesStatsDispatch<T>(IRequest<NodesStatsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> NodesStatsDispatch<T>(IRequest<NodesStatsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2448,23 +2448,23 @@ namespace Nest
 			throw InvalidDispatch("NodesStats", p, new [] { GET }, "/_nodes/stats", "/_nodes/{node_id}/stats", "/_nodes/stats/{metric}", "/_nodes/{node_id}/stats/{metric}", "/_nodes/stats/{metric}/{index_metric}", "/_nodes/{node_id}/stats/{metric}/{index_metric}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> NodesStatsDispatchAsync<T>(IRequest<NodesStatsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> NodesStatsDispatchAsync<T>(IRequest<NodesStatsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.NodeId, p.RouteValues.Metric, p.RouteValues.IndexMetric)) return _lowLevel.NodesStatsAsync<T>(p.RouteValues.NodeId,p.RouteValues.Metric,p.RouteValues.IndexMetric,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.NodeId, p.RouteValues.Metric)) return _lowLevel.NodesStatsAsync<T>(p.RouteValues.NodeId,p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Metric, p.RouteValues.IndexMetric)) return _lowLevel.NodesStatsForAllAsync<T>(p.RouteValues.Metric,p.RouteValues.IndexMetric,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.NodesStatsAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Metric)) return _lowLevel.NodesStatsForAllAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.NodesStatsForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.NodeId, p.RouteValues.Metric, p.RouteValues.IndexMetric)) return _lowLevel.NodesStatsAsync<T>(p.RouteValues.NodeId,p.RouteValues.Metric,p.RouteValues.IndexMetric,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.NodeId, p.RouteValues.Metric)) return _lowLevel.NodesStatsAsync<T>(p.RouteValues.NodeId,p.RouteValues.Metric,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Metric, p.RouteValues.IndexMetric)) return _lowLevel.NodesStatsForAllAsync<T>(p.RouteValues.Metric,p.RouteValues.IndexMetric,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.NodesStatsAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Metric)) return _lowLevel.NodesStatsForAllAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,ct);
+					return _lowLevel.NodesStatsForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("NodesStats", p, new [] { GET }, "/_nodes/stats", "/_nodes/{node_id}/stats", "/_nodes/stats/{metric}", "/_nodes/{node_id}/stats/{metric}", "/_nodes/stats/{metric}/{index_metric}", "/_nodes/{node_id}/stats/{metric}/{index_metric}");
 		}
 		
-		internal ElasticsearchResponse<T> NodesUsageDispatch<T>(IRequest<NodesUsageRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> NodesUsageDispatch<T>(IRequest<NodesUsageRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2478,21 +2478,21 @@ namespace Nest
 			throw InvalidDispatch("NodesUsage", p, new [] { GET }, "/_nodes/usage", "/_nodes/{node_id}/usage", "/_nodes/usage/{metric}", "/_nodes/{node_id}/usage/{metric}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> NodesUsageDispatchAsync<T>(IRequest<NodesUsageRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> NodesUsageDispatchAsync<T>(IRequest<NodesUsageRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.NodeId, p.RouteValues.Metric)) return _lowLevel.NodesUsageAsync<T>(p.RouteValues.NodeId,p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.NodesUsageAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Metric)) return _lowLevel.NodesUsageForAllAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.NodesUsageForAllAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.NodeId, p.RouteValues.Metric)) return _lowLevel.NodesUsageAsync<T>(p.RouteValues.NodeId,p.RouteValues.Metric,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.NodeId)) return _lowLevel.NodesUsageAsync<T>(p.RouteValues.NodeId,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Metric)) return _lowLevel.NodesUsageForAllAsync<T>(p.RouteValues.Metric,u => p.RequestParameters,ct);
+					return _lowLevel.NodesUsageForAllAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("NodesUsage", p, new [] { GET }, "/_nodes/usage", "/_nodes/{node_id}/usage", "/_nodes/usage/{metric}", "/_nodes/{node_id}/usage/{metric}");
 		}
 		
-		internal ElasticsearchResponse<T> PingDispatch<T>(IRequest<PingRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> PingDispatch<T>(IRequest<PingRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2503,18 +2503,18 @@ namespace Nest
 			throw InvalidDispatch("Ping", p, new [] { HEAD }, "/");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> PingDispatchAsync<T>(IRequest<PingRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> PingDispatchAsync<T>(IRequest<PingRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case HEAD:
-					return _lowLevel.PingAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.PingAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Ping", p, new [] { HEAD }, "/");
 		}
 		
-		internal ElasticsearchResponse<T> PutScriptDispatch<T>(IRequest<PutScriptRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> PutScriptDispatch<T>(IRequest<PutScriptRequestParameters> p,SerializableData<IPutScriptRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2532,25 +2532,25 @@ namespace Nest
 			throw InvalidDispatch("PutScript", p, new [] { PUT, POST }, "/_scripts/{id}", "/_scripts/{id}/{context}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> PutScriptDispatchAsync<T>(IRequest<PutScriptRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> PutScriptDispatchAsync<T>(IRequest<PutScriptRequestParameters> p,SerializableData<IPutScriptRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSet(p.RouteValues.Id, p.RouteValues.Context)) return _lowLevel.PutScriptAsync<T>(p.RouteValues.Id,p.RouteValues.Context,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.PutScriptAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id, p.RouteValues.Context)) return _lowLevel.PutScriptAsync<T>(p.RouteValues.Id,p.RouteValues.Context,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.PutScriptAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.Id, p.RouteValues.Context)) return _lowLevel.PutScriptPostAsync<T>(p.RouteValues.Id,p.RouteValues.Context,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.PutScriptPostAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id, p.RouteValues.Context)) return _lowLevel.PutScriptPostAsync<T>(p.RouteValues.Id,p.RouteValues.Context,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.PutScriptPostAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("PutScript", p, new [] { PUT, POST }, "/_scripts/{id}", "/_scripts/{id}/{context}");
 		}
 		
-		internal ElasticsearchResponse<T> ReindexDispatch<T>(IRequest<ReindexOnServerRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> ReindexDispatch<T>(IRequest<ReindexOnServerRequestParameters> p,SerializableData<IReindexOnServerRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2561,18 +2561,18 @@ namespace Nest
 			throw InvalidDispatch("Reindex", p, new [] { POST }, "/_reindex");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ReindexDispatchAsync<T>(IRequest<ReindexOnServerRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ReindexDispatchAsync<T>(IRequest<ReindexOnServerRequestParameters> p,SerializableData<IReindexOnServerRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.ReindexAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ReindexAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Reindex", p, new [] { POST }, "/_reindex");
 		}
 		
-		internal ElasticsearchResponse<T> ReindexRethrottleDispatch<T>(IRequest<ReindexRethrottleRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> ReindexRethrottleDispatch<T>(IRequest<ReindexRethrottleRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2584,19 +2584,19 @@ namespace Nest
 			throw InvalidDispatch("ReindexRethrottle", p, new [] { POST }, "/_reindex/{task_id}/_rethrottle", "/_update_by_query/{task_id}/_rethrottle", "/_delete_by_query/{task_id}/_rethrottle");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ReindexRethrottleDispatchAsync<T>(IRequest<ReindexRethrottleRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ReindexRethrottleDispatchAsync<T>(IRequest<ReindexRethrottleRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.ReindexRethrottleAsync<T>(p.RouteValues.TaskId,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.ReindexRethrottleAsync<T>(p.RouteValues.TaskId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("ReindexRethrottle", p, new [] { POST }, "/_reindex/{task_id}/_rethrottle", "/_update_by_query/{task_id}/_rethrottle", "/_delete_by_query/{task_id}/_rethrottle");
 		}
 		
-		internal ElasticsearchResponse<T> RenderSearchTemplateDispatch<T>(IRequest<RenderSearchTemplateRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> RenderSearchTemplateDispatch<T>(IRequest<RenderSearchTemplateRequestParameters> p,SerializableData<IRenderSearchTemplateRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2612,23 +2612,23 @@ namespace Nest
 			throw InvalidDispatch("RenderSearchTemplate", p, new [] { GET, POST }, "/_render/template", "/_render/template/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> RenderSearchTemplateDispatchAsync<T>(IRequest<RenderSearchTemplateRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> RenderSearchTemplateDispatchAsync<T>(IRequest<RenderSearchTemplateRequestParameters> p,SerializableData<IRenderSearchTemplateRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Id)) return _lowLevel.RenderSearchTemplateGetAsync<T>(p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.RenderSearchTemplateGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id)) return _lowLevel.RenderSearchTemplateGetAsync<T>(p.RouteValues.Id,u => p.RequestParameters,ct);
+					return _lowLevel.RenderSearchTemplateGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Id)) return _lowLevel.RenderSearchTemplateAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.RenderSearchTemplateAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id)) return _lowLevel.RenderSearchTemplateAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
+					return _lowLevel.RenderSearchTemplateAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("RenderSearchTemplate", p, new [] { GET, POST }, "/_render/template", "/_render/template/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> ScrollDispatch<T>(IRequest<ScrollRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> ScrollDispatch<T>(IRequest<ScrollRequestParameters> p,SerializableData<IScrollRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2642,21 +2642,21 @@ namespace Nest
 			throw InvalidDispatch("Scroll", p, new [] { GET, POST }, "/_search/scroll");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> ScrollDispatchAsync<T>(IRequest<ScrollRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> ScrollDispatchAsync<T>(IRequest<ScrollRequestParameters> p,SerializableData<IScrollRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.ScrollGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ScrollGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					return _lowLevel.ScrollAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.ScrollAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Scroll", p, new [] { GET, POST }, "/_search/scroll");
 		}
 		
-		internal ElasticsearchResponse<T> SearchDispatch<T>(IRequest<SearchRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> SearchDispatch<T>(IRequest<SearchRequestParameters> p,SerializableData<ISearchRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2674,25 +2674,25 @@ namespace Nest
 			throw InvalidDispatch("Search", p, new [] { GET, POST }, "/_search", "/{index}/_search", "/{index}/{type}/_search");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SearchDispatchAsync<T>(IRequest<SearchRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SearchDispatchAsync<T>(IRequest<SearchRequestParameters> p,SerializableData<ISearchRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.SearchGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.SearchGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.SearchGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.SearchGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.SearchAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.SearchAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.SearchAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.SearchAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("Search", p, new [] { GET, POST }, "/_search", "/{index}/_search", "/{index}/{type}/_search");
 		}
 		
-		internal ElasticsearchResponse<T> SearchShardsDispatch<T>(IRequest<SearchShardsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> SearchShardsDispatch<T>(IRequest<SearchShardsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2708,23 +2708,23 @@ namespace Nest
 			throw InvalidDispatch("SearchShards", p, new [] { GET, POST }, "/_search_shards", "/{index}/_search_shards");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SearchShardsDispatchAsync<T>(IRequest<SearchShardsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SearchShardsDispatchAsync<T>(IRequest<SearchShardsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchShardsGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.SearchShardsGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchShardsGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.SearchShardsGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchShardsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.SearchShardsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchShardsAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.SearchShardsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("SearchShards", p, new [] { GET, POST }, "/_search_shards", "/{index}/_search_shards");
 		}
 		
-		internal ElasticsearchResponse<T> SearchTemplateDispatch<T>(IRequest<SearchTemplateRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> SearchTemplateDispatch<T>(IRequest<SearchTemplateRequestParameters> p,SerializableData<ISearchTemplateRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2742,25 +2742,25 @@ namespace Nest
 			throw InvalidDispatch("SearchTemplate", p, new [] { GET, POST }, "/_search/template", "/{index}/_search/template", "/{index}/{type}/_search/template");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SearchTemplateDispatchAsync<T>(IRequest<SearchTemplateRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SearchTemplateDispatchAsync<T>(IRequest<SearchTemplateRequestParameters> p,SerializableData<ISearchTemplateRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.SearchTemplateGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchTemplateGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.SearchTemplateGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.SearchTemplateGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchTemplateGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.SearchTemplateGetAsync<T>(u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.SearchTemplateAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchTemplateAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.SearchTemplateAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.SearchTemplateAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.SearchTemplateAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
+					return _lowLevel.SearchTemplateAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("SearchTemplate", p, new [] { GET, POST }, "/_search/template", "/{index}/_search/template", "/{index}/{type}/_search/template");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotCreateDispatch<T>(IRequest<SnapshotRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> SnapshotCreateDispatch<T>(IRequest<SnapshotRequestParameters> p,SerializableData<ISnapshotRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2776,23 +2776,23 @@ namespace Nest
 			throw InvalidDispatch("SnapshotCreate", p, new [] { PUT, POST }, "/_snapshot/{repository}/{snapshot}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotCreateDispatchAsync<T>(IRequest<SnapshotRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotCreateDispatchAsync<T>(IRequest<SnapshotRequestParameters> p,SerializableData<ISnapshotRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotCreateAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotCreateAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotCreatePostAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotCreatePostAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("SnapshotCreate", p, new [] { PUT, POST }, "/_snapshot/{repository}/{snapshot}");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotCreateRepositoryDispatch<T>(IRequest<CreateRepositoryRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> SnapshotCreateRepositoryDispatch<T>(IRequest<CreateRepositoryRequestParameters> p,SerializableData<ICreateRepositoryRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2808,23 +2808,23 @@ namespace Nest
 			throw InvalidDispatch("SnapshotCreateRepository", p, new [] { PUT, POST }, "/_snapshot/{repository}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryDispatchAsync<T>(IRequest<CreateRepositoryRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotCreateRepositoryDispatchAsync<T>(IRequest<CreateRepositoryRequestParameters> p,SerializableData<ICreateRepositoryRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Repository)) return _lowLevel.SnapshotCreateRepositoryAsync<T>(p.RouteValues.Repository,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository)) return _lowLevel.SnapshotCreateRepositoryAsync<T>(p.RouteValues.Repository,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Repository)) return _lowLevel.SnapshotCreateRepositoryPostAsync<T>(p.RouteValues.Repository,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository)) return _lowLevel.SnapshotCreateRepositoryPostAsync<T>(p.RouteValues.Repository,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("SnapshotCreateRepository", p, new [] { PUT, POST }, "/_snapshot/{repository}");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotDeleteDispatch<T>(IRequest<DeleteSnapshotRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> SnapshotDeleteDispatch<T>(IRequest<DeleteSnapshotRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2836,19 +2836,19 @@ namespace Nest
 			throw InvalidDispatch("SnapshotDelete", p, new [] { DELETE }, "/_snapshot/{repository}/{snapshot}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotDeleteDispatchAsync<T>(IRequest<DeleteSnapshotRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotDeleteDispatchAsync<T>(IRequest<DeleteSnapshotRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotDeleteAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotDeleteAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("SnapshotDelete", p, new [] { DELETE }, "/_snapshot/{repository}/{snapshot}");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotDeleteRepositoryDispatch<T>(IRequest<DeleteRepositoryRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> SnapshotDeleteRepositoryDispatch<T>(IRequest<DeleteRepositoryRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2860,19 +2860,19 @@ namespace Nest
 			throw InvalidDispatch("SnapshotDeleteRepository", p, new [] { DELETE }, "/_snapshot/{repository}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotDeleteRepositoryDispatchAsync<T>(IRequest<DeleteRepositoryRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotDeleteRepositoryDispatchAsync<T>(IRequest<DeleteRepositoryRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Repository)) return _lowLevel.SnapshotDeleteRepositoryAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository)) return _lowLevel.SnapshotDeleteRepositoryAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("SnapshotDeleteRepository", p, new [] { DELETE }, "/_snapshot/{repository}");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotGetDispatch<T>(IRequest<GetSnapshotRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> SnapshotGetDispatch<T>(IRequest<GetSnapshotRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2884,19 +2884,19 @@ namespace Nest
 			throw InvalidDispatch("SnapshotGet", p, new [] { GET }, "/_snapshot/{repository}/{snapshot}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotGetDispatchAsync<T>(IRequest<GetSnapshotRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotGetDispatchAsync<T>(IRequest<GetSnapshotRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotGetAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotGetAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("SnapshotGet", p, new [] { GET }, "/_snapshot/{repository}/{snapshot}");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotGetRepositoryDispatch<T>(IRequest<GetRepositoryRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> SnapshotGetRepositoryDispatch<T>(IRequest<GetRepositoryRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2908,19 +2908,19 @@ namespace Nest
 			throw InvalidDispatch("SnapshotGetRepository", p, new [] { GET }, "/_snapshot", "/_snapshot/{repository}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotGetRepositoryDispatchAsync<T>(IRequest<GetRepositoryRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotGetRepositoryDispatchAsync<T>(IRequest<GetRepositoryRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Repository)) return _lowLevel.SnapshotGetRepositoryAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.SnapshotGetRepositoryAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Repository)) return _lowLevel.SnapshotGetRepositoryAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,ct);
+					return _lowLevel.SnapshotGetRepositoryAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("SnapshotGetRepository", p, new [] { GET }, "/_snapshot", "/_snapshot/{repository}");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotRestoreDispatch<T>(IRequest<RestoreRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> SnapshotRestoreDispatch<T>(IRequest<RestoreRequestParameters> p,SerializableData<IRestoreRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2932,19 +2932,19 @@ namespace Nest
 			throw InvalidDispatch("SnapshotRestore", p, new [] { POST }, "/_snapshot/{repository}/{snapshot}/_restore");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotRestoreDispatchAsync<T>(IRequest<RestoreRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotRestoreDispatchAsync<T>(IRequest<RestoreRequestParameters> p,SerializableData<IRestoreRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotRestoreAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotRestoreAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("SnapshotRestore", p, new [] { POST }, "/_snapshot/{repository}/{snapshot}/_restore");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotStatusDispatch<T>(IRequest<SnapshotStatusRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> SnapshotStatusDispatch<T>(IRequest<SnapshotStatusRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2957,20 +2957,20 @@ namespace Nest
 			throw InvalidDispatch("SnapshotStatus", p, new [] { GET }, "/_snapshot/_status", "/_snapshot/{repository}/_status", "/_snapshot/{repository}/{snapshot}/_status");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotStatusDispatchAsync<T>(IRequest<SnapshotStatusRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotStatusDispatchAsync<T>(IRequest<SnapshotStatusRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotStatusAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,u => p.RequestParameters,cancellationToken);
-					if (AllSet(p.RouteValues.Repository)) return _lowLevel.SnapshotStatusAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.SnapshotStatusAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Repository, p.RouteValues.Snapshot)) return _lowLevel.SnapshotStatusAsync<T>(p.RouteValues.Repository,p.RouteValues.Snapshot,u => p.RequestParameters,ct);
+					if (AllSet(p.RouteValues.Repository)) return _lowLevel.SnapshotStatusAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,ct);
+					return _lowLevel.SnapshotStatusAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("SnapshotStatus", p, new [] { GET }, "/_snapshot/_status", "/_snapshot/{repository}/_status", "/_snapshot/{repository}/{snapshot}/_status");
 		}
 		
-		internal ElasticsearchResponse<T> SnapshotVerifyRepositoryDispatch<T>(IRequest<VerifyRepositoryRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> SnapshotVerifyRepositoryDispatch<T>(IRequest<VerifyRepositoryRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -2982,19 +2982,19 @@ namespace Nest
 			throw InvalidDispatch("SnapshotVerifyRepository", p, new [] { POST }, "/_snapshot/{repository}/_verify");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> SnapshotVerifyRepositoryDispatchAsync<T>(IRequest<VerifyRepositoryRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> SnapshotVerifyRepositoryDispatchAsync<T>(IRequest<VerifyRepositoryRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Repository)) return _lowLevel.SnapshotVerifyRepositoryAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Repository)) return _lowLevel.SnapshotVerifyRepositoryAsync<T>(p.RouteValues.Repository,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("SnapshotVerifyRepository", p, new [] { POST }, "/_snapshot/{repository}/_verify");
 		}
 		
-		internal ElasticsearchResponse<T> TasksCancelDispatch<T>(IRequest<CancelTasksRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> TasksCancelDispatch<T>(IRequest<CancelTasksRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3006,19 +3006,19 @@ namespace Nest
 			throw InvalidDispatch("TasksCancel", p, new [] { POST }, "/_tasks/_cancel", "/_tasks/{task_id}/_cancel");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> TasksCancelDispatchAsync<T>(IRequest<CancelTasksRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> TasksCancelDispatchAsync<T>(IRequest<CancelTasksRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.TasksCancelAsync<T>(p.RouteValues.TaskId,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.TasksCancelAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.TasksCancelAsync<T>(p.RouteValues.TaskId,u => p.RequestParameters,ct);
+					return _lowLevel.TasksCancelAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("TasksCancel", p, new [] { POST }, "/_tasks/_cancel", "/_tasks/{task_id}/_cancel");
 		}
 		
-		internal ElasticsearchResponse<T> TasksGetDispatch<T>(IRequest<GetTaskRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> TasksGetDispatch<T>(IRequest<GetTaskRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3030,19 +3030,19 @@ namespace Nest
 			throw InvalidDispatch("TasksGet", p, new [] { GET }, "/_tasks/{task_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> TasksGetDispatchAsync<T>(IRequest<GetTaskRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> TasksGetDispatchAsync<T>(IRequest<GetTaskRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.TasksGetAsync<T>(p.RouteValues.TaskId,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.TaskId)) return _lowLevel.TasksGetAsync<T>(p.RouteValues.TaskId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("TasksGet", p, new [] { GET }, "/_tasks/{task_id}");
 		}
 		
-		internal ElasticsearchResponse<T> TasksListDispatch<T>(IRequest<ListTasksRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> TasksListDispatch<T>(IRequest<ListTasksRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3053,18 +3053,18 @@ namespace Nest
 			throw InvalidDispatch("TasksList", p, new [] { GET }, "/_tasks");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> TasksListDispatchAsync<T>(IRequest<ListTasksRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> TasksListDispatchAsync<T>(IRequest<ListTasksRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.TasksListAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.TasksListAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("TasksList", p, new [] { GET }, "/_tasks");
 		}
 		
-		internal ElasticsearchResponse<T> TermvectorsDispatch<T>(IRequest<TermVectorsRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> TermvectorsDispatch<T,TDocument>(IRequest<TermVectorsRequestParameters> p,SerializableData<ITermVectorsRequest<TDocument>> body) where T : class where TDocument : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3082,25 +3082,25 @@ namespace Nest
 			throw InvalidDispatch("Termvectors", p, new [] { GET, POST }, "/{index}/{type}/_termvectors", "/{index}/{type}/{id}/_termvectors");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> TermvectorsDispatchAsync<T>(IRequest<TermVectorsRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> TermvectorsDispatchAsync<T,TDocument>(IRequest<TermVectorsRequestParameters> p,SerializableData<ITermVectorsRequest<TDocument>> body, CancellationToken ct) where T : class where TDocument : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.TermvectorsGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.TermvectorsGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.TermvectorsGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.TermvectorsGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.TermvectorsAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.TermvectorsAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.TermvectorsAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.TermvectorsAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("Termvectors", p, new [] { GET, POST }, "/{index}/{type}/_termvectors", "/{index}/{type}/{id}/_termvectors");
 		}
 		
-		internal ElasticsearchResponse<T> UpdateDispatch<T>(IRequest<UpdateRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> UpdateDispatch<T,TDocument,TPartialDocument>(IRequest<UpdateRequestParameters> p,SerializableData<IUpdateRequest<TDocument, TPartialDocument>> body) where T : class where TDocument : class where TPartialDocument : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3112,19 +3112,19 @@ namespace Nest
 			throw InvalidDispatch("Update", p, new [] { POST }, "/{index}/{type}/{id}/_update");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> UpdateDispatchAsync<T>(IRequest<UpdateRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> UpdateDispatchAsync<T,TDocument,TPartialDocument>(IRequest<UpdateRequestParameters> p,SerializableData<IUpdateRequest<TDocument, TPartialDocument>> body, CancellationToken ct) where T : class where TDocument : class where TPartialDocument : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.UpdateAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Index, p.RouteValues.Type, p.RouteValues.Id)) return _lowLevel.UpdateAsync<T>(p.RouteValues.Index,p.RouteValues.Type,p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("Update", p, new [] { POST }, "/{index}/{type}/{id}/_update");
 		}
 		
-		internal ElasticsearchResponse<T> UpdateByQueryDispatch<T>(IRequest<UpdateByQueryRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> UpdateByQueryDispatch<T>(IRequest<UpdateByQueryRequestParameters> p,SerializableData<IUpdateByQueryRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3137,20 +3137,20 @@ namespace Nest
 			throw InvalidDispatch("UpdateByQuery", p, new [] { POST }, "/{index}/_update_by_query", "/{index}/{type}/_update_by_query");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> UpdateByQueryDispatchAsync<T>(IRequest<UpdateByQueryRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> UpdateByQueryDispatchAsync<T>(IRequest<UpdateByQueryRequestParameters> p,SerializableData<IUpdateByQueryRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.UpdateByQueryAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("UpdateByQuery", p, new [] { POST }, "/{index}/_update_by_query", "/{index}/{type}/_update_by_query");
 		}
 		
-		internal ElasticsearchResponse<T> XpackGraphExploreDispatch<T>(IRequest<GraphExploreRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackGraphExploreDispatch<T>(IRequest<GraphExploreRequestParameters> p,SerializableData<IGraphExploreRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3168,25 +3168,25 @@ namespace Nest
 			throw InvalidDispatch("XpackGraphExplore", p, new [] { GET, POST }, "/{index}/_xpack/graph/_explore", "/{index}/{type}/_xpack/graph/_explore");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackGraphExploreDispatchAsync<T>(IRequest<GraphExploreRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackGraphExploreDispatchAsync<T>(IRequest<GraphExploreRequestParameters> p,SerializableData<IGraphExploreRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.XpackGraphExploreGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.XpackGraphExploreGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.XpackGraphExploreGetAsync<T>(p.RouteValues.Index,p.RouteValues.Type,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.XpackGraphExploreGetAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.XpackGraphExploreAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.XpackGraphExploreAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index, p.RouteValues.Type)) return _lowLevel.XpackGraphExploreAsync<T>(p.RouteValues.Index,p.RouteValues.Type,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.Index)) return _lowLevel.XpackGraphExploreAsync<T>(p.RouteValues.Index,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackGraphExplore", p, new [] { GET, POST }, "/{index}/_xpack/graph/_explore", "/{index}/{type}/_xpack/graph/_explore");
 		}
 		
-		internal ElasticsearchResponse<T> XpackDeprecationInfoDispatch<T>(IRequest<DeprecationInfoRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackDeprecationInfoDispatch<T>(IRequest<DeprecationInfoRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3198,19 +3198,19 @@ namespace Nest
 			throw InvalidDispatch("XpackDeprecationInfo", p, new [] { GET }, "/_xpack/migration/deprecations", "/{index}/_xpack/migration/deprecations");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackDeprecationInfoDispatchAsync<T>(IRequest<DeprecationInfoRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackDeprecationInfoDispatchAsync<T>(IRequest<DeprecationInfoRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Index)) return _lowLevel.XpackDeprecationInfoAsync<T>(p.RouteValues.Index,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackDeprecationInfoAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Index)) return _lowLevel.XpackDeprecationInfoAsync<T>(p.RouteValues.Index,u => p.RequestParameters,ct);
+					return _lowLevel.XpackDeprecationInfoAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackDeprecationInfo", p, new [] { GET }, "/_xpack/migration/deprecations", "/{index}/_xpack/migration/deprecations");
 		}
 		
-		internal ElasticsearchResponse<T> XpackInfoDispatch<T>(IRequest<XPackInfoRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackInfoDispatch<T>(IRequest<XPackInfoRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3221,18 +3221,18 @@ namespace Nest
 			throw InvalidDispatch("XpackInfo", p, new [] { GET }, "/_xpack");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackInfoDispatchAsync<T>(IRequest<XPackInfoRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackInfoDispatchAsync<T>(IRequest<XPackInfoRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.XpackInfoAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackInfoAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackInfo", p, new [] { GET }, "/_xpack");
 		}
 		
-		internal ElasticsearchResponse<T> XpackUsageDispatch<T>(IRequest<XPackUsageRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackUsageDispatch<T>(IRequest<XPackUsageRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3243,18 +3243,18 @@ namespace Nest
 			throw InvalidDispatch("XpackUsage", p, new [] { GET }, "/_xpack/usage");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackUsageDispatchAsync<T>(IRequest<XPackUsageRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackUsageDispatchAsync<T>(IRequest<XPackUsageRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.XpackUsageAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackUsageAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackUsage", p, new [] { GET }, "/_xpack/usage");
 		}
 		
-		internal ElasticsearchResponse<T> XpackLicenseDeleteDispatch<T>(IRequest<DeleteLicenseRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackLicenseDeleteDispatch<T>(IRequest<DeleteLicenseRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3265,18 +3265,18 @@ namespace Nest
 			throw InvalidDispatch("XpackLicenseDelete", p, new [] { DELETE }, "/_xpack/license");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackLicenseDeleteDispatchAsync<T>(IRequest<DeleteLicenseRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackLicenseDeleteDispatchAsync<T>(IRequest<DeleteLicenseRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					return _lowLevel.XpackLicenseDeleteAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackLicenseDeleteAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackLicenseDelete", p, new [] { DELETE }, "/_xpack/license");
 		}
 		
-		internal ElasticsearchResponse<T> XpackLicenseGetDispatch<T>(IRequest<GetLicenseRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackLicenseGetDispatch<T>(IRequest<GetLicenseRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3287,18 +3287,18 @@ namespace Nest
 			throw InvalidDispatch("XpackLicenseGet", p, new [] { GET }, "/_xpack/license");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackLicenseGetDispatchAsync<T>(IRequest<GetLicenseRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackLicenseGetDispatchAsync<T>(IRequest<GetLicenseRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.XpackLicenseGetAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackLicenseGetAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackLicenseGet", p, new [] { GET }, "/_xpack/license");
 		}
 		
-		internal ElasticsearchResponse<T> XpackLicensePostDispatch<T>(IRequest<PostLicenseRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackLicensePostDispatch<T>(IRequest<PostLicenseRequestParameters> p,SerializableData<IPostLicenseRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3309,18 +3309,18 @@ namespace Nest
 			throw InvalidDispatch("XpackLicensePost", p, new [] { PUT }, "/_xpack/license");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackLicensePostDispatchAsync<T>(IRequest<PostLicenseRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackLicensePostDispatchAsync<T>(IRequest<PostLicenseRequestParameters> p,SerializableData<IPostLicenseRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					return _lowLevel.XpackLicensePostAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackLicensePostAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackLicensePost", p, new [] { PUT }, "/_xpack/license");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlCloseJobDispatch<T>(IRequest<CloseJobRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlCloseJobDispatch<T>(IRequest<CloseJobRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3332,19 +3332,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlCloseJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_close");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlCloseJobDispatchAsync<T>(IRequest<CloseJobRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlCloseJobDispatchAsync<T>(IRequest<CloseJobRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlCloseJobAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlCloseJobAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlCloseJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_close");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlDeleteDatafeedDispatch<T>(IRequest<DeleteDatafeedRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlDeleteDatafeedDispatch<T>(IRequest<DeleteDatafeedRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3356,19 +3356,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlDeleteDatafeed", p, new [] { DELETE }, "/_xpack/ml/datafeeds/{datafeed_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlDeleteDatafeedDispatchAsync<T>(IRequest<DeleteDatafeedRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlDeleteDatafeedDispatchAsync<T>(IRequest<DeleteDatafeedRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlDeleteDatafeedAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlDeleteDatafeedAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlDeleteDatafeed", p, new [] { DELETE }, "/_xpack/ml/datafeeds/{datafeed_id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlDeleteExpiredDataDispatch<T>(IRequest<DeleteExpiredDataRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlDeleteExpiredDataDispatch<T>(IRequest<DeleteExpiredDataRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3379,18 +3379,18 @@ namespace Nest
 			throw InvalidDispatch("XpackMlDeleteExpiredData", p, new [] { DELETE }, "/_xpack/ml/_delete_expired_data");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlDeleteExpiredDataDispatchAsync<T>(IRequest<DeleteExpiredDataRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlDeleteExpiredDataDispatchAsync<T>(IRequest<DeleteExpiredDataRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					return _lowLevel.XpackMlDeleteExpiredDataAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackMlDeleteExpiredDataAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackMlDeleteExpiredData", p, new [] { DELETE }, "/_xpack/ml/_delete_expired_data");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlDeleteJobDispatch<T>(IRequest<DeleteJobRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlDeleteJobDispatch<T>(IRequest<DeleteJobRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3402,19 +3402,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlDeleteJob", p, new [] { DELETE }, "/_xpack/ml/anomaly_detectors/{job_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlDeleteJobDispatchAsync<T>(IRequest<DeleteJobRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlDeleteJobDispatchAsync<T>(IRequest<DeleteJobRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlDeleteJobAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlDeleteJobAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlDeleteJob", p, new [] { DELETE }, "/_xpack/ml/anomaly_detectors/{job_id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlDeleteModelSnapshotDispatch<T>(IRequest<DeleteModelSnapshotRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlDeleteModelSnapshotDispatch<T>(IRequest<DeleteModelSnapshotRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3426,19 +3426,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlDeleteModelSnapshot", p, new [] { DELETE }, "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlDeleteModelSnapshotDispatchAsync<T>(IRequest<DeleteModelSnapshotRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlDeleteModelSnapshotDispatchAsync<T>(IRequest<DeleteModelSnapshotRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlDeleteModelSnapshotAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlDeleteModelSnapshotAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlDeleteModelSnapshot", p, new [] { DELETE }, "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlFlushJobDispatch<T>(IRequest<FlushJobRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlFlushJobDispatch<T>(IRequest<FlushJobRequestParameters> p,SerializableData<IFlushJobRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3450,19 +3450,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlFlushJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_flush");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlFlushJobDispatchAsync<T>(IRequest<FlushJobRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlFlushJobDispatchAsync<T>(IRequest<FlushJobRequestParameters> p,SerializableData<IFlushJobRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlFlushJobAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlFlushJobAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlFlushJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_flush");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetBucketsDispatch<T>(IRequest<GetBucketsRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetBucketsDispatch<T>(IRequest<GetBucketsRequestParameters> p,SerializableData<IGetBucketsRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3478,23 +3478,23 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetBuckets", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/results/buckets");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetBucketsDispatchAsync<T>(IRequest<GetBucketsRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetBucketsDispatchAsync<T>(IRequest<GetBucketsRequestParameters> p,SerializableData<IGetBucketsRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetBucketsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetBucketsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetBucketsAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetBucketsAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlGetBuckets", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/results/buckets");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetCategoriesDispatch<T>(IRequest<GetCategoriesRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetCategoriesDispatch<T>(IRequest<GetCategoriesRequestParameters> p,SerializableData<IGetCategoriesRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3512,25 +3512,25 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetCategories", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/results/categories/{category_id}", "/_xpack/ml/anomaly_detectors/{job_id}/results/categories/");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetCategoriesDispatchAsync<T>(IRequest<GetCategoriesRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetCategoriesDispatchAsync<T>(IRequest<GetCategoriesRequestParameters> p,SerializableData<IGetCategoriesRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.JobId, p.RouteValues.CategoryId)) return _lowLevel.XpackMlGetCategoriesAsync<T>(p.RouteValues.JobId,long.Parse(p.RouteValues.CategoryId),u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetCategoriesAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.JobId, p.RouteValues.CategoryId)) return _lowLevel.XpackMlGetCategoriesAsync<T>(p.RouteValues.JobId,long.Parse(p.RouteValues.CategoryId),u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetCategoriesAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.JobId, p.RouteValues.CategoryId)) return _lowLevel.XpackMlGetCategoriesAsync<T>(p.RouteValues.JobId,long.Parse(p.RouteValues.CategoryId),body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetCategoriesAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.JobId, p.RouteValues.CategoryId)) return _lowLevel.XpackMlGetCategoriesAsync<T>(p.RouteValues.JobId,long.Parse(p.RouteValues.CategoryId),body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetCategoriesAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlGetCategories", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/results/categories/{category_id}", "/_xpack/ml/anomaly_detectors/{job_id}/results/categories/");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetDatafeedsDispatch<T>(IRequest<GetDatafeedsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetDatafeedsDispatch<T>(IRequest<GetDatafeedsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3542,19 +3542,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetDatafeeds", p, new [] { GET }, "/_xpack/ml/datafeeds/{datafeed_id}", "/_xpack/ml/datafeeds");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetDatafeedsDispatchAsync<T>(IRequest<GetDatafeedsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetDatafeedsDispatchAsync<T>(IRequest<GetDatafeedsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlGetDatafeedsAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackMlGetDatafeedsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlGetDatafeedsAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,ct);
+					return _lowLevel.XpackMlGetDatafeedsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackMlGetDatafeeds", p, new [] { GET }, "/_xpack/ml/datafeeds/{datafeed_id}", "/_xpack/ml/datafeeds");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetDatafeedStatsDispatch<T>(IRequest<GetDatafeedStatsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetDatafeedStatsDispatch<T>(IRequest<GetDatafeedStatsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3566,19 +3566,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetDatafeedStats", p, new [] { GET }, "/_xpack/ml/datafeeds/{datafeed_id}/_stats", "/_xpack/ml/datafeeds/_stats");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetDatafeedStatsDispatchAsync<T>(IRequest<GetDatafeedStatsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetDatafeedStatsDispatchAsync<T>(IRequest<GetDatafeedStatsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlGetDatafeedStatsAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackMlGetDatafeedStatsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlGetDatafeedStatsAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,ct);
+					return _lowLevel.XpackMlGetDatafeedStatsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackMlGetDatafeedStats", p, new [] { GET }, "/_xpack/ml/datafeeds/{datafeed_id}/_stats", "/_xpack/ml/datafeeds/_stats");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetInfluencersDispatch<T>(IRequest<GetInfluencersRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetInfluencersDispatch<T>(IRequest<GetInfluencersRequestParameters> p,SerializableData<IGetInfluencersRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3594,23 +3594,23 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetInfluencers", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/results/influencers");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetInfluencersDispatchAsync<T>(IRequest<GetInfluencersRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetInfluencersDispatchAsync<T>(IRequest<GetInfluencersRequestParameters> p,SerializableData<IGetInfluencersRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetInfluencersAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetInfluencersAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetInfluencersAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetInfluencersAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlGetInfluencers", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/results/influencers");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetJobsDispatch<T>(IRequest<GetJobsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetJobsDispatch<T>(IRequest<GetJobsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3622,19 +3622,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetJobs", p, new [] { GET }, "/_xpack/ml/anomaly_detectors/{job_id}", "/_xpack/ml/anomaly_detectors/");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetJobsDispatchAsync<T>(IRequest<GetJobsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetJobsDispatchAsync<T>(IRequest<GetJobsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.JobId)) return _lowLevel.XpackMlGetJobsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackMlGetJobsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.JobId)) return _lowLevel.XpackMlGetJobsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
+					return _lowLevel.XpackMlGetJobsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackMlGetJobs", p, new [] { GET }, "/_xpack/ml/anomaly_detectors/{job_id}", "/_xpack/ml/anomaly_detectors/");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetJobStatsDispatch<T>(IRequest<GetJobStatsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetJobStatsDispatch<T>(IRequest<GetJobStatsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3646,19 +3646,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetJobStats", p, new [] { GET }, "/_xpack/ml/anomaly_detectors/_stats", "/_xpack/ml/anomaly_detectors/{job_id}/_stats");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetJobStatsDispatchAsync<T>(IRequest<GetJobStatsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetJobStatsDispatchAsync<T>(IRequest<GetJobStatsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.JobId)) return _lowLevel.XpackMlGetJobStatsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackMlGetJobStatsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.JobId)) return _lowLevel.XpackMlGetJobStatsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
+					return _lowLevel.XpackMlGetJobStatsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackMlGetJobStats", p, new [] { GET }, "/_xpack/ml/anomaly_detectors/_stats", "/_xpack/ml/anomaly_detectors/{job_id}/_stats");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetModelSnapshotsDispatch<T>(IRequest<GetModelSnapshotsRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetModelSnapshotsDispatch<T>(IRequest<GetModelSnapshotsRequestParameters> p,SerializableData<IGetModelSnapshotsRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3676,25 +3676,25 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetModelSnapshots", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}", "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsDispatchAsync<T>(IRequest<GetModelSnapshotsRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetModelSnapshotsDispatchAsync<T>(IRequest<GetModelSnapshotsRequestParameters> p,SerializableData<IGetModelSnapshotsRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlGetModelSnapshotsAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetModelSnapshotsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlGetModelSnapshotsAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetModelSnapshotsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlGetModelSnapshotsAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,body,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetModelSnapshotsAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlGetModelSnapshotsAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,body,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetModelSnapshotsAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlGetModelSnapshots", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}", "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlGetRecordsDispatch<T>(IRequest<GetAnomalyRecordsRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlGetRecordsDispatch<T>(IRequest<GetAnomalyRecordsRequestParameters> p,SerializableData<IGetAnomalyRecordsRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3710,23 +3710,23 @@ namespace Nest
 			throw InvalidDispatch("XpackMlGetRecords", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/results/records");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlGetRecordsDispatchAsync<T>(IRequest<GetAnomalyRecordsRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlGetRecordsDispatchAsync<T>(IRequest<GetAnomalyRecordsRequestParameters> p,SerializableData<IGetAnomalyRecordsRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetRecordsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetRecordsAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetRecordsAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlGetRecordsAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlGetRecords", p, new [] { GET, POST }, "/_xpack/ml/anomaly_detectors/{job_id}/results/records");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlOpenJobDispatch<T>(IRequest<OpenJobRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlOpenJobDispatch<T>(IRequest<OpenJobRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3738,19 +3738,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlOpenJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_open");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlOpenJobDispatchAsync<T>(IRequest<OpenJobRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlOpenJobDispatchAsync<T>(IRequest<OpenJobRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlOpenJobAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlOpenJobAsync<T>(p.RouteValues.JobId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlOpenJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_open");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlPostDataDispatch<T>(IRequest<PostJobDataRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlPostDataDispatch<T>(IRequest<PostJobDataRequestParameters> p,SerializableData<IPostJobDataRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3762,19 +3762,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlPostData", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_data");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlPostDataDispatchAsync<T>(IRequest<PostJobDataRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlPostDataDispatchAsync<T>(IRequest<PostJobDataRequestParameters> p,SerializableData<IPostJobDataRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlPostDataAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlPostDataAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlPostData", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_data");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlPreviewDatafeedDispatch<T>(IRequest<PreviewDatafeedRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlPreviewDatafeedDispatch<T>(IRequest<PreviewDatafeedRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3786,19 +3786,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlPreviewDatafeed", p, new [] { GET }, "/_xpack/ml/datafeeds/{datafeed_id}/_preview");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlPreviewDatafeedDispatchAsync<T>(IRequest<PreviewDatafeedRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlPreviewDatafeedDispatchAsync<T>(IRequest<PreviewDatafeedRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlPreviewDatafeedAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlPreviewDatafeedAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlPreviewDatafeed", p, new [] { GET }, "/_xpack/ml/datafeeds/{datafeed_id}/_preview");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlPutDatafeedDispatch<T>(IRequest<PutDatafeedRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlPutDatafeedDispatch<T>(IRequest<PutDatafeedRequestParameters> p,SerializableData<IPutDatafeedRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3810,19 +3810,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlPutDatafeed", p, new [] { PUT }, "/_xpack/ml/datafeeds/{datafeed_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlPutDatafeedDispatchAsync<T>(IRequest<PutDatafeedRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlPutDatafeedDispatchAsync<T>(IRequest<PutDatafeedRequestParameters> p,SerializableData<IPutDatafeedRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlPutDatafeedAsync<T>(p.RouteValues.DatafeedId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlPutDatafeedAsync<T>(p.RouteValues.DatafeedId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlPutDatafeed", p, new [] { PUT }, "/_xpack/ml/datafeeds/{datafeed_id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlPutJobDispatch<T>(IRequest<PutJobRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlPutJobDispatch<T>(IRequest<PutJobRequestParameters> p,SerializableData<IPutJobRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3834,19 +3834,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlPutJob", p, new [] { PUT }, "/_xpack/ml/anomaly_detectors/{job_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlPutJobDispatchAsync<T>(IRequest<PutJobRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlPutJobDispatchAsync<T>(IRequest<PutJobRequestParameters> p,SerializableData<IPutJobRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlPutJobAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlPutJobAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlPutJob", p, new [] { PUT }, "/_xpack/ml/anomaly_detectors/{job_id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlRevertModelSnapshotDispatch<T>(IRequest<RevertModelSnapshotRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlRevertModelSnapshotDispatch<T>(IRequest<RevertModelSnapshotRequestParameters> p,SerializableData<IRevertModelSnapshotRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3858,19 +3858,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlRevertModelSnapshot", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_revert");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlRevertModelSnapshotDispatchAsync<T>(IRequest<RevertModelSnapshotRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlRevertModelSnapshotDispatchAsync<T>(IRequest<RevertModelSnapshotRequestParameters> p,SerializableData<IRevertModelSnapshotRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlRevertModelSnapshotAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlRevertModelSnapshotAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlRevertModelSnapshot", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_revert");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlStartDatafeedDispatch<T>(IRequest<StartDatafeedRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlStartDatafeedDispatch<T>(IRequest<StartDatafeedRequestParameters> p,SerializableData<IStartDatafeedRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3882,19 +3882,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlStartDatafeed", p, new [] { POST }, "/_xpack/ml/datafeeds/{datafeed_id}/_start");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlStartDatafeedDispatchAsync<T>(IRequest<StartDatafeedRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlStartDatafeedDispatchAsync<T>(IRequest<StartDatafeedRequestParameters> p,SerializableData<IStartDatafeedRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlStartDatafeedAsync<T>(p.RouteValues.DatafeedId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlStartDatafeedAsync<T>(p.RouteValues.DatafeedId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlStartDatafeed", p, new [] { POST }, "/_xpack/ml/datafeeds/{datafeed_id}/_start");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlStopDatafeedDispatch<T>(IRequest<StopDatafeedRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackMlStopDatafeedDispatch<T>(IRequest<StopDatafeedRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3906,19 +3906,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlStopDatafeed", p, new [] { POST }, "/_xpack/ml/datafeeds/{datafeed_id}/_stop");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlStopDatafeedDispatchAsync<T>(IRequest<StopDatafeedRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlStopDatafeedDispatchAsync<T>(IRequest<StopDatafeedRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlStopDatafeedAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlStopDatafeedAsync<T>(p.RouteValues.DatafeedId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlStopDatafeed", p, new [] { POST }, "/_xpack/ml/datafeeds/{datafeed_id}/_stop");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlUpdateDatafeedDispatch<T>(IRequest<UpdateDatafeedRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlUpdateDatafeedDispatch<T>(IRequest<UpdateDatafeedRequestParameters> p,SerializableData<IUpdateDatafeedRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3930,19 +3930,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlUpdateDatafeed", p, new [] { POST }, "/_xpack/ml/datafeeds/{datafeed_id}/_update");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlUpdateDatafeedDispatchAsync<T>(IRequest<UpdateDatafeedRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlUpdateDatafeedDispatchAsync<T>(IRequest<UpdateDatafeedRequestParameters> p,SerializableData<IUpdateDatafeedRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlUpdateDatafeedAsync<T>(p.RouteValues.DatafeedId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.DatafeedId)) return _lowLevel.XpackMlUpdateDatafeedAsync<T>(p.RouteValues.DatafeedId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlUpdateDatafeed", p, new [] { POST }, "/_xpack/ml/datafeeds/{datafeed_id}/_update");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlUpdateJobDispatch<T>(IRequest<UpdateJobRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlUpdateJobDispatch<T>(IRequest<UpdateJobRequestParameters> p,SerializableData<IUpdateJobRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3954,19 +3954,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlUpdateJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_update");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlUpdateJobDispatchAsync<T>(IRequest<UpdateJobRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlUpdateJobDispatchAsync<T>(IRequest<UpdateJobRequestParameters> p,SerializableData<IUpdateJobRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlUpdateJobAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlUpdateJobAsync<T>(p.RouteValues.JobId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlUpdateJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_update");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlUpdateModelSnapshotDispatch<T>(IRequest<UpdateModelSnapshotRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlUpdateModelSnapshotDispatch<T>(IRequest<UpdateModelSnapshotRequestParameters> p,SerializableData<IUpdateModelSnapshotRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -3978,19 +3978,19 @@ namespace Nest
 			throw InvalidDispatch("XpackMlUpdateModelSnapshot", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_update");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlUpdateModelSnapshotDispatchAsync<T>(IRequest<UpdateModelSnapshotRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlUpdateModelSnapshotDispatchAsync<T>(IRequest<UpdateModelSnapshotRequestParameters> p,SerializableData<IUpdateModelSnapshotRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlUpdateModelSnapshotAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.JobId, p.RouteValues.SnapshotId)) return _lowLevel.XpackMlUpdateModelSnapshotAsync<T>(p.RouteValues.JobId,p.RouteValues.SnapshotId,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackMlUpdateModelSnapshot", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_update");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlValidateDispatch<T>(IRequest<ValidateJobRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlValidateDispatch<T>(IRequest<ValidateJobRequestParameters> p,SerializableData<IValidateJobRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4001,18 +4001,18 @@ namespace Nest
 			throw InvalidDispatch("XpackMlValidate", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/_validate");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlValidateDispatchAsync<T>(IRequest<ValidateJobRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlValidateDispatchAsync<T>(IRequest<ValidateJobRequestParameters> p,SerializableData<IValidateJobRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.XpackMlValidateAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackMlValidateAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackMlValidate", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/_validate");
 		}
 		
-		internal ElasticsearchResponse<T> XpackMlValidateDetectorDispatch<T>(IRequest<ValidateDetectorRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackMlValidateDetectorDispatch<T>(IRequest<ValidateDetectorRequestParameters> p,SerializableData<IValidateDetectorRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4023,18 +4023,18 @@ namespace Nest
 			throw InvalidDispatch("XpackMlValidateDetector", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/_validate/detector");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackMlValidateDetectorDispatchAsync<T>(IRequest<ValidateDetectorRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackMlValidateDetectorDispatchAsync<T>(IRequest<ValidateDetectorRequestParameters> p,SerializableData<IValidateDetectorRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.XpackMlValidateDetectorAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackMlValidateDetectorAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackMlValidateDetector", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/_validate/detector");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityAuthenticateDispatch<T>(IRequest<AuthenticateRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityAuthenticateDispatch<T>(IRequest<AuthenticateRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4045,18 +4045,18 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityAuthenticate", p, new [] { GET }, "/_xpack/security/_authenticate");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityAuthenticateDispatchAsync<T>(IRequest<AuthenticateRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityAuthenticateDispatchAsync<T>(IRequest<AuthenticateRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					return _lowLevel.XpackSecurityAuthenticateAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackSecurityAuthenticateAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackSecurityAuthenticate", p, new [] { GET }, "/_xpack/security/_authenticate");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityChangePasswordDispatch<T>(IRequest<ChangePasswordRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityChangePasswordDispatch<T>(IRequest<ChangePasswordRequestParameters> p,SerializableData<IChangePasswordRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4072,23 +4072,23 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityChangePassword", p, new [] { PUT, POST }, "/_xpack/security/user/{username}/_password", "/_xpack/security/user/_password");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordDispatchAsync<T>(IRequest<ChangePasswordRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityChangePasswordDispatchAsync<T>(IRequest<ChangePasswordRequestParameters> p,SerializableData<IChangePasswordRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityChangePasswordAsync<T>(p.RouteValues.Username,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackSecurityChangePasswordAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityChangePasswordAsync<T>(p.RouteValues.Username,body,u => p.RequestParameters,ct);
+					return _lowLevel.XpackSecurityChangePasswordAsync<T>(body,u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityChangePasswordPostAsync<T>(p.RouteValues.Username,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackSecurityChangePasswordPostAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityChangePasswordPostAsync<T>(p.RouteValues.Username,body,u => p.RequestParameters,ct);
+					return _lowLevel.XpackSecurityChangePasswordPostAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackSecurityChangePassword", p, new [] { PUT, POST }, "/_xpack/security/user/{username}/_password", "/_xpack/security/user/_password");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityClearCachedRealmsDispatch<T>(IRequest<ClearCachedRealmsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityClearCachedRealmsDispatch<T>(IRequest<ClearCachedRealmsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4100,19 +4100,19 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityClearCachedRealms", p, new [] { POST }, "/_xpack/security/realm/{realms}/_clear_cache");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityClearCachedRealmsDispatchAsync<T>(IRequest<ClearCachedRealmsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityClearCachedRealmsDispatchAsync<T>(IRequest<ClearCachedRealmsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Realms)) return _lowLevel.XpackSecurityClearCachedRealmsAsync<T>(p.RouteValues.Realms,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Realms)) return _lowLevel.XpackSecurityClearCachedRealmsAsync<T>(p.RouteValues.Realms,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityClearCachedRealms", p, new [] { POST }, "/_xpack/security/realm/{realms}/_clear_cache");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityClearCachedRolesDispatch<T>(IRequest<ClearCachedRolesRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityClearCachedRolesDispatch<T>(IRequest<ClearCachedRolesRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4124,19 +4124,19 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityClearCachedRoles", p, new [] { POST }, "/_xpack/security/role/{name}/_clear_cache");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityClearCachedRolesDispatchAsync<T>(IRequest<ClearCachedRolesRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityClearCachedRolesDispatchAsync<T>(IRequest<ClearCachedRolesRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityClearCachedRolesAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityClearCachedRolesAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityClearCachedRoles", p, new [] { POST }, "/_xpack/security/role/{name}/_clear_cache");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityDeleteRoleDispatch<T>(IRequest<DeleteRoleRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityDeleteRoleDispatch<T>(IRequest<DeleteRoleRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4148,19 +4148,19 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityDeleteRole", p, new [] { DELETE }, "/_xpack/security/role/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityDeleteRoleDispatchAsync<T>(IRequest<DeleteRoleRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityDeleteRoleDispatchAsync<T>(IRequest<DeleteRoleRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityDeleteRoleAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityDeleteRoleAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityDeleteRole", p, new [] { DELETE }, "/_xpack/security/role/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityDeleteRoleMappingDispatch<T>(IRequest<DeleteRoleMappingRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityDeleteRoleMappingDispatch<T>(IRequest<DeleteRoleMappingRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4172,19 +4172,19 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityDeleteRoleMapping", p, new [] { DELETE }, "/_xpack/security/role_mapping/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityDeleteRoleMappingDispatchAsync<T>(IRequest<DeleteRoleMappingRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityDeleteRoleMappingDispatchAsync<T>(IRequest<DeleteRoleMappingRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityDeleteRoleMappingAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityDeleteRoleMappingAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityDeleteRoleMapping", p, new [] { DELETE }, "/_xpack/security/role_mapping/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityDeleteUserDispatch<T>(IRequest<DeleteUserRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityDeleteUserDispatch<T>(IRequest<DeleteUserRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4196,19 +4196,19 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityDeleteUser", p, new [] { DELETE }, "/_xpack/security/user/{username}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityDeleteUserDispatchAsync<T>(IRequest<DeleteUserRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityDeleteUserDispatchAsync<T>(IRequest<DeleteUserRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Username)) return _lowLevel.XpackSecurityDeleteUserAsync<T>(p.RouteValues.Username,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Username)) return _lowLevel.XpackSecurityDeleteUserAsync<T>(p.RouteValues.Username,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityDeleteUser", p, new [] { DELETE }, "/_xpack/security/user/{username}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityDisableUserDispatch<T>(IRequest<DisableUserRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityDisableUserDispatch<T>(IRequest<DisableUserRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4224,23 +4224,23 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityDisableUser", p, new [] { PUT, POST }, "/_xpack/security/user/{username}/_disable");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityDisableUserDispatchAsync<T>(IRequest<DisableUserRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityDisableUserDispatchAsync<T>(IRequest<DisableUserRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityDisableUserAsync<T>(p.RouteValues.Username,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityDisableUserAsync<T>(p.RouteValues.Username,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityDisableUserPostAsync<T>(p.RouteValues.Username,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityDisableUserPostAsync<T>(p.RouteValues.Username,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityDisableUser", p, new [] { PUT, POST }, "/_xpack/security/user/{username}/_disable");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityEnableUserDispatch<T>(IRequest<EnableUserRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityEnableUserDispatch<T>(IRequest<EnableUserRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4256,23 +4256,23 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityEnableUser", p, new [] { PUT, POST }, "/_xpack/security/user/{username}/_enable");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityEnableUserDispatchAsync<T>(IRequest<EnableUserRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityEnableUserDispatchAsync<T>(IRequest<EnableUserRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityEnableUserAsync<T>(p.RouteValues.Username,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityEnableUserAsync<T>(p.RouteValues.Username,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityEnableUserPostAsync<T>(p.RouteValues.Username,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityEnableUserPostAsync<T>(p.RouteValues.Username,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityEnableUser", p, new [] { PUT, POST }, "/_xpack/security/user/{username}/_enable");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityGetRoleDispatch<T>(IRequest<GetRoleRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityGetRoleDispatch<T>(IRequest<GetRoleRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4284,19 +4284,19 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityGetRole", p, new [] { GET }, "/_xpack/security/role/{name}", "/_xpack/security/role");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityGetRoleDispatchAsync<T>(IRequest<GetRoleRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityGetRoleDispatchAsync<T>(IRequest<GetRoleRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Name)) return _lowLevel.XpackSecurityGetRoleAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackSecurityGetRoleAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Name)) return _lowLevel.XpackSecurityGetRoleAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
+					return _lowLevel.XpackSecurityGetRoleAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackSecurityGetRole", p, new [] { GET }, "/_xpack/security/role/{name}", "/_xpack/security/role");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityGetRoleMappingDispatch<T>(IRequest<GetRoleMappingRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityGetRoleMappingDispatch<T>(IRequest<GetRoleMappingRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4308,19 +4308,19 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityGetRoleMapping", p, new [] { GET }, "/_xpack/security/role_mapping/{name}", "/_xpack/security/role_mapping");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityGetRoleMappingDispatchAsync<T>(IRequest<GetRoleMappingRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityGetRoleMappingDispatchAsync<T>(IRequest<GetRoleMappingRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Name)) return _lowLevel.XpackSecurityGetRoleMappingAsync<T>(p.RouteValues.Name,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackSecurityGetRoleMappingAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Name)) return _lowLevel.XpackSecurityGetRoleMappingAsync<T>(p.RouteValues.Name,u => p.RequestParameters,ct);
+					return _lowLevel.XpackSecurityGetRoleMappingAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackSecurityGetRoleMapping", p, new [] { GET }, "/_xpack/security/role_mapping/{name}", "/_xpack/security/role_mapping");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityGetTokenDispatch<T>(IRequest<GetUserAccessTokenRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityGetTokenDispatch<T>(IRequest<GetUserAccessTokenRequestParameters> p,SerializableData<IGetUserAccessTokenRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4331,18 +4331,18 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityGetToken", p, new [] { POST }, "/_xpack/security/oauth2/token");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityGetTokenDispatchAsync<T>(IRequest<GetUserAccessTokenRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityGetTokenDispatchAsync<T>(IRequest<GetUserAccessTokenRequestParameters> p,SerializableData<IGetUserAccessTokenRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.XpackSecurityGetTokenAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackSecurityGetTokenAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackSecurityGetToken", p, new [] { POST }, "/_xpack/security/oauth2/token");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityGetUserDispatch<T>(IRequest<GetUserRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityGetUserDispatch<T>(IRequest<GetUserRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4354,19 +4354,19 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityGetUser", p, new [] { GET }, "/_xpack/security/user/{username}", "/_xpack/security/user");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityGetUserDispatchAsync<T>(IRequest<GetUserRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityGetUserDispatchAsync<T>(IRequest<GetUserRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityGetUserAsync<T>(p.RouteValues.Username,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackSecurityGetUserAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Username)) return _lowLevel.XpackSecurityGetUserAsync<T>(p.RouteValues.Username,u => p.RequestParameters,ct);
+					return _lowLevel.XpackSecurityGetUserAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackSecurityGetUser", p, new [] { GET }, "/_xpack/security/user/{username}", "/_xpack/security/user");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityInvalidateTokenDispatch<T>(IRequest<InvalidateUserAccessTokenRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityInvalidateTokenDispatch<T>(IRequest<InvalidateUserAccessTokenRequestParameters> p,SerializableData<IInvalidateUserAccessTokenRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4377,18 +4377,18 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityInvalidateToken", p, new [] { DELETE }, "/_xpack/security/oauth2/token");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityInvalidateTokenDispatchAsync<T>(IRequest<InvalidateUserAccessTokenRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityInvalidateTokenDispatchAsync<T>(IRequest<InvalidateUserAccessTokenRequestParameters> p,SerializableData<IInvalidateUserAccessTokenRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					return _lowLevel.XpackSecurityInvalidateTokenAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackSecurityInvalidateTokenAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackSecurityInvalidateToken", p, new [] { DELETE }, "/_xpack/security/oauth2/token");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityPutRoleDispatch<T>(IRequest<PutRoleRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityPutRoleDispatch<T>(IRequest<PutRoleRequestParameters> p,SerializableData<IPutRoleRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4404,23 +4404,23 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityPutRole", p, new [] { PUT, POST }, "/_xpack/security/role/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityPutRoleDispatchAsync<T>(IRequest<PutRoleRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityPutRoleDispatchAsync<T>(IRequest<PutRoleRequestParameters> p,SerializableData<IPutRoleRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityPutRoleAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityPutRoleAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityPutRolePostAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityPutRolePostAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityPutRole", p, new [] { PUT, POST }, "/_xpack/security/role/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityPutRoleMappingDispatch<T>(IRequest<PutRoleMappingRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityPutRoleMappingDispatch<T>(IRequest<PutRoleMappingRequestParameters> p,SerializableData<IPutRoleMappingRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4436,23 +4436,23 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityPutRoleMapping", p, new [] { PUT, POST }, "/_xpack/security/role_mapping/{name}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingDispatchAsync<T>(IRequest<PutRoleMappingRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityPutRoleMappingDispatchAsync<T>(IRequest<PutRoleMappingRequestParameters> p,SerializableData<IPutRoleMappingRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityPutRoleMappingAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityPutRoleMappingAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityPutRoleMappingPostAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Name)) return _lowLevel.XpackSecurityPutRoleMappingPostAsync<T>(p.RouteValues.Name,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityPutRoleMapping", p, new [] { PUT, POST }, "/_xpack/security/role_mapping/{name}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackSecurityPutUserDispatch<T>(IRequest<PutUserRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackSecurityPutUserDispatch<T>(IRequest<PutUserRequestParameters> p,SerializableData<IPutUserRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4468,23 +4468,23 @@ namespace Nest
 			throw InvalidDispatch("XpackSecurityPutUser", p, new [] { PUT, POST }, "/_xpack/security/user/{username}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackSecurityPutUserDispatchAsync<T>(IRequest<PutUserRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackSecurityPutUserDispatchAsync<T>(IRequest<PutUserRequestParameters> p,SerializableData<IPutUserRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Username)) return _lowLevel.XpackSecurityPutUserAsync<T>(p.RouteValues.Username,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Username)) return _lowLevel.XpackSecurityPutUserAsync<T>(p.RouteValues.Username,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Username)) return _lowLevel.XpackSecurityPutUserPostAsync<T>(p.RouteValues.Username,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Username)) return _lowLevel.XpackSecurityPutUserPostAsync<T>(p.RouteValues.Username,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackSecurityPutUser", p, new [] { PUT, POST }, "/_xpack/security/user/{username}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherAckWatchDispatch<T>(IRequest<AcknowledgeWatchRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherAckWatchDispatch<T>(IRequest<AcknowledgeWatchRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4502,25 +4502,25 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherAckWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{watch_id}/_ack", "/_xpack/watcher/watch/{watch_id}/_ack/{action_id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherAckWatchDispatchAsync<T>(IRequest<AcknowledgeWatchRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherAckWatchDispatchAsync<T>(IRequest<AcknowledgeWatchRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSet(p.RouteValues.WatchId, p.RouteValues.ActionId)) return _lowLevel.XpackWatcherAckWatchAsync<T>(p.RouteValues.WatchId,p.RouteValues.ActionId,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherAckWatchAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.WatchId, p.RouteValues.ActionId)) return _lowLevel.XpackWatcherAckWatchAsync<T>(p.RouteValues.WatchId,p.RouteValues.ActionId,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherAckWatchAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSet(p.RouteValues.WatchId, p.RouteValues.ActionId)) return _lowLevel.XpackWatcherAckWatchPostAsync<T>(p.RouteValues.WatchId,p.RouteValues.ActionId,u => p.RequestParameters,cancellationToken);
-					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherAckWatchPostAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.WatchId, p.RouteValues.ActionId)) return _lowLevel.XpackWatcherAckWatchPostAsync<T>(p.RouteValues.WatchId,p.RouteValues.ActionId,u => p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherAckWatchPostAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackWatcherAckWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{watch_id}/_ack", "/_xpack/watcher/watch/{watch_id}/_ack/{action_id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherActivateWatchDispatch<T>(IRequest<ActivateWatchRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherActivateWatchDispatch<T>(IRequest<ActivateWatchRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4536,23 +4536,23 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherActivateWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{watch_id}/_activate");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherActivateWatchDispatchAsync<T>(IRequest<ActivateWatchRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherActivateWatchDispatchAsync<T>(IRequest<ActivateWatchRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherActivateWatchAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherActivateWatchAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherActivateWatchPostAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherActivateWatchPostAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackWatcherActivateWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{watch_id}/_activate");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherDeactivateWatchDispatch<T>(IRequest<DeactivateWatchRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherDeactivateWatchDispatch<T>(IRequest<DeactivateWatchRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4568,23 +4568,23 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherDeactivateWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{watch_id}/_deactivate");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherDeactivateWatchDispatchAsync<T>(IRequest<DeactivateWatchRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherDeactivateWatchDispatchAsync<T>(IRequest<DeactivateWatchRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherDeactivateWatchAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherDeactivateWatchAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherDeactivateWatchPostAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.WatchId)) return _lowLevel.XpackWatcherDeactivateWatchPostAsync<T>(p.RouteValues.WatchId,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackWatcherDeactivateWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{watch_id}/_deactivate");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherDeleteWatchDispatch<T>(IRequest<DeleteWatchRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherDeleteWatchDispatch<T>(IRequest<DeleteWatchRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4596,19 +4596,19 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherDeleteWatch", p, new [] { DELETE }, "/_xpack/watcher/watch/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherDeleteWatchDispatchAsync<T>(IRequest<DeleteWatchRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherDeleteWatchDispatchAsync<T>(IRequest<DeleteWatchRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case DELETE:
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.XpackWatcherDeleteWatchAsync<T>(p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.XpackWatcherDeleteWatchAsync<T>(p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackWatcherDeleteWatch", p, new [] { DELETE }, "/_xpack/watcher/watch/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherExecuteWatchDispatch<T>(IRequest<ExecuteWatchRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherExecuteWatchDispatch<T>(IRequest<ExecuteWatchRequestParameters> p,SerializableData<IExecuteWatchRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4624,23 +4624,23 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherExecuteWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{id}/_execute", "/_xpack/watcher/watch/_execute");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchDispatchAsync<T>(IRequest<ExecuteWatchRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherExecuteWatchDispatchAsync<T>(IRequest<ExecuteWatchRequestParameters> p,SerializableData<IExecuteWatchRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSet(p.RouteValues.Id)) return _lowLevel.XpackWatcherExecuteWatchAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackWatcherExecuteWatchAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id)) return _lowLevel.XpackWatcherExecuteWatchAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
+					return _lowLevel.XpackWatcherExecuteWatchAsync<T>(body,u => p.RequestParameters,ct);
 
 				case POST:
-					if (AllSet(p.RouteValues.Id)) return _lowLevel.XpackWatcherExecuteWatchPostAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackWatcherExecuteWatchPostAsync<T>(body,u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.Id)) return _lowLevel.XpackWatcherExecuteWatchPostAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
+					return _lowLevel.XpackWatcherExecuteWatchPostAsync<T>(body,u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackWatcherExecuteWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{id}/_execute", "/_xpack/watcher/watch/_execute");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherGetWatchDispatch<T>(IRequest<GetWatchRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherGetWatchDispatch<T>(IRequest<GetWatchRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4652,19 +4652,19 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherGetWatch", p, new [] { GET }, "/_xpack/watcher/watch/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherGetWatchDispatchAsync<T>(IRequest<GetWatchRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherGetWatchDispatchAsync<T>(IRequest<GetWatchRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.XpackWatcherGetWatchAsync<T>(p.RouteValues.Id,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.XpackWatcherGetWatchAsync<T>(p.RouteValues.Id,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackWatcherGetWatch", p, new [] { GET }, "/_xpack/watcher/watch/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherPutWatchDispatch<T>(IRequest<PutWatchRequestParameters> p , PostData<object> body) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherPutWatchDispatch<T>(IRequest<PutWatchRequestParameters> p,SerializableData<IPutWatchRequest> body) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4680,23 +4680,23 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherPutWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{id}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherPutWatchDispatchAsync<T>(IRequest<PutWatchRequestParameters> p , PostData<object> body, CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherPutWatchDispatchAsync<T>(IRequest<PutWatchRequestParameters> p,SerializableData<IPutWatchRequest> body, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case PUT:
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.XpackWatcherPutWatchAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.XpackWatcherPutWatchAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.XpackWatcherPutWatchPostAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,cancellationToken);
+					if (AllSetNoFallback(p.RouteValues.Id)) return _lowLevel.XpackWatcherPutWatchPostAsync<T>(p.RouteValues.Id,body,u => p.RequestParameters,ct);
 					break;
 
 			}
 			throw InvalidDispatch("XpackWatcherPutWatch", p, new [] { PUT, POST }, "/_xpack/watcher/watch/{id}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherRestartDispatch<T>(IRequest<RestartWatcherRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherRestartDispatch<T>(IRequest<RestartWatcherRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4707,18 +4707,18 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherRestart", p, new [] { POST }, "/_xpack/watcher/_restart");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherRestartDispatchAsync<T>(IRequest<RestartWatcherRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherRestartDispatchAsync<T>(IRequest<RestartWatcherRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.XpackWatcherRestartAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackWatcherRestartAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackWatcherRestart", p, new [] { POST }, "/_xpack/watcher/_restart");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherStartDispatch<T>(IRequest<StartWatcherRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherStartDispatch<T>(IRequest<StartWatcherRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4729,18 +4729,18 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherStart", p, new [] { POST }, "/_xpack/watcher/_start");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherStartDispatchAsync<T>(IRequest<StartWatcherRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherStartDispatchAsync<T>(IRequest<StartWatcherRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.XpackWatcherStartAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackWatcherStartAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackWatcherStart", p, new [] { POST }, "/_xpack/watcher/_start");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherStatsDispatch<T>(IRequest<WatcherStatsRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherStatsDispatch<T>(IRequest<WatcherStatsRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4752,19 +4752,19 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherStats", p, new [] { GET }, "/_xpack/watcher/stats", "/_xpack/watcher/stats/{watcher_stats_metric}");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherStatsDispatchAsync<T>(IRequest<WatcherStatsRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherStatsDispatchAsync<T>(IRequest<WatcherStatsRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case GET:
-					if (AllSet(p.RouteValues.WatcherStatsMetric)) return _lowLevel.XpackWatcherStatsAsync<T>(p.RouteValues.WatcherStatsMetric.Value,u => p.RequestParameters,cancellationToken);
-					return _lowLevel.XpackWatcherStatsAsync<T>(u => p.RequestParameters,cancellationToken);
+					if (AllSet(p.RouteValues.WatcherStatsMetric)) return _lowLevel.XpackWatcherStatsAsync<T>(p.RouteValues.WatcherStatsMetric.Value,u => p.RequestParameters,ct);
+					return _lowLevel.XpackWatcherStatsAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackWatcherStats", p, new [] { GET }, "/_xpack/watcher/stats", "/_xpack/watcher/stats/{watcher_stats_metric}");
 		}
 		
-		internal ElasticsearchResponse<T> XpackWatcherStopDispatch<T>(IRequest<StopWatcherRequestParameters> p ) where T : class
+		internal ElasticsearchResponse<T> XpackWatcherStopDispatch<T>(IRequest<StopWatcherRequestParameters> p) where T : class
 		{
 			switch(p.HttpMethod)
 			{
@@ -4775,12 +4775,12 @@ namespace Nest
 			throw InvalidDispatch("XpackWatcherStop", p, new [] { POST }, "/_xpack/watcher/_stop");
 		}
 		
-		internal Task<ElasticsearchResponse<T>> XpackWatcherStopDispatchAsync<T>(IRequest<StopWatcherRequestParameters> p , CancellationToken cancellationToken) where T : class
+		internal Task<ElasticsearchResponse<T>> XpackWatcherStopDispatchAsync<T>(IRequest<StopWatcherRequestParameters> p, CancellationToken ct) where T : class
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					return _lowLevel.XpackWatcherStopAsync<T>(u => p.RequestParameters,cancellationToken);
+					return _lowLevel.XpackWatcherStopAsync<T>(u => p.RequestParameters,ct);
 
 			}
 			throw InvalidDispatch("XpackWatcherStop", p, new [] { POST }, "/_xpack/watcher/_stop");

--- a/src/Serializers/Nest.JsonNetSerializer/JsonNetSourceSerializerBase.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/JsonNetSourceSerializerBase.cs
@@ -80,7 +80,7 @@ namespace Nest.JsonNetSerializer
 			}
 		}
 
-		public void Serialize(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented)
+		public void Serialize<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented)
 		{
 			using (var writer = new StreamWriter(stream, ExpectedEncoding, BufferSize, leaveOpen: true))
 			using (var jsonWriter = new JsonTextWriter(writer))
@@ -90,7 +90,7 @@ namespace Nest.JsonNetSerializer
 
 		//we still support net45 so Task.Completed is not available
 		private static readonly Task CompletedTask = Task.FromResult(false);
-		public Task SerializeAsync(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
+		public Task SerializeAsync<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
 			CancellationToken cancellationToken = default(CancellationToken))
 		{
 			//This makes no sense now but we need the async method on the interface in 6.x so we can start swapping this out

--- a/src/Serializers/Nest.JsonNetSerializer/JsonNetSourceSerializerBase.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/JsonNetSourceSerializerBase.cs
@@ -87,5 +87,16 @@ namespace Nest.JsonNetSerializer
 				(formatting == SerializationFormatting.Indented ? _serializer : _collapsedSerializer)
 					.Serialize(jsonWriter, data);
 		}
+
+		//we still support net45 so Task.Completed is not available
+		private static readonly Task CompletedTask = Task.FromResult(false);
+		public Task SerializeAsync(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
+			CancellationToken cancellationToken = default(CancellationToken))
+		{
+			//This makes no sense now but we need the async method on the interface in 6.x so we can start swapping this out
+			//for an implementation that does make sense without having to wait for 7.x
+			this.Serialize(data, stream, formatting);
+			return CompletedTask;
+		}
 	}
 }

--- a/src/Tests/Cat/CatFielddata/CatFielddataApiTests.cs
+++ b/src/Tests/Cat/CatFielddata/CatFielddataApiTests.cs
@@ -28,7 +28,7 @@ namespace Tests.Cat.CatFielddata
 				.Query(q => q
 					.Terms(t => t
 						.Field(p => p.CuratedTags.First().Name)
-						.Terms(Tag.Generator.GenerateLocked(50).Select(ct => ct.Name))
+						.Terms(Tag.Generator.Generate(50).Select(ct => ct.Name))
 					)
 				)
 			);

--- a/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/Transports.Doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/Transports.Doc.cs
@@ -12,7 +12,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 	{
 		/**=== Transports
 		*
-		* The `ITransport` interface can be seen as the motor block of the client. Its interface is 
+		* The `ITransport` interface can be seen as the motor block of the client. Its interface is
         * deceitfully simple, yet it's ultimately responsible for translating a client call to a response.
 		*
 		* If for some reason you do not agree with the way we wrote the internals of the client,
@@ -43,13 +43,13 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 			var response = inMemoryTransport.Request<SearchResponse<Project>>(
 				HttpMethod.GET,
 				"/_search",
-				new { query = new { match_all = new { } } });
+				PostData.Serializable(new { query = new { match_all = new { } } }));
 
 			response = await inMemoryTransport.RequestAsync<SearchResponse<Project>>(
 				HttpMethod.GET,
 				"/_search",
 				default(CancellationToken),
-				new { query = new { match_all = new { } } });
+				PostData.Serializable(new { query = new { match_all = new { } } }));
 		}
 	}
 }

--- a/src/Tests/ClientConcepts/HighLevel/GettingStarted.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/GettingStarted.doc.cs
@@ -103,9 +103,9 @@ namespace Tests.ClientConcepts.HighLevel
 				LastName = "Laarman"
 			};
 
-			var indexResponse = client.Index(person); //<1> synchronous method that returns an `IIndexResponse`
+			var indexResponse = client.IndexDocument(person); //<1> synchronous method that returns an `IIndexResponse`
 
-			var asyncIndexResponse = await client.IndexAsync(person); //<2> asynchronous method that returns a `Task<IIndexResponse>` that can be awaited
+			var asyncIndexResponse = await client.IndexDocumentAsync(person); //<2> asynchronous method that returns a `Task<IIndexResponse>` that can be awaited
 		}
 
 		/**
@@ -254,7 +254,7 @@ namespace Tests.ClientConcepts.HighLevel
 
 	    public void SearchingWithTheLowLevelClient()
 	    {
-            var searchResponse = client.LowLevel.Search<SearchResponse<Person>>("people", "person", new
+            var searchResponse = client.LowLevel.Search<SearchResponse<Person>>("people", "person", PostData.Serializable(new
             {
                 from = 0,
                 size = 10,
@@ -266,7 +266,7 @@ namespace Tests.ClientConcepts.HighLevel
                         query = "Martijn"
                     }
                 }
-            });
+            }));
 
             var responseJson = searchResponse.Body;
         }

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/ParentChildJoins.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/ParentChildJoins.doc.cs
@@ -125,7 +125,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 				ParentProperty = "a parent prop",
 				MyJoinField = JoinField.Root<MyParent>() // <1> this lets the join data type know this is a root document of type `myparent`
 			};
-			var indexParent = client.Index<MyDocument>(parentDocument);
+			var indexParent = client.IndexDocument<MyDocument>(parentDocument);
 			//json
 			var expected = new
 			{
@@ -144,7 +144,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 			 * Linking the child document to its parent follows a similar pattern.
 			 * Here we create a link by inferring the id from our parent instance `parentDocument`
 			 */
-			var indexChild = client.Index<MyDocument>(new MyChild
+			var indexChild = client.IndexDocument<MyDocument>(new MyChild
 			{
 				MyJoinField = JoinField.Link<MyChild, MyParent>(parentDocument)
 			});
@@ -152,7 +152,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 			 * or here we are simply stating this document is of type `mychild` and should be linked
 			 * to parent id 1 from `parentDocument`.
 			 */
-			indexChild = client.Index<MyDocument>(new MyChild
+			indexChild = client.IndexDocument<MyDocument>(new MyChild
 			{
 				Id = 2,
 				MyJoinField = JoinField.Link<MyChild>(1)

--- a/src/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs
@@ -35,8 +35,6 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 	 */
 	public class GettingStarted
 	{
-		private IElasticClient client = new ElasticClient(new ConnectionSettings(new SingleNodeConnectionPool(new Uri("http://localhost:9200")), new InMemoryConnection()));
-
 		/**[float]
 		 * === Injecting a new serializer
 		 *
@@ -54,14 +52,20 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 		public class VanillaSerializer : IElasticsearchSerializer
 		{
 			public T Deserialize<T>(Stream stream) => throw new NotImplementedException();
+
 			public object Deserialize(Type type, Stream stream) => throw new NotImplementedException();
 
 			public Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default(CancellationToken)) =>
 				throw new NotImplementedException();
+
 			public Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default(CancellationToken)) =>
 				throw new NotImplementedException();
 
 			public void Serialize(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented) =>
+				throw new NotImplementedException();
+
+			public Task SerializeAsync(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
+				CancellationToken cancellationToken = default(CancellationToken)) =>
 				throw new NotImplementedException();
 		}
 

--- a/src/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs
@@ -61,10 +61,10 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 			public Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default(CancellationToken)) =>
 				throw new NotImplementedException();
 
-			public void Serialize(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented) =>
+			public void Serialize<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented) =>
 				throw new NotImplementedException();
 
-			public Task SerializeAsync(object data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
+			public Task SerializeAsync<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
 				CancellationToken cancellationToken = default(CancellationToken)) =>
 				throw new NotImplementedException();
 		}

--- a/src/Tests/ClientConcepts/HighLevel/Serialization/SendsUsingSourceSerializer.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Serialization/SendsUsingSourceSerializer.cs
@@ -55,7 +55,7 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 		[U] public void IndexRequest()
 		{
 			CanAlterSource(
-				r => r.Index(new ADocument()),
+				r => r.IndexDocument(new ADocument()),
 				usingDefaults: DefaultSerialized,
 				withSourceSerializer: IncludesNullAndType
 			);
@@ -64,7 +64,7 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 		[U] public void CreateRequest()
 		{
 			CanAlterSource(
-				r => r.Create(new ADocument()),
+				r => r.CreateDocument(new ADocument()),
 				usingDefaults: DefaultSerialized,
 				withSourceSerializer: IncludesNullAndType
 			);

--- a/src/Tests/ClientConcepts/LowLevel/GettingStarted.doc.cs
+++ b/src/Tests/ClientConcepts/LowLevel/GettingStarted.doc.cs
@@ -107,10 +107,10 @@ namespace Tests.ClientConcepts.LowLevel
                 LastName = "Laarman"
             };
 
-            var indexResponse = lowlevelClient.Index<byte[]>("people", "person", "1", person); //<1> synchronous method that returns an `IIndexResponse`
+            var indexResponse = lowlevelClient.Index<byte[]>("people", "person", "1", PostData.Serializable(person)); //<1> synchronous method that returns an `IIndexResponse`
             byte[] responseBytes = indexResponse.Body;
 
-            var asyncIndexResponse = await lowlevelClient.IndexAsync<string>("people", "person", "1", person); //<2> asynchronous method that returns a `Task<IIndexResponse>` that can be awaited
+            var asyncIndexResponse = await lowlevelClient.IndexAsync<string>("people", "person", "1", PostData.Serializable(person)); //<2> asynchronous method that returns a `Task<IIndexResponse>` that can be awaited
             string responseString = asyncIndexResponse.Body;
         }
 
@@ -130,7 +130,7 @@ namespace Tests.ClientConcepts.LowLevel
 				LastName = "Laarman"
 			};
 
-			var indexResponse = await lowlevelClient.IndexAsync<Stream>("people", "person", "1", person);
+			var indexResponse = await lowlevelClient.IndexAsync<Stream>("people", "person", "1", PostData.Serializable(person));
 			Stream responseStream = indexResponse.Body; // <1> If returning a `Stream`, be sure to properly https://msdn.microsoft.com/en-us/library/b1yfkh5e(v=vs.110).aspx[dispose] of it when you are finished with it.
 		}
 
@@ -159,7 +159,7 @@ namespace Tests.ClientConcepts.LowLevel
 				new { FirstName = "Russ", LastName = "Cam" },
 		    };
 
-			var indexResponse = lowlevelClient.Bulk<Stream>(people);
+			var indexResponse = lowlevelClient.Bulk<Stream>(PostData.MultiJson(people));
 			Stream responseStream = indexResponse.Body;
 		}
 		/**
@@ -175,7 +175,7 @@ namespace Tests.ClientConcepts.LowLevel
 		*/
 		public void SearchingWithAnonymousTypes()
         {
-            var searchResponse = lowlevelClient.Search<string>("people", "person", new
+            var searchResponse = lowlevelClient.Search<string>("people", "person", PostData.Serializable(new
             {
                 from = 0,
                 size = 10,
@@ -187,7 +187,7 @@ namespace Tests.ClientConcepts.LowLevel
                         query = "Martijn"
                     }
                 }
-            });
+            }));
 
             var successful = searchResponse.Success;
             var responseJson = searchResponse.Body;
@@ -243,7 +243,7 @@ namespace Tests.ClientConcepts.LowLevel
         */
         public void ResponseProperties()
         {
-            var searchResponse = lowlevelClient.Search<byte[]>("people", "person", new { match_all = new {} });
+            var searchResponse = lowlevelClient.Search<byte[]>("people", "person", PostData.Serializable(new { match_all = new {} }));
 
             var success = searchResponse.Success; // <1> Response is in the 200 range, or an expected response for the given request
             var successOrKnownError = searchResponse.SuccessOrKnownError; // <2> Response is successful, or has a response code between 400-599 that indicates the request cannot be retried.

--- a/src/Tests/ClientConcepts/LowLevel/PostDataBenchmarks.cs
+++ b/src/Tests/ClientConcepts/LowLevel/PostDataBenchmarks.cs
@@ -13,22 +13,22 @@ namespace Tests.ClientConcepts.LowLevel
 	[BenchmarkConfig(1000)]
 	public class PostDataBenchmarks
 	{
-		private readonly PostData<byte[]> _postDataOfBytes;
+		private readonly PostData _postDataOfBytes;
 
 
-		private readonly PostData<byte[]> _postDataOfBytesDisableDirectStreaming;
-		private readonly PostData<List<object>> _postDataOfCollectionOfComplexObjects;
-		private readonly PostData<List<object>> _postDataOfCollectionOfComplexObjectsDisableDirectStreaming;
-		private readonly PostData<List<object>> _postDataOfCollectionOfSimpleObjects;
-		private readonly PostData<List<object>> _postDataOfCollectionOfSimpleObjectsDisableDirectStreaming;
-		private readonly PostData<List<string>> _postDataOfCollectionOfStrings;
-		private readonly PostData<List<string>> _postDataOfCollectionOfStringsDisableDirectStreaming;
-		private readonly PostData<object> _postDataOfComplexObject;
-		private readonly PostData<object> _postDataOfComplexObjectDisableDirectStreaming;
-		private readonly PostData<object> _postDataOfSimpleObject;
-		private readonly PostData<object> _postDataOfSimpleObjectDisableDirectStreaming;
-		private readonly PostData<string> _postDataOfString;
-		private readonly PostData<string> _postDataOfStringDisableDirectStreaming;
+		private readonly PostData _postDataOfBytesDisableDirectStreaming;
+		private readonly PostData _postDataOfCollectionOfComplexObjects;
+		private readonly PostData _postDataOfCollectionOfComplexObjectsDisableDirectStreaming;
+		private readonly PostData _postDataOfCollectionOfSimpleObjects;
+		private readonly PostData _postDataOfCollectionOfSimpleObjectsDisableDirectStreaming;
+		private readonly PostData _postDataOfCollectionOfStrings;
+		private readonly PostData _postDataOfCollectionOfStringsDisableDirectStreaming;
+		private readonly PostData _postDataOfComplexObject;
+		private readonly PostData _postDataOfComplexObjectDisableDirectStreaming;
+		private readonly PostData _postDataOfSimpleObject;
+		private readonly PostData _postDataOfSimpleObjectDisableDirectStreaming;
+		private readonly PostData _postDataOfString;
+		private readonly PostData _postDataOfStringDisableDirectStreaming;
 		private readonly byte[] bytes = Encoding.UTF8.GetBytes("{my_property=\"value\"}");
 		private readonly List<object> collectionOfComplexObjects;
 		private readonly List<object> collectionOfSimpleObjects;
@@ -327,21 +327,26 @@ namespace Tests.ClientConcepts.LowLevel
 			collectionOfSimpleObjects = Enumerable.Range(0, 5).Select(i => simpleObject).ToList();
 			collectionOfComplexObjects = Enumerable.Range(0, 5).Select(i => complexObject).ToList();
 
-			_postDataOfString = new PostData<string>(@string);
-			_postDataOfBytes = new PostData<byte[]>(bytes);
-			_postDataOfCollectionOfStrings = new PostData<List<string>>(collectionOfStrings);
-			_postDataOfCollectionOfSimpleObjects = new PostData<List<object>>(collectionOfSimpleObjects);
-			_postDataOfCollectionOfComplexObjects = new PostData<List<object>>(collectionOfComplexObjects);
-			_postDataOfSimpleObject = new PostData<object>(simpleObject);
-			_postDataOfComplexObject = new PostData<object>(complexObject);
+			_postDataOfString = PostData.String(@string);
+			_postDataOfBytes = PostData.Bytes(bytes);
+			_postDataOfCollectionOfStrings = PostData.MultiJson(collectionOfStrings);
+			_postDataOfCollectionOfSimpleObjects = PostData.MultiJson(collectionOfSimpleObjects);
+			_postDataOfCollectionOfComplexObjects = PostData.MultiJson(collectionOfComplexObjects);
+			_postDataOfSimpleObject = PostData.Serializable(simpleObject);
+			_postDataOfComplexObject = PostData.Serializable(complexObject);
 
-			_postDataOfStringDisableDirectStreaming = new PostData<string>(@string) {DisableDirectStreaming = true};
-			_postDataOfBytesDisableDirectStreaming = new PostData<byte[]>(bytes) {DisableDirectStreaming = true};
-			_postDataOfCollectionOfStringsDisableDirectStreaming = new PostData<List<string>>(collectionOfStrings) {DisableDirectStreaming = true};
-			_postDataOfCollectionOfSimpleObjectsDisableDirectStreaming = new PostData<List<object>>(collectionOfSimpleObjects) {DisableDirectStreaming = true};
-			_postDataOfCollectionOfComplexObjectsDisableDirectStreaming = new PostData<List<object>>(collectionOfComplexObjects) {DisableDirectStreaming = true};
-			_postDataOfSimpleObjectDisableDirectStreaming = new PostData<object>(simpleObject) {DisableDirectStreaming = true};
-			_postDataOfComplexObjectDisableDirectStreaming = new PostData<object>(complexObject) {DisableDirectStreaming = true};
+			PostData DisableStreaming(PostData data)
+			{
+				data.DisableDirectStreaming = true;
+				return data;
+			}
+			_postDataOfStringDisableDirectStreaming = DisableStreaming(PostData.String(@string));
+			_postDataOfBytesDisableDirectStreaming = DisableStreaming(PostData.Bytes(bytes));
+			_postDataOfCollectionOfStringsDisableDirectStreaming = DisableStreaming(PostData.MultiJson(collectionOfStrings));
+			_postDataOfCollectionOfSimpleObjectsDisableDirectStreaming = DisableStreaming(PostData.MultiJson(collectionOfSimpleObjects));
+			_postDataOfCollectionOfComplexObjectsDisableDirectStreaming = DisableStreaming(PostData.MultiJson(collectionOfComplexObjects));
+			_postDataOfSimpleObjectDisableDirectStreaming = DisableStreaming(PostData.Serializable(simpleObject));
+			_postDataOfComplexObjectDisableDirectStreaming = DisableStreaming(PostData.Serializable(complexObject));
 		}
 
 		[Benchmark]

--- a/src/Tests/Cluster/TaskManagement/GetTask/GetTaskApiTests.cs
+++ b/src/Tests/Cluster/TaskManagement/GetTask/GetTaskApiTests.cs
@@ -50,7 +50,7 @@ namespace Tests.Cluster.TaskManagement.GetTask
 		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
 		{
 			// get a suitable load of projects in order to get a decent task status out
-			var bulkResponse = client.IndexMany(Project.Generator.GenerateLocked(10000), "project-origin");
+			var bulkResponse = client.IndexMany(Project.Generator.Generate(10000), "project-origin");
 			if (!bulkResponse.IsValid)
 				throw new Exception("failure in setting up integration");
 

--- a/src/Tests/Cluster/TaskManagement/TasksList/TasksListApiTests.cs
+++ b/src/Tests/Cluster/TaskManagement/TasksList/TasksListApiTests.cs
@@ -81,7 +81,7 @@ namespace Tests.Cluster.TaskManagement.TasksList
 			seeder.SeedNode();
 
 			// get a suitable load of projects in order to get a decent task status out
-			var bulkResponse = client.IndexMany(Project.Generator.GenerateLocked(20000));
+			var bulkResponse = client.IndexMany(Project.Generator.Generate(20000));
 			if (!bulkResponse.IsValid)
 				throw new Exception("failure in setting up integration");
 

--- a/src/Tests/CodeStandards/ElasticClient.doc.cs
+++ b/src/Tests/CodeStandards/ElasticClient.doc.cs
@@ -113,6 +113,8 @@ namespace Tests.CodeStandards
 					(methodInfo.ReturnType.IsGenericType()
 					 && typeof(Task<>) == methodInfo.ReturnType.GetGenericTypeDefinition()
 					 && typeof(IResponse).IsAssignableFrom(methodInfo.ReturnType.GetGenericArguments()[0]))
+				where !methodInfo.Name.Contains("CreateDocument")
+				where !methodInfo.Name.Contains("IndexDocument")
 				let method = new MethodWithRequestParameter(methodInfo)
 				group method by method.Name into methodGroup
 				select methodGroup;

--- a/src/Tests/Document/Multiple/Bulk/BulkIndexingBenchmarkTests.cs
+++ b/src/Tests/Document/Multiple/Bulk/BulkIndexingBenchmarkTests.cs
@@ -48,7 +48,7 @@ namespace Tests.Document.Multiple.Bulk
 		[ProfilingSetup]
 		public void Setup()
 		{
-			_messages = Message.Generator.GenerateLocked(250000).Partition(1000).ToList();
+			_messages = Message.Generator.Generate(250000).Partition(1000).ToList();
 		}
 
 		[Benchmark]

--- a/src/Tests/Document/Multiple/Bulk/BulkProfileTests.cs
+++ b/src/Tests/Document/Multiple/Bulk/BulkProfileTests.cs
@@ -31,7 +31,7 @@ namespace Tests.Document.Multiple.Bulk
         public void Sync()
         {
             var bulkResponse = _client.Bulk(b => b
-                .IndexMany(Developer.Generator.GenerateLocked(1000), (bd, d) => bd
+                .IndexMany(Developer.Generator.Generate(1000), (bd, d) => bd
                     .Index(IndexName)
                     .Document(d)
                 ));
@@ -46,7 +46,7 @@ namespace Tests.Document.Multiple.Bulk
         public async Task Async()
         {
             var bulkResponse = await _client.BulkAsync(b => b
-                .IndexMany(Developer.Generator.GenerateLocked(1000), (bd, d) => bd
+                .IndexMany(Developer.Generator.Generate(1000), (bd, d) => bd
                     .Index(IndexName)
                     .Document(d)
                 )).ConfigureAwait(false);

--- a/src/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
+++ b/src/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
@@ -55,12 +55,12 @@ namespace Tests.Document.Multiple.Reindex
 			this._client = cluster.Client;
 
 			// create a couple of projects
-			var projects = Project.Generator.GenerateLocked(2);
+			var projects = Project.Generator.Generate(2).ToList();
 			var indexProjectsResponse = this._client.IndexMany(projects, IndexName);
 			this._client.Refresh(IndexName);
 
 			// create a thousand commits and associate with the projects
-			var commits = CommitActivity.Generator.GenerateLocked(5000);
+			var commits = CommitActivity.Generator.Generate(5000).ToList();
 			var bb = new BulkDescriptor();
 			for (int i = 0; i < commits.Count; i++)
 			{

--- a/src/Tests/Document/Single/Create/CreateApiTests.cs
+++ b/src/Tests/Document/Single/Create/CreateApiTests.cs
@@ -28,16 +28,14 @@ namespace Tests.Document.Single.Create
 			SourceOnly = TestClient.Configuration.UsingCustomSourceSerializer ? new SourceOnlyObject() : null
 		};
 
-		public CreateApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage)
-		{
-		}
+		public CreateApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override LazyResponses ClientUsage() => Calls(
 			fluent: (client, f) => client.Create(this.Document, f),
 			fluentAsync: (client, f) => client.CreateAsync(this.Document, f),
 			request: (client, r) => client.Create(r),
 			requestAsync: (client, r) => client.CreateAsync(r)
-			);
+		);
 
 		protected override bool ExpectIsValid => true;
 		protected override int ExpectStatusCode => 201;
@@ -86,7 +84,7 @@ namespace Tests.Document.Single.Create
 		public void CreateWithSameIndexTypeAndId()
 		{
 			var index = RandomString();
-			var project = Project.Generator.GenerateLocked(1).First();
+			var project = Project.Generator.Generate(1).First();
 			var createResponse = this.Client.Create(project, f => f
 				.Index(index)
 			);

--- a/src/Tests/Document/Single/Create/CreateUrlTests.cs
+++ b/src/Tests/Document/Single/Create/CreateUrlTests.cs
@@ -22,9 +22,9 @@ namespace Tests.Document.Single.Create
 				}));
 
 			await PUT("/project/doc/NEST/_create")
-				.Fluent(c => c.Create(project))
+				.Fluent(c => c.CreateDocument(project))
 				.Request(c => c.Create(new CreateRequest<Project>(project)))
-				.FluentAsync(c => c.CreateAsync(project))
+				.FluentAsync(c => c.CreateDocumentAsync(project))
 				.RequestAsync(c => c.CreateAsync(new CreateRequest<Project>(project)));
 
 			await PUT("/project/project/NEST/_create")

--- a/src/Tests/Document/Single/DocumentCrudTests.cs
+++ b/src/Tests/Document/Single/DocumentCrudTests.cs
@@ -15,7 +15,7 @@ namespace Tests.Document.Single
 
 		protected override bool SupportsDeletes => true;
 
-		protected override LazyResponses Create() => Calls<IndexDescriptor<Project>, IndexRequest<Project>, IIndexRequest, IIndexResponse>(
+		protected override LazyResponses Create() => Calls<IndexDescriptor<Project>, IndexRequest<Project>, IIndexRequest<Project>, IIndexResponse>(
 			CreateInitializer,
 			CreateFluent,
 			fluent: (s, c, f) => c.Index(Project.Instance, f),

--- a/src/Tests/Document/Single/Index/IndexApiTests.cs
+++ b/src/Tests/Document/Single/Index/IndexApiTests.cs
@@ -85,7 +85,7 @@ namespace Tests.Document.Single.Index
 		[I] public void OpTypeCreate()
 		{
 			var indexName = RandomString();
-			var project = Project.Generator.GenerateLocked(1).First();
+			var project = Project.Generator.Generate(1).First();
 			var indexResult = this.Client.Index(project, f => f
 				.Index(indexName)
 				.OpType(OpType.Create)

--- a/src/Tests/Document/Single/Index/IndexUrlTests.cs
+++ b/src/Tests/Document/Single/Index/IndexUrlTests.cs
@@ -33,10 +33,10 @@ namespace Tests.Document.Single.Index
 				;
 
 			await PUT("/project/doc/NEST")
-				.Fluent(c => c.Index(project))
+				.Fluent(c => c.IndexDocument(project))
 				.Request(c => c.Index(new IndexRequest<Project>("project", "doc", "NEST") { Document = project }))
 				.Request(c => c.Index(new IndexRequest<Project>(project)))
-				.FluentAsync(c => c.IndexAsync(project))
+				.FluentAsync(c => c.IndexDocumentAsync(project))
 				.RequestAsync(c => c.IndexAsync(new IndexRequest<Project>(project)))
 				;
 		}

--- a/src/Tests/Framework/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
@@ -73,7 +73,7 @@ namespace Tests.Framework.ManagedElasticsearch.NodeSeeders
 		{
 			this.Client.IndexMany(Project.Projects);
 			this.Client.IndexMany(Developer.Developers);
-			this.Client.Index(new ProjectPercolation
+			this.Client.IndexDocument(new ProjectPercolation
 			{
 				Id = "1",
 				Query = new MatchAllQuery()

--- a/src/Tests/Framework/MockData/CommitActivity.cs
+++ b/src/Tests/Framework/MockData/CommitActivity.cs
@@ -39,7 +39,7 @@ namespace Tests.Framework.MockData
 		}
 
 		public static Faker<CommitActivity> Generator { get; } =
-			Gimme.Lock(() => new Faker<CommitActivity>()
+			new Faker<CommitActivity>()
 				.RuleFor(p => p.Id, p => Guid.NewGuid().ToString("N").Substring(0, 8))
 				.RuleFor(p => p.ProjectName, p => Project.Projects[Gimme.Random.Number(0, Project.Projects.Count -1)].Name)
 				.RuleFor(p => p.Committer, p => Developer.Developers[Gimme.Random.Number(0, Developer.Developers.Count -1)])
@@ -56,10 +56,9 @@ namespace Tests.Framework.MockData
 					TimeSpan.FromHours(4.23),
 					TimeSpan.FromDays(5),
 				}))
-			);
+			;
 
-		public static IList<CommitActivity> CommitActivities { get; } =
-			Generator.GenerateLocked(1000).ToList();
+		public static IList<CommitActivity> CommitActivities { get; } = Generator.Generate(1000).ToList();
 	}
 
 	internal class StringTimeSpanConverter : JsonConverter

--- a/src/Tests/Framework/MockData/Developer.cs
+++ b/src/Tests/Framework/MockData/Developer.cs
@@ -16,7 +16,7 @@ namespace Tests.Framework.MockData
 		public GeoIp GeoIp { get; set; }
 
 		public new static Faker<Developer> Generator { get; } =
-			Gimme.Lock(() => new Faker<Developer>()
+			new Faker<Developer>()
 				.RuleFor(p => p.Id, p => IdState++)
 				.RuleFor(p => p.FirstName, p => p.Name.FirstName())
 				.RuleFor(p => p.LastName, p => p.Name.LastName())
@@ -26,9 +26,8 @@ namespace Tests.Framework.MockData
 				.RuleFor(p => p.Gender, p => p.PickRandom<Gender>())
 				.RuleFor(p => p.PrivateValue, p => "THIS SHOULD NEVER BE INDEXED")
 				.RuleFor(p => p.IpAddress, p => p.Internet.Ip())
-			);
+			;
 
-		public static IList<Developer> Developers { get; } =
-			Developer.Generator.GenerateLocked(1000).ToList();
+		public static IList<Developer> Developers { get; } = Developer.Generator.Generate(1000).ToList();
 	}
 }

--- a/src/Tests/Framework/MockData/Gimme.cs
+++ b/src/Tests/Framework/MockData/Gimme.cs
@@ -11,28 +11,5 @@ namespace Tests.Framework.MockData
 
 		private static readonly object _lock = new object();
 
-		/// <summary>
-		/// Still hitting locking issues, whereas i though https://github.com/bchavez/Bogus/issues/46
-		/// fixed it.
-		/// </summary>
-		public static T Lock<T>(Func<T> act)
-		{
-			lock (_lock)
-			{
-				return act();
-			}
-		}
-
-		//TODO this is not lazy new bogus has GenerateLazy()
-		public static IList<T> GenerateLocked<T>(this Faker<T> faker, int count) where T : class
-		{
-			return Gimme.Lock(() => faker.Generate(count)).ToList();
-		}
-		public static T GenerateLocked<T>(this Faker<T> faker) where T : class
-		{
-			return Gimme.Lock(() => faker.Generate());
-		}
 	}
-
-
 }

--- a/src/Tests/Framework/MockData/Message.cs
+++ b/src/Tests/Framework/MockData/Message.cs
@@ -16,11 +16,11 @@ namespace Tests.Framework.MockData
 		private static readonly string[] Words = { "molestie", "vel", "metus", "neque", "dui", "volutpat", "sollicitudin", "sociis", "ac", "imperdiet", "tristique", "et", "nascetur", "ad", "rhoncus", "viverra", "ornare", "consectetur", "ultrices", "orci", "parturient", "lorem", "massa", "quis", "platea", "aenean", "fermentum", "augue", "placerat", "auctor", "natoque", "habitasse", "pharetra", "ridiculus", "leo", "sit", "cras", "est", "venenatis", "aptent", "nibh", "magnis", "sodales", "malesuada", "praesent", "potenti", "lobortis", "justo", "quam", "cubilia", "pellentesque", "porttitor", "pretium", "adipiscing", "phasellus", "lectus", "vivamus", "id", "mi", "bibendum", "feugiat", "odio", "rutrum", "vestibulum", "posuere", "elementum", "suscipit", "purus", "accumsan", "egestas", "mus", "varius", "a", "arcu", "commodo", "dis", "lacinia", "tellus", "cursus", "aliquet", "interdum", "turpis", "maecenas", "dapibus", "cum", "fames", "montes", "iaculis", "erat", "euismod", "hac", "faucibus", "mauris", "tempus", "primis", "velit", "sem", "duis", "luctus", "penatibus", "sapien", "blandit", "eros", "suspendisse", "urna", "ipsum", "congue", "nulla", "taciti", "mollis", "facilisis", "at", "amet", "laoreet", "dignissim", "fringilla", "in", "nostra", "quisque", "donec", "enim", "eleifend", "nisl", "morbi", "felis", "torquent", "eget", "convallis", "etiam", "tincidunt", "facilisi", "pulvinar", "vulputate", "integre", "himenaeos", "netus", "senectus", "non", "litora", "per", "curae", "ultricies", "nec", "nam", "eu", "ante", "mattis", "vehicula", "sociosqu", "nunc", "semper", "lacus", "proin", "risus", "condimentum", "scelerisque", "conubia", "consequat", "dolor", "libero", "diam", "ut", "inceptos", "porta", "nullam", "dictumst", "magna", "tempor", "fusce", "vitae", "aliquam", "curabitur", "ligula", "habitant", "class", "hendrerit", "sagittis", "gravida", "nisi", "tortor", "ullamcorper", "dictum", "elit", "sed" };
 
 		public static Faker<Message> Generator { get; } =
-			Gimme.Lock(() => new Faker<Message>()
+			new Faker<Message>()
 				.RuleFor(m => m.Id, m => Guid.NewGuid())
 				.RuleFor(m => m.Body, m => GetMessageText())
 				.RuleFor(m => m.Timestamp, m => DateTime.UtcNow)
-			);
+			;
 
 		private static string GetMessageText()
 		{

--- a/src/Tests/Framework/MockData/Person.cs
+++ b/src/Tests/Framework/MockData/Person.cs
@@ -16,15 +16,15 @@ namespace Tests.Framework.MockData
 		protected static int IdState = 0;
 
 		public static Faker<Person> Generator { get; } =
-			Gimme.Lock(() => new Faker<Person>()
+			new Faker<Person>()
 				.RuleFor(p => p.Id, p => IdState++)
 				.RuleFor(p => p.FirstName, p => p.Name.FirstName())
 				.RuleFor(p => p.LastName, p => p.Name.LastName())
 				.RuleFor(p => p.JobTitle, p => p.Name.JobTitle())
 				.RuleFor(p => p.Location, p => new GeoLocation(Gimme.Random.Number(-90, 90), Gimme.Random.Number(-180, 180)))
-			);
+			;
 
 		public static IList<Person> Persons { get; } =
-			Person.Generator.GenerateLocked(1000).ToList();
+			Person.Generator.Generate(1000).ToList();
 	}
 }

--- a/src/Tests/Framework/MockData/Project.cs
+++ b/src/Tests/Framework/MockData/Project.cs
@@ -36,7 +36,7 @@ namespace Tests.Framework.MockData
 		public SourceOnlyObject SourceOnly { get; set; }
 
 		public static Faker<Project> Generator { get; } =
-			Gimme.Lock(() => new Faker<Project>()
+			new Faker<Project>()
 				.RuleFor(p => p.Name, f => f.Person.Company.Name)
 				.RuleFor(p => p.Description, f => f.Lorem.Paragraphs(3))
 				.RuleFor(p => p.State, f => f.PickRandom<StateOfBeing>())
@@ -45,12 +45,12 @@ namespace Tests.Framework.MockData
 				.RuleFor(p => p.DateString, (p, d) => d.StartedOn.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"))
 				.RuleFor(p => p.LastActivity, p => p.Date.Recent())
 				.RuleFor(p => p.LeadDeveloper, p => Developer.Developers[Gimme.Random.Number(0, Developer.Developers.Count -1)])
-				.RuleFor(p => p.Tags, f => Tag.Generator.GenerateLocked(Gimme.Random.Number(2, 50)))
-				.RuleFor(p => p.CuratedTags, f => Tag.Generator.GenerateLocked(Gimme.Random.Number(1, 5)).ToList())
-				.RuleFor(p => p.Location, f => SimpleGeoPoint.Generator.GenerateLocked())
+				.RuleFor(p => p.Tags, f => Tag.Generator.Generate(Gimme.Random.Number(2, 50)))
+				.RuleFor(p => p.CuratedTags, f => Tag.Generator.Generate(Gimme.Random.Number(1, 5)).ToList())
+				.RuleFor(p => p.Location, f => SimpleGeoPoint.Generator.Generate())
 				.RuleFor(p => p.NumberOfCommits, f => Gimme.Random.Number(1, 1000))
 				.RuleFor(p => p.NumberOfContributors, f => Gimme.Random.Number(1, 200))
-				.RuleFor(p => p.Ranges, f => Ranges.Generator.GenerateLocked())
+				.RuleFor(p => p.Ranges, f => Ranges.Generator.Generate())
 				.RuleFor(p => p.SourceOnly, f =>
 					TestClient.Configuration.UsingCustomSourceSerializer ? new SourceOnlyObject() : null
 				)
@@ -62,9 +62,9 @@ namespace Tests.Framework.MockData
 						{ "color", new [] { "red", "blue", "green", "violet", "yellow" }.Take(Gimme.Random.Number(1, 4)) }
 					}
 				})
-			);
+			;
 
-		public static IList<Project> Projects { get; } = Project.Generator.GenerateLocked(100).ToList();
+		public static IList<Project> Projects { get; } = Project.Generator.Generate(100).ToList();
 
 	    public static Project First { get; } = Projects.First();
 
@@ -117,10 +117,10 @@ namespace Tests.Framework.MockData
 		public double Lon { get; set; }
 
 		public static Faker<SimpleGeoPoint> Generator { get; } =
-			Gimme.Lock(() => new Faker<SimpleGeoPoint>()
+			new Faker<SimpleGeoPoint>()
 				.RuleFor(p => p.Lat, f => f.Address.Latitude())
 				.RuleFor(p => p.Lon, f => f.Address.Longitude())
-			);
+			;
 	}
 
 	//the first applies when using internal source serializer the latter when using JsonNetSourceSerializer

--- a/src/Tests/Framework/MockData/Ranges.cs
+++ b/src/Tests/Framework/MockData/Ranges.cs
@@ -78,8 +78,8 @@ namespace Tests.Framework.MockData
 		}
 
 		public static Faker<Ranges> Generator { get; } =
-			Gimme.Lock(() => new Faker<Ranges>()
+			new Faker<Ranges>()
 				.CustomInstantiator((f) => new Ranges(f))
-			);
+			;
 	}
 }

--- a/src/Tests/Framework/MockData/Tag.cs
+++ b/src/Tests/Framework/MockData/Tag.cs
@@ -10,9 +10,9 @@ namespace Tests.Framework.MockData
 		public string Name { get; set; }
 
 		public static Faker<Tag> Generator { get; } =
-			Gimme.Lock(() => new Faker<Tag>()
+			new Faker<Tag>()
 				.RuleFor(p => p.Name, p => p.Lorem.Words(1).First())
 				.RuleFor(p => p.Added, p => p.Date.Recent())
-			);
+			;
 	}
 }

--- a/src/Tests/QueryDsl/Specialized/Percolate/PercolateQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/Specialized/Percolate/PercolateQueryUsageTests.cs
@@ -81,7 +81,7 @@ namespace Tests.QueryDsl.Specialized.Percolate
 						Query = "Martijn"
 					})
 				}, d => d.Index(percolationIndex));
-				this.Client.Index(Project.Instance);
+				this.Client.IndexDocument(Project.Instance);
 				this.Client.Refresh(Nest.Indices.Index(percolationIndex).And<Project>());
 			}
 		}

--- a/src/Tests/Reproduce/GithubIssue2052.cs
+++ b/src/Tests/Reproduce/GithubIssue2052.cs
@@ -52,9 +52,9 @@ namespace Tests.Reproduce
 			this.AssertRequestEquals(request, postData);
 		}
 
-		private PostData<object> CreatePostData(Exception e)
+		private PostData CreatePostData(Exception e)
 		{
-			PostData<object> postData = new List<object>
+			PostData postData = PostData.MultiJson(new List<object>
 			{
 				_bulkHeader,
 				new
@@ -62,7 +62,7 @@ namespace Tests.Reproduce
 					message = "My message",
 					exception = this.ExceptionJson(e).ToArray(),
 				}
-			};
+			});
 			return postData;
 		}
 
@@ -156,14 +156,14 @@ namespace Tests.Reproduce
 				_bulkHeader,
 				document
 			};
-			var response = this._client.Bulk<byte[]>(payload);
+			var response = this._client.Bulk<byte[]>(PostData.MultiJson(payload));
 
 
 			var request = Encoding.UTF8.GetString(response.RequestBodyInBytes);
 			return request;
 		}
 
-		private void AssertRequestEquals(string request, PostData<object> postData)
+		private void AssertRequestEquals(string request, PostData postData)
 		{
 			using (var ms = new MemoryStream())
 			{

--- a/src/Tests/Search/MultiSearch/MultiSearchLowLevelPostDataTests.cs
+++ b/src/Tests/Search/MultiSearch/MultiSearchLowLevelPostDataTests.cs
@@ -39,9 +39,7 @@ namespace Tests.Search.MultiSearch
 
 		[I] public void PostEnumerableOfObjects()
 		{
-			var response = this._client.LowLevel.Msearch<dynamic>("project", "project", this.Search);
-			AssertResponse(response);
-			response = this._client.LowLevel.Msearch<dynamic>("project", "project", (object)this.Search);
+			var response = this._client.LowLevel.Msearch<dynamic>("project", "project", PostData.MultiJson(this.Search));
 			AssertResponse(response);
 		}
 
@@ -51,9 +49,7 @@ namespace Tests.Search.MultiSearch
 				.Select(s => this._client.RequestResponseSerializer.SerializeToString(s, SerializationFormatting.None))
 				.ToList();
 
-			var response = this._client.LowLevel.Msearch<dynamic>("project", "project", listOfStrings);
-			AssertResponse(response);
-			response = this._client.LowLevel.Msearch<dynamic>("project", "project", (object)listOfStrings);
+			var response = this._client.LowLevel.Msearch<dynamic>("project", "project", PostData.MultiJson(listOfStrings));
 			AssertResponse(response);
 		}
 
@@ -65,8 +61,6 @@ namespace Tests.Search.MultiSearch
 				.Aggregate(new StringBuilder(), (sb, s) => sb.Append(s + "\n"), sb => sb.ToString());
 
 			var response = this._client.LowLevel.Msearch<dynamic>("project", "project", str);
-			AssertResponse(response);
-			response = this._client.LowLevel.Msearch<dynamic>("project", "project", (object)str);
 			AssertResponse(response);
 		}
 
@@ -80,8 +74,6 @@ namespace Tests.Search.MultiSearch
 			var bytes = Encoding.UTF8.GetBytes(str);
 
 			var response = this._client.LowLevel.Msearch<dynamic>("project", "project", bytes);
-			AssertResponse(response);
-			response = this._client.LowLevel.Msearch<dynamic>("project", "project", (object)bytes);
 			AssertResponse(response);
 		}
 

--- a/src/Tests/Search/Request/InnerHitsUsageTests.cs
+++ b/src/Tests/Search/Request/InnerHitsUsageTests.cs
@@ -29,8 +29,8 @@ namespace Tests.Search.Request
 		public string Name { get; set; }
 
 		public static Faker<TRoyal> Generator { get; } =
-			Gimme.Lock(() => new Faker<TRoyal>()
-				.RuleFor(p => p.Name, f => f.Person.Company.Name + IdState++));
+			new Faker<TRoyal>()
+				.RuleFor(p => p.Name, f => f.Person.Company.Name + IdState++);
 	}
 
 	public abstract class RoyalBase<TRoyal, TSubject> : RoyalBase<TRoyal>
@@ -103,10 +103,10 @@ namespace Tests.Search.Request
 					)
 				)
 			);
-			var kings = King.Generator.GenerateLocked(2)
+			var kings = King.Generator.Generate(2)
 				.Select(k =>
 				{
-					var foes = King.Generator.GenerateLocked(2).Select(f =>
+					var foes = King.Generator.Generate(2).Select(f =>
 					{
 						f.Join = null;
 						return f;
@@ -117,10 +117,10 @@ namespace Tests.Search.Request
 
 			var bulk = new BulkDescriptor();
 			IndexAll(bulk, () => kings, indexChildren: king =>
-				IndexAll(bulk, () => Prince.Generator.GenerateLocked(2), king, prince =>
-					IndexAll(bulk, () => Duke.Generator.GenerateLocked(3), prince, duke =>
-						IndexAll(bulk, () => Earl.Generator.GenerateLocked(5), duke, earl =>
-							IndexAll(bulk, () => Baron.Generator.GenerateLocked(1), earl)
+				IndexAll(bulk, () => Prince.Generator.Generate(2), king, prince =>
+					IndexAll(bulk, () => Duke.Generator.Generate(3), prince, duke =>
+						IndexAll(bulk, () => Earl.Generator.Generate(5), duke, earl =>
+							IndexAll(bulk, () => Baron.Generator.Generate(1), earl)
 						)
 					)
 				)


### PR DESCRIPTION
`PostData<object>` was introduced as a union'esque type that
`byte[]/string/object/IEnumerable<string>/<IEnumerable<object>` could
all implicitly convert to automagically making the lowel client easy
to use without exploding the already massive method list on
ILowLevelClient.

This abstraction meant that we always boxed for NEST types

In preparation for all the serialization/perf work we want to do in 6.x
it would be great if we can take `T` that we we want to serialize all
the way to the `IElasticsearchSerializer` which we can do with this PR
now.

We sacrifice on the implicit operators in the low level client (for the
most part: byte[] and string still do). TBF most of the time I've seen
people use the low level client they would instantiate
`PostData<object>` directly already. Or worse see: #2656. We weren't
really helping anyone here.

`PostData<object>` now has a base class `PostData` that we use
throughout. There is also `SerializableData<T>` subclass that we now use
for anything that needs serializing.

This dispatcher is now aware of what generics an `IRequest`
implementation has. Because of this our hack to make `Index(document)`
and `CreateIndex(document)` work when document == IIndexRequest or not
no longer works. Rather than fighting C# resolution of overloads (and
its lack of not constraints :() the methods are now called
`IndexDocument()` and `CreateDocument()`.