### PR TITLE
Fix/5.x whole time units

### DIFF
--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -138,7 +138,7 @@ Expect("2015-05-05T00:00:00||+1d-1m").WhenSerializing(
 ==== Fractional times
 
 DateMath expressions do not support fractional numbers so will
-pick the largest unit (up to days, `d`, when constructing a Time from a `TimeSpan` or `double`) in which the number can be expressed as an integer
+pick the largest unit in which the number can be expressed as an integer
 
 [source,csharp]
 ----
@@ -158,7 +158,14 @@ Expect("now+1y")
     .WhenSerializing(Nest.DateMath.Now.Add("1y"))
     .WhenSerializing(Nest.DateMath.Now.Add(new Time(1, Nest.TimeUnit.Year)));
 
-Expect("now+364d").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+Expect("now+6M")
+    .WhenSerializing(Nest.DateMath.Now.Add("6M"))
+    .WhenSerializing(Nest.DateMath.Now.Add("0.5y"))
+    .WhenSerializing(Nest.DateMath.Now.Add(new Time(0.5, Nest.TimeUnit.Year)))
+    .WhenSerializing(Nest.DateMath.Now.Add(new Time(6, Nest.TimeUnit.Month)));
+
+Expect("now+364d")
+    .WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
 
 Expect("now+52w")
     .WhenSerializing(Nest.DateMath.Now.Add(new Time("52w")))

--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -137,8 +137,8 @@ Expect("2015-05-05T00:00:00||+1d-1m").WhenSerializing(
 
 ==== Fractional times
 
-DateMath expressions do not support fractional numbers so unlike `Time` DateMath will
-pick the biggest integer unit it can represent
+DateMath expressions do not support fractional numbers so will
+pick the largest unit (up to days, `d`) in which the number can be expressed as an integer
 
 [source,csharp]
 ----
@@ -150,7 +150,7 @@ where as `Time` on its own serializes like this
 
 [source,csharp]
 ----
-Expect("1.04166666666667d").WhenSerializing(new Time(TimeSpan.FromHours(25)));
+Expect("25h").WhenSerializing(new Time(TimeSpan.FromHours(25)));
 
 Expect("now+90001s").WhenSerializing(
     Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromSeconds(1))));
@@ -161,7 +161,10 @@ Expect("now+90000001ms").WhenSerializing(
 Expect("now+1y").WhenSerializing(
     Nest.DateMath.Now.Add("1y"));
 
-Expect("now+52w").WhenSerializing(
+Expect("now+364d").WhenSerializing(
     Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+
+Expect("now+52w").WhenSerializing(
+    Nest.DateMath.Now.Add(new Time("52w")));
 ----
 

--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -138,19 +138,15 @@ Expect("2015-05-05T00:00:00||+1d-1m").WhenSerializing(
 ==== Fractional times
 
 DateMath expressions do not support fractional numbers so will
-pick the largest unit (up to days, `d`) in which the number can be expressed as an integer
+pick the largest unit (up to days, `d`, when constructing a Time from a `TimeSpan` or `double`) in which the number can be expressed as an integer
 
 [source,csharp]
 ----
-Expect("now+25h").WhenSerializing(
-    Nest.DateMath.Now.Add(TimeSpan.FromHours(25)));
-----
-
-where as `Time` on its own serializes like this 
-
-[source,csharp]
-----
-Expect("25h").WhenSerializing(new Time(TimeSpan.FromHours(25)));
+Expect("now+25h")
+    .WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromHours(25)))
+    .WhenSerializing(Nest.DateMath.Now.Add(90000000))
+    .WhenSerializing(Nest.DateMath.Now.Add(new Time(25, Nest.TimeUnit.Hour)))
+    .WhenSerializing(Nest.DateMath.Now.Add("25h"));
 
 Expect("now+90001s").WhenSerializing(
     Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromSeconds(1))));
@@ -158,13 +154,14 @@ Expect("now+90001s").WhenSerializing(
 Expect("now+90000001ms").WhenSerializing(
     Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromMilliseconds(1))));
 
-Expect("now+1y").WhenSerializing(
-    Nest.DateMath.Now.Add("1y"));
+Expect("now+1y")
+    .WhenSerializing(Nest.DateMath.Now.Add("1y"))
+    .WhenSerializing(Nest.DateMath.Now.Add(new Time(1, Nest.TimeUnit.Year)));
 
