### PR TITLE
Generate documentation again

### DIFF
--- a/build/scripts/Documentation.fsx
+++ b/build/scripts/Documentation.fsx
@@ -20,7 +20,7 @@ module Documentation =
         ExecProcess (fun p ->
             p.WorkingDirectory <- Paths.Source("CodeGeneration") @@ docGenerator.Name
             p.FileName <- generator
-        ) (TimeSpan.FromMinutes 1.) |> ignore
+        ) (TimeSpan.FromMinutes 2.) |> ignore
 
     // TODO: hook documentation validation into the process
     let Validate() = 

--- a/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
@@ -21,8 +21,8 @@ A multi-bucket aggregation similar to the histogram except it can only be applie
 From a functionality perspective, this histogram supports the same features as the normal histogram.
 The main difference is that the interval can be specified by date/time expressions.
 
-NOTE: When specifying a `format` **and** `extended_bounds`, in order for Elasticsearch to be able to parse
-the serialized `DateTime` of `extended_bounds` correctly, the `date_optional_time` format is included
+NOTE: When specifying a `format` **and** `extended_bounds` or `missing`, in order for Elasticsearch to be able to parse
+the serialized `DateTime` of `extended_bounds` or `missing` correctly, the `date_optional_time` format is included
 as part of the `format` value.
 
 Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-datehistogram-aggregation.html[Date Histogram Aggregation].

--- a/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
@@ -38,6 +38,7 @@ s => s
             r => r.To(DateMath.Now.Add(TimeSpan.FromDays(1)).Subtract("30m").RoundTo(TimeUnit.Hour)),
             r => r.From(DateMath.Anchored("2012-05-05").Add(TimeSpan.FromDays(1)).Subtract("1m"))
         )
+        .TimeZone("CET")
         .Aggregations(childAggs => childAggs
             .Terms("project_tags", avg => avg.Field(p => p.Tags))
         )
@@ -60,6 +61,7 @@ new SearchRequest<Project>
             new DateRangeExpression { To = DateMath.Now.Add(TimeSpan.FromDays(1)).Subtract("30m").RoundTo(TimeUnit.Hour) },
             new DateRangeExpression { From = DateMath.Anchored("2012-05-05").Add(TimeSpan.FromDays(1)).Subtract("1m") }
         },
+        TimeZone = "CET",
         Aggregations =
             new TermsAggregation("project_tags") { Field = Field<Project>(p => p.Tags) }
     }
@@ -85,7 +87,8 @@ new SearchRequest<Project>
           {
             "from": "2012-05-05||+1d-1m"
           }
-        ]
+        ],
+        "time_zone": "CET"
       },
       "aggs": {
         "project_tags": {

--- a/docs/aggregations/bucket/geo-distance/geo-distance-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-distance/geo-distance-aggregation-usage.asciidoc
@@ -89,7 +89,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var ringsAroundAmsterdam = response.Aggs.GeoDistance("rings_around_amsterdam");
 ringsAroundAmsterdam.Should().NotBeNull();
 ringsAroundAmsterdam.Buckets.FirstOrDefault(r => r.Key == "*-100.0").Should().NotBeNull();

--- a/docs/aggregations/bucket/histogram/histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/histogram/histogram-aggregation-usage.asciidoc
@@ -28,6 +28,7 @@ s => s
         .Interval(100)
         .Missing(0)
         .Order(HistogramOrder.KeyDescending)
+        .Offset(1.1)
     )
 )
 ----
@@ -43,7 +44,8 @@ new SearchRequest<Project>
         Field = Field<Project>(p => p.NumberOfCommits),
         Interval = 100,
         Missing = 0,
-        Order = HistogramOrder.KeyDescending
+        Order = HistogramOrder.KeyDescending,
+        Offset = 1.1
     }
 }
 ----
@@ -60,7 +62,8 @@ new SearchRequest<Project>
         "missing": 0.0,
         "order": {
           "_key": "desc"
-        }
+        },
+        "offset": 1.1
       }
     }
   }

--- a/docs/aggregations/bucket/sampler/sampler-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/sampler/sampler-aggregation-usage.asciidoc
@@ -82,5 +82,8 @@ var sample = response.Aggs.Sampler("sample");
 sample.Should().NotBeNull();
 var sigTags = sample.SignificantTerms("significant_names");
 sigTags.Should().NotBeNull();
+sigTags.DocCount.Should().BeGreaterThan(0);
+if (TestClient.VersionUnderTestSatisfiedBy(">=5.5.0"))
+    sigTags.BgCount.Should().BeGreaterThan(0);
 ----
 

--- a/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
@@ -60,7 +60,7 @@ new SearchRequest<Project>
         ShardSize = 100,
         ExecutionHint = TermsAggregationExecutionHint.Map,
         Missing = "n/a",
-        Script = new InlineScript("'State of Being: '+_value") { Lang = "groovy" },
+        Script = new InlineScript("'State of Being: '+_value") {Lang = "groovy"},
         Order = new List<TermsOrder>
         {
             TermsOrder.TermAscending,
@@ -68,7 +68,7 @@ new SearchRequest<Project>
         },
         Meta = new Dictionary<string, object>
         {
-            { "foo", "bar" }
+            {"foo", "bar"}
         }
     }
 }
@@ -113,7 +113,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var states = response.Aggs.Terms("states");
 states.Should().NotBeNull();
 states.DocCountErrorUpperBound.Should().HaveValue();
@@ -174,7 +174,7 @@ new SearchRequest<Project>
         ShardSize = 100,
         ExecutionHint = TermsAggregationExecutionHint.Map,
         Missing = "n/a",
-        Include = new TermsIncludeExclude { Pattern = "(Stable|VeryActive)" },
+        Include = new TermsIncludeExclude {Pattern = "(Stable|VeryActive)"},
         Order = new List<TermsOrder>
         {
             TermsOrder.TermAscending,
@@ -182,7 +182,7 @@ new SearchRequest<Project>
         },
         Meta = new Dictionary<string, object>
         {
-            { "foo", "bar" }
+            {"foo", "bar"}
         }
     }
 }
@@ -224,7 +224,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var states = response.Aggs.Terms("states");
 states.Should().NotBeNull();
 states.DocCountErrorUpperBound.Should().HaveValue();
@@ -260,7 +260,7 @@ s => s
         .ShardSize(100)
         .ExecutionHint(TermsAggregationExecutionHint.Map)
         .Missing("n/a")
-        .Include(new [] { StateOfBeing.Stable.ToString(), StateOfBeing.VeryActive.ToString() })
+        .Include(new[] {StateOfBeing.Stable.ToString(), StateOfBeing.VeryActive.ToString()})
         .Order(TermsOrder.TermAscending)
         .Order(TermsOrder.CountDescending)
         .Meta(m => m
@@ -285,7 +285,7 @@ new SearchRequest<Project>
         ShardSize = 100,
         ExecutionHint = TermsAggregationExecutionHint.Map,
         Missing = "n/a",
-        Include = new TermsIncludeExclude { Values = new[] { StateOfBeing.Stable.ToString(), StateOfBeing.VeryActive.ToString() } },
+        Include = new TermsIncludeExclude {Values = new[] {StateOfBeing.Stable.ToString(), StateOfBeing.VeryActive.ToString()}},
         Order = new List<TermsOrder>
         {
             TermsOrder.TermAscending,
@@ -293,7 +293,7 @@ new SearchRequest<Project>
         },
         Meta = new Dictionary<string, object>
         {
-            { "foo", "bar" }
+            {"foo", "bar"}
         }
     }
 }
@@ -338,7 +338,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var states = response.Aggs.Terms("states");
 states.Should().NotBeNull();
 states.DocCountErrorUpperBound.Should().HaveValue();
@@ -425,7 +425,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var commits = response.Aggs.Terms<int>("commits");
 commits.Should().NotBeNull();
 commits.DocCountErrorUpperBound.Should().HaveValue();
@@ -453,6 +453,7 @@ s => s
 .Aggregations(a => a
     .Terms("commits", st => st
         .Field(p => p.NumberOfCommits)
+        .ShowTermDocCountError()
     )
 )
 ----
@@ -466,7 +467,8 @@ new SearchRequest<Project>
     Size = 0,
     Aggregations = new TermsAggregation("commits")
     {
-        Field = Infer.Field<Project>(p => p.NumberOfCommits),
+        Field = Field<Project>(p => p.NumberOfCommits),
+        ShowTermDocCountError = true
     }
 }
 ----
@@ -479,7 +481,8 @@ new SearchRequest<Project>
   "aggs": {
     "commits": {
       "terms": {
-        "field": "numberOfCommits"
+        "field": "numberOfCommits",
+        "show_term_doc_count_error": true
       }
     }
   }
@@ -490,7 +493,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var commits = response.Aggs.Terms<int>("commits");
 commits.Should().NotBeNull();
 commits.DocCountErrorUpperBound.Should().HaveValue();
@@ -502,5 +505,6 @@ foreach (var item in commits.Buckets)
     item.Key.Should().BeGreaterThan(0);
     item.DocCount.Should().BeGreaterOrEqualTo(1);
 }
+commits.Buckets.Should().Contain(b => b.DocCountErrorUpperBound.HasValue);
 ----
 

--- a/docs/aggregations/metric/extended-stats/extended-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/extended-stats/extended-stats-aggregation-usage.asciidoc
@@ -25,6 +25,7 @@ s => s
 .Aggregations(a => a
     .ExtendedStats("commit_stats", es => es
         .Field(p => p.NumberOfCommits)
+        .Sigma(1)
     )
 )
 ----
@@ -35,7 +36,7 @@ s => s
 ----
 new SearchRequest<Project>
 {
-    Aggregations = new ExtendedStatsAggregation("commit_stats", Field<Project>(p => p.NumberOfCommits))
+    Aggregations = new ExtendedStatsAggregation("commit_stats", Field<Project>(p => p.NumberOfCommits)) { Sigma = 1 }
 }
 ----
 
@@ -46,7 +47,8 @@ new SearchRequest<Project>
   "aggs": {
     "commit_stats": {
       "extended_stats": {
-        "field": "numberOfCommits"
+        "field": "numberOfCommits",
+        "sigma": 1.0
       }
     }
   }

--- a/docs/aggregations/metric/geo-centroid/geo-centroid-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-centroid/geo-centroid-aggregation-usage.asciidoc
@@ -133,7 +133,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 
 var projects = response.Aggs.Terms("projects");
 

--- a/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
@@ -24,10 +24,10 @@ please modify the original csharp file found at the link and submit the PR with 
 s => s
 .Aggregations(a => a
     .ScriptedMetric("sum_the_hard_way", sm => sm
-        .InitScript(ss=>ss.Inline("_agg['commits'] = []").Lang("groovy"))
-        .MapScript(ss=>ss.Inline("if (doc['state'].value == \"Stable\") { _agg.commits.add(doc['numberOfCommits']) }").Lang("groovy"))
-        .CombineScript(ss=>ss.Inline("sum = 0; for (c in _agg.commits) { sum += c }; return sum").Lang("groovy"))
-        .ReduceScript(ss=>ss.Inline("sum = 0; for (a in _aggs) { sum += a }; return sum").Lang("groovy"))
+        .InitScript(ss => ss.Inline("_agg['commits'] = []").Lang("groovy"))
+        .MapScript(ss => ss.Inline("if (doc['state'].value == \"Stable\") { _agg.commits.add(doc['numberOfCommits']) }").Lang("groovy"))
+        .CombineScript(ss => ss.Inline("sum = 0; for (c in _agg.commits) { sum += c }; return sum").Lang("groovy"))
+        .ReduceScript(ss => ss.Inline("sum = 0; for (a in _aggs) { sum += a }; return sum").Lang("groovy"))
     )
 )
 ----
@@ -40,10 +40,10 @@ new SearchRequest<Project>
 {
     Aggregations = new ScriptedMetricAggregation("sum_the_hard_way")
     {
-        InitScript = new InlineScript("_agg['commits'] = []") { Lang = "groovy" },
-        MapScript = new InlineScript("if (doc['state'].value == \"Stable\") { _agg.commits.add(doc['numberOfCommits']) }"){ Lang = "groovy" },
-        CombineScript = new InlineScript("sum = 0; for (c in _agg.commits) { sum += c }; return sum"){ Lang = "groovy" },
-        ReduceScript = new InlineScript("sum = 0; for (a in _aggs) { sum += a }; return sum"){ Lang = "groovy" }
+        InitScript = new InlineScript("_agg['commits'] = []") {Lang = "groovy"},
+        MapScript = new InlineScript("if (doc['state'].value == \"Stable\") { _agg.commits.add(doc['numberOfCommits']) }") {Lang = "groovy"},
+        CombineScript = new InlineScript("sum = 0; for (c in _agg.commits) { sum += c }; return sum") {Lang = "groovy"},
+        ReduceScript = new InlineScript("sum = 0; for (a in _aggs) { sum += a }; return sum") {Lang = "groovy"}
     }
 }
 ----
@@ -85,5 +85,108 @@ response.ShouldBeValid();
 var sumTheHardWay = response.Aggs.ScriptedMetric("sum_the_hard_way");
 sumTheHardWay.Should().NotBeNull();
 sumTheHardWay.Value<int>().Should().BeGreaterThan(0);
