### PR TITLE
6.0 Script changes

### DIFF
--- a/src/Nest/Modules/Scripting/IStoredScript.cs
+++ b/src/Nest/Modules/Scripting/IStoredScript.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Elasticsearch.Net;
+using Newtonsoft.Json;
 
 namespace Nest
 {
@@ -6,31 +7,61 @@ namespace Nest
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<StoredScript>))]
 	public interface IStoredScript
 	{
+		[JsonProperty("lang")]
+		string Lang { get; set; }
+
 		[JsonProperty("source")]
 		string Source { get; set; }
 	}
+
 	public class StoredScript : IStoredScript
 	{
+		[JsonProperty("lang")]
+		string IStoredScript.Lang { get; set; }
+
 		[JsonProperty("source")]
 		string IStoredScript.Source { get; set; }
 
 		//used for deserialization
-		internal StoredScript() { }
-
-		protected StoredScript(string source)
+		internal StoredScript()
 		{
+		}
+
+		/// <summary>
+		/// Stored Script constructor
+		/// </summary>
+		/// <param name="lang">Used only for Mustache and Lucene Expression templates.</param>
+		/// <param name="source">Script source</param>
+		protected StoredScript(string lang, string source)
+		{
+			((IStoredScript) this).Lang = lang;
 			((IStoredScript) this).Source = source;
 		}
 	}
 
 	public class PainlessScript : StoredScript
 	{
-		public PainlessScript(string source) : base(source) { }
+		public PainlessScript(string source) : base(null, source)
+		{
+		}
+	}
+
+	public class LuceneExpressionScript : StoredScript
+	{
+		private static readonly string Lang = ScriptLang.Expression.GetStringValue();
+		public LuceneExpressionScript(string source) : base(Lang, source) { }
+	}
+
+	public class MustacheScript : StoredScript
+	{
+		private static readonly string Lang = ScriptLang.Mustache.GetStringValue();
+	 	public MustacheScript(string source) : base(Lang, source) { }
 	}
 
 	public class StoredScriptDescriptor : DescriptorBase<StoredScriptDescriptor, IStoredScript>, IStoredScript
 	{
 		string IStoredScript.Source { get; set; }
+		string IStoredScript.Lang { get; set; }
 
 		public StoredScriptDescriptor Source(string source) => Assign(a => a.Source = source);
 	}

--- a/src/Nest/Modules/Scripting/IStoredScript.cs
+++ b/src/Nest/Modules/Scripting/IStoredScript.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using Elasticsearch.Net;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Nest
 {
@@ -8,66 +6,31 @@ namespace Nest
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<StoredScript>))]
 	public interface IStoredScript
 	{
-		[JsonProperty("lang")]
-		string Lang { get; set; }
-
 		[JsonProperty("source")]
 		string Source { get; set; }
 	}
 	public class StoredScript : IStoredScript
 	{
-		[JsonProperty("lang")]
-		string IStoredScript.Lang { get; set; }
 		[JsonProperty("source")]
 		string IStoredScript.Source { get; set; }
 
 		//used for deserialization
 		internal StoredScript() { }
 
-		protected StoredScript(string lang, string source)
+		protected StoredScript(string source)
 		{
-			((IStoredScript) this).Lang = lang;
 			((IStoredScript) this).Source = source;
 		}
 	}
 
 	public class PainlessScript : StoredScript
 	{
-		private static readonly string Lang = ScriptLang.Painless.GetStringValue();
-		public PainlessScript(string source) : base(Lang, source) { }
-	}
-	public class GroovyScript : StoredScript
-	{
-		private static readonly string Lang = ScriptLang.Groovy.GetStringValue();
-		public GroovyScript(string source) : base(Lang, source) { }
-	}
-	public class JavaScriptScript : StoredScript
-	{
-		private static readonly string Lang = ScriptLang.JS.GetStringValue();
-		public JavaScriptScript(string source) : base(Lang, source) { }
-	}
-	public class PythonScript : StoredScript
-	{
-		private static readonly string Lang = ScriptLang.Python.GetStringValue();
-		public PythonScript(string source) : base(Lang, source) { }
-	}
-	public class LuceneExpressionScript : StoredScript
-	{
-		private static readonly string Lang = ScriptLang.Expression.GetStringValue();
-		public LuceneExpressionScript(string source) : base(Lang, source) { }
-	}
-	public class MustacheScript : StoredScript
-	{
-		private static readonly string Lang = ScriptLang.Mustache.GetStringValue();
-		public MustacheScript(string source) : base(Lang, source) { }
+		public PainlessScript(string source) : base(source) { }
 	}
 
 	public class StoredScriptDescriptor : DescriptorBase<StoredScriptDescriptor, IStoredScript>, IStoredScript
 	{
-		string IStoredScript.Lang { get; set; }
 		string IStoredScript.Source { get; set; }
-
-		public StoredScriptDescriptor Lang(string lang) => Assign(a => a.Lang = lang);
 
 		public StoredScriptDescriptor Source(string source) => Assign(a => a.Source = source);
 	}