-Expect("now+364d").WhenSerializing(
-    Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+Expect("now+364d").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
 
-Expect("now+52w").WhenSerializing(
-    Nest.DateMath.Now.Add(new Time("52w")));
+Expect("now+52w")
+    .WhenSerializing(Nest.DateMath.Now.Add(new Time("52w")))
+    .WhenSerializing(Nest.DateMath.Now.Add(new Time(52, Nest.TimeUnit.Week)));
 ----
 

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -162,7 +162,7 @@ new Time("-1").Should().Be(Time.MinusOne);
 new Time(-1).Should().Be(Time.MinusOne);
 ((Time) (-1)).Should().Be(Time.MinusOne);
 ((Time) "-1").Should().Be(Time.MinusOne);
-((Time) (-1)).Should().Be("-1");
+((Time) (-1)).Should().Be((Time) "-1");
 ----
 
 Similarly, the following are all equal to `Time.Zero`
@@ -174,7 +174,7 @@ new Time("0").Should().Be(Time.Zero);
 new Time(0).Should().Be(Time.Zero);
 ((Time) 0).Should().Be(Time.Zero);
 ((Time) "0").Should().Be(Time.Zero);
-((Time) 0).Should().Be("0");
+((Time) 0).Should().Be((Time) "0");
 ----
 
 Special Time values `0` and `-1` can be compared against other Time values

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -55,7 +55,7 @@ Expect("2d")
     .WhenSerializing(unitMilliseconds);
 ----
 
-The `Milliseconds` property on `Time` is calculated even when not using the constructor that takes a double
+The `Milliseconds` property on `Time` is calculated even when not using the constructor that takes a `double`
 
 [source,csharp]
 ----
@@ -67,37 +67,41 @@ unitString.Milliseconds.Should().Be(1000*60*60*24*2);
 
 ==== Implicit conversion
 
-Alternatively to using the constructor, `string`, `TimeSpan` and `double` can be implicitly converted to `Time`
+There are implicit conversions from `string`, `TimeSpan` and `double` to an instance of `Time`, making them
+easier to work with
 
 [source,csharp]
 ----
 Time oneAndHalfYear = "1.5y";
-Time twoWeeks = TimeSpan.FromDays(14);
+Time fourteenDays = TimeSpan.FromDays(14);
 Time twoDays = 1000*60*60*24*2;
 
 Expect("1.5y").WhenSerializing(oneAndHalfYear);
-Expect("2w").WhenSerializing(twoWeeks);
+Expect("14d").WhenSerializing(fourteenDays);
 Expect("2d").WhenSerializing(twoDays);
+----
 
+==== Equality and Comparison
+
+Milliseconds are calculated even when values are not passed as `double` milliseconds
+
+[source,csharp]
+----
+Time fourteenDays = TimeSpan.FromDays(14);
+fourteenDays.Milliseconds.Should().Be(1209600000);
+----
+
+When dealing with years or months however, whose millsecond value cannot
+be calculated *accurately*, `Milliseconds` will be -1. This is because
+they are not fixed durations. For example
+
+* 30 vs. 31 vs. 28 vs. 29 days in a month
+
+* 365 vs. 366 days in a year
+
+[source,csharp]
+----
 Time oneAndHalfYear = "1.5y";
-Time twoWeeks = TimeSpan.FromDays(14);
-Time twoDays = 1000*60*60*24*2;
-----
-
-Milliseconds are calculated even when values are not passed as long...
-
-[source,csharp]
-----
-twoWeeks.Milliseconds.Should().BeGreaterThan(1);
-----
-
-...**except** when dealing with years or months, whose millsecond value cannot
-be calculated *accurately*, since they are not fixed durations. For instance,
-30 vs 31 vs 28 days in a month, or 366 vs 365 days in a year.
-In this instance, Milliseconds will be -1.
-
-[source,csharp]
-----
 oneAndHalfYear.Milliseconds.Should().Be(-1);
 ----
 
@@ -105,27 +109,18 @@ This allows you to do comparisons on the expressions
 
 [source,csharp]
 ----
-oneAndHalfYear.Should().BeGreaterThan(twoWeeks);
-(oneAndHalfYear > twoWeeks).Should().BeTrue();
-(oneAndHalfYear >= twoWeeks).Should().BeTrue();
+Time twoDays = 1000*60*60*24*2;
+
+oneAndHalfYear.Should().BeGreaterThan(fourteenDays);
+(oneAndHalfYear > fourteenDays).Should().BeTrue();
+(oneAndHalfYear >= fourteenDays).Should().BeTrue();
 (twoDays != null).Should().BeTrue();
 (twoDays >= new Time("2d")).Should().BeTrue();
 
-twoDays.Should().BeLessThan(twoWeeks);
-(twoDays < twoWeeks).Should().BeTrue();
-(twoDays <= twoWeeks).Should().BeTrue();
+twoDays.Should().BeLessThan(fourteenDays);
+(twoDays < fourteenDays).Should().BeTrue();
+(twoDays <= fourteenDays).Should().BeTrue();
 (twoDays <= new Time("2d")).Should().BeTrue();
-----
-
-Special Time values `0` and `-1` can be compared against each other
-and other Time values although admittingly this is a tad non-sensical.
-
-[source,csharp]
-----
-Time.MinusOne.Should().BeLessThan(Time.Zero);
-Time.Zero.Should().BeGreaterThan(Time.MinusOne);
-Time.Zero.Should().BeLessThan(twoDays);
-Time.MinusOne.Should().BeLessThan(twoDays);
 ----
 
 And assert equality
@@ -136,15 +131,78 @@ twoDays.Should().Be(new Time("2d"));
 (twoDays == new Time("2d")).Should().BeTrue();
 (twoDays != new Time("2.1d")).Should().BeTrue();
 (new Time("2.1d") == new Time(TimeSpan.FromDays(2.1))).Should().BeTrue();
-//the string "-1" is not the same as double -1 which is milliseconds
-(new Time("-1") == new Time(-1)).Should().BeFalse();
-(new Time("-1") == Time.MinusOne).Should().BeTrue();
+----
+
+Equality has down to 1/10 nanosecond precision
+
+[source,csharp]
+----
+Time oneNanosecond = new Time(1, Nest.TimeUnit.Nanoseconds);
+Time onePointNoughtNineNanoseconds = "1.09nanos";
+Time onePointOneNanoseconds = "1.1nanos";
+
+(oneNanosecond == onePointNoughtNineNanoseconds).Should().BeTrue();
+(oneNanosecond == onePointOneNanoseconds).Should().BeFalse();
+----
+
+==== Special Time values
+
+Elasticsearch has two special values that can sometimes be passed where a `Time` is accepted
+
+* `0` represented as `Time.Zero`
+
+* `-1` represented as `Time.MinusOne`
+
+The following are all equal to `Time.MinusOne`
+
+[source,csharp]
+----
+Time.MinusOne.Should().Be(Time.MinusOne);
+new Time("-1").Should().Be(Time.MinusOne);
+new Time(-1).Should().Be(Time.MinusOne);
+((Time) (-1)).Should().Be(Time.MinusOne);
+((Time) "-1").Should().Be(Time.MinusOne);
+((Time) (-1)).Should().Be("-1");
+----
+
+Similarly, the following are all equal to `Time.Zero`
+
+[source,csharp]
+----
+Time.Zero.Should().Be(Time.Zero);
+new Time("0").Should().Be(Time.Zero);
+new Time(0).Should().Be(Time.Zero);
+((Time) 0).Should().Be(Time.Zero);
+((Time) "0").Should().Be(Time.Zero);
+((Time) 0).Should().Be("0");
+----
+
+Special Time values `0` and `-1` can be compared against other Time values
+although admittedly, this is a tad nonsensical.
+
+[source,csharp]
+----
+var twoDays = new Time(2, Nest.TimeUnit.Day);
+Time.MinusOne.Should().BeLessThan(Time.Zero);
+Time.Zero.Should().BeGreaterThan(Time.MinusOne);
+Time.Zero.Should().BeLessThan(twoDays);
+Time.MinusOne.Should().BeLessThan(twoDays);
+----
+
+If there is a need to construct a time of -1ms or 0ms, use the constructor
+that accepts a factor and time unit, or specify a string with ms time units
+
+[source,csharp]
+----
+(new Time(-1, Nest.TimeUnit.Millisecond) == new Time("-1ms")).Should().BeTrue();
+(new Time(0, Nest.TimeUnit.Millisecond) == new Time("0ms")).Should().BeTrue();
 ----
 
 ==== Units of Time
 
-Units of `Time` are specified as a union of either a `DateInterval` or `Time`,
-both of which implicitly convert to the `Union` of these two.
+Where Units of Time can be specified as a union of either a `DateInterval` or `Time`,
+a `DateInterval` or `Time` may be passed which will be implicity converted to a`Union<DateInterval, Time>`, the serialized form of which represents the initial value
+passed
 
 [source,csharp]
 ----
@@ -158,6 +216,6 @@ Expect("week").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Week);
 Expect("year").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Year);
 
 Expect("2d").WhenSerializing<Union<DateInterval, Time>>((Time)"2d");