+----
+
+==== Fluent DSL example
+
+[source,csharp]
+----
+s => s
+.Aggregations(a => a
+    .ScriptedMetric("by_state_total", sm => sm
+        .InitScript(ss => ss.Inline(First.Init).Lang(First.Language))
+        .MapScript(ss => ss.Inline(First.Map).Lang(First.Language))
+        .ReduceScript(ss => ss.Inline(First.Reduce).Lang(First.Language))
+    )
+    .ScriptedMetric("total_commits", sm => sm
+        .InitScript(ss => ss.Inline(Second.Init).Lang(Second.Language))
+        .MapScript(ss => ss.Inline(Second.Map).Lang(Second.Language))
+        .CombineScript(ss => ss.Inline(Second.Combine).Lang(Second.Language))
+        .ReduceScript(ss => ss.Inline(Second.Reduce).Lang(Second.Language))
+    )
+)
+----
+
+==== Object Initializer syntax example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    Aggregations =
+        new ScriptedMetricAggregation("by_state_total")
+        {
+            InitScript = new InlineScript(First.Init) {Lang = First.Language},
+            MapScript = new InlineScript(First.Map) {Lang = First.Language},
+            ReduceScript = new InlineScript(First.Reduce) {Lang = First.Language}
+        } &&
+        new ScriptedMetricAggregation("total_commits")
+        {
+            InitScript = new InlineScript(Second.Init) {Lang = Second.Language},
+            MapScript = new InlineScript(Second.Map) {Lang = Second.Language},
+            CombineScript = new InlineScript(Second.Combine) {Lang = Second.Language},
+            ReduceScript = new InlineScript(Second.Reduce) {Lang = Second.Language}
+        }
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "aggs": {
+    "by_state_total": {
+      "scripted_metric": {
+        "init_script": {
+          "inline": "params._agg.map = [:]",
+          "lang": "painless"
+        },
+        "map_script": {
+          "inline": "if (params._agg.map.containsKey(doc['state'].value)) params._agg.map[doc['state'].value] += 1 else params._agg.map[doc['state'].value] = 1;",
+          "lang": "painless"
+        },
+        "reduce_script": {
+          "inline": "def reduce = [:]; for (agg in params._aggs) { for (entry in agg.map.entrySet()) { if (reduce.containsKey(entry.getKey())) reduce[entry.getKey()] += entry.getValue(); else reduce[entry.getKey()] = entry.getValue(); } } return reduce;",
+          "lang": "painless"
+        }
+      }
+    },
+    "total_commits": {
+      "scripted_metric": {
+        "init_script": {
+          "inline": "params._agg.commits = []",
+          "lang": "painless"
+        },
+        "map_script": {
+          "inline": "if (doc['state'].value == \"Stable\") { params._agg.commits.add(doc['numberOfCommits'].value) }",
+          "lang": "painless"
+        },
+        "combine_script": {
+          "inline": "def sum = 0.0; for (c in params._agg.commits) { sum += c } return sum",
+          "lang": "painless"
+        },
+        "reduce_script": {
+          "inline": "def sum = 0.0; for (a in params._aggs) { sum += a } return sum",
+          "lang": "painless"
+        }
+      }
+    }
+  }
+}
+----
+
+==== Handling Responses
+
+[source,csharp]
+----
+response.ShouldBeValid();
+var by_state_total = response.Aggs.ScriptedMetric("by_state_total");
+var total_commits = response.Aggs.ScriptedMetric("total_commits");
+
+by_state_total.Should().NotBeNull();
+total_commits.Should().NotBeNull();
+
+by_state_total.Value<IDictionary<string, int>>().Should().NotBeNull();
+total_commits.Value<int>().Should().BeGreaterThan(0);
 ----
 

--- a/docs/aggregations/metric/sum/sum-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/sum/sum-aggregation-usage.asciidoc
@@ -57,7 +57,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var commitsSum = response.Aggs.Sum("commits_sum");
 commitsSum.Should().NotBeNull();
 commitsSum.Value.Should().BeGreaterThan(0);

--- a/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
@@ -34,15 +34,19 @@ s => s
                 .Source(src => src
                     .Includes(fs => fs
                         .Field(p => p.Name)
-                        .Field(p => p.StartedOn)
+                        .Field(p => p.LastActivity)
                     )
                 )
                 .Size(1)
                 .Version()
+                .TrackScores()
                 .Explain()
                 .FielddataFields(fd => fd
                     .Field(p => p.State)
                     .Field(p => p.NumberOfCommits)
+                )
+                .StoredFields(f => f
+                    .Field(p => p.StartedOn)
                 )
                 .Highlight(h => h
                     .Fields(
@@ -79,12 +83,14 @@ new SearchRequest<Project>
             },
             Source = new SourceFilter
             {
-                Includes = new [] { "name", "startedOn" }
+                Includes = new [] { "name", "lastActivity" }
             },
             Size = 1,
             Version = true,
+            TrackScores = true,
             Explain = true,
             FielddataFields = new [] { "state", "numberOfCommits" },
+            StoredFields = new[] { "startedOn" },
             Highlight = new Highlight
             {
                 Fields = new Dictionary<Nest.Field, IHighlightField>
@@ -126,15 +132,19 @@ new SearchRequest<Project>
             "_source": {
               "includes": [
                 "name",
-                "startedOn"
+                "lastActivity"
               ]
             },
             "size": 1,
             "version": true,
+            "track_scores": true,
             "explain": true,
             "fielddata_fields": [
               "state",
               "numberOfCommits"
+            ],
+            "stored_fields": [
+              "startedOn"
             ],
             "highlight": {
               "fields": {
@@ -162,7 +172,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var states = response.Aggs.Terms("states");
 states.Should().NotBeNull();
 states.Buckets.Should().NotBeNullOrEmpty();
@@ -180,7 +190,11 @@ foreach(var state in states.Buckets)
     hits.All(h => h.Fields.ValuesOf<StateOfBeing>("state").Any()).Should().BeTrue();
     hits.All(h => h.Fields.ValuesOf<int>("numberOfCommits").Any()).Should().BeTrue();
     hits.All(h => h.Fields.ValuesOf<int>("commit_factor").Any()).Should().BeTrue();
-    topStateHits.Documents<Project>().Should().NotBeEmpty();
+    hits.All(h => h.Fields.ValuesOf<DateTime>("startedOn").Any()).Should().BeTrue();
+    var projects = topStateHits.Documents<Project>();
+    projects.Should().NotBeEmpty();
+    projects.Should().OnlyContain(p=>!string.IsNullOrWhiteSpace(p.Name), "source filter included name");
+    projects.Should().OnlyContain(p=>string.IsNullOrWhiteSpace(p.Description), "source filter does NOT include description");
 }
 ----
 

--- a/docs/aggregations/metric/value-count/value-count-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/value-count/value-count-aggregation-usage.asciidoc
@@ -57,7 +57,7 @@ new SearchRequest<Project>
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 var commitCount = response.Aggs.ValueCount("commit_count");
 commitCount.Should().NotBeNull();
 commitCount.Value.Should().BeGreaterThan(0);

--- a/docs/aggregations/pipeline/moving-average/moving-average-holt-linear-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-holt-linear-aggregation-usage.asciidoc
@@ -63,7 +63,7 @@ new SearchRequest<Project>()
                 Model = new HoltLinearModel
                 {
                     Alpha = 0.5f,
-                    Beta = 0.5f,
+                    Beta = 0.5f
                 }
             }
     }

--- a/docs/aggregations/pipeline/moving-average/moving-average-holt-winters-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-holt-winters-aggregation-usage.asciidoc
@@ -33,14 +33,14 @@ s => s
             )
             .MovingAverage("commits_moving_avg", mv => mv
                 .BucketsPath("commits")
-                .Window(60)
+                .Window(4)
                 .Model(m => m
                     .HoltWinters(hw => hw
                         .Type(HoltWintersType.Multiplicative)
                         .Alpha(0.5f)
                         .Beta(0.5f)
                         .Gamma(0.5f)
-                        .Period(30)
+                        .Period(2)
                         .Pad(false)
                     )
                 )
@@ -65,14 +65,14 @@ new SearchRequest<Project>()
             new SumAggregation("commits", "numberOfCommits") &&
             new MovingAverageAggregation("commits_moving_avg", "commits")
             {
-                Window = 60,
+                Window = 4,
                 Model = new HoltWintersModel
                 {
                     Type = HoltWintersType.Multiplicative,
                     Alpha = 0.5f,
                     Beta = 0.5f,
                     Gamma = 0.5f,
-                    Period = 30,
+                    Period = 2,
                     Pad = false
                 }
             }
@@ -100,14 +100,14 @@ new SearchRequest<Project>()
         "commits_moving_avg": {
           "moving_avg": {
             "buckets_path": "commits",
-            "window": 60,
+            "window": 4,
             "model": "holt_winters",
             "settings": {
               "type": "mult",
               "alpha": 0.5,
               "beta": 0.5,
               "gamma": 0.5,
-              "period": 30,
+              "period": 2,
               "pad": false
             }
           }
@@ -123,5 +123,34 @@ new SearchRequest<Project>()
 [source,csharp]
 ----
 response.ShouldBeValid();
+
+var projectsPerMonth = response.Aggs.DateHistogram("projects_started_per_month");
+projectsPerMonth.Should().NotBeNull();
+projectsPerMonth.Buckets.Should().NotBeNull();
+projectsPerMonth.Buckets.Count.Should().BeGreaterThan(0);
+
+int bucketCount = 0;
+foreach (var item in projectsPerMonth.Buckets)
+{
+    bucketCount++;
+
+    var commits = item.Sum("commits");
+    commits.Should().NotBeNull();
+    commits.Value.Should().BeGreaterThan(0);
+
+    var movingAverage = item.MovingAverage("commits_moving_avg");
+
+    // Moving Average specifies a window of 4 so
+    // moving average values should exist from 5th bucketr onwards
+    if (bucketCount <= 4)
+    {
+        movingAverage.Should().BeNull();
+    }
+    else
+    {
+        movingAverage.Should().NotBeNull();
+        movingAverage.Value.Should().BeGreaterThan(0);
+    }
+}
 ----
 

--- a/docs/aggregations/pipeline/serial-differencing/serial-differencing-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/serial-differencing/serial-differencing-aggregation-usage.asciidoc
@@ -31,9 +31,9 @@ s => s
             .Sum("commits", sm => sm
                 .Field(p => p.NumberOfCommits)
             )
-            .SerialDifferencing("thirtieth_difference", d => d
+            .SerialDifferencing("second_difference", d => d
                 .BucketsPath("commits")
-                .Lag(30)
+                .Lag(2)
             )
         )
     )
@@ -53,9 +53,9 @@ new SearchRequest<Project>
         Interval = DateInterval.Month,
         Aggregations =
             new SumAggregation("commits", "numberOfCommits") &&
-            new SerialDifferencingAggregation("thirtieth_difference", "commits")
+            new SerialDifferencingAggregation("second_difference", "commits")
             {
-                Lag = 30
+                Lag = 2
             }
     }
 }
@@ -78,10 +78,10 @@ new SearchRequest<Project>
             "field": "numberOfCommits"
           }
         },
-        "thirtieth_difference": {
+        "second_difference": {
           "serial_diff": {
             "buckets_path": "commits",
-            "lag": 30
+            "lag": 2
           }
         }
       }
@@ -101,11 +101,28 @@ projectsPerMonth.Should().NotBeNull();
 projectsPerMonth.Buckets.Should().NotBeNull();
 projectsPerMonth.Buckets.Count.Should().BeGreaterThan(0);
 
+var differenceCount = 0;
+
 foreach (var item in projectsPerMonth.Buckets)
 {
+    differenceCount++;
     var commits = item.Sum("commits");
     commits.Should().NotBeNull();
     commits.Value.Should().NotBe(null);
+
+    var secondDifference = item.SerialDifferencing("second_difference");
+
+    // serial differencing specified a lag of 2, so
+    // only expect values from the 3rd bucket onwards
+    if (differenceCount <= 2)
+    {
+        secondDifference.Should().BeNull();
+    }
+    else
+    {
+        secondDifference.Should().NotBeNull();
+        secondDifference.Value.Should().NotBe(null);
+    }
 }
 ----
 

--- a/docs/aggregations/pipeline/sum-bucket/sum-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/sum-bucket/sum-bucket-aggregation-usage.asciidoc
@@ -88,7 +88,7 @@ new SearchRequest<Project>()
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 
 var projectsPerMonth = response.Aggs.DateHistogram("projects_started_per_month");
 projectsPerMonth.Should().NotBeNull();

