### PR TITLE
Support non string values for sort missing

### DIFF
--- a/src/Nest/Search/Search/Sort/SortBase.cs
+++ b/src/Nest/Search/Search/Sort/SortBase.cs
@@ -4,47 +4,103 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// Allows to add one or more sort on specific fields.
+	/// </summary>
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	[ContractJsonConverter(typeof(SortJsonConverter))]
 	public interface ISort
 	{
+		/// <summary>
+		/// The field to sort on
+		/// </summary>
 		Field SortKey { get; }
 
-		[JsonProperty("missing")]
+		/// <summary>
+		/// Specifies how docs which are missing the field should be treated
+		/// </summary>
+		[JsonIgnore]
+		[Obsolete("Use MissingValue")]
 		string Missing { get; set; }
 
+		/// <summary>
+		/// Specifies how docs which are missing the field should be treated
+		/// </summary>
+		[JsonProperty("missing")]
+		object MissingValue { get; set; }
+
+		/// <summary>
+		/// The sort order
+		/// </summary>
 		[JsonProperty("order")]
 		SortOrder? Order { get; set; }
 
+		/// <summary>
+		/// Elasticsearch supports sorting by array or multi-valued fields. <see cref="Mode"/>
+		/// controls what array value is picked for sorting the document it belongs to.
+		/// </summary>
 		[JsonProperty("mode")]
 		SortMode? Mode { get; set; }
 
+		/// <summary>
+		/// A filter that the inner objects inside the nested path should match with in order for its field values
+		/// to be taken into account by sorting.
+		/// Common case is to repeat the query / filter inside the nested filter or query.
+		/// </summary>
 		[JsonProperty("nested_filter")]
 		QueryContainer NestedFilter { get; set; }
 
+		/// <summary>
+		/// Defines on which nested object to sort. The actual sort field must be a direct field inside
+		/// this nested object. When sorting by nested field, this field is mandatory.
+		/// </summary>
 		[JsonProperty("nested_path")]
 		Field NestedPath { get; set; }
 	}
 
+	/// <inheritdoc/>
 	public abstract class SortBase : ISort
 	{
-		public string Missing { get; set; }
+		/// <inheritdoc/>
+		[Obsolete("Use MissingValue")]
+		public string Missing
+		{
+			get => MissingValue as string;
+			set => MissingValue = value;
+		}
+		/// <inheritdoc/>
+		public object MissingValue { get; set; }
+		/// <inheritdoc/>
 		public SortOrder? Order { get; set; }
+		/// <inheritdoc/>
 		public SortMode? Mode { get; set; }
+		/// <inheritdoc/>
 		public QueryContainer NestedFilter { get; set; }
+		/// <inheritdoc/>
 		public Field NestedPath { get; set; }
+		/// <inheritdoc/>
 		Field ISort.SortKey => this.SortKey;
+		/// <summary>
+		/// The field to sort on
+		/// </summary>
 		protected abstract Field SortKey { get; }
 	}
 
-	public abstract class SortDescriptorBase<TDescriptor, TInterface, T> : DescriptorBase<TDescriptor, TInterface>, ISort 
-		where T : class 
+	public abstract class SortDescriptorBase<TDescriptor, TInterface, T> : DescriptorBase<TDescriptor, TInterface>, ISort
+		where T : class
 		where TDescriptor : SortDescriptorBase<TDescriptor, TInterface, T>, TInterface, ISort
 		where TInterface : class, ISort
 	{
 		Field ISort.SortKey => this.SortKey;
 
-		string ISort.Missing { get; set; }
+		[Obsolete("Use MissingValue")]
+		string ISort.Missing
+		{
+			get => Self.MissingValue as string;
+			set => Self.MissingValue = value;
+		}
+
+		object ISort.MissingValue { get; set; }
 
 		SortOrder? ISort.Order { get; set; }
 
@@ -71,11 +127,12 @@ namespace Nest
 
 		public virtual TDescriptor NestedPath(Expression<Func<T, object>> objectPath) => Assign(a => a.NestedPath = objectPath);
 
-		public virtual TDescriptor MissingLast() => Assign(a => a.Missing = "_last");
+		public virtual TDescriptor MissingLast() => Assign(a => a.MissingValue = "_last");
 
-		public virtual TDescriptor MissingFirst() => Assign(a => a.Missing = "_first");
+		public virtual TDescriptor MissingFirst() => Assign(a => a.MissingValue = "_first");
 
-		public virtual TDescriptor MissingValue(string value) => Assign(a => a.Missing = value);
+		public virtual TDescriptor MissingValue(string value) => Assign(a => a.MissingValue = value);
 
+		public virtual TDescriptor Missing(object value) => Assign(a => a.MissingValue = value);
 	}
 }

--- a/src/Tests/Search/Request/SortUsageTests.cs
+++ b/src/Tests/Search/Request/SortUsageTests.cs
@@ -38,6 +38,12 @@ namespace Tests.Search.Request
 						}
 					},
 					new {
+						numberOfCommits = new {
+							missing = -1,
+							order = "desc"
+						}
+					},
+					new {
 						_geo_distance = new {
 							location = new [] {
 								new {
@@ -86,6 +92,11 @@ namespace Tests.Search.Request
 					.NestedPath(p => p.Tags)
 					.NestedFilter(q => q.MatchAll())
 				)
+				.Field(f => f
+					.Field(p => p.NumberOfCommits)
+					.Order(SortOrder.Descending)
+					.Missing(-1)
+				)
 				.GeoDistance(g => g
 					.Field(p => p.Location)
 					.DistanceType(GeoDistanceType.Arc)
@@ -118,11 +129,17 @@ namespace Tests.Search.Request
 					{
 						Field = Field<Project>(p=>p.LastActivity),
 						Order = SortOrder.Descending,
-						Missing = "_last",
+						MissingValue = "_last",
 						UnmappedType = FieldType.Date,
 						Mode = SortMode.Average,
 						NestedPath = Field<Project>(p=>p.Tags),
 						NestedFilter = new MatchAllQuery(),
+					},
+					new SortField
+					{
+						Field = Field<Project>(p=>p.NumberOfCommits),
+						Order = SortOrder.Descending,
+						MissingValue = -1
 					},
 					new GeoDistanceSort
 					{


### PR DESCRIPTION
Non-binary breaking backport
Closes #2857

(cherry picked from commit f5959d66c15574a23595cdee2777f6987319775b)