-Expect("1.15714285714286w").WhenSerializing<Union<DateInterval, Time>>((Time)TimeSpan.FromDays(8.1));
+Expect("11664m").WhenSerializing<Union<DateInterval, Time>>((Time)TimeSpan.FromDays(8.1));
 ----
 

--- a/src/Nest/CommonOptions/TimeUnit/Time.cs
+++ b/src/Nest/CommonOptions/TimeUnit/Time.cs
@@ -138,7 +138,7 @@ namespace Nest
 
 		/// <summary>
 		/// Converts an instance of <see cref="Time"/> with a fractional value to an instance of <see cref="Time"/>
-		/// with a whole value. The largest unit is <see cref="TimeUnit.Day"/>. For fractional values in
+		/// with a whole value. For fractional values in
 		/// <see cref="TimeUnit.Nanoseconds"/>, value will be rounded to the nearest nanosecond.
 		/// </summary>
 		public static Time ToFirstUnitYieldingInteger(Time fractionalTime)
@@ -146,23 +146,35 @@ namespace Nest
 			var fraction = fractionalTime.Factor.GetValueOrDefault(double.Epsilon);
 			if (IsIntegerGreaterThanZero(fraction)) return fractionalTime;
 
+			// fractional year value to months
+			if (fractionalTime.Interval == TimeUnit.Year)
+			{
+				fraction = fraction * 12;
+				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Month);
+			}
+
 			var ms = fractionalTime.ApproximateMilliseconds;