--- a/docs/aggregations/writing-aggregations.asciidoc
+++ b/docs/aggregations/writing-aggregations.asciidoc
@@ -100,13 +100,14 @@ new SearchRequest<Project>
 {
     Aggregations = new AggregationDictionary
     {
-        { "name_of_child_agg", new ChildrenAggregation("name_of_child_agg", typeof(CommitActivity))
+        {
+            "name_of_child_agg", new ChildrenAggregation("name_of_child_agg", typeof(CommitActivity))
             {
                 Aggregations = new AggregationDictionary
                 {
-                    { "average_per_child", new AverageAggregation("average_per_child", "confidenceFactor") },
-                    { "max_per_child", new MaxAggregation("max_per_child", "confidenceFactor") },
-                    { "min_per_child", new MinAggregation("min_per_child", "confidenceFactor") },
+                    {"average_per_child", new AverageAggregation("average_per_child", "confidenceFactor")},
+                    {"max_per_child", new MaxAggregation("max_per_child", "confidenceFactor")},
+                    {"min_per_child", new MinAggregation("min_per_child", "confidenceFactor")},
                 }
             }
         }
@@ -145,52 +146,91 @@ Now that's much cleaner! Assigning an `*Aggregation` type directly to the `Aggre
  on a search request works because there are implicit conversions within NEST to handle this for you.
 
 [float]
+=== Mixed usage of object initializer and fluent
+
+Sometimes its useful to mix and match fluent and object initializer, the fluent Aggregations method therefore
+also accepts `AggregationDictionary` directly.
+
+==== Fluent DSL example
+
+[source,csharp]
+----
+s => s
+.Aggregations(new ChildrenAggregation("name_of_child_agg", typeof(CommitActivity))
+{
+    Aggregations =
+        new AverageAggregation("average_per_child", Field<CommitActivity>(p => p.ConfidenceFactor))
+        && new MaxAggregation("max_per_child", Field<CommitActivity>(p => p.ConfidenceFactor))
+        && new MinAggregation("min_per_child", Field<CommitActivity>(p => p.ConfidenceFactor))
+})
+----
+
+[float]
+=== Binary operators off the same descriptor
+
+For dynamic aggregation building using the fluent syntax it can be useful to abstract to methods as much as possible.
+You can use the binary operator `&&` on the same descriptor to compose the graph. Each side of the
+binary operation can return null dynamically.
+
+[source,csharp]
+----
+s => s
+.Aggregations(aggs => aggs
+    .Children<CommitActivity>("name_of_child_agg", child => child
+        .Aggregations(Combine)
+    )
+)
+----
+
+[float]
+=== Returning a different AggregationContainer in fluent syntax
+
+All the fluent selector expects is an `IAggregationContainer` to be returned. You could abstract this to a
+method returning `AggregationContainer` which is free to use the object initializer syntax
+to compose that `AggregationContainer`.
+
+[source,csharp]
+----
+s => s
+.Aggregations(aggs => aggs
+    .Children<CommitActivity>("name_of_child_agg", child => child
+        .Aggregations(childAggs => Combine())
+    )
+)
+----
+
+[float]
 === Aggregating over a collection of aggregations
 
 An advanced scenario may involve an existing collection of aggregation functions that should be set as aggregations
 on the request. Using LINQ's `.Aggregate()` method, each function can be applied to the aggregation descriptor
 `childAggs` below) in turn, returning the descriptor after each function application.
 
-==== Fluent DSL example
-
 [source,csharp]
 ----
-var aggregations = new List<Func<AggregationContainerDescriptor<CommitActivity>, IAggregationContainer>> <1>
-{
-    a => a.Average("average_per_child", avg => avg.Field(p => p.ConfidenceFactor)),
-    a => a.Max("max_per_child", avg => avg.Field(p => p.ConfidenceFactor)),
-    a => a.Min("min_per_child", avg => avg.Field(p => p.ConfidenceFactor))
-};
-
-return s => s
-    .Aggregations(aggs => aggs
-        .Children<CommitActivity>("name_of_child_agg", child => child
-            .Aggregations(childAggs =>
-                aggregations.Aggregate(childAggs, (acc, agg) => { agg(acc); return acc; }) <2>
-            )
-        )
-    );
-----
-<1> a list of aggregation functions to apply
-<2> Using LINQ's `Aggregate()` function to accumulate/apply all of the aggregation functions
-
-Combining multiple `AggregationDescriptor` is also possible using the bitwise `&&` operator
-
-[source,csharp]
-----
-var aggregations = new AggregationContainerDescriptor<CommitActivity>()
-        .Average("average_per_child", avg => avg.Field(p => p.ConfidenceFactor))
-        .Max("max_per_child", avg => avg.Field(p => p.ConfidenceFactor))
-        && new AggregationContainerDescriptor<CommitActivity>()
-            .Min("min_per_child", avg => avg.Field(p => p.ConfidenceFactor));
+var aggregations =
+        new List<Func<AggregationContainerDescriptor<CommitActivity>, IAggregationContainer>> <1>
+        {
+            a => a.Average("average_per_child", avg => avg.Field(p => p.ConfidenceFactor)),
+            a => a.Max("max_per_child", avg => avg.Field(p => p.ConfidenceFactor)),
+            a => a.Min("min_per_child", avg => avg.Field(p => p.ConfidenceFactor))
+        };
 
 return s => s
         .Aggregations(aggs => aggs
             .Children<CommitActivity>("name_of_child_agg", child => child
-                .Aggregations(childAggs => aggregations)
+                .Aggregations(childAggs =>
+                        aggregations.Aggregate(childAggs, (acc, agg) =>
+                        {
+                            agg(acc);
+                            return acc;
+                        }) <2>
+                )
             )
         );
 ----
+<1> a list of aggregation functions to apply
+<2> Using LINQ's `Aggregate()` function to accumulate/apply all of the aggregation functions
 
 [[aggs-vs-aggregations]]
 [float]
@@ -224,7 +264,7 @@ the `Average` and `Max` sub aggregations.
 
 [source,csharp]
 ----
-response.IsValid.Should().BeTrue();
+response.ShouldBeValid();
 
 var childAggregation = response.Aggs.Children("name_of_child_agg");
 

--- a/docs/analysis/token-filters/token-filter-usage.asciidoc
+++ b/docs/analysis/token-filters/token-filter-usage.asciidoc
@@ -39,7 +39,7 @@ InitializerExample
     "filter": {
       "myAscii": {
         "type": "asciifolding",
-        "preserveOriginal": true
+        "preserve_original": true
       },
       "myCommonGrams": {
         "type": "common_grams",
@@ -281,6 +281,23 @@ InitializerExample
       },
       "wd": {
         "type": "word_delimiter",
+        "generate_word_parts": true,
+        "generate_number_parts": true,
+        "catenate_words": true,
+        "catenate_numbers": true,
+        "catenate_all": true,
+        "split_on_case_change": true,
+        "preserve_original": true,
+        "split_on_numerics": true,
+        "stem_english_possessive": true,
+        "protected_words": [
+          "x",
+          "y",
+          "z"
+        ]
+      },
+      "wdg": {
+        "type": "word_delimiter_graph",
         "generate_word_parts": true,
         "generate_number_parts": true,
         "catenate_words": true,

--- a/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
@@ -243,3 +243,41 @@ client.ConnectionSettings.ConnectionPool
     .Should().BeOfType<StickyConnectionPool>();
 ----
 
+[[sticky-sniffing-connection-pool]]
+==== Sticky Sniffing Connection Pool
+
+A type of connection pool that returns the first live node to issue a request against, such that the node is _sticky_ between requests.
+This implementation supports sniffing and sorting so that each instance of your application can favor a node in the same rack based
+on node attributes for instance.
+
+[source,csharp]
+----
+var uris = Enumerable.Range(9200, 5)
+    .Select(port => new Uri($"http://localhost:{port}"));
+----
+
+a sniffing sorted sticky pool takes a second parameter `Func` takes a Node and returns a weight.
+Nodes will be sorted descending by weight. In the following example we score nodes that are client nodes
+AND in rack_id `rack_one` the highest
+
+[source,csharp]
+----
+var pool = new StickySniffingConnectionPool(uris, n =>
+    (n.ClientNode ? 10 : 0)
+    + (n.Settings.TryGetValue("node.attr.rack_id", out string rackId)
+               && rackId == "rack_one" ? 10 : 0));
+
+pool.SupportsReseeding.Should().BeTrue();
+pool.SupportsPinging.Should().BeTrue();
+----
+
+To create a client using the sticky sniffing connection pool pass
+the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
+
+[source,csharp]
+----
+var client = new ElasticClient(new ConnectionSettings(pool));
+client.ConnectionSettings.ConnectionPool
+    .Should().BeOfType<StickySniffingConnectionPool>();
+----
+

--- a/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
@@ -1,0 +1,158 @@
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/5.3
+
+:xpack_current: https://www.elastic.co/guide/en/x-pack/5.3
+
+:github: https://github.com/elastic/elasticsearch-net
+
+:nuget: https://www.nuget.org/packages
+
+////
+IMPORTANT NOTE
+==============
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/5.x/src/Tests/ClientConcepts/ConnectionPooling/Sticky/StickySniffingConnectionPool.doc.cs. 
+If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
+please modify the original csharp file found at the link and submit the PR with that change. Thanks!
+////
+
+[[sticky-sniffing-connection-pool]]
+=== Sticky Sniffing Connection Pool
+
+Sticky sniffing connection pool
+
+This pool is a is an extended StickyConnectionPool that supports sniffing and sorting
+the nodes a sniff returns.
+
+[source,csharp]
+----
+var numberOfNodes = 10;
+var uris = Enumerable.Range(9200, numberOfNodes).Select(p => new Uri("http://localhost:" + p));
+var pool = new Elasticsearch.Net.StickySniffingConnectionPool(uris, (n)=>0f);
+----
+
+Here we have setup a sticky connection pool seeded with 10 nodes all weighted the same.
+So what order we expect? Imagine the following:
+
+Thread A calls `.CreateView()` and gets returned the first live node
+Thread B calls `.CreateView()` and gets returned the same node, since the first
+node is still good
+
+[source,csharp]
+----
+var startingPositions = Enumerable.Range(0, numberOfNodes)
+    .Select(i => pool.CreateView().First())
+    .Select(n => n.Uri.Port)
+    .ToList();
+
+var expectedOrder = Enumerable.Repeat(9200, numberOfNodes);
+startingPositions.Should().ContainInOrder(expectedOrder);
+
+IEnumerable<Node> Nodes(int start) => Enumerable.Range(start, 4)
+    .Select(i => new Uri($"http://localhost:{9200 + i}"))
+    .Select((u, i) => new Node(u)
+    {
+        Settings = new Dictionary<string, string> {{"rack", $"rack_{u.Port - 9200}"}}
+    });
+----
+
+We set up a cluster with 4 nodes all having a different rack id
+				our Sticky Sniffing Connection Pool gives the most weight to rack_2 and rack_11.
+				We initially only seed nodes `9200-9203` in racks 0 to 3. So we should be sticky on rack_2.
+				We setup node 9202 to fail after two client calls in which case we sniff and find nodes
+			 `9210-9213` in which case we should become sticky on rack_11.
+
+[source,csharp]
+----
+var audit = new Auditor(() => Framework.Cluster
+    .Nodes(Nodes(0))
+    .ClientCalls(p => p.OnPort(9202).Succeeds(Twice).ThrowsAfterSucceeds())
+    .ClientCalls(p => p.FailAlways())
+    .Sniff(s=>s.SucceedAlways(Framework.Cluster
+        .Nodes(Nodes(10))
+        .ClientCalls(p => p.SucceedAlways()))
+    )
+    .StickySniffingConnectionPool(n=>
+        (n.Settings.TryGetValue("rack", out string v) && v == "rack_2" ? 10 : 0)
+        +(n.Settings.TryGetValue("rack", out string r) && r == "rack_11" ? 10 : 0)
+    )
+    .Settings(p => p.DisablePing().SniffOnStartup(false))
+);
+----
+
+Our first call happens on 9202 because we sorted that to the top as its on rack_2
+After two succesful calls our sticky node throws an exception and we sniff and failover.
+Sniffing happens on the next node in order (9200) and the sniffing response returns nodes
+9210 to 9213. We should now be stick on 9211 as its on rack_11
+
+[source,csharp]
+----
+await audit.TraceCalls(
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall {
+        { BadResponse, 9202 },
+        { SniffOnFail },
+        { SniffSuccess, 9200 },
+        { HealthyResponse, 9211},
+    },
+    /** Now we are sticky on 9211 onwards */
+    new ClientCall { { HealthyResponse, 9211 } },
+    new ClientCall { { HealthyResponse, 9211 } },
+    new ClientCall { { HealthyResponse, 9211 } },
+    new ClientCall { { HealthyResponse, 9211 } },
+    new ClientCall { { HealthyResponse, 9211 } },
+    new ClientCall { { HealthyResponse, 9211 } },
+    new ClientCall { { HealthyResponse, 9211 } }
+);
+
+IEnumerable<Node> Nodes(int start) => Enumerable.Range(start, 4)
+    .Select(i => new Uri($"http://localhost:{9200 + i}"))
+    .Select((u, i) => new Node(u)
+    {
+        Settings = new Dictionary<string, string> {{"rack", $"rack_{u.Port - 9200}"}}
+    });
+----
+
+We seed a cluster with an array of 4 Uri's starting at port 9200.
+Our sniffing sorted connection pool is set up to favor nodes in rack_2
+
+[source,csharp]
+----
+var audit = new Auditor(() => Framework.Cluster
+    .Nodes(4)
+    .ClientCalls(p => p.SucceedAlways())
+    .Sniff(s=>s.SucceedAlways(Framework.Cluster
+        .Nodes(Nodes(0))
+        .ClientCalls(p => p.SucceedAlways()))
+    )
+    .StickySniffingConnectionPool(n=>
+        (n.Settings.TryGetValue("rack", out string v) && v == "rack_2" ? 10 : 0)
+    )
+    .Settings(p => p.DisablePing())
+);
+----
+
+Sniff happens on 9200 because our seed has no knowledge of rack ids
+However when we reseed the nodes from the sniff response we sort 9202 to to top
+because it lives in rack_2
+
+[source,csharp]
+----
+await audit.TraceCalls(
+    new ClientCall
+    {
+        { SniffOnStartup },
+        { SniffSuccess, 9200 },
+        { HealthyResponse, 9202},
+    },
+    /** We are sticky on 9202 for as long as it keeps returning valid responses */
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall { { HealthyResponse, 9202} },
+    new ClientCall { { HealthyResponse, 9202} }
+);
+----
+

--- a/docs/client-concepts/connection-pooling/sticky/sticky.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky.asciidoc
@@ -17,7 +17,7 @@ please modify the original csharp file found at the link and submit the PR with 
 [[sticky]]
 === Sticky
 
-Sticky
+Sticky Connection Pool
 Each connection pool returns the first `live` node so that it is sticky between requests
 
 [source,csharp]

--- a/docs/client-concepts/connection/modifying-default-connection.asciidoc
+++ b/docs/client-concepts/connection/modifying-default-connection.asciidoc
@@ -103,7 +103,7 @@ from our fixed `InMemoryConnection` response
 
 [source,csharp]
 ----
-searchResponse.IsValid.Should().BeTrue();
+searchResponse.ShouldBeValid();
 searchResponse.Documents.Count.Should().Be(25);
 ----
 

--- a/docs/client-concepts/high-level/analysis/testing-analyzers.asciidoc
+++ b/docs/client-concepts/high-level/analysis/testing-analyzers.asciidoc
@@ -20,7 +20,7 @@ please modify the original csharp file found at the link and submit the PR with 
 When <<writing-analyzers, building your own analyzers>>, it's useful to test that the analyzer
 does what we expect it to. This is where the {ref_current}/indices-analyze.html[Analyze API] comes in.
 
-==== Testing built-in analyzers
+==== Testing in-built analyzers
 
 To get started with the Analyze API, we can test to see how a built-in analyzer will analyze
 a piece of text

--- a/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
+++ b/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
@@ -29,27 +29,29 @@ public interface ISearchResult
 {
     string Name { get; set; }
 }
+
+public abstract class BaseX : ISearchResult
+{
+    public string Name { get; set; }
+}
 ----
 
 We have three implementations of `ISearchResult` namely `A`, `B` and `C`
 
 [source,csharp]
 ----
-public class A : ISearchResult
+public class A : BaseX
 {
-    public string Name { get; set; }
     public int PropertyOnA { get; set; }
 }
 
-public class B : ISearchResult
+public class B : BaseX
 {
-    public string Name { get; set; }
     public int PropertyOnB { get; set; }
 }
 
-public class C : ISearchResult
+public class C : BaseX
 {
-    public string Name { get; set; }
     public int PropertyOnC { get; set; }
 }
 ----
@@ -242,6 +244,30 @@ and assume that properties that only exist on the subclass itself are properly f
 
 [source,csharp]
 ----
+aDocuments.Should().OnlyContain(a => a.PropertyOnA > 0);
+bDocuments.Should().OnlyContain(a => a.PropertyOnB > 0);
+cDocuments.Should().OnlyContain(a => a.PropertyOnC > 0);
+----
+
+Covariance also works over subclasses not just interfaces
+
+[source,csharp]
+----
+var result = this._client.Search<BaseX>(s => s
+    .Type(Types.Type(typeof(A), typeof(B), typeof(C)))
+    .Size(100)
+);
+result.ShouldBeValid();
+result.Documents.Count.Should().Be(100);
+
+var aDocuments = result.Documents.OfType<A>();
+var bDocuments = result.Documents.OfType<B>();
+var cDocuments = result.Documents.OfType<C>();
+
+aDocuments.Count().Should().Be(25);
+bDocuments.Count().Should().Be(25);
+cDocuments.Count().Should().Be(50);
+
 aDocuments.Should().OnlyContain(a => a.PropertyOnA > 0);
 bDocuments.Should().OnlyContain(a => a.PropertyOnB > 0);
 cDocuments.Should().OnlyContain(a => a.PropertyOnC > 0);

--- a/docs/client-concepts/high-level/serialization/modifying-default-serializer.asciidoc
+++ b/docs/client-concepts/high-level/serialization/modifying-default-serializer.asciidoc
@@ -121,3 +121,35 @@ from `JsonNetSerializer`.
 
 ====
 
+==== Adding contract JsonConverters
+
+If you want to register custom json converters without attributing your classes you can register
+Functions that given a type return a JsonConverter. This is cached as part of the types json contract so once
+Json.NET knows a type has a certain converter it won't ask anymore for the duration of the application.
+
+Override `ContractConverters` getter property and have it return a list of these functions
+
+[source,csharp]
+----
+public class CustomContractsJsonNetSerializer : CustomJsonNetSerializer
+{
+    public CustomContractsJsonNetSerializer(IConnectionSettingsValues settings) : base(settings) { }
+    public CustomContractsJsonNetSerializer(IConnectionSettingsValues settings, JsonConverter statefulConverter)
+         : base(settings, statefulConverter) { }
+
+     protected override IList<Func<Type, JsonConverter>> ContractConverters { get; } = new List<Func<Type, JsonConverter>>
+     {
+((t) => t == typeof(Project) ? new MyCustomJsonConverter() : null)
+     };
+}
+
+public class MyCustomJsonConverter : JsonConverter
+        {
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) { }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) => null;
+
+    public override bool CanConvert(Type objectType) => false;
+        }
+----
+

--- a/docs/client-concepts/troubleshooting/audit-trail.asciidoc
+++ b/docs/client-concepts/troubleshooting/audit-trail.asciidoc
@@ -26,7 +26,7 @@ first usage, so we can get an audit trail with a few events out
 
 [source,csharp]
 ----
-var pool = new SniffingConnectionPool(new []{ new Uri($"http://localhost:{_cluster.Node.Port}") });
+var pool = new SniffingConnectionPool(new []{ new Uri($"http://{TestClient.DefaultHost}:9200") });
 var connectionSettings = new ConnectionSettings(pool)
     .InferMappingFor<Project>(i => i
         .IndexName("project")

--- a/docs/code-standards/descriptors.asciidoc
+++ b/docs/code-standards/descriptors.asciidoc
@@ -52,6 +52,7 @@ var exclusions = new Dictionary<Type, Type>
     { typeof(TransformDescriptor), typeof(TransformContainer) },
     { typeof(SmoothingModelContainerDescriptor), typeof(SmoothingModelContainer) },
     { typeof(InputDescriptor), typeof(InputContainer) },
+    { typeof(RoleMappingRuleDescriptor), typeof(RoleMappingRuleBase) },
     { typeof(FluentDictionary<,>), typeof(FluentDictionary<,>) }
 };
 

--- a/docs/code-standards/naming-conventions.asciidoc
+++ b/docs/code-standards/naming-conventions.asciidoc
@@ -95,6 +95,8 @@ the `Exists` requests.
 ----
 var exceptions = new[] <1>
 {
+    typeof(SourceExistsRequest),
+    typeof(SourceExistsRequest<>),
     typeof(DocumentExistsRequest),
     typeof(DocumentExistsRequest<>),
     typeof(AliasExistsRequest),

--- a/docs/code-standards/responses.asciidoc
+++ b/docs/code-standards/responses.asciidoc
@@ -27,9 +27,7 @@ var exceptions = new HashSet<PropertyInfo>
     typeof(ITypeMapping).GetProperty(nameof(ITypeMapping.Meta)),
     typeof(TypeMapping).GetProperty(nameof(TypeMapping.DynamicDateFormats)),
     typeof(TypeMapping).GetProperty(nameof(TypeMapping.Meta)),
-#pragma warning disable 618
     typeof(IMultiPercolateResponse).GetProperty(nameof(IMultiPercolateResponse.Responses)),
-#pragma warning restore 618
     typeof(IBulkResponse).GetProperty(nameof(IBulkResponse.ItemsWithErrors)),
     typeof(IMultiSearchResponse).GetProperty(nameof(IMultiSearchResponse.AllResponses)),
 };

--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -150,7 +150,7 @@ where as `Time` on its own serializes like this
 
 [source,csharp]
 ----
-Expect("1.04d").WhenSerializing(new Time(TimeSpan.FromHours(25)));
+Expect("1.04166666666667d").WhenSerializing(new Time(TimeSpan.FromHours(25)));
 
 Expect("now+90001s").WhenSerializing(
     Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromSeconds(1))));

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -158,6 +158,6 @@ Expect("week").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Week);
 Expect("year").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Year);
 
 Expect("2d").WhenSerializing<Union<DateInterval, Time>>((Time)"2d");