--- a/src/Nest/Modules/Scripting/IStoredScript.cs
+++ b/src/Nest/Modules/Scripting/IStoredScript.cs
@@ -3,17 +3,27 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// A Stored script
+	/// </summary>
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<StoredScript>))]
 	public interface IStoredScript
 	{
+		/// <summary>
+		/// The script language
+		/// </summary>
 		[JsonProperty("lang")]
 		string Lang { get; set; }
 
+		/// <summary>
+		/// The script source
+		/// </summary>
 		[JsonProperty("source")]
 		string Source { get; set; }
 	}
 
+	/// <inheritdoc />
 	public class StoredScript : IStoredScript
 	{
 		[JsonProperty("lang")]
@@ -23,27 +33,25 @@ namespace Nest
 		string IStoredScript.Source { get; set; }
 
 		//used for deserialization
-		internal StoredScript()
-		{
-		}
+		internal StoredScript() {}
 
 		/// <summary>
-		/// Stored Script constructor
+		/// Instantiates a new instance of <see cref="StoredScript"/>
 		/// </summary>
-		/// <param name="lang">Used only for Mustache and Lucene Expression templates.</param>
+		/// <param name="lang">Script language</param>
 		/// <param name="source">Script source</param>
 		protected StoredScript(string lang, string source)
 		{
-			((IStoredScript) this).Lang = lang;
-			((IStoredScript) this).Source = source;
+			IStoredScript self = this;
+			self.Lang = lang;
+			self.Source = source;
 		}
 	}
 
 	public class PainlessScript : StoredScript
 	{
-		public PainlessScript(string source) : base(null, source)
-		{
-		}
+		private static readonly string Lang = ScriptLang.Painless.GetStringValue();
+		public PainlessScript(string source) : base(Lang, source) { }
 	}
 
 	public class LuceneExpressionScript : StoredScript
@@ -64,5 +72,9 @@ namespace Nest
 		string IStoredScript.Lang { get; set; }
 
 		public StoredScriptDescriptor Source(string source) => Assign(a => a.Source = source);
+
+		public StoredScriptDescriptor Lang(string lang) => Assign(a => a.Lang = lang);
+
+		public StoredScriptDescriptor Lang(ScriptLang lang) => Assign(a => a.Lang = lang.GetStringValue());
 	}
 }

--- a/src/Nest/Modules/Scripting/PutScript/PutScriptRequest.cs
+++ b/src/Nest/Modules/Scripting/PutScript/PutScriptRequest.cs
@@ -22,8 +22,19 @@ namespace Nest
 		public PutScriptDescriptor Script(Func<StoredScriptDescriptor, IStoredScript> selector) =>
 			Assign(a => a.Script = selector?.Invoke(new StoredScriptDescriptor()));
 
+		/// <summary>
+		/// A Painless language script
+		/// </summary>
 		public PutScriptDescriptor Painless(string source) => Assign(a => a.Script = new PainlessScript(source));
+
+		/// <summary>
+		/// A Lucene expression language script
+		/// </summary>
 		public PutScriptDescriptor LuceneExpression(string source) => Assign(a => a.Script = new LuceneExpressionScript(source));
+
+		/// <summary>
+		/// A Mustache template language script
+		/// </summary>
 		public PutScriptDescriptor Mustache(string source) => Assign(a => a.Script = new MustacheScript(source));
 	}
 }

--- a/src/Nest/Modules/Scripting/PutScript/PutScriptRequest.cs
+++ b/src/Nest/Modules/Scripting/PutScript/PutScriptRequest.cs
@@ -23,5 +23,7 @@ namespace Nest
 			Assign(a => a.Script = selector?.Invoke(new StoredScriptDescriptor()));
 
 		public PutScriptDescriptor Painless(string source) => Assign(a => a.Script = new PainlessScript(source));
+		public PutScriptDescriptor LuceneExpression(string source) => Assign(a => a.Script = new LuceneExpressionScript(source));
+		public PutScriptDescriptor Mustache(string source) => Assign(a => a.Script = new MustacheScript(source));
 	}
 }

--- a/src/Nest/Modules/Scripting/PutScript/PutScriptRequest.cs
+++ b/src/Nest/Modules/Scripting/PutScript/PutScriptRequest.cs
@@ -23,10 +23,5 @@ namespace Nest
 			Assign(a => a.Script = selector?.Invoke(new StoredScriptDescriptor()));
 
 		public PutScriptDescriptor Painless(string source) => Assign(a => a.Script = new PainlessScript(source));