-			if (ms > MillisecondsInADay)
+			if (ms >= MillisecondsInAWeek)
+			{
+				fraction = ms / MillisecondsInAWeek;
+				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Week);
+			}
+			if (ms >= MillisecondsInADay)
 			{
 				fraction = ms / MillisecondsInADay;
 				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Day);
 			}
-			if (ms > MillisecondsInAnHour)
+			if (ms >= MillisecondsInAnHour)
 			{
 				fraction = ms / MillisecondsInAnHour;
 				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Hour);
 			}
-			if (ms > MillisecondsInAMinute)
+			if (ms >= MillisecondsInAMinute)
 			{
 				fraction = ms / MillisecondsInAMinute;
 				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Minute);
 			}
-			if (ms > MillisecondsInASecond)
+			if (ms >= MillisecondsInASecond)
 			{
 				fraction = ms / MillisecondsInASecond;
 				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Second);
@@ -171,7 +183,7 @@ namespace Nest
 			{
 				return new Time(ms, TimeUnit.Millisecond);
 			}
-			if (ms > MillisecondsInAMicrosecond)
+			if (ms >= MillisecondsInAMicrosecond)
 			{
 				fraction = ms / MillisecondsInAMicrosecond;
 				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Microseconds);

--- a/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
+++ b/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
@@ -94,18 +94,18 @@ namespace Tests.CommonOptions.DateMath
 					.Subtract(TimeSpan.FromMinutes(1)));
 		}
 
+		/**
+		* ==== Fractional times
+		* DateMath expressions do not support fractional numbers so will
+		* pick the largest unit (up to days, `d`, when constructing a Time from a `TimeSpan` or `double`) in which the number can be expressed as an integer
+		*/
 		[U] public void FractionalsUnitsAreDroppedToIntegerPart()
 		{
-			/**
-			* ==== Fractional times
-			* DateMath expressions do not support fractional numbers so will
-			* pick the largest unit (up to days, `d`) in which the number can be expressed as an integer
-			*/
-			Expect("now+25h").WhenSerializing(
-				Nest.DateMath.Now.Add(TimeSpan.FromHours(25)));
-
-			/** where as `Time` on its own serializes like this */
-			Expect("25h").WhenSerializing(new Time(TimeSpan.FromHours(25)));
+			Expect("now+25h")
+				.WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromHours(25)))
+				.WhenSerializing(Nest.DateMath.Now.Add(90000000))
+				.WhenSerializing(Nest.DateMath.Now.Add(new Time(25, Nest.TimeUnit.Hour)))
+				.WhenSerializing(Nest.DateMath.Now.Add("25h"));
 
 			Expect("now+90001s").WhenSerializing(
 				Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromSeconds(1))));
@@ -113,14 +113,15 @@ namespace Tests.CommonOptions.DateMath
 			Expect("now+90000001ms").WhenSerializing(
 				Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromMilliseconds(1))));
 
-			Expect("now+1y").WhenSerializing(
-				Nest.DateMath.Now.Add("1y"));
+			Expect("now+1y")
+				.WhenSerializing(Nest.DateMath.Now.Add("1y"))
+				.WhenSerializing(Nest.DateMath.Now.Add(new Time(1, Nest.TimeUnit.Year)));
 
-			Expect("now+364d").WhenSerializing(
-				Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+			Expect("now+364d").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
 
-			Expect("now+52w").WhenSerializing(
-				Nest.DateMath.Now.Add(new Time("52w")));
+			Expect("now+52w")
+				.WhenSerializing(Nest.DateMath.Now.Add(new Time("52w")))
+				.WhenSerializing(Nest.DateMath.Now.Add(new Time(52, Nest.TimeUnit.Week)));
 		}
 	}
 }

--- a/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
+++ b/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
@@ -94,18 +94,18 @@ namespace Tests.CommonOptions.DateMath
 					.Subtract(TimeSpan.FromMinutes(1)));
 		}
 