-Expect("1.16w").WhenSerializing<Union<DateInterval, Time>>((Time)TimeSpan.FromDays(8.1));
+Expect("1.15714285714286w").WhenSerializing<Union<DateInterval, Time>>((Time)TimeSpan.FromDays(8.1));
 ----
 

--- a/docs/query-dsl/full-text/query-string/query-string-usage.asciidoc
+++ b/docs/query-dsl/full-text/query-string/query-string-usage.asciidoc
@@ -71,6 +71,7 @@ new QueryStringQuery
     AutoGeneratePhraseQueries = true,
     MaximumDeterminizedStates = 2,
     LowercaseExpendedTerms = true,
+    Locale = "en_US",
     EnablePositionIncrements = true,
     Escape = true,
     UseDisMax = true,
@@ -83,8 +84,7 @@ new QueryStringQuery
     AnalyzeWildcard = true,
     MinimumShouldMatch = 2,
     QuoteFieldSuffix = "'",
-    Lenient = true,
-    Locale = "en_US",
+    Lenient = true,            
     Timezone = "root"
 }
 ----

--- a/docs/query-dsl/term-level/term/term-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/term/term-query-usage.asciidoc
@@ -57,3 +57,46 @@ new TermQuery
 }
 ----
 
+[float]
+== Verbatim term query
+
+By default an empty term is conditionless so will be rewritten. Sometimes sending an empty term to
+match nothing makes sense. You can either use the `ConditionlessQuery` construct from NEST to provide a fallback or make the
+query verbatim as followed:
+
+==== Fluent DSL example
+
+[source,csharp]
+----
+q
+.Term(c => c
+    .Verbatim()
+    .Field(p => p.Description)
+    .Value(string.Empty)
+)
+----
+
+==== Object Initializer syntax example
+
+[source,csharp]
+----
+new TermQuery
+{
+    IsVerbatim = true,
+    Field = "description",
+    Value = "",
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "term": {
+    "description": {
+      "value": ""
+    }
+  }
+}
+----
+

--- a/docs/query-dsl/term-level/terms/terms-list-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-list-query-usage.asciidoc
@@ -105,7 +105,7 @@ new TermsQuery
 
 [source,csharp]
 ----
-response.IsValid.Should().BeFalse();
+response.ShouldNotBeValid();
 
 response.ServerError.Should().NotBeNull();
 response.ServerError.Status.Should().Be(400);

--- a/docs/query-dsl/term-level/terms/terms-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-query-usage.asciidoc
@@ -78,3 +78,44 @@ q
 )
 ----
 
+[float]
+== Verbatim terms query
+
+By default an empty terms array is conditionless so will be rewritten. Sometimes sending an empty an empty array to mean
+match nothing makes sense. You can either use the `ConditionlessQuery` construct from NEST to provide a fallback or make the
+query verbatim as followed:
+
+==== Object Initializer syntax example
+
+[source,csharp]
+----
+new TermsQuery
+{
+    IsVerbatim = true,
+    Field = "description",
+    Terms = new string[] {},
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "terms": {
+    "description": []
+  }
+}
+----
+
+==== Fluent DSL example
+
+[source,csharp]
+----
+q
+.Terms(c => c
+    .Verbatim()
+    .Field(p => p.Description)
+    .Terms(new string[] {})
+)
+----
+

--- a/docs/search/request/highlighting-usage.asciidoc
+++ b/docs/search/request/highlighting-usage.asciidoc
@@ -43,6 +43,7 @@ s => s
             .Type("plain")
             .ForceSource()
             .FragmentSize(150)
+            .Fragmenter(HighlighterFragmenter.Span)
             .NumberOfFragments(3)
             .NoMatchSize(150),
         fs => fs
@@ -98,6 +99,7 @@ new SearchRequest<Project>
                     Type = HighlighterType.Plain,
                     ForceSource = true,
                     FragmentSize = 150,
+                    Fragmenter = HighlighterFragmenter.Span,
                     NumberOfFragments = 3,
                     NoMatchSize = 150
                 }
@@ -155,6 +157,7 @@ new SearchRequest<Project>
         "type": "plain",
         "force_source": true,
         "fragment_size": 150,
+        "fragmenter": "span",
         "number_of_fragments": 3,
         "no_match_size": 150
       },

--- a/docs/search/request/sort-usage.asciidoc
+++ b/docs/search/request/sort-usage.asciidoc
@@ -40,6 +40,11 @@ s => s
         .NestedPath(p => p.Tags)
         .NestedFilter(q => q.MatchAll())
     )