-		public PutScriptDescriptor Groovy(string source) => Assign(a => a.Script = new GroovyScript(source));
-		public PutScriptDescriptor JavaScript(string source) => Assign(a => a.Script = new JavaScriptScript(source));
-		public PutScriptDescriptor Python(string source) => Assign(a => a.Script = new PythonScript(source));
-		public PutScriptDescriptor LuceneExpression(string source) => Assign(a => a.Script = new LuceneExpressionScript(source));
-		public PutScriptDescriptor Mustache(string source) => Assign(a => a.Script = new MustacheScript(source));
 	}
 }

--- a/src/Nest/Modules/Scripting/ScriptLang.cs
+++ b/src/Nest/Modules/Scripting/ScriptLang.cs
@@ -10,15 +10,6 @@ namespace Nest
 		[EnumMember(Value = "painless")]
 		Painless,
 
-		[EnumMember(Value = "groovy")]
-		Groovy,
-
-		[EnumMember(Value = "js")]
-		JS,
-
-		[EnumMember(Value = "python")]
-		Python,
-
 		[EnumMember(Value = "expression")]
 		Expression,
 

--- a/src/Tests/Modules/Scripting/PutScript/PutScriptApiTests.cs
+++ b/src/Tests/Modules/Scripting/PutScript/PutScriptApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Elasticsearch.Net;
+using FluentAssertions;
 using Nest;
 using Tests.Framework;
 using Tests.Framework.Integration;
@@ -9,12 +10,11 @@ using Xunit;
 namespace Tests.Modules.Scripting.PutScript
 {
 	public class PutScriptApiTests
-		: ApiTestBase<ReadOnlyCluster, IPutScriptResponse, IPutScriptRequest, PutScriptDescriptor, PutScriptRequest>
+		: ApiIntegrationTestBase<ReadOnlyCluster, IPutScriptResponse, IPutScriptRequest, PutScriptDescriptor, PutScriptRequest>
 	{
 		public PutScriptApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		private static readonly string _name = "scrpt1";
-
 
 		protected override LazyResponses ClientUsage() => Calls(
 			fluent: (client, f) => client.PutScript(_name, f),
@@ -25,12 +25,18 @@ namespace Tests.Modules.Scripting.PutScript
 
 		protected override HttpMethod HttpMethod => HttpMethod.PUT;
 		protected override string UrlPath => $"/_scripts/{_name}";
+		protected override int ExpectStatusCode => 200;
+		protected override bool ExpectIsValid => true;
 
 		protected override bool SupportsDeserialization => false;
 
-		protected override object ExpectJson { get; } = new
+		protected override object ExpectJson => new
 		{
-			script = new { source = "1+1" }
+			script = new
+			{
+				lang = "painless",
+				source = "1+1"
+			}
 		};
 
 		protected override PutScriptDescriptor NewDescriptor() => new PutScriptDescriptor(_name);
@@ -42,5 +48,11 @@ namespace Tests.Modules.Scripting.PutScript
 		{
 			Script = new PainlessScript("1+1")
 		};
+
+		protected override void ExpectResponse(IPutScriptResponse response)
+		{
+			response.ShouldBeValid();
+			response.Acknowledged.Should().BeTrue();
+		}
 	}
 }

--- a/src/Tests/Modules/Scripting/PutScript/PutScriptApiTests.cs
+++ b/src/Tests/Modules/Scripting/PutScript/PutScriptApiTests.cs
@@ -30,7 +30,7 @@ namespace Tests.Modules.Scripting.PutScript
 
 		protected override object ExpectJson { get; } = new
 		{
-			script = new { lang = "painless", source = "1+1" }
+			script = new { source = "1+1" }
 		};
 
 		protected override PutScriptDescriptor NewDescriptor() => new PutScriptDescriptor(_name);


### PR DESCRIPTION
PR may contradict breaking change information here: https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_60_scripting_changes.html#_stored_search_template_apis_removed

---

- Groovy, JavaScript, and Python languages removed
The Groovy, JavaScript, and Python scripting languages were deprecated in elasticsearch 5.0 and have now been removed. Use painless instead.

- lang can no longer be specified when using a stored script as part of a request
The lang variable can no longer be specified as part of a request that uses a stored script otherwise an error will occur. Note that a request using a stored script is different from a request that puts a stored script. The language of the script has already been stored as part of the cluster state and an id is sufficient to access all of the information necessary to execute a stored script.

- lang can no longer be used when putting, getting, or deleting a stored script
Stored scripts can no longer have the lang parameter specified as part of the url when performing PUT, GET, and DELETE actions on the _scripts/ path. All stored scripts must have a unique id as the namespace is only id now and no longer lang and id.

Addresses: https://github.com/elastic/elasticsearch-net/issues/2935
and items on https://github.com/elastic/elasticsearch-net/issues/2923