-		[U] public void FractionalsUnitsAreDroppeToIntegerPart()
+		[U] public void FractionalsUnitsAreDroppedToIntegerPart()
 		{
 			/**
 			* ==== Fractional times
-			* DateMath expressions do not support fractional numbers so unlike `Time` DateMath will
-			* pick the biggest integer unit it can represent
+			* DateMath expressions do not support fractional numbers so will
+			* pick the largest unit (up to days, `d`) in which the number can be expressed as an integer
 			*/
 			Expect("now+25h").WhenSerializing(
 				Nest.DateMath.Now.Add(TimeSpan.FromHours(25)));
 
 			/** where as `Time` on its own serializes like this */
-			Expect("1.04166666666667d").WhenSerializing(new Time(TimeSpan.FromHours(25)));
+			Expect("25h").WhenSerializing(new Time(TimeSpan.FromHours(25)));
 
 			Expect("now+90001s").WhenSerializing(
 				Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromSeconds(1))));
@@ -116,8 +116,11 @@ namespace Tests.CommonOptions.DateMath
 			Expect("now+1y").WhenSerializing(
 				Nest.DateMath.Now.Add("1y"));
 
-			Expect("now+52w").WhenSerializing(
+			Expect("now+364d").WhenSerializing(
 				Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+
+			Expect("now+52w").WhenSerializing(
+				Nest.DateMath.Now.Add(new Time("52w")));
 		}
 	}
 }

--- a/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
+++ b/src/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
@@ -97,7 +97,7 @@ namespace Tests.CommonOptions.DateMath
 		/**
 		* ==== Fractional times
 		* DateMath expressions do not support fractional numbers so will
-		* pick the largest unit (up to days, `d`, when constructing a Time from a `TimeSpan` or `double`) in which the number can be expressed as an integer
+		* pick the largest unit in which the number can be expressed as an integer
 		*/
 		[U] public void FractionalsUnitsAreDroppedToIntegerPart()
 		{
@@ -117,7 +117,14 @@ namespace Tests.CommonOptions.DateMath
 				.WhenSerializing(Nest.DateMath.Now.Add("1y"))
 				.WhenSerializing(Nest.DateMath.Now.Add(new Time(1, Nest.TimeUnit.Year)));
 
-			Expect("now+364d").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+			Expect("now+6M")
+				.WhenSerializing(Nest.DateMath.Now.Add("6M"))
+				.WhenSerializing(Nest.DateMath.Now.Add("0.5y"))
+				.WhenSerializing(Nest.DateMath.Now.Add(new Time(0.5, Nest.TimeUnit.Year)))
+				.WhenSerializing(Nest.DateMath.Now.Add(new Time(6, Nest.TimeUnit.Month)));
+
+			Expect("now+364d")
+				.WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
 
 			Expect("now+52w")
 				.WhenSerializing(Nest.DateMath.Now.Add(new Time("52w")))

--- a/src/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs
+++ b/src/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs
@@ -298,7 +298,7 @@ namespace Tests.CommonOptions.TimeUnit
 				{ "2.2ms", "2200micros" },
 				{ "1.5d", "36h" },
 				{ "1y", "1y" },
-				{ "1.5y", "13140h" }, // cannot be expressed in days because 365 * 1.5
+				{ "1.5y", "18M" },
 				{ "1M", "1M" },
 				{ "1.5M", "45d" },
 				{ "1w", "1w" }

--- a/src/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs
+++ b/src/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs
@@ -44,7 +44,7 @@ namespace Tests.CommonOptions.TimeUnit
 				.WhenSerializing(unitMilliseconds);
 
 			/**
-			* The `Milliseconds` property on `Time` is calculated even when not using the constructor that takes a double
+			* The `Milliseconds` property on `Time` is calculated even when not using the constructor that takes a `double`
 			*/
 			unitMilliseconds.Milliseconds.Should().Be(1000*60*60*24*2);
 			unitComposed.Milliseconds.Should().Be(1000*60*60*24*2);
@@ -53,62 +53,59 @@ namespace Tests.CommonOptions.TimeUnit
 		}
 		/**
 		* ==== Implicit conversion
-		* Alternatively to using the constructor, `string`, `TimeSpan` and `double` can be implicitly converted to `Time`
+		* There are implicit conversions from `string`, `TimeSpan` and `double` to an instance of `Time`, making them
+		 * easier to work with
 		*/
 		[U] [SuppressMessage("ReSharper", "SuggestVarOrType_SimpleTypes")]
 		public void ImplicitConversion()
 		{
 			Time oneAndHalfYear = "1.5y";
-			Time twoWeeks = TimeSpan.FromDays(14);
+			Time fourteenDays = TimeSpan.FromDays(14);
 			Time twoDays = 1000*60*60*24*2;
 
 			Expect("1.5y").WhenSerializing(oneAndHalfYear);
-			Expect("2w").WhenSerializing(twoWeeks);
+			Expect("14d").WhenSerializing(fourteenDays);
 			Expect("2d").WhenSerializing(twoDays);
 		}
 