+    .Field(f => f
+        .Field(p => p.NumberOfCommits)
+        .Order(SortOrder.Descending)
+        .Missing(-1)
+    )
     .GeoDistance(g => g
         .Field(p => p.Location)
         .DistanceType(GeoDistanceType.Arc)
@@ -77,11 +82,17 @@ new SearchRequest<Project>
         {
             Field = Field<Project>(p=>p.LastActivity),
             Order = SortOrder.Descending,
-            Missing = "_last",
+            MissingValue = "_last",
             UnmappedType = FieldType.Date,
             Mode = SortMode.Average,
             NestedPath = Field<Project>(p=>p.Tags),
             NestedFilter = new MatchAllQuery(),
+        },
+        new SortField
+        {
+            Field = Field<Project>(p=>p.NumberOfCommits),
+            Order = SortOrder.Descending,
+            MissingValue = -1
         },
         new GeoDistanceSort
         {
@@ -144,6 +155,12 @@ new SearchRequest<Project>
         },
         "nested_path": "tags",
         "unmapped_type": "date"
+      }
+    },
+    {
+      "numberOfCommits": {
+        "missing": -1,
+        "order": "desc"
       }
     },
     {

--- a/docs/x-pack/security/role-mapping/role-mapping-rules.asciidoc
+++ b/docs/x-pack/security/role-mapping/role-mapping-rules.asciidoc
@@ -1,0 +1,163 @@
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/5.3
+
+:xpack_current: https://www.elastic.co/guide/en/x-pack/5.3
+
+:github: https://github.com/elastic/elasticsearch-net
+
+:nuget: https://www.nuget.org/packages
+
+////
+IMPORTANT NOTE
+==============
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/5.x/src/Tests/XPack/Security/RoleMapping/RoleMappingRules.doc.cs. 
+If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
+please modify the original csharp file found at the link and submit the PR with that change. Thanks!
+////
+
+[[role-mapping-rules]]
+=== Role Mapping Rules
+
+X-Pack Security allows you to map role rules through the API as of 5.5
+NEST exposes this role rules DSL in a strongy typed fashion
+
+[source,csharp]
+----
+true
+----
+
+==== Rule Conjunction
+
+You can create a conjuction of many rules using either `+` or `&` which are both overloaded to produce an `all` rule.
+
+[source,csharp]
+----
+var allRule = new UsernameRule("u1") + new UsernameRule("u2") & new UsernameRule("u3");
+allRule.All.Should().NotBeEmpty().And.HaveCount(3);
+----
+
+using `+=` assignments you can build rules more dynamically *
+
+[source,csharp]
+----
+RoleMappingRuleBase rules = null;
+for(var i = 0;i<10;i++)
+    rules += new UsernameRule($"user_{i}");
+rules.Should().BeOfType<AllRoleMappingRule>();
+
+allRule = (AllRoleMappingRule) rules;
+allRule.All.Should().NotBeEmpty().And.HaveCount(10);
+----
+
+==== Rule Disjunction
+
+The produce an `any` disjunction rule over many rules you can use the overloaded `|`
+
+[source,csharp]
+----
+var anyRule = new UsernameRule("u1") | new UsernameRule("u2") | new UsernameRule("u3");
+anyRule.Any.Should().NotBeEmpty().And.HaveCount(3);
+----
+
+using `|=` assignments you can build disjunction rules more dynamically *
+
+[source,csharp]
+----
+RoleMappingRuleBase rules = null;
+for(var i = 0;i<10;i++)
+    rules |= new UsernameRule($"user_{i}");
+rules.Should().BeOfType<AnyRoleMappingRule>();
+
+anyRule = (AnyRoleMappingRule) rules;
+anyRule.Any.Should().NotBeEmpty().And.HaveCount(10);
+----
+
+==== Rule Negation
+
+You can automatically negate any rule by using the `!` infix operator
+
+[source,csharp]
+----
+var exceptRule = !new UsernameRule("user_1");
+exceptRule.Should().BeOfType<ExceptRoleMappingRole>();
+----
+
+==== Full Example
+
+Combining all of these you can build role mapping rules quite elegantly
+
+[source,csharp]
+----
+var dn = "*,ou=admin,dc=example,dc=com";
+var username = "mpdreamz";
+var realm = "some_realm";
+var metadata = Tuple.Create("a", "b");
+var groups = new [] {"group1", "group2"};
+----
+
+using the operators we can succintly combine field rules  
+
+[source,csharp]
+----
+var dsl =
+    (new DistinguishedNameRule(dn) | new UsernameRule(username) | new RealmRule(realm))
+    & new MetadataRule(metadata.Item1, metadata.Item2)
+    & !new GroupsRule(groups);
+----
+
+We can also use an explicit object initializer syntax to compose the same graph 
+
+[source,csharp]
+----
+var ois = new AllRoleMappingRule(
+    new AnyRoleMappingRule(
+        new DistinguishedNameRule(dn),
+        new UsernameRule(username),
+        new RealmRule(realm)
+    )
+    , new MetadataRule(metadata.Item1, metadata.Item2)
+    , new ExceptRoleMappingRole(new GroupsRule(groups))
+);
+
+var writingStyles = Setup(dsl, ois);
+
+Assert(writingStyles, json: new {
+    all = new object[] {
+        new {
+            any = new object[] {
+                new { field = new { dn = "*,ou=admin,dc=example,dc=com" } },
+                new { field = new { username = "mpdreamz" } },
+                new { field = new Dictionary<string, object>(){ {"realm.name", "some_realm" } } }
+            }
+        },
+        new { field = new Dictionary<string, object>(){ {"metadata.a", "b" } } },
+        new { except = new { field = new { groups = new [] { "group1", "group2" } } } }
+    }
+});
+
+Tuple.Create(dsl, ois)
+Assert(json, rules.Item1);
+Assert(json, rules.Item2);
+
+Expect(new
+{
+    enabled = true,
+    roles = new[] {"admin"},
+    rules = json,
+    metadata = new
+    {
+        x = "y",
+        z = (object) null
+    }
+}).WhenSerializing(new PutRoleMappingRequest("x")
+{
+    Enabled = true,
+    Roles = new[] {"admin"},
+    Rules = rules,
+    Metadata = new Dictionary<string, object>
+    {
+        {"x", "y"},
+        {"z", null}
+    }
+});
+----
+

--- a/src/CodeGeneration/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
+++ b/src/CodeGeneration/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
@@ -283,12 +283,12 @@ namespace DocGenerator.AsciiDoc
                 switch (assemblyName.ToLowerInvariant())
                 {
                     case "elasticsearch.net":
-                        xmlDocsFile = Path.GetFullPath(Path.Combine(Program.BuildOutputPath, "Elasticsearch.Net.XML"));
+                        xmlDocsFile = Path.GetFullPath(Path.Combine(Program.BuildOutputPath, "Elasticsearch.Net", "net46", "Elasticsearch.Net.XML"));
                         assembly = typeof(ElasticLowLevelClient).Assembly;
                         assemblyNamespace = typeof(ElasticLowLevelClient).Namespace;
                         break;
                     default:
-                        xmlDocsFile = Path.GetFullPath(Path.Combine(Program.BuildOutputPath, "Nest.XML"));
+                        xmlDocsFile = Path.GetFullPath(Path.Combine(Program.BuildOutputPath, "Nest", "net46", "Nest.XML"));
                         assembly = typeof(ElasticClient).Assembly;
                         assemblyNamespace = typeof(ElasticClient).Namespace;
                         break;

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/AnalyzerManager.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/AnalyzerManager.cs
@@ -1,0 +1,163 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocGenerator.Buildalyzer.Logging;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.Logging;
+
+namespace DocGenerator.Buildalyzer
+{
+ public class AnalyzerManager
+    {
+        private readonly Dictionary<string, ProjectAnalyzer> _projects = new Dictionary<string, ProjectAnalyzer>();
+
+        public IReadOnlyDictionary<string, ProjectAnalyzer> Projects => _projects;
+
+        internal ILogger<ProjectAnalyzer> ProjectLogger { get; }
+
+        internal LoggerVerbosity LoggerVerbosity { get; }
+
+        public string SolutionDirectory { get; }
+
+        public AnalyzerManager(ILoggerFactory loggerFactory = null, LoggerVerbosity loggerVerbosity = LoggerVerbosity.Normal)
+            : this(null, loggerFactory, loggerVerbosity)
+        {
+        }
+
+        public AnalyzerManager(TextWriter logWriter, LoggerVerbosity loggerVerbosity = LoggerVerbosity.Normal)
+            : this(null, logWriter, loggerVerbosity)
+        {
+        }
+
+        public AnalyzerManager(string solutionFilePath, ILoggerFactory loggerFactory = null, LoggerVerbosity loggerVerbosity = LoggerVerbosity.Normal)
+        {
+            LoggerVerbosity = loggerVerbosity;
+            ProjectLogger = loggerFactory?.CreateLogger<ProjectAnalyzer>();
+
+            if (solutionFilePath != null)
+            {
+                solutionFilePath = ValidatePath(solutionFilePath, true);
+                SolutionDirectory = Path.GetDirectoryName(solutionFilePath);
+                GetProjectsInSolution(solutionFilePath);
+            }
+        }
+
+        public AnalyzerManager(string solutionFilePath, TextWriter logWriter, LoggerVerbosity loggerVerbosity = LoggerVerbosity.Normal)
+        {
+            LoggerVerbosity = loggerVerbosity;
+            if (logWriter != null)
+            {
+                LoggerFactory loggerFactory = new LoggerFactory();
+                loggerFactory.AddProvider(new TextWriterLoggerProvider(logWriter));
+                ProjectLogger = loggerFactory.CreateLogger<ProjectAnalyzer>();
+            }
+
+            if (solutionFilePath != null)
+            {
+                solutionFilePath = ValidatePath(solutionFilePath, true);
+                SolutionDirectory = Path.GetDirectoryName(solutionFilePath);
+                GetProjectsInSolution(solutionFilePath);
+            }
+        }
+
+        private void GetProjectsInSolution(string solutionFilePath)
+        {
+            var supportedType = new[]
+            {
+                SolutionProjectType.KnownToBeMSBuildFormat,
+                SolutionProjectType.WebProject
+            };
+
+            SolutionFile solution = SolutionFile.Parse(solutionFilePath);
+            foreach(ProjectInSolution project in solution.ProjectsInOrder)
+            {
+                if (!supportedType.Contains(project.ProjectType))
+                    continue;
+                GetProject(project.AbsolutePath);
+            }
+        }
+
+        public ProjectAnalyzer GetProject(string projectFilePath)
+        {
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
+
+            // Normalize as .sln uses backslash regardless of OS the sln is created on
+            projectFilePath = projectFilePath.Replace('\\', Path.DirectorySeparatorChar);
+            projectFilePath = ValidatePath(projectFilePath, true);
+            if (_projects.TryGetValue(projectFilePath, out ProjectAnalyzer project))
+            {
+                return project;
+            }
+            project = new ProjectAnalyzer(this, projectFilePath);
+            _projects.Add(projectFilePath, project);
+            return project;
+        }
+
+        public ProjectAnalyzer GetProject(string projectFilePath, XDocument projectDocument)
+        {
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
+            if (projectDocument == null)
+            {
+                throw new ArgumentNullException(nameof(projectDocument));
+            }
+
+            // Normalize as .sln uses backslash regardless of OS the sln is created on
+            projectFilePath = projectFilePath.Replace('\\', Path.DirectorySeparatorChar);
+            projectFilePath = ValidatePath(projectFilePath, false);
+            if (_projects.TryGetValue(projectFilePath, out ProjectAnalyzer project))
+            {
+                return project;
+            }
+            project = new ProjectAnalyzer(this, projectFilePath, projectDocument);
+            _projects.Add(projectFilePath, project);
+            return project;
+        }
+
+        private static string ValidatePath(string path, bool checkExists)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+            path = Path.GetFullPath(path); // Normalize the path
+            if (checkExists && !File.Exists(path))
+            {
+                throw new ArgumentException($"The path {path} could not be found.");
+            }
+            return path;
+        }
+    }
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/AnalyzerManagerExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/AnalyzerManagerExtensions.cs
@@ -1,0 +1,41 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using Microsoft.CodeAnalysis;
+
+namespace DocGenerator.Buildalyzer
+{
+	public static class AnalyzerManagerExtensions
+	{
+		public static AdhocWorkspace GetWorkspace(this AnalyzerManager manager)
+		{
+			AdhocWorkspace workspace = new AdhocWorkspace();
+			foreach (ProjectAnalyzer project in manager.Projects.Values)
+			{
+				project.AddToWorkspace(workspace);
+			}
+			return workspace;
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/BuildEnvironment.cs
@@ -1,0 +1,74 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System.Collections.Generic;
+
+namespace DocGenerator.Buildalyzer.Environment
+{
+	internal abstract class BuildEnvironment
+	{
+		private string _oldMsBuildExtensionsPath = null;
+		private string _oldMsBuildSdksPath = null;
+
+		public abstract string GetToolsPath();
+
+		public virtual Dictionary<string, string> GetGlobalProperties(string solutionDir) =>
+			new Dictionary<string, string>
+			{
+				{ MsBuildProperties.SolutionDir, solutionDir },
+				{ MsBuildProperties.DesignTimeBuild, "true" },
+				{ MsBuildProperties.BuildProjectReferences, "false" },
+				{ MsBuildProperties.SkipCompilerExecution, "true" },
+				{ MsBuildProperties.ProvideCommandLineArgs, "true" },
+				// Workaround for a problem with resource files, see https://github.com/dotnet/sdk/issues/346#issuecomment-257654120
+				{ MsBuildProperties.GenerateResourceMSBuildArchitecture, "CurrentArchitecture" }
+			};
+
+		public virtual void SetEnvironmentVars(IReadOnlyDictionary<string, string> globalProperties)
+		{
+			if (globalProperties.TryGetValue(MsBuildProperties.MSBuildExtensionsPath, out var msBuildExtensionsPath))
+			{
+				_oldMsBuildExtensionsPath = System.Environment.GetEnvironmentVariable(MsBuildProperties.MSBuildExtensionsPath);
+				System.Environment.SetEnvironmentVariable(MsBuildProperties.MSBuildExtensionsPath, msBuildExtensionsPath);
+			}
+			if (globalProperties.TryGetValue(MsBuildProperties.MSBuildSDKsPath, out var msBuildSDKsPath))
+			{
+				_oldMsBuildSdksPath = System.Environment.GetEnvironmentVariable(MsBuildProperties.MSBuildSDKsPath);
+				System.Environment.SetEnvironmentVariable(MsBuildProperties.MSBuildSDKsPath, msBuildSDKsPath);
+			}
+		}
+
+		public virtual void UnsetEnvironmentVars()
+		{
+			if (_oldMsBuildExtensionsPath != null)
+			{
+				System.Environment.SetEnvironmentVariable(MsBuildProperties.MSBuildExtensionsPath, _oldMsBuildExtensionsPath);
+			}
+			if (_oldMsBuildSdksPath != null)
+			{
+				System.Environment.SetEnvironmentVariable(MsBuildProperties.MSBuildSDKsPath, _oldMsBuildSdksPath);
+			}
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/CoreEnvironment.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/CoreEnvironment.cs
@@ -1,0 +1,59 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace DocGenerator.Buildalyzer.Environment
+{
+	// Based on code from OmniSharp
+	// https://github.com/OmniSharp/omnisharp-roslyn/blob/78ccc8b4376c73da282a600ac6fb10fce8620b52/src/OmniSharp.Abstractions/Services/DotNetCliService.cs
+	internal class CoreEnvironment : BuildEnvironment
+	{
+		public string ToolsPath { get; }
+		public string ExtensionsPath { get; }
+		public string SDKsPath { get; }
+		public string RoslynTargetsPath { get; }
+
+		public CoreEnvironment(string projectPath)
+		{
+			string dotnetPath = DotnetPathResolver.ResolvePath(projectPath);
+			ToolsPath = dotnetPath;
+			ExtensionsPath = dotnetPath;
+			SDKsPath = Path.Combine(dotnetPath, "Sdks");
+			RoslynTargetsPath = Path.Combine(dotnetPath, "Roslyn");
+		}
+
+		public override string GetToolsPath() => ToolsPath;
+
+		public override Dictionary<string, string> GetGlobalProperties(string solutionDir)
+		{
+			Dictionary<string, string> globalProperties = base.GetGlobalProperties(solutionDir);
+			globalProperties.Add(MsBuildProperties.MSBuildExtensionsPath, ExtensionsPath);
+			globalProperties.Add(MsBuildProperties.MSBuildSDKsPath, SDKsPath);
+			globalProperties.Add(MsBuildProperties.RoslynTargetsPath, RoslynTargetsPath);
+			return globalProperties;
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/DotnetPathResolver.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/DotnetPathResolver.cs
@@ -1,0 +1,147 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace DocGenerator.Buildalyzer.Environment
+{
+	internal static class DotnetPathResolver
+	{
+		const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
+
+		private static readonly object BasePathLock = new object();
+		private static string BasePath = null;
+
+		public static string ResolvePath(string projectPath)
+		{
+			lock(BasePathLock)
+			{
+				if(BasePath != null)
+				{
+					return BasePath;
+				}
+
+				// Need to rety calling "dotnet --info" and do a hacky timeout for the process otherwise it occasionally locks up during testing (and possibly in the field)
+				List<string> lines = GetInfo(projectPath);
+				int retry = 0;
+				do
+				{
+					lines = GetInfo(projectPath);
+					retry++;
+				} while ((lines == null || lines.Count == 0) && retry < 5);
+				BasePath = ParseBasePath(lines);
+
+				return BasePath;
+			}
+		}
+
+		private static List<string> GetInfo(string projectPath)
+		{
+			// Ensure that we set the DOTNET_CLI_UI_LANGUAGE environment variable to "en-US" before
+			// running 'dotnet --info'. Otherwise, we may get localized results.
+			string originalCliLanguage = System.Environment.GetEnvironmentVariable(DOTNET_CLI_UI_LANGUAGE);
+			System.Environment.SetEnvironmentVariable(DOTNET_CLI_UI_LANGUAGE, "en-US");
+
+			try
+			{
+				// Create the process info
+				Process process = new Process();
+				process.StartInfo.FileName = "dotnet";
+				process.StartInfo.Arguments = "--info";
+				process.StartInfo.WorkingDirectory = Path.GetDirectoryName(projectPath); // global.json may change the version, so need to set working directory
+				process.StartInfo.CreateNoWindow = true;
+				process.StartInfo.UseShellExecute = false;
+
+				// Capture output
+				List<string> lines = new List<string>();
+				process.StartInfo.RedirectStandardOutput = true;
+				process.OutputDataReceived += (s, e) => lines.Add(e.Data);
+
+				// Execute the process
+				process.Start();
+				process.BeginOutputReadLine();
+				Stopwatch sw = new Stopwatch();
+				sw.Start();
+				while (!process.HasExited)
+				{
+					if (sw.ElapsedMilliseconds > 1000)
+					{
+						break;
+					}
+				}
+				sw.Stop();
+				process.Close();
+				return lines;
+			}
+			finally
+			{
+				System.Environment.SetEnvironmentVariable(DOTNET_CLI_UI_LANGUAGE, originalCliLanguage);
+			}
+		}
+
+		private static string ParseBasePath(List<string> lines)
+		{
+			if (lines == null || lines.Count == 0)
+			{
+				throw new InvalidOperationException("Could not get results from `dotnet --info` call");
+			}
+
+			foreach (string line in lines)
+			{
+				int colonIndex = line.IndexOf(':');
+				if (colonIndex >= 0
+				    && line.Substring(0, colonIndex).Trim().Equals("Base Path", StringComparison.OrdinalIgnoreCase))
+				{
+					string basePath = line.Substring(colonIndex + 1).Trim();
+
+					// Make sure the base path matches the runtime architecture if on Windows
+					// Note that this only works for the default installation locations under "Program Files"
+					if (basePath.Contains(@"\Program Files\") && !System.Environment.Is64BitProcess)
+					{
+						string newBasePath = basePath.Replace(@"\Program Files\", @"\Program Files (x86)\");
+						if (Directory.Exists(newBasePath))
+						{
+							basePath = newBasePath;
+						}
+					}
+					else if (basePath.Contains(@"\Program Files (x86)\") && System.Environment.Is64BitProcess)
+					{
+						string newBasePath = basePath.Replace(@"\Program Files (x86)\", @"\Program Files\");
+						if (Directory.Exists(newBasePath))
+						{
+							basePath = newBasePath;
+						}
+					}
+
+					return basePath;
+				}
+			}
+
+			throw new InvalidOperationException("Could not locate base path in `dotnet --info` results");
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/EnvironmentFactory.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/EnvironmentFactory.cs
@@ -1,0 +1,77 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace DocGenerator.Buildalyzer.Environment
+{
+	internal abstract class EnvironmentFactory
+	{
+		public static BuildEnvironment GetBuildEnvironment(string projectPath, XDocument projectDocument)
+		{
+			// If we're running on .NET Core, use the .NET Core SDK regardless of the project file
+			if (System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
+				.Replace(" ", "").StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase))
+			{
+				return new CoreEnvironment(projectPath);
+			}
+
+			// Look at the project file to determine
+			XElement projectElement = projectDocument.GetDescendants("Project").FirstOrDefault();
+			if (projectElement != null)
+			{
+				// Does this project use the SDK?
+				// Check for an SDK attribute on the project element
+				// If no <Project> attribute, check for a SDK import (see https://github.com/Microsoft/msbuild/issues/1493)
+				if (projectElement.GetAttributeValue("Sdk") != null
+				    || projectElement.GetDescendants("Import").Any(x => x.GetAttributeValue("Sdk") != null))
+				{
+					// Use the Framework tools if this project targets .NET Framework ("net" followed by a digit)
+					// https://docs.microsoft.com/en-us/dotnet/standard/frameworks
+					string targetFramework = projectElement.GetDescendants("TargetFramework").FirstOrDefault()?.Value;
+					if(targetFramework != null
+					   && targetFramework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
+					   && targetFramework.Length > 3
+					   && char.IsDigit(targetFramework[4]))
+					{
+						return new FrameworkEnvironment(projectPath, true);
+					}
+
+					// Otherwise use the .NET Core SDK
+					return new CoreEnvironment(projectPath);
+				}
+
+				// Use Framework tools if a ToolsVersion attribute
+				if (projectElement.GetAttributeValue("ToolsVersion") != null)
+				{
+					return new FrameworkEnvironment(projectPath, false);
+				}
+			}
+
+			throw new InvalidOperationException("Unrecognized project file format");
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/FrameworkEnvironment.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/FrameworkEnvironment.cs
@@ -1,0 +1,91 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Utilities;
+
+namespace DocGenerator.Buildalyzer.Environment
+{
+	internal class FrameworkEnvironment : BuildEnvironment
+	{
+		private readonly bool _sdkProject;
+
+		public string ToolsPath { get; }
+		public string ExtensionsPath { get; }
+		public string SDKsPath { get; }
+		public string RoslynTargetsPath { get; }
+
+		public FrameworkEnvironment(string projectPath, bool sdkProject)
+		{
+			ToolsPath = LocateToolsPath();
+			ExtensionsPath = Path.GetFullPath(Path.Combine(ToolsPath, @"..\..\"));
+			SDKsPath = Path.Combine(sdkProject ? DotnetPathResolver.ResolvePath(projectPath) : ExtensionsPath, "Sdks");
+			RoslynTargetsPath = Path.Combine(ToolsPath, "Roslyn");
+		}
+
+		public override string GetToolsPath() => ToolsPath;
+
+		public override Dictionary<string, string> GetGlobalProperties(string solutionDir)
+		{
+			Dictionary<string, string> globalProperties = base.GetGlobalProperties(solutionDir);
+			globalProperties.Add(MsBuildProperties.MSBuildExtensionsPath, ExtensionsPath);
+			globalProperties.Add(MsBuildProperties.MSBuildSDKsPath, SDKsPath);
+			globalProperties.Add(MsBuildProperties.RoslynTargetsPath, RoslynTargetsPath);
+			return globalProperties;
+		}
+
+		private static string LocateToolsPath()
+		{
+			string toolsPath = ToolLocationHelper.GetPathToBuildToolsFile("msbuild.exe", ToolLocationHelper.CurrentToolsVersion);
+			if (string.IsNullOrEmpty(toolsPath))
+			{
+				// Could not find the tools path, possibly due to https://github.com/Microsoft/msbuild/issues/2369
+				// Try to poll for it
+				toolsPath = PollForToolsPath();
+			}
+			if (string.IsNullOrEmpty(toolsPath))
+			{
+				throw new InvalidOperationException("Could not locate the tools (msbuild.exe) path");
+			}
+			return Path.GetDirectoryName(toolsPath);
+		}
+
+		// From https://github.com/KirillOsenkov/MSBuildStructuredLog/blob/4649f55f900a324421bad5a714a2584926a02138/src/StructuredLogViewer/MSBuildLocator.cs
+		private static string PollForToolsPath()
+		{
+			string programFilesX86 = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFilesX86);
+			return new[]
+				{
+					Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"),
+					Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"),
+					Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe")
+				}
+				.Where(File.Exists)
+				.FirstOrDefault();
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/MsBuildProperties.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Environment/MsBuildProperties.cs
@@ -1,0 +1,44 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+namespace DocGenerator.Buildalyzer.Environment
+{
+	public static class MsBuildProperties
+	{
+		// MSBuild Project Loading
+		public const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
+		public const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
+		public const string RoslynTargetsPath = nameof(RoslynTargetsPath);
+		public const string SolutionDir = nameof(SolutionDir);
+
+		// Design-time Build
+		public const string DesignTimeBuild = nameof(DesignTimeBuild);
+		public const string BuildProjectReferences = nameof(BuildProjectReferences);
+		public const string SkipCompilerExecution = nameof(SkipCompilerExecution);
+		public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
+
+		// Others
+		public const string GenerateResourceMSBuildArchitecture = nameof(GenerateResourceMSBuildArchitecture);
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Logging/EmptyDisposable.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Logging/EmptyDisposable.cs
@@ -1,0 +1,35 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+
+namespace DocGenerator.Buildalyzer.Logging
+{
+	public class EmptyDisposable : IDisposable
+	{
+		public void Dispose()
+		{
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Logging/TextWriterLogger.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Logging/TextWriterLogger.cs
@@ -1,0 +1,47 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace DocGenerator.Buildalyzer.Logging
+{
+	internal class TextWriterLogger : ILogger
+	{
+		private readonly TextWriter _textWriter;
+
+		public TextWriterLogger(TextWriter textWriter)
+		{
+			_textWriter = textWriter;
+		}
+
+		public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) =>
+			_textWriter.Write(formatter(state, exception));
+
+		public bool IsEnabled(LogLevel logLevel) => true;
+
+		public IDisposable BeginScope<TState>(TState state) => new EmptyDisposable();
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/Logging/TextWriterLoggerProvider.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/Logging/TextWriterLoggerProvider.cs
@@ -1,0 +1,45 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace DocGenerator.Buildalyzer.Logging
+{
+	public class TextWriterLoggerProvider : ILoggerProvider
+	{
+		private readonly TextWriter _textWriter;
+
+		public TextWriterLoggerProvider(TextWriter textWriter)
+		{
+			_textWriter = textWriter;
+		}
+
+		public void Dispose()
+		{
+		}
+
+		public ILogger CreateLogger(string categoryName) => new TextWriterLogger(_textWriter);
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/ProjectAnalyzer.cs
@@ -1,0 +1,224 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using DocGenerator.Buildalyzer.Environment;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Logging;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Utilities;
+using Microsoft.Extensions.Logging;
+using ILogger = Microsoft.Build.Framework.ILogger;
+
+namespace DocGenerator.Buildalyzer
+{
+	public class ProjectAnalyzer
+	{
+		private readonly XDocument _projectDocument;
+		private readonly Dictionary<string, string> _globalProperties;
+		private readonly BuildEnvironment _buildEnvironment;
+		private readonly ConsoleLogger _logger;
+
+		private Project _project = null;
+		private ProjectInstance _compiledProject = null;
+
+		public AnalyzerManager Manager { get; }
+
+		public string ProjectFilePath { get; }
+
+		/// <summary>
+		/// The global properties for MSBuild. By default, each project
+		/// is configured with properties that use a design-time build without calling the compiler.
+		/// </summary>
+		public IReadOnlyDictionary<string, string> GlobalProperties => _globalProperties;
+
+		public Project Project => Load();
+
+		public ProjectInstance CompiledProject => Compile();
+
+		internal ProjectAnalyzer(AnalyzerManager manager, string projectFilePath)
+			: this(manager, projectFilePath, XDocument.Load(projectFilePath))
+		{
+		}
+
+		internal ProjectAnalyzer(AnalyzerManager manager, string projectFilePath, XDocument projectDocument)
+		{
+			Manager = manager;
+			ProjectFilePath = projectFilePath;
+			_projectDocument = TweakProjectDocument(projectDocument);
+
+			// Get the paths
+			_buildEnvironment = EnvironmentFactory.GetBuildEnvironment(projectFilePath, _projectDocument);
+
+			// Preload/enforce referencing some required asemblies
+			Copy copy = new Copy();
+
+			// Set global properties
+			string solutionDir = manager.SolutionDirectory ?? Path.GetDirectoryName(projectFilePath);
+			_globalProperties = _buildEnvironment.GetGlobalProperties(solutionDir);
+
+			// Create the logger
+			if (manager.ProjectLogger != null)
+			{
+				_logger = new ConsoleLogger(manager.LoggerVerbosity, x => manager.ProjectLogger.LogInformation(x), null, null);
+			}
+		}
+
+		public Project Load()
+		{
+			if (_project != null)
+			{
+				return _project;
+			}
+
+			// Create a project collection for each project since the toolset might change depending on the type of project
+			ProjectCollection projectCollection = CreateProjectCollection();
+
+			// Load the project
+			_buildEnvironment.SetEnvironmentVars(GlobalProperties);
+			try
+			{
+				using (XmlReader projectReader = _projectDocument.CreateReader())
+				{
+					_project = projectCollection.LoadProject(projectReader);
+					_project.FullPath = ProjectFilePath;
+				}
+				return _project;
+			}
+			finally
+			{
+				_buildEnvironment.UnsetEnvironmentVars();
+			}
+		}
+
+		// Tweaks the project file a bit to ensure a succesfull build
+		private static XDocument TweakProjectDocument(XDocument projectDocument)
+		{
+			// Add SkipGetTargetFrameworkProperties to every ProjectReference
+			foreach (XElement projectReference in projectDocument.GetDescendants("ProjectReference").ToArray())
+			{
+				projectReference.AddChildElement("SkipGetTargetFrameworkProperties", "true");
+			}
+
+			// Removes all EnsureNuGetPackageBuildImports
+			foreach (XElement ensureNuGetPackageBuildImports in
+				projectDocument.GetDescendants("Target").Where(x => x.GetAttributeValue("Name") == "EnsureNuGetPackageBuildImports").ToArray())
+			{
+				ensureNuGetPackageBuildImports.Remove();
+			}
+
+			return projectDocument;
+		}
+
+		private ProjectCollection CreateProjectCollection()
+		{
+			ProjectCollection projectCollection = new ProjectCollection(_globalProperties);
+			projectCollection.RemoveAllToolsets(); // Make sure we're only using the latest tools
+			projectCollection.AddToolset(
+				new Toolset(ToolLocationHelper.CurrentToolsVersion, _buildEnvironment.GetToolsPath(), projectCollection, string.Empty));
+			projectCollection.DefaultToolsVersion = ToolLocationHelper.CurrentToolsVersion;
+			if (_logger != null)
+			{
+				projectCollection.RegisterLogger(_logger);
+			}
+			return projectCollection;
+		}
+
+		public ProjectInstance Compile()
+		{
+			if (_compiledProject != null)
+			{
+				return _compiledProject;
+			}
+			Project project = Load();
+			if (project == null)
+			{
+				return null;
+			}
+
+			// Compile the project
+			_buildEnvironment.SetEnvironmentVars(GlobalProperties);
+			try
+			{
+				ProjectInstance projectInstance = project.CreateProjectInstance();
+				if (!projectInstance.Build("Clean", _logger == null ? null : new ILogger[] { _logger }))
+				{
+					return null;
+				}
+				if (!projectInstance.Build("Compile", _logger == null ? null : new ILogger[] { _logger }))
+				{
+					return null;
+				}
+				_compiledProject = projectInstance;
+				return _compiledProject;
+			}
+			finally
+			{
+				_buildEnvironment.UnsetEnvironmentVars();
+			}
+		}
+
+		public IReadOnlyList<string> GetSourceFiles() =>
+			Compile()?.Items
+				.Where(x => x.ItemType == "CscCommandLineArgs" && !x.EvaluatedInclude.StartsWith("/"))
+				.Select(x => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.EvaluatedInclude)))
+				.ToList();
+
+		public IReadOnlyList<string> GetReferences() =>
+			Compile()?.Items
+				.Where(x => x.ItemType == "CscCommandLineArgs" && x.EvaluatedInclude.StartsWith("/reference:"))
+				.Select(x => x.EvaluatedInclude.Substring(11).Trim('"'))
+				.ToList();
+
+		public IReadOnlyList<string> GetProjectReferences() =>
+			Compile()?.Items
+				.Where(x => x.ItemType == "ProjectReference")
+				.Select(x => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(ProjectFilePath), x.EvaluatedInclude)))
+				.ToList();
+
+		public void SetGlobalProperty(string key, string value)
+		{
+			if (_project != null)
+			{
+				throw new InvalidOperationException("Can not change global properties once project has been loaded");
+			}
+			_globalProperties[key] = value;
+		}
+
+		public bool RemoveGlobalProperty(string key)
+		{
+			if (_project != null)
+			{
+				throw new InvalidOperationException("Can not change global properties once project has been loaded");
+			}
+			return _globalProperties.Remove(key);
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/ProjectAnalyzerExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/ProjectAnalyzerExtensions.cs
@@ -1,0 +1,220 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
+
+namespace DocGenerator.Buildalyzer
+{
+	public static class ProjectAnalyzerExtensions
+	{
+		/// <summary>
+		/// Gets a Roslyn workspace for the analyzed project.
+		/// </summary>
+		/// <param name="analyzer">The Buildalyzer project analyzer.</param>
+		/// <param name="addProjectReferences"><c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.</param>
+		/// <returns>A Roslyn workspace.</returns>
+		public static AdhocWorkspace GetWorkspace(this ProjectAnalyzer analyzer, bool addProjectReferences = false)
+		{
+			if (analyzer == null)
+			{
+				throw new ArgumentNullException(nameof(analyzer));
+			}
+			AdhocWorkspace workspace = new AdhocWorkspace();
+			AddToWorkspace(analyzer, workspace, addProjectReferences);
+			return workspace;
+		}
+
+		/// <summary>
+		/// Adds a project to an existing Roslyn workspace.
+		/// </summary>
+		/// <param name="analyzer">The Buildalyzer project analyzer.</param>
+		/// <param name="workspace">A Roslyn workspace.</param>
+		/// <param name="addProjectReferences"><c>true</c> to add projects to the workspace for project references that exist in the same <see cref="AnalyzerManager"/>.</param>
+		/// <returns>The newly added Roslyn project.</returns>
+		public static Project AddToWorkspace(this ProjectAnalyzer analyzer, AdhocWorkspace workspace, bool addProjectReferences = false)
+		{
+			if (analyzer == null)
+			{
+				throw new ArgumentNullException(nameof(analyzer));
+			}
+			if (workspace == null)
+			{
+				throw new ArgumentNullException(nameof(workspace));
+			}
+
+			// Get or create an ID for this project
+			string projectGuid = analyzer.CompiledProject?.GetPropertyValue("ProjectGuid");
+			ProjectId projectId = !string.IsNullOrEmpty(projectGuid)
+			                      && Guid.TryParse(analyzer.CompiledProject?.GetPropertyValue("ProjectGuid"), out var projectIdGuid)
+				? ProjectId.CreateFromSerialized(projectIdGuid)
+				: ProjectId.CreateNewId();
+
+			// Create and add the project
+			ProjectInfo projectInfo = GetProjectInfo(analyzer, workspace, projectId);
+			Solution solution = workspace.CurrentSolution.AddProject(projectInfo);
+
+			// Check if this project is referenced by any other projects in the workspace
+			foreach (Project existingProject in solution.Projects.ToArray())
+			{
+				if (!existingProject.Id.Equals(projectId)
+				    && analyzer.Manager.Projects.TryGetValue(existingProject.FilePath, out ProjectAnalyzer existingAnalyzer)
+				    && (existingAnalyzer.GetProjectReferences()?.Contains(analyzer.ProjectFilePath) ?? false))
+				{
+					// Add the reference to the existing project
+					ProjectReference projectReference = new ProjectReference(projectId);
+					solution = solution.AddProjectReference(existingProject.Id, projectReference);
+				}
+			}
+
+			// Apply solution changes
+			if (!workspace.TryApplyChanges(solution))
+			{
+				throw new InvalidOperationException("Could not apply workspace solution changes");
+			}
+
+			// Add any project references not already added
+			if(addProjectReferences)
+			{
+				foreach(ProjectAnalyzer referencedAnalyzer in GetReferencedAnalyzerProjects(analyzer))
+				{
+					// Check if the workspace contains the project inside the loop since adding one might also add this one due to transitive references
+					if(!workspace.CurrentSolution.Projects.Any(x => x.FilePath == referencedAnalyzer.ProjectFilePath))
+					{
+						AddToWorkspace(referencedAnalyzer, workspace, addProjectReferences);
+					}
+				}
+			}
+
+			// Find and return this project
+			return workspace.CurrentSolution.GetProject(projectId);
+		}
+
+		private static ProjectInfo GetProjectInfo(ProjectAnalyzer analyzer, AdhocWorkspace workspace, ProjectId projectId)
+		{
+			string projectName = Path.GetFileNameWithoutExtension(analyzer.ProjectFilePath);
+			string languageName = GetLanguageName(analyzer.ProjectFilePath);
+			ProjectInfo projectInfo = ProjectInfo.Create(
+				projectId,
+				VersionStamp.Create(),
+				projectName,
+				projectName,
+				languageName,
+				filePath: analyzer.ProjectFilePath,
+				outputFilePath: analyzer.CompiledProject?.GetPropertyValue("TargetPath"),
+				documents: GetDocuments(analyzer, projectId),
+				projectReferences: GetExistingProjectReferences(analyzer, workspace),
+				metadataReferences: GetMetadataReferences(analyzer),
+				compilationOptions: CreateCompilationOptions(analyzer.Project, languageName));
+			return projectInfo;
+		}
+
+		private static CompilationOptions CreateCompilationOptions(Microsoft.Build.Evaluation.Project project, string languageName)
+		{
+			string outputType = project.GetPropertyValue("OutputType");
+			OutputKind? kind = null;
+			switch (outputType)
+			{
+				case "Library":
+					kind = OutputKind.DynamicallyLinkedLibrary;
+					break;
+				case "Exe":
+					kind = OutputKind.ConsoleApplication;
+					break;
+				case "Module":
+					kind = OutputKind.NetModule;
+					break;
+				case "Winexe":
+					kind = OutputKind.WindowsApplication;
+					break;
+			}
+
+			if (kind.HasValue)
+			{
+				if (languageName == LanguageNames.CSharp)
+				{
+					return new CSharpCompilationOptions(kind.Value);
+				}
+				if (languageName == LanguageNames.VisualBasic)
+				{
+					return new VisualBasicCompilationOptions(kind.Value);
+				}
+			}
+
+			return null;
+		}
+
+		private static IEnumerable<ProjectReference> GetExistingProjectReferences(ProjectAnalyzer analyzer, AdhocWorkspace workspace) =>
+			analyzer.GetProjectReferences()
+				?.Select(x => workspace.CurrentSolution.Projects.FirstOrDefault(y => y.FilePath == x))
+				.Where(x => x != null)
+				.Select(x => new ProjectReference(x.Id))
+			?? Array.Empty<ProjectReference>();
+
+		private static IEnumerable<ProjectAnalyzer> GetReferencedAnalyzerProjects(ProjectAnalyzer analyzer) =>
+			analyzer.GetProjectReferences()
+				?.Select(x => analyzer.Manager.Projects.TryGetValue(x, out ProjectAnalyzer a) ? a : null)
+				.Where(x => x != null)
+			?? Array.Empty<ProjectAnalyzer>();
+
+		private static IEnumerable<DocumentInfo> GetDocuments(ProjectAnalyzer analyzer, ProjectId projectId) =>
+			analyzer
+				.GetSourceFiles()
+				?.Where(File.Exists)
+				.Select(x => DocumentInfo.Create(
+					DocumentId.CreateNewId(projectId),
+					Path.GetFileName(x),
+					loader: TextLoader.From(
+						TextAndVersion.Create(
+							SourceText.From(File.ReadAllText(x)), VersionStamp.Create())),
+					filePath: x))
+			?? Array.Empty<DocumentInfo>();
+
+		private static IEnumerable<MetadataReference> GetMetadataReferences(ProjectAnalyzer analyzer) =>
+			analyzer
+				.GetReferences()
+				?.Where(File.Exists)
+				.Select(x => MetadataReference.CreateFromFile(x))
+			?? (IEnumerable<MetadataReference>)Array.Empty<MetadataReference>();
+
+		private static string GetLanguageName(string projectPath)
+		{
+			switch (Path.GetExtension(projectPath))
+			{
+				case ".csproj":
+					return LanguageNames.CSharp;
+				case ".vbproj":
+					return LanguageNames.VisualBasic;
+				default:
+					throw new InvalidOperationException("Could not determine supported language from project path");
+			}
+		}
+	}
+}

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/XDocumentExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/XDocumentExtensions.cs
@@ -1,0 +1,47 @@
+﻿#region License
+//MIT License
+//
+//Copyright (c) 2017 Dave Glick
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace DocGenerator.Buildalyzer
+{
+	internal static class XDocumentExtensions
+	{
+		public static IEnumerable<XElement> GetDescendants(this XDocument document, string name) =>
+			document.Descendants().Where(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
+
+		public static IEnumerable<XElement> GetDescendants(this XElement element, string name) =>
+			element.Descendants().Where(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
+
+		public static string GetAttributeValue(this XElement element, string name) =>
+			element.Attributes().FirstOrDefault(x => string.Equals(x.Name.LocalName, name, StringComparison.OrdinalIgnoreCase))?.Value;
+
+		// Adds a child element with the same namespace as the parent
+		public static void AddChildElement(this XElement element, string name, string value) =>
+			element.Add(new XElement(XName.Get(name, element.Name.NamespaceName), value));
+	}
+}

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -8,6 +8,8 @@
     <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
     <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.2" />

--- a/src/CodeGeneration/DocGenerator/Documentation/Blocks/CSharpBlock.cs
+++ b/src/CodeGeneration/DocGenerator/Documentation/Blocks/CSharpBlock.cs
@@ -16,7 +16,7 @@ namespace DocGenerator.Documentation.Blocks
         private List<string> Callouts { get; } = new List<string>();
 
         public CSharpBlock(SyntaxNode node, int depth, string memberName = null)
-            : base(node.WithoutLeadingTrivia().ToFullString(),
+            : base(node.WithoutLeadingTrivia().ToFullStringWithoutPragmaWarningDirectiveTrivia(),
                 node.StartingLine(),
                 node.IsKind(SyntaxKind.ClassDeclaration) ? depth : depth + 2,
                 "csharp",
@@ -24,7 +24,7 @@ namespace DocGenerator.Documentation.Blocks
         {
         }
 
-        public void AddNode(SyntaxNode node) => Lines.Add(node.WithLeadingEndOfLineTrivia().ToFullString());
+        public void AddNode(SyntaxNode node) => Lines.Add(node.WithLeadingEndOfLineTrivia().ToFullStringWithoutPragmaWarningDirectiveTrivia());
 
         public override string ToAsciiDoc()
         {
@@ -52,7 +52,7 @@ namespace DocGenerator.Documentation.Blocks
 
         /// <summary>
         /// Extracts the callouts from code. The callout comment is defined inline within
-        /// source code to play nicely with C# semantics, but needs to be extracted and placed after the 
+        /// source code to play nicely with C# semantics, but needs to be extracted and placed after the
         /// source block delimiter to be valid asciidoc.
         /// </summary>
         private string ExtractCallOutsFromCode(string value)

--- a/src/CodeGeneration/DocGenerator/Documentation/Files/CSharpDocumentationFile.cs
+++ b/src/CodeGeneration/DocGenerator/Documentation/Files/CSharpDocumentationFile.cs
@@ -16,17 +16,17 @@ namespace DocGenerator.Documentation.Files
         private readonly Document _document;
         private readonly Dictionary<string, Project> _projects;
 
-        public CSharpDocumentationFile(Document document, Dictionary<string, Project> projects) 
+        public CSharpDocumentationFile(Document document, Dictionary<string, Project> projects)
             : base(new FileInfo(document.FilePath))
         {
             _document = document;
             _projects = projects;
         }
 
-        public override async Task SaveToDocumentationFolderAsync()
+	    public override async Task SaveToDocumentationFolderAsync()
         {
             var converter = new DocConverter();
-            var blocks = await converter.ConvertAsync(_document).ConfigureAwait(false);
+	        var blocks = await converter.ConvertAsync(_document).ConfigureAwait(false);
 
             if (!blocks.Any()) return;
 
@@ -36,7 +36,7 @@ namespace DocGenerator.Documentation.Files
                 foreach (var block in blocks)
                     await writer.WriteLineAsync(block.ToAsciiDoc()).ConfigureAwait(false);
             }
-         
+
             var destination = this.CreateDocumentationLocation();
 
             // Now add Asciidoc headers, rearrange sections, etc.

--- a/src/CodeGeneration/DocGenerator/StringExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/StringExtensions.cs
@@ -31,8 +31,8 @@ namespace DocGenerator
 		public static string LowercaseHyphenToPascal(this string lowercaseHyphenatedInput)
 		{
 			return Regex.Replace(
-                lowercaseHyphenatedInput.Replace("-", " "), 
-                @"\b([a-z])", 
+                lowercaseHyphenatedInput.Replace("-", " "),
+                @"\b([a-z])",
                 m => m.Captures[0].Value.ToUpper());
 		}
 
@@ -76,7 +76,7 @@ namespace DocGenerator
 		}
 
         ///<summary>
-        /// Removes the specified number of tabs (or spaces, assuming 4 spaces = 1 tab) 
+        /// Removes the specified number of tabs (or spaces, assuming 4 spaces = 1 tab)
         /// from each line of the input
         /// </summary>
         public static string RemoveNumberOfLeadingTabsOrSpacesAfterNewline(this string input, int numberOfTabs)
@@ -146,7 +146,16 @@ namespace DocGenerator
 			{ "_ctxNumberofCommits", "\"_source.numberOfCommits > 0\"" },
 			{ "Project.First.Name", "\"Lesch Group\"" },
 			{ "Project.First.NumberOfCommits", "775" },
-			{ "LastNameSearch", "\"Stokes\"" }
+			{ "LastNameSearch", "\"Stokes\"" },
+			{ "First.Language", "\"painless\"" },
+			{ "First.Init", "\"params._agg.map = [:]\"" },
+			{ "First.Map", "\"if (params._agg.map.containsKey(doc['state'].value)) params._agg.map[doc['state'].value] += 1 else params._agg.map[doc['state'].value] = 1;\"" },
+			{ "First.Reduce", "\"def reduce = [:]; for (agg in params._aggs) { for (entry in agg.map.entrySet()) { if (reduce.containsKey(entry.getKey())) reduce[entry.getKey()] += entry.getValue(); else reduce[entry.getKey()] = entry.getValue(); } } return reduce;\"" },
+			{ "Second.Language", "\"painless\"" },
+			{ "Second.Combine", "\"def sum = 0.0; for (c in params._agg.commits) { sum += c } return sum\"" },
+			{ "Second.Init", "\"params._agg.commits = []\"" },
+			{ "Second.Map", "\"if (doc['state'].value == \\\"Stable\\\") { params._agg.commits.add(doc['numberOfCommits'].value) }\"" },
+			{ "Second.Reduce", "\"def sum = 0.0; for (a in params._aggs) { sum += a } return sum\"" },
 		};
 
 		public static bool TryGetJsonForAnonymousType(this string anonymousTypeString, out string json)

--- a/src/CodeGeneration/DocGenerator/SyntaxNodeExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/SyntaxNodeExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
@@ -15,7 +16,7 @@ namespace DocGenerator
         /// Determines if the node should be hidden i.e. not included in the documentation,
         /// based on the precedence of a //hide single line comment
         /// </summary>
-        public static bool ShouldBeHidden(this SyntaxNode node) => 
+        public static bool ShouldBeHidden(this SyntaxNode node) =>
             node.HasLeadingTrivia && ShouldBeHidden(node, node.GetLeadingTrivia());
 
         public static bool ShouldBeHidden(this SyntaxNode node, SyntaxTriviaList leadingTrivia) =>
@@ -26,7 +27,7 @@ namespace DocGenerator
         /// Determines if the node should be json serialized based on the precedence of
         /// a //json single line comment
         /// </summary>
-        public static bool ShouldBeConvertedToJson(this SyntaxNode node) => 
+        public static bool ShouldBeConvertedToJson(this SyntaxNode node) =>
             node.HasLeadingTrivia && ShouldBeConvertedToJson(node, node.GetLeadingTrivia());
 
         /// <summary>
@@ -58,7 +59,7 @@ namespace DocGenerator
         /// Determines if the node is preceded by any multiline documentation.
         /// </summary>
         /// <param name="node">The node.</param>
-        public static bool HasMultiLineDocumentationCommentTrivia(this SyntaxNode node) => 
+        public static bool HasMultiLineDocumentationCommentTrivia(this SyntaxNode node) =>
             node.HasLeadingTrivia &&
 	        node.GetLeadingTrivia().Any(c => c.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia));
 
@@ -87,7 +88,7 @@ namespace DocGenerator
         /// </summary>
         /// <param name="node">The node.</param>
         /// <returns></returns>
-        public static int StartingLine(this SyntaxNode node) => 
+        public static int StartingLine(this SyntaxNode node) =>
             node.SyntaxTree.GetLineSpan(node.Span).StartLinePosition.Line;
 
 	    public static SyntaxNode WithLeadingEndOfLineTrivia(this SyntaxNode node)
@@ -101,5 +102,16 @@ namespace DocGenerator
 
 	        return node;
 	    }
+
+		/// <summary>
+		/// Gets the text representation of a syntax node without #pragma directives
+		/// </summary>
+		/// <param name="node">The node.</param>
+		/// <returns></returns>
+		public static string ToFullStringWithoutPragmaWarningDirectiveTrivia(this SyntaxNode node)
+		{
+			var pragma = node.DescendantTrivia(s => true, true).Where(t => t.IsKind(SyntaxKind.PragmaWarningDirectiveTrivia));
+			return node.ReplaceTrivia(pragma, (s, r) => default(SyntaxTrivia)).ToFullString();
+		}
     }
 }

--- a/src/CodeGeneration/outputpath.props
+++ b/src/CodeGeneration/outputpath.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutputPath Condition="'$(OutputPathBaseDir)' != ''">$(OutputPathBaseDir)\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/Tests/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregationUsageTests.cs
@@ -84,6 +84,7 @@ namespace Tests.Aggregations.Metric.ScriptedMetric
 	/// </summary>
 	public class ScriptedMetricMultiAggregationTests : AggregationUsageTestBase
 	{
+		// hide
 		class Scripted
 		{
 			public string Language { get; set; }

--- a/src/Tests/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringUsageTests.cs
+++ b/src/Tests/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringUsageTests.cs
@@ -39,7 +39,7 @@ namespace Tests.QueryDsl.FullText.SimpleQueryString
 			Analyzer = "standard",
 			DefaultOperator = Operator.Or,
 			Flags = SimpleQueryStringFlags.And|SimpleQueryStringFlags.Near,
-#pragma warning disable 618 // usage of lowercase_expanded_terms and locale
+#pragma warning disable 618
 			Locale = "en_US",
 			LowercaseExpendedTerms = true,
 #pragma warning restore 618
@@ -49,7 +49,7 @@ namespace Tests.QueryDsl.FullText.SimpleQueryString
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
-#pragma warning disable 618 // usage of lowercase_expanded_terms and locale
+#pragma warning disable 618
 			.SimpleQueryString(c => c
 				.Name("named_query")
 				.Boost(1.1)

--- a/src/build/Clients.Common.targets
+++ b/src/build/Clients.Common.targets
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Default Version numbers -->
+    <CurrentVersion>0.0.0-bad</CurrentVersion>
+    <CurrentAssemblyVersion>0.0.0</CurrentAssemblyVersion>
+    <CurrentAssemblyFileVersion>0.0.0.0</CurrentAssemblyFileVersion>
+    <!-- 'dotnet xunit' does a build but has no way to pass properties or prevent build so we snoop for TRAVIS here
+    Ideally we handle this in the FAKE script (which we do for 'dotnet build')
+    TODO too lazy to write and test a <CHOOSE>
+    -->
+    <DotNetCoreOnly Condition="'$(TRAVIS)'=='true'">1</DotNetCoreOnly>
+    <DotNetCoreOnly Condition="'$(TRAVIS)'==''"></DotNetCoreOnly>
+    <DoSourceLink></DoSourceLink>
+
+    <!-- Version and Informational reflect actual version -->
+    <Version>$(CurrentVersion)</Version>
+    <InformationalVersion>$(CurrentVersion)</InformationalVersion>
+    <!-- Assembly version is sticky to MAJOR.0.0.0 to avoid binding redirects because we strong name our assemblies -->
+    <AssemblyVersion>$(CurrentAssemblyVersion)</AssemblyVersion>
+    <!-- File version reflects actual version number without prelease since that not allowed in its struct -->
+    <FileVersion>$(CurrentAssemblyFileVersion)</FileVersion>
+
+    <SignAssembly Condition="'$(DotNetCoreOnly)'==''">true</SignAssembly>
+    <AssemblyOriginatorKeyFile Condition="'$(DotNetCoreOnly)'==''">..\..\build\keys\keypair.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile Condition="'$(DotNetCoreOnly)'==''">true</GenerateDocumentationFile>
+    <NoWarn>1591,1572,1571,1573,1587,1570</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
+    <DefineConstants Condition="'$(TargetFramework)'=='netstandard1.3' OR '$(DotNetCoreOnly)'=='1'">$(DefineConstants);DOTNETCORE</DefineConstants>
+    <DebugType Condition="'$(DotNetCoreOnly)'==''">embedded</DebugType>
+    <DebugType Condition="'$(Configuration)'=='Debug'">full</DebugType>
+    <SourceLink Condition="'$(DoSourceLink)'!=''">$(BaseIntermediateOutputPath)\sl-$(MsBuildProjectName)-$(TargetFramework).json</SourceLink>
+    <RepoUri>https://raw.githubusercontent.com/elastic/elasticsearch-net</RepoUri>
+  </PropertyGroup>
+
+  <Target Name="GenerateSourceLink" BeforeTargets="CoreCompile" Condition="'$(DoSourceLink)'!=''">
+    <Delete Files="$(SourceLink)" Condition="Exists('$(SourceLink)')" />
+    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="LatestCommit" />
+    </Exec>
+    <Exec Command="git rev-parse --show-toplevel" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitRootFolder" />
+    </Exec>
+    <WriteLinesToFile File="$(SourceLink)" Lines="{&quot;documents&quot;: { &quot;$([System.IO.Path]::GetFullPath('$(GitRootFolder)/').Replace('\','\\'))*&quot; : &quot;$(RepoUri)/$(LatestCommit)/*&quot; }}" />
+  </Target>
+</Project>


### PR DESCRIPTION
With the move to the newer csproj format, the DocGenerator project no longer generated documentation from the Tests source documents, due to Roslyn's `MsBuildWorkspace` lack of support for the new project format; it is possible to get the project correctly compiling, but none of the projects within a solution have documents associated with them.

This PR gets documentation generation working again by using components from Buildalyzer to create an `AdhocWorkspace`. Source documents within the Tests project still need to be manually added to the project because Buildalyzer also does not add documents within a project directory by convention either, similar to `MsBuildWorkspace`.

The DocGenerator project requires that the solution be compiled before running, so that the XML comment files exist on the filesystem. Whilst the process will not fail, since Source documents are not added to the Nest and Elasticsearch.Net projects, compiling those projects to emit a documentation file will yield an empty file.

Doc generation should be revisited when Roslyn's support for the new project format has improved. 