### PR TITLE
 Add additional sort options to Top Hits Aggregation

### DIFF
--- a/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
@@ -28,8 +28,18 @@ s => s
         .Aggregations(aa => aa
             .TopHits("top_state_hits", th => th
                 .Sort(srt => srt
-                    .Field(p => p.StartedOn)
-                    .Order(SortOrder.Descending)
+                    .Field(sf => sf
+                        .Field(p => p.StartedOn)
+                        .Order(SortOrder.Descending)
+                    )
+                    .Script(ss => ss
+                        .Type("number")
+                        .Script(sss => sss
+                            .Inline("Math.sin(34*(double)doc['numberOfCommits'].value)")
+                            .Lang("painless")
+                        )
+                        .Order(SortOrder.Descending)
+                    )
                 )
                 .Source(src => src
                     .Includes(fs => fs
@@ -79,7 +89,13 @@ new SearchRequest<Project>
         {
             Sort = new List<ISort>
             {
-                new SortField { Field = Field<Project>(p => p.StartedOn), Order = SortOrder.Descending }
+                new SortField { Field = Field<Project>(p => p.StartedOn), Order = SortOrder.Descending },
+                new ScriptSort
+                {
+                    Type = "number",
+                    Script = new InlineScript("Math.sin(34*(double)doc['numberOfCommits'].value)") { Lang = "painless" },
+                    Order = SortOrder.Descending
+                },
             },
             Source = new SourceFilter
             {
@@ -125,6 +141,16 @@ new SearchRequest<Project>
             "sort": [
               {
                 "startedOn": {
+                  "order": "desc"
+                }
+              },
+              {
+                "_script": {
+                  "type": "number",
+                  "script": {
+                    "lang": "painless",
+                    "inline": "Math.sin(34*(double)doc['numberOfCommits'].value)"
+                  },
                   "order": "desc"
                 }
               }

--- a/src/Nest/Aggregations/Metric/TopHits/TopHitsAggregation.cs
+++ b/src/Nest/Aggregations/Metric/TopHits/TopHitsAggregation.cs
@@ -95,12 +95,16 @@ namespace Nest
 
 		public TopHitsAggregationDescriptor<T> Size(int size) => Assign(a => a.Size = size);
 
+		[Obsolete("Use Sort(Func<SortDescriptor<T>, IPromise<IList<ISort>>>) that accepts multiple sort options")]
 		public TopHitsAggregationDescriptor<T> Sort(Func<SortFieldDescriptor<T>, IFieldSort> sortSelector) => Assign(a =>
 		{
 			a.Sort = a.Sort ?? new List<ISort>();
 			var sort = sortSelector?.Invoke(new SortFieldDescriptor<T>());
 			if (sort != null) a.Sort.Add(sort);
 		});
+
+		public TopHitsAggregationDescriptor<T> Sort(Func<SortDescriptor<T>, IPromise<IList<ISort>>> sortSelector) =>
+			Assign(a => a.Sort = sortSelector?.Invoke(new SortDescriptor<T>())?.Value);
 
 		public TopHitsAggregationDescriptor<T> Source(bool enabled = true) =>
 			Assign(a => a.Source = enabled);

--- a/src/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Security;
 using FluentAssertions;
 using Nest;
 using Tests.Framework;
@@ -37,6 +38,19 @@ namespace Tests.Aggregations.Metric.TopHits
 									{
 										startedOn = new
 										{
+											order = "desc"
+										}
+									},
+									new
+									{
+										_script = new
+										{
+											type = "number",
+											script = new
+											{
+												lang = "painless",
+												inline = "Math.sin(34*(double)doc['numberOfCommits'].value)"
+											},
 											order = "desc"
 										}
 									}
@@ -84,8 +98,18 @@ namespace Tests.Aggregations.Metric.TopHits
 					.Aggregations(aa => aa
 						.TopHits("top_state_hits", th => th
 							.Sort(srt => srt
-								.Field(p => p.StartedOn)
-								.Order(SortOrder.Descending)
+								.Field(sf => sf
+									.Field(p => p.StartedOn)
+									.Order(SortOrder.Descending)
+								)
+								.Script(ss => ss
+									.Type("number")
+									.Script(sss => sss
+										.Inline("Math.sin(34*(double)doc['numberOfCommits'].value)")
+										.Lang("painless")
+									)
+									.Order(SortOrder.Descending)
+								)
 							)
 							.Source(src => src
 								.Includes(fs => fs
@@ -131,7 +155,13 @@ namespace Tests.Aggregations.Metric.TopHits
 					{
 						Sort = new List<ISort>
 						{
-							new SortField { Field = Field<Project>(p => p.StartedOn), Order = SortOrder.Descending }
+							new SortField { Field = Field<Project>(p => p.StartedOn), Order = SortOrder.Descending },
+							new ScriptSort
+							{
+								Type = "number",
+								Script = new InlineScript("Math.sin(34*(double)doc['numberOfCommits'].value)") { Lang = "painless" },
+								Order = SortOrder.Descending
+							},
 						},
 						Source = new SourceFilter
 						{

--- a/src/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Security;
 using FluentAssertions;
 using Nest;
 using Tests.Framework;


### PR DESCRIPTION
Top Hits Aggregation fluent lambda syntax constrains sort options to field sorting, even though ITopHitsAggregation can accept any implementation of ISort. This commit deprecates the current fluent Sort implementation in favour of an implementation that allow multiple sort options besides field sorting, and assigns the resulting collection of sort options to IList<ISort>.

Update TopHitsAggregation usage test to call the new Sort method.

Fixes #2913 