+		/**
+		 * ==== Equality and Comparison
+		 */
 		[U] [SuppressMessage("ReSharper", "SuggestVarOrType_SimpleTypes")]
 		public void EqualityAndComparable()
 		{
+			/**
+			* Milliseconds are calculated even when values are not passed as `double` milliseconds
+			*/
+			Time fourteenDays = TimeSpan.FromDays(14);
+			fourteenDays.Milliseconds.Should().Be(1209600000);
+
+			/**
+			* When dealing with years or months however, whose millsecond value cannot
+			* be calculated *accurately*, `Milliseconds` will be -1. This is because
+			* they are not fixed durations. For example
+			*
+			* - 30 vs. 31 vs. 28 vs. 29 days in a month
+			* - 365 vs. 366 days in a year
+			*/
 			Time oneAndHalfYear = "1.5y";
-			Time twoWeeks = TimeSpan.FromDays(14);
-			Time twoDays = 1000*60*60*24*2;
-
-			/**
-			* Milliseconds are calculated even when values are not passed as long...
-			*/
-			twoWeeks.Milliseconds.Should().BeGreaterThan(1);
-
-			/**
-			* ...**except** when dealing with years or months, whose millsecond value cannot
-			* be calculated *accurately*, since they are not fixed durations. For instance,
-			* 30 vs 31 vs 28 days in a month, or 366 vs 365 days in a year.
-			* In this instance, Milliseconds will be -1.
-			*/
 			oneAndHalfYear.Milliseconds.Should().Be(-1);
 
 			/**
 			* This allows you to do comparisons on the expressions
 			*/
-			oneAndHalfYear.Should().BeGreaterThan(twoWeeks);
-			(oneAndHalfYear > twoWeeks).Should().BeTrue();
-			(oneAndHalfYear >= twoWeeks).Should().BeTrue();
+			Time twoDays = 1000*60*60*24*2;
+
+			oneAndHalfYear.Should().BeGreaterThan(fourteenDays);
+			(oneAndHalfYear > fourteenDays).Should().BeTrue();
+			(oneAndHalfYear >= fourteenDays).Should().BeTrue();
 		    (twoDays != null).Should().BeTrue();
             (twoDays >= new Time("2d")).Should().BeTrue();
 
-			twoDays.Should().BeLessThan(twoWeeks);
-			(twoDays < twoWeeks).Should().BeTrue();
-			(twoDays <= twoWeeks).Should().BeTrue();
+			twoDays.Should().BeLessThan(fourteenDays);
+			(twoDays < fourteenDays).Should().BeTrue();
+			(twoDays <= fourteenDays).Should().BeTrue();
 			(twoDays <= new Time("2d")).Should().BeTrue();
-
-			/**
-			* Special Time values `0` and `-1` can be compared against each other
-			* and other Time values although admittingly this is a tad non-sensical.
-			*/
-			Time.MinusOne.Should().BeLessThan(Time.Zero);
-			Time.Zero.Should().BeGreaterThan(Time.MinusOne);
-			Time.Zero.Should().BeLessThan(twoDays);
-			Time.MinusOne.Should().BeLessThan(twoDays);
 
 			/**
 			* And assert equality
@@ -117,9 +114,62 @@ namespace Tests.CommonOptions.TimeUnit
 			(twoDays == new Time("2d")).Should().BeTrue();
 			(twoDays != new Time("2.1d")).Should().BeTrue();
 			(new Time("2.1d") == new Time(TimeSpan.FromDays(2.1))).Should().BeTrue();
-			//the string "-1" is not the same as double -1 which is milliseconds
-			(new Time("-1") == new Time(-1)).Should().BeFalse();
-			(new Time("-1") == Time.MinusOne).Should().BeTrue();
+
+			/**
+			 * Equality has down to 1/10 nanosecond precision
+			 */
+			Time oneNanosecond = new Time(1, Nest.TimeUnit.Nanoseconds);
+			Time onePointNoughtNineNanoseconds = "1.09nanos";
+			Time onePointOneNanoseconds = "1.1nanos";
+
+			(oneNanosecond == onePointNoughtNineNanoseconds).Should().BeTrue();
+			(oneNanosecond == onePointOneNanoseconds).Should().BeFalse();
+		}
+
+		/** ==== Special Time values
+		 *
+		 * Elasticsearch has two special values that can sometimes be passed where a `Time` is accepted
+		 *
+		 * - `0` represented as `Time.Zero`
+		 * - `-1` represented as `Time.MinusOne`
+		 */
+		[U] public void SpecialTimeValues()
+		{
+			/**
+			 * The following are all equal to `Time.MinusOne`
+			 */
+			Time.MinusOne.Should().Be(Time.MinusOne);
+			new Time("-1").Should().Be(Time.MinusOne);
+			new Time(-1).Should().Be(Time.MinusOne);
+			((Time) (-1)).Should().Be(Time.MinusOne);
+			((Time) "-1").Should().Be(Time.MinusOne);
+			((Time) (-1)).Should().Be("-1");
+
+			/**
+			 * Similarly, the following are all equal to `Time.Zero`
+			 */
+			Time.Zero.Should().Be(Time.Zero);
+			new Time("0").Should().Be(Time.Zero);
+			new Time(0).Should().Be(Time.Zero);
+			((Time) 0).Should().Be(Time.Zero);
+			((Time) "0").Should().Be(Time.Zero);
+			((Time) 0).Should().Be("0");
+
+			/** Special Time values `0` and `-1` can be compared against other Time values
+			 * although admittedly, this is a tad nonsensical.
+			 */
+			var twoDays = new Time(2, Nest.TimeUnit.Day);
+			Time.MinusOne.Should().BeLessThan(Time.Zero);
+			Time.Zero.Should().BeGreaterThan(Time.MinusOne);
+			Time.Zero.Should().BeLessThan(twoDays);
+			Time.MinusOne.Should().BeLessThan(twoDays);
+
+			/**
+			 * If there is a need to construct a time of -1ms or 0ms, use the constructor
+			 * that accepts a factor and time unit, or specify a string with ms time units
+			 */
+			(new Time(-1, Nest.TimeUnit.Millisecond) == new Time("-1ms")).Should().BeTrue();
+			(new Time(0, Nest.TimeUnit.Millisecond) == new Time("0ms")).Should().BeTrue();
 		}
 
         // hide
