### PR TITLE
Change Node settings to Dictionary<string,object>

### DIFF
--- a/src/Elasticsearch.Net/ConnectionPool/Node.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/Node.cs
@@ -47,8 +47,8 @@ namespace Elasticsearch.Net
 		/// <summary>The name of the node, defaults to null when unknown/unspecified</summary>
 		public string Name { get; set; }
 
-		private static readonly IReadOnlyDictionary<string, string> EmptySettings = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
-		public IReadOnlyDictionary<string, string> Settings { get; set; } = EmptySettings;
+		private static readonly IReadOnlyDictionary<string, object> EmptySettings = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+		public IReadOnlyDictionary<string, object> Settings { get; set; } = EmptySettings;
 
 		/// <summary> The number of failed attempts trying to use this node, resets when a node is marked alive</summary>
 		public int FailedAttempts { get; private set; }

--- a/src/Elasticsearch.Net/Responses/Sniff/SniffResponse.cs
+++ b/src/Elasticsearch.Net/Responses/Sniff/SniffResponse.cs
@@ -53,7 +53,7 @@ namespace Elasticsearch.Net
 					HoldsData = info.HoldsData,
 					IngestEnabled = info.IngestEnabled,
 					HttpEnabled = info.HttpEnabled,
-					Settings = new ReadOnlyDictionary<string, string>(info.settings)
+					Settings = new ReadOnlyDictionary<string, object>(info.settings)
 				};
 				yield return node;
 			}
@@ -70,7 +70,7 @@ namespace Elasticsearch.Net
 		public string build_hash { get; set; }
 		public IList<string> roles { get; set; }
 		public NodeInfoHttp http { get; set; }
-		public IDictionary<string, string> settings { get; set; }
+		public IDictionary<string, object> settings { get; set; }
 
 		internal bool MasterEligible => this.roles?.Contains("master") ?? false;
 		internal bool HoldsData => this.roles?.Contains("data") ?? false;

--- a/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -200,8 +200,8 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 
 			var pool = new StickySniffingConnectionPool(uris, n =>
 				(n.ClientNode ? 10 : 0)
-				+ (n.Settings.TryGetValue("node.attr.rack_id", out string rackId)
-				   		&& rackId == "rack_one" ? 10 : 0));
+				+ (n.Settings.TryGetValue("node.attr.rack_id", out var rackId)
+				   		&& rackId.ToString() == "rack_one" ? 10 : 0));
 
 			pool.SupportsReseeding.Should().BeTrue();
 			pool.SupportsPinging.Should().BeTrue();

--- a/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
@@ -215,7 +215,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 					.DisablePing() // <1> for testing simplicity, disable pings
 					.NodePredicate(node => // <2> We only want to execute API calls to nodes in rack_one
 						node.Settings.ContainsKey(setting) &&
-						node.Settings[setting] == value
+						node.Settings[setting].ToString() == value
 					)
 				)
 			)

--- a/src/Tests/ClientConcepts/ConnectionPooling/Sticky/StickySniffingConnectionPool.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Sticky/StickySniffingConnectionPool.doc.cs
@@ -50,7 +50,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sticky
 				.Select(i => new Uri($"http://localhost:{9200 + i}"))
 				.Select((u, i) => new Node(u)
 				{
-					Settings = new Dictionary<string, string> {{"rack", $"rack_{u.Port - 9200}"}}
+					Settings = new Dictionary<string, object> {{"rack", $"rack_{u.Port - 9200}"}}
 				});
 
 			/** We set up a cluster with 4 nodes all having a different rack id
@@ -68,8 +68,8 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sticky
 					.ClientCalls(p => p.SucceedAlways()))
 				)
 				.StickySniffingConnectionPool(n=>
-					(n.Settings.TryGetValue("rack", out string v) && v == "rack_2" ? 10 : 0)
-					+(n.Settings.TryGetValue("rack", out string r) && r == "rack_11" ? 10 : 0)
+					(n.Settings.TryGetValue("rack", out var v) && v.ToString() == "rack_2" ? 10 : 0)
+					+(n.Settings.TryGetValue("rack", out var r) && r.ToString() == "rack_11" ? 10 : 0)
 				)
 				.Settings(p => p.DisablePing().SniffOnStartup(false))
 			);
@@ -105,7 +105,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sticky
 				.Select(i => new Uri($"http://localhost:{9200 + i}"))
 				.Select((u, i) => new Node(u)
 				{
-					Settings = new Dictionary<string, string> {{"rack", $"rack_{u.Port - 9200}"}}
+					Settings = new Dictionary<string, object> {{"rack", $"rack_{u.Port - 9200}"}}
 				});
 
 			/** We seed a cluster with an array of 4 Uri's starting at port 9200.
@@ -119,7 +119,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sticky
 					.ClientCalls(p => p.SucceedAlways()))
 				)
 				.StickySniffingConnectionPool(n=>
-					(n.Settings.TryGetValue("rack", out string v) && v == "rack_2" ? 10 : 0)
+					(n.Settings.TryGetValue("rack", out var v) && v.ToString() == "rack_2" ? 10 : 0)
 				)
 				.Settings(p => p.DisablePing())
 			);

--- a/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
+++ b/src/Tests/Framework/VirtualClustering/VirtualCluster.cs
@@ -56,7 +56,7 @@ namespace Tests.Framework
 		public VirtualCluster HasSetting(string key, string value, params int[] ports)
 		{
 			foreach (var node in this._nodes.Where(n => ports.Contains(n.Uri.Port)))
-				node.Settings = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>{{key, value}});
+				node.Settings = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>{{key, value}});
 			return this;
 		}
 		public VirtualCluster HttpDisabled(params int[] ports)


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/27805

Elasticsearch 6.1.0 returns path.data as an array of values. Cater for this by making settings a `Dictionary<string,object>` as opposed to `Dictionary<string,string>`