### PR TITLE
Do not capture synchronization context on async calls

### DIFF
--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -235,18 +235,18 @@ namespace Nest
 
 			try
 			{
-				var tasks = new List<Task>();
+				var tasks = new List<Task>(maxDegreeOfParallelism);
 				foreach (var item in lazyList)
 				{
 					tasks.Add(ProcessAsync(item, taskSelector, resultProcessor, semaphore, additionalRateLimitter, page++));
-					if (tasks.Count <= maxDegreeOfParallelism)
+					if (tasks.Count < maxDegreeOfParallelism)
 						continue;
 
-					var task = await Task.WhenAny(tasks);
+					var task = await Task.WhenAny(tasks).ConfigureAwait(false);
 					tasks.Remove(task);
 				}
 
-				await Task.WhenAll(tasks);
+				await Task.WhenAll(tasks).ConfigureAwait(false);
 				done(null);
 			}
 			catch (Exception e)

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
@@ -88,7 +88,7 @@ namespace Nest
 			while (searchResult.IsValid && searchResult.Documents.HasAny())
 			{
 				if (this._backPressure != null)
-					await this._backPressure.WaitAsync(_compositeCancelToken);
+					await this._backPressure.WaitAsync(_compositeCancelToken).ConfigureAwait(false);
 
 				observer.OnNext(new ScrollAllResponse<T>()
 				{


### PR DESCRIPTION
Relates elastic/support-dev-help#2934

The sychronization context is captured in some of the asychronous calls made within the paths of the *All observable methods. Whilst this does not exhibit problems with the synchronization context within a console application, it causes problems with the synchronization context within ASP.NET 4.5 MVC, resulting in the response to an MVC controller to be returned before the last response is returned from Elasticsearch:

![screenshot 2017-12-08 15 05 39](https://user-images.githubusercontent.com/208231/33751340-608050d0-dc2e-11e7-8775-554a585956de.png)

Whilst there are integration tests for *All observable methods, this was not picked up because async methods within tests run with the same synchronization context as a console application.

With this PR, the behaviour is now correct within ASP.NET 4.5. MVC:

![screenshot 2017-12-08 15 13 40](https://user-images.githubusercontent.com/208231/33751405-c9b84ca6-dc2e-11e7-9608-149271c809ef.png)

Other changes:

- Continue only when the count of tasks is less than degrees of parallelism
- Initialize the size of the task list to the degrees of parallelism

Closes #2904