@@ -180,12 +230,72 @@ namespace Tests.CommonOptions.TimeUnit
 			}
 		}
 
+		// hide
+		private class DoubleParsingTestCases : List<Tuple<double, TimeSpan, string>>
+		{
+			public void Add(double original, TimeSpan expect, string toString) =>
+				this.Add(Tuple.Create(original, expect, toString));
+		}
+
+		// hide
+		[U]public void DoubleImplicitConversionParsing()
+		{
+			// from: https://msdn.microsoft.com/en-us/library/system.timespan.frommilliseconds.aspx
+			// The value parameter is converted to ticks, and that number of ticks is used to initialize the new TimeSpan.
+			// Therefore, value will only be considered accurate to the nearest millisecond. This means that
+			// fractional millisecond values with TimeSpan.FromMilliseconds(fraction) will be rounded.
+			var testCases = new DoubleParsingTestCases
+			{
+				{ 1e-4, new TimeSpan(1) , "100nanos"}, // smallest value that can be represented with ticks
+				{ 1e-3, new TimeSpan(10), "1micros"},
+				{ 1, TimeSpan.FromMilliseconds(1), "1ms"},
+				{ 10, TimeSpan.FromMilliseconds(10), "10ms"},
+				{ 100, TimeSpan.FromMilliseconds(100), "100ms"},
+				{ 1000, TimeSpan.FromSeconds(1), "1s" },
+				{ 60000, TimeSpan.FromMinutes(1), "1m" },
+				{ 3.6e+6, TimeSpan.FromHours(1), "1h" },
+				{ 8.64e+7, TimeSpan.FromDays(1), "1d" },
+				{ 1.296e+8, TimeSpan.FromDays(1.5), "36h" },
+			};
+			foreach (var testCase in testCases)
+			{
+				var time = new Time(testCase.Item1);
+				time.ToTimeSpan().Should().Be(testCase.Item2, "we passed in {0}", testCase.Item1);
+				time.ToString().Should().Be(testCase.Item3);
+			}
+		}
+
+		// hide
+		[U]
+		public void DoubleImplicitConversionOneNanosecond()
+		{
+			Time oneNanosecond = 1e-6; // cannot be expressed as a TimeSpan using ToTimeSpan(), as smaller than a one tick.
+			oneNanosecond.ToString().Should().Be("1nanos");
+		}
+
+		// hide
+		[U]public void TimeSpanZero()
+		{
+			Time zero = TimeSpan.Zero;
+			zero.Should().Be(Time.Zero);
+		}
+
+		// hide
+		[U]public void TimeSpanMinusOne()
+		{
+			Time minusOne = TimeSpan.FromMilliseconds(-1);
+			minusOne.Should().Be(Time.MinusOne);
+		}
+
 		[U] public void UsingInterval()
 		{
 			/**
 			* ==== Units of Time
-			* Units of `Time` are specified as a union of either a `DateInterval` or `Time`,
-			* both of which implicitly convert to the `Union` of these two.
+			*
+			* Where Units of Time can be specified as a union of either a `DateInterval` or `Time`,
+			* a `DateInterval` or `Time` may be passed which will be implicity converted to a
+			* `Union<DateInterval, Time>`, the serialized form of which represents the initial value
+			* passed
 			*/
 			Expect("month").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Month);
 			Expect("day").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Day);
