### PR TITLE
Allow non-string values for Sort "missing" field

### DIFF
--- a/src/Nest/Search/Search/Sort/SortBase.cs
+++ b/src/Nest/Search/Search/Sort/SortBase.cs
@@ -11,7 +11,7 @@ namespace Nest
 		Field SortKey { get; }
 
 		[JsonProperty("missing")]
-		string Missing { get; set; }
+		object Missing { get; set; }
 
 		[JsonProperty("order")]
 		SortOrder? Order { get; set; }
@@ -28,7 +28,7 @@ namespace Nest
 
 	public abstract class SortBase : ISort
 	{
-		public string Missing { get; set; }
+		public object Missing { get; set; }
 		public SortOrder? Order { get; set; }
 		public SortMode? Mode { get; set; }
 		public QueryContainer NestedFilter { get; set; }
@@ -37,14 +37,14 @@ namespace Nest
 		protected abstract Field SortKey { get; }
 	}
 
-	public abstract class SortDescriptorBase<TDescriptor, TInterface, T> : DescriptorBase<TDescriptor, TInterface>, ISort 
-		where T : class 
+	public abstract class SortDescriptorBase<TDescriptor, TInterface, T> : DescriptorBase<TDescriptor, TInterface>, ISort
+		where T : class
 		where TDescriptor : SortDescriptorBase<TDescriptor, TInterface, T>, TInterface, ISort
 		where TInterface : class, ISort
 	{
 		Field ISort.SortKey => this.SortKey;
 
-		string ISort.Missing { get; set; }
+		object ISort.Missing { get; set; }
 
 		SortOrder? ISort.Order { get; set; }
 
@@ -75,7 +75,7 @@ namespace Nest
 
 		public virtual TDescriptor MissingFirst() => Assign(a => a.Missing = "_first");
 
-		public virtual TDescriptor MissingValue(string value) => Assign(a => a.Missing = value);
+		public virtual TDescriptor Missing(object value) => Assign(a => a.Missing = value);
 
 	}
 }

--- a/src/Nest/Search/Search/Sort/SortGeoDistance.cs
+++ b/src/Nest/Search/Search/Sort/SortGeoDistance.cs
@@ -30,7 +30,6 @@ namespace Nest
 	public class SortGeoDistanceDescriptor<T> : SortDescriptorBase<SortGeoDistanceDescriptor<T>, IGeoDistanceSort, T>, IGeoDistanceSort
 		where T : class
 	{
-
 		protected override Field SortKey => "_geo_distance";
 
 		Field IGeoDistanceSort.Field { get; set; }
@@ -38,8 +37,9 @@ namespace Nest
 		DistanceUnit? IGeoDistanceSort.GeoUnit { get; set; }
 		GeoDistanceType? IGeoDistanceSort.DistanceType { get; set; }
 
-		public SortGeoDistanceDescriptor<T> PinTo(params GeoLocation[] geoLocations) => Assign(a => a.Points = geoLocations);
-		public SortGeoDistanceDescriptor<T> PinTo(IEnumerable<GeoLocation> geoLocations) => Assign(a => a.Points = geoLocations);
+		public SortGeoDistanceDescriptor<T> Points(params GeoLocation[] geoLocations) => Assign(a => a.Points = geoLocations);
+
+		public SortGeoDistanceDescriptor<T> Points(IEnumerable<GeoLocation> geoLocations) => Assign(a => a.Points = geoLocations);
 
 		public SortGeoDistanceDescriptor<T> Unit(DistanceUnit unit) => Assign(a => a.GeoUnit = unit);
 

--- a/src/Tests/Search/Request/SortUsageTests.cs
+++ b/src/Tests/Search/Request/SortUsageTests.cs
@@ -38,6 +38,12 @@ namespace Tests.Search.Request
 						}
 					},
 					new {
+						numberOfCommits = new {
+							missing = -1,
+							order = "desc"
+						}
+					},
+					new {
 						_geo_distance = new {
 							location = new [] {
 								new {
@@ -85,6 +91,11 @@ namespace Tests.Search.Request
 					.NestedPath(p => p.Tags)
 					.NestedFilter(q => q.MatchAll())
 				)
+				.Field(f => f
+					.Field(p => p.NumberOfCommits)
+					.Order(SortOrder.Descending)
+					.Missing(-1)
+				)
 				.GeoDistance(g => g
 					.Field(p => p.Location)
 					.DistanceType(GeoDistanceType.Arc)
@@ -121,6 +132,12 @@ namespace Tests.Search.Request
 						Mode = SortMode.Average,
 						NestedPath = Field<Project>(p=>p.Tags),
 						NestedFilter = new MatchAllQuery(),
+					},
+					new SortField
+					{
+						Field = Field<Project>(p=>p.NumberOfCommits),
+						Order = SortOrder.Descending,
+						Missing = -1
 					},
 					new GeoDistanceSort
 					{

--- a/src/Tests/Search/Request/SortUsageTests.cs
+++ b/src/Tests/Search/Request/SortUsageTests.cs
@@ -102,7 +102,7 @@ namespace Tests.Search.Request
 					.Order(SortOrder.Ascending)
 					.Unit(DistanceUnit.Centimeters)
 					.Mode(SortMode.Min)
-					.PinTo(new GeoLocation(70, -70), new GeoLocation(-12, 12))
+					.Points(new GeoLocation(70, -70), new GeoLocation(-12, 12))
 				)
 				.Script(sc => sc
 					.Type("number")


### PR DESCRIPTION
This PR allows non string values to be passed for the value of the "missing" field by using `object` as the property type.

Rename `PinTo()` to `Points()` to align the fluent method for setting Points to the object initializer name.

Requires backporting to 2.x and 5.x in a non-binary breaking way

Closes #2857 