@@ -197,26 +307,28 @@ namespace Tests.CommonOptions.TimeUnit
 			Expect("year").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Year);
 
 			Expect("2d").WhenSerializing<Union<DateInterval, Time>>((Time)"2d");
-			Expect("1.15714285714286w").WhenSerializing<Union<DateInterval, Time>>((Time)TimeSpan.FromDays(8.1));
+			Expect("11664m").WhenSerializing<Union<DateInterval, Time>>((Time)TimeSpan.FromDays(8.1));
 		}
 
 		//hide
 		[U] public void MillisecondsNeverSerializeToMonthsOrYears()
 		{
 			double millisecondsInAMonth = 2592000000;
-			Expect("4.28571428571429w").WhenSerializing(new Time(millisecondsInAMonth));
-			Expect("8.57142857142857w").WhenSerializing(new Time(millisecondsInAMonth * 2));
-			Expect("51.4285714285714w").WhenSerializing(new Time(millisecondsInAMonth * 12));
-			Expect("102.857142857143w").WhenSerializing(new Time(millisecondsInAMonth * 24));
+			Expect("30d").WhenSerializing(new Time(millisecondsInAMonth));
+			Expect("60d").WhenSerializing(new Time(millisecondsInAMonth * 2));
+			Expect("360d").WhenSerializing(new Time(millisecondsInAMonth * 12));
+			Expect("720d").WhenSerializing(new Time(millisecondsInAMonth * 24));
 		}
 
 		//hide
 		[U] public void ExpectedValues()
 		{
-			Expect("0ms").WhenSerializing(new Time(0));
+			Expect(0).WhenSerializing(new Time(0));
+			Expect(0).WhenSerializing((Time)0);
 			Expect(0).WhenSerializing(new Time("0"));
 			Expect(0).WhenSerializing(Time.Zero);
-			Expect("-1ms").WhenSerializing(new Time(-1));
+			Expect(-1).WhenSerializing(new Time(-1));
+			Expect(-1).WhenSerializing((Time)(-1));
 			Expect(-1).WhenSerializing(new Time("-1"));
 			Expect(-1).WhenSerializing(Time.MinusOne);
 
@@ -235,8 +347,7 @@ namespace Tests.CommonOptions.TimeUnit
 			Assert(
 				1, Nest.TimeUnit.Week, TimeSpan.FromDays(7).TotalMilliseconds, "1w",
 				new Time(1, Nest.TimeUnit.Week),
-				new Time("1w"),
-				new Time(TimeSpan.FromDays(7).TotalMilliseconds)
+				new Time("1w")
 			);
 
 			Assert(


### PR DESCRIPTION
This commit changes the implementation of Time within the client for better consistency with Elasticsearch's TimeValue. The Time type in NEST 5.x is used to represent both Elasticsearch's TimeValue (which allows from nanos up to days as unit), and as time modifiers within DateMath expressions, for which Elasticsearch accepts units of  y (years) M (months), w (weeks), d (days), h/H (hours), m (minutes) and s (seconds).

- When converting from a TimeSpan to Time, the serialized value is a whole number with the largest unit of days. This fixes the implementation to be in line with Elasticsearch 5.0+ with elastic/elasticsearch#19102 where weeks was removed as a supported unit for TimeValue.

- When constructing a Time using the constructor that takes a double of milliseconds, make the implementation consistent with the implicit conversion from double implementation; in the case of -1, both should be Time.MinusOne and the case of 0, both should be Time.Zero. If needing to express -1ms or 0ms, the constructor taking a factor and unit, or the constructor taking a string value with unit should be used.

- When constructing a Time from double or TimeSpan, try to reduce the value to a whole number factor and largest represented unit (up to unit of days). For values smaller than 1 nanosecond, retain the factor as a fraction of nanoseconds.

- When converting a Time to a TimeSpan, round the value to the nearest TimeSpan tick for microseconds and nanoseconds, and milliseconds for all other units.

- When converting to a Time within a DateMath expression using Time.ToFirstUnitYieldingInteger(), when the value is fractional nanoseconds, round to the nearest nanosecond. Although this method is only used within the client for DateMath expressions and can return times with units smaller than a second (the smallest unit that DateMath within Elasticsearch accepts), the method is public so could be used by consumers for purposes other than DateMath. Because of this, don't break the implementation for units smaller than one second.

- Allow the implicit conversion from string and the constructor that takes a string to continue to accept fractional units, which can be returned from Elasticsearch as per TimeValue's toString implementation https://github.com/elastic/elasticsearch/blob/f2501130399f6e3788e110d74dd62b3aad66804a/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java#L253-L290

- Update documentation

Closes #2818