### PR TITLE
 Add Params to PhraseSuggestCollate (forward port to master)

### DIFF
--- a/docs/search/request/suggest-usage.asciidoc
+++ b/docs/search/request/suggest-usage.asciidoc
@@ -62,8 +62,8 @@ s => s
         .Collate(c => c
             .Query(q => q
                 .Source("{ \"match\": { \"{{field_name}}\": \"{{suggestion}}\" }}")
-                .Params(p => p.Add("field_name", "title"))
             )
+            .Params(p => p.Add("field_name", "title"))
             .Prune()
         )
         .Confidence(10.1)
@@ -134,13 +134,13 @@ new SearchRequest<Project>
             {
                 Collate = new PhraseSuggestCollate
                 {
-                    Query = new TemplateQuery
+                    Query = new PhraseSuggestCollateQuery
                     {
                         Source = "{ \"match\": { \"{{field_name}}\": \"{{suggestion}}\" }}",
-                        Params = new Dictionary<string, object>
-                        {
-                            { "field_name", "title" }
-                        }
+                    },
+                    Params = new Dictionary<string, object>
+                    {
+                        { "field_name", "title" }
                     },
                     Prune = true
                 },
@@ -189,10 +189,10 @@ new SearchRequest<Project>
       "phrase": {
         "collate": {
           "query": {
-            "source": "{ \"match\": { \"{{field_name}}\": \"{{suggestion}}\" }}",
-            "params": {
-              "field_name": "title"
-            }
+            "source": "{ \"match\": { \"{{field_name}}\": \"{{suggestion}}\" }}"
+          },
+          "params": {
+            "field_name": "title"
           },
           "prune": true
         },

--- a/src/Nest/QueryDsl/Abstractions/Container/IQueryContainer.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/IQueryContainer.cs
@@ -137,8 +137,10 @@ namespace Nest
 		[JsonProperty("function_score")]
 		IFunctionScoreQuery FunctionScore { get; set; }
 
+#pragma warning disable 618
 		[JsonProperty("template")]
 		ITemplateQuery Template { get; set; }
+#pragma warning restore 618
 
 		[JsonProperty("geo_bounding_box")]
 		IGeoBoundingBoxQuery GeoBoundingBox { get; set; }

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
@@ -46,7 +46,9 @@ namespace Nest
 		private IIndicesQuery _indices;
 #pragma warning restore 618
 		private IFunctionScoreQuery _functionScore;
+#pragma warning disable 618
 		private ITemplateQuery _template;
+#pragma warning restore 618
 		private IGeoBoundingBoxQuery _geoBoundingBox;
 		private IGeoDistanceQuery _geoDistance;
 		private IGeoPolygonQuery _geoPolygon;
@@ -110,7 +112,9 @@ namespace Nest
 		IIndicesQuery IQueryContainer.Indices { get { return _indices; } set { _indices = Set(value); } }
 #pragma warning restore 618
 		IFunctionScoreQuery IQueryContainer.FunctionScore { get { return _functionScore; } set { _functionScore = Set(value); } }
+#pragma warning disable 618
 		ITemplateQuery IQueryContainer.Template { get { return _template; } set { _template = Set(value); } }
+#pragma warning restore 618
 		IGeoBoundingBoxQuery IQueryContainer.GeoBoundingBox { get { return _geoBoundingBox; } set { _geoBoundingBox = Set(value); } }
 		IGeoDistanceQuery IQueryContainer.GeoDistance { get { return _geoDistance; } set { _geoDistance = Set(value); } }
 		IGeoPolygonQuery IQueryContainer.GeoPolygon { get { return _geoPolygon; } set { _geoPolygon = Set(value); } }

--- a/src/Nest/QueryDsl/Specialized/Template/TemplateQuery.cs
+++ b/src/Nest/QueryDsl/Specialized/Template/TemplateQuery.cs
@@ -4,13 +4,11 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	[Obsolete("Deprecated in 5.0.0. Use Search Template API instead")]
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<TemplateQuery>))]
 	public interface ITemplateQuery : IQuery
 	{
-		[JsonProperty("file")]
-		string File { get; set; }
-
 		[JsonProperty("source")]
 		string Source { get; set; }
 
@@ -25,28 +23,33 @@ namespace Nest
 		IDictionary<string, object> Params { get; set; }
 	}
 
+	[Obsolete("Deprecated in 5.0.0. Use Search Template API instead")]
 	public class TemplateQuery : QueryBase, ITemplateQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
-		public string File { get; set; }
+
 		/// <summary> An inline script to be executed </summary>
 		public string Source { get; set; }
+
 		/// <summary> An inline script to be executed </summary>
 		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
 		public string Inline { get => this.Source; set => this.Source = value; }
+
 		public Id Id { get; set; }
+
 		public IDictionary<string, object> Params { get; set;}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Template = this;
-		internal static bool IsConditionless(ITemplateQuery q) => q.File.IsNullOrEmpty() && q.Id == null && q.Source.IsNullOrEmpty();
+		internal static bool IsConditionless(ITemplateQuery q) => q.Id == null && q.Source.IsNullOrEmpty();
 	}
 
+	[Obsolete("Deprecated in 5.0.0. Use Search Template API instead")]
 	public class TemplateQueryDescriptor<T>
 		: QueryDescriptorBase<TemplateQueryDescriptor<T>, ITemplateQuery>
 		, ITemplateQuery where T : class
 	{
 		protected override bool Conditionless => TemplateQuery.IsConditionless(this);
-		string ITemplateQuery.File { get; set; }
+
 		string ITemplateQuery.Source { get; set; }
 		string ITemplateQuery.Inline { get => Self.Source; set => Self.Source = value; }
 		Id ITemplateQuery.Id { get; set; }
@@ -54,9 +57,8 @@ namespace Nest
 
 		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
 		public TemplateQueryDescriptor<T> Inline(string script) => Assign(a => a.Inline = script);
-		public TemplateQueryDescriptor<T> Source(string script) => Assign(a => a.Source = script);
 
-		public TemplateQueryDescriptor<T> File(string file) => Assign(a => a.File = file);
+		public TemplateQueryDescriptor<T> Source(string script) => Assign(a => a.Source = script);
 
 		public TemplateQueryDescriptor<T> Id(Id id) => Assign(a => a.Id = id);
 

--- a/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
@@ -155,7 +155,9 @@ namespace Nest
 
 		public virtual void Visit(IGeoHashCellQuery filter) => Write("geohash_cell");
 
+#pragma warning disable 618
 		public virtual void Visit(ITemplateQuery query) => Write("template");
+#pragma warning restore 618
 
 		public virtual void Visit(ISpanMultiTermQuery query) => Write("span_multi_term");
 

--- a/src/Nest/QueryDsl/Visitor/QueryVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/QueryVisitor.cs
@@ -66,7 +66,9 @@
 		void Visit(IDateRangeQuery query);
 		void Visit(INumericRangeQuery query);
 		void Visit(ITermRangeQuery query);
+#pragma warning disable 618
 		void Visit(ITemplateQuery query);
+#pragma warning restore 618
 		void Visit(ISpanFirstQuery query);
 		void Visit(ISpanNearQuery query);
 		void Visit(ISpanNotQuery query);
@@ -209,7 +211,9 @@
 
 		public virtual void Visit(IGeoHashCellQuery query) { }
 
+#pragma warning disable 618
 		public virtual void Visit(ITemplateQuery query) { }
+#pragma warning restore 618
 
 		public virtual void Visit(IGeoShapeMultiPointQuery query) { }
 

--- a/src/Nest/Search/Suggesters/PhraseSuggester/PhraseSuggestCollate.cs
+++ b/src/Nest/Search/Suggesters/PhraseSuggester/PhraseSuggestCollate.cs
@@ -4,34 +4,77 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// Checks each suggestion against the specified query to prune suggestions
+	/// for which no matching docs exist in the index.
+	/// </summary>
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<PhraseSuggestCollate>))]
 	public interface IPhraseSuggestCollate
 	{
+		/// <summary>
+		/// The collate query to run.
+		/// </summary>
 		[JsonProperty("query")]
-		ITemplateQuery Query { get; set; }
+		IPhraseSuggestCollateQuery Query { get; set; }
 
+		/// <summary>
+		/// Controls if all phrase suggestions will be returned. When set to <c>true</c>, the suggestions will have
+		/// an additional option collate_match, which will be <c>true</c> if matching documents for the phrase was found,
+		/// <c>false</c> otherwise. The default value for <see cref="Prune"/> is <c>false</c>.
+		/// </summary>
 		[JsonProperty("prune")]
 		bool? Prune { get; set; }
+
+		/// <summary>
+		/// The parameters for the query. the suggestion value will be added to the variables you specify.
+		/// </summary>
+		[JsonProperty("params")]
+		IDictionary<string, object> Params { get; set; }
 	}
 
+	/// <inheritdoc />
 	public class PhraseSuggestCollate : IPhraseSuggestCollate
 	{
-		public ITemplateQuery Query { get; set; }
+		/// <inheritdoc />
+		public IPhraseSuggestCollateQuery Query { get; set; }
 
+		/// <inheritdoc />
 		public bool? Prune { get; set; }
+
+		/// <inheritdoc />
+		public IDictionary<string, object> Params { get; set; }
 	}
 
 	public class PhraseSuggestCollateDescriptor<T> : DescriptorBase<PhraseSuggestCollateDescriptor<T>, IPhraseSuggestCollate>, IPhraseSuggestCollate
 		where T : class
 	{
-		ITemplateQuery IPhraseSuggestCollate.Query { get; set; }
-
+		IPhraseSuggestCollateQuery IPhraseSuggestCollate.Query { get; set; }
+		IDictionary<string, object> IPhraseSuggestCollate.Params { get; set; }
 		bool? IPhraseSuggestCollate.Prune { get; set; }
 
-		public PhraseSuggestCollateDescriptor<T> Query(Func<TemplateQueryDescriptor<T>, ITemplateQuery> selector) =>
-			Assign(a => a.Query = selector?.Invoke(new TemplateQueryDescriptor<T>()));
+		/// <summary>
+		/// The collate query to run
+		/// </summary>
+		public PhraseSuggestCollateDescriptor<T> Query(Func<PhraseSuggestCollateQueryDescriptor, IPhraseSuggestCollateQuery> selector) =>
+			Assign(a => a.Query = selector?.Invoke(new PhraseSuggestCollateQueryDescriptor()));
 
+		/// <summary>
+		/// Controls if all phrase suggestions will be returned. When set to <c>true</c>, the suggestions will have
+		/// an additional option collate_match, which will be <c>true</c> if matching documents for the phrase was found,
+		/// <c>false</c> otherwise. The default value for <see cref="Prune"/> is <c>false</c>.
+		/// </summary>
 		public PhraseSuggestCollateDescriptor<T> Prune(bool? prune = true) => Assign(a => a.Prune = prune);
+
+		/// <summary>
+		/// The parameters for the query. the suggestion value will be added to the variables you specify.
+		/// </summary>
+		public PhraseSuggestCollateDescriptor<T> Params(IDictionary<string, object> paramsDictionary) => Assign(a => a.Params = paramsDictionary);
+
+		/// <summary>
+		/// The parameters for the query. the suggestion value will be added to the variables you specify.
+		/// </summary>
+		public PhraseSuggestCollateDescriptor<T> Params(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> paramsDictionary) =>
+			Assign(a => a.Params = paramsDictionary(new FluentDictionary<string, object>()));
 	}
 }

--- a/src/Nest/Search/Suggesters/PhraseSuggester/PhraseSuggestCollateQuery.cs
+++ b/src/Nest/Search/Suggesters/PhraseSuggester/PhraseSuggestCollateQuery.cs
@@ -1,0 +1,48 @@
+﻿using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A query to run for a phrase suggester collate
+	/// </summary>
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	[JsonConverter(typeof(ReadAsTypeJsonConverter<PhraseSuggestCollateQuery>))]
+	public interface IPhraseSuggestCollateQuery
+	{
+		/// <summary>
+		/// The source script to be executed
+		/// </summary>
+		[JsonProperty("source")]
+		string Source { get; set; }
+
+		/// <summary>
+		/// The id for a stored script to execute
+		/// </summary>
+		[JsonProperty("id")]
+		Id Id { get; set; }
+	}
+
+	/// <inheritdoc />
+	public class PhraseSuggestCollateQuery : IPhraseSuggestCollateQuery
+	{
+		/// <inheritdoc />
+		public string Source { get; set; }
+
+		/// <inheritdoc />
+		public Id Id { get; set; }
+	}
+
+	/// <inheritdoc />
+	public class PhraseSuggestCollateQueryDescriptor :
+		DescriptorBase<PhraseSuggestCollateQueryDescriptor, IPhraseSuggestCollateQuery>, IPhraseSuggestCollateQuery
+	{
+		string IPhraseSuggestCollateQuery.Source { get; set; }
+		Id IPhraseSuggestCollateQuery.Id { get; set; }
+
+		/// <inheritdoc />
+		public PhraseSuggestCollateQueryDescriptor Source(string source) => Assign(a => a.Source = source);
+
+		/// <inheritdoc />
+		public PhraseSuggestCollateQueryDescriptor Id(Id id) => Assign(a => a.Id = id);
+	}
+}

--- a/src/Tests/QueryDsl/Specialized/Template/TemplateQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/Specialized/Template/TemplateQueryUsageTests.cs
@@ -26,6 +26,7 @@ namespace Tests.QueryDsl.Specialized.Template
 			}
 		};
 
+#pragma warning disable 618
 		protected override QueryContainer QueryInitializer => new TemplateQuery
 		{
 			Name = "named_query",
@@ -37,7 +38,6 @@ namespace Tests.QueryDsl.Specialized.Template
 			}
 		};
 
-#pragma warning disable 618
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
 			.Template(sn => sn
 				.Name("named_query")
@@ -45,20 +45,18 @@ namespace Tests.QueryDsl.Specialized.Template
 				.Source(_templateString)
 				.Params(p=>p.Add("query_string", "all about search"))
 			);
-#pragma warning restore 618
 
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<ITemplateQuery>(a => a.Template)
 		{
 			q => {
 				q.Source = "";
 				q.Id = null;
-				q.File = "";
 			},
 			q => {
 				q.Source = null;
 				q.Id = null;
-				q.File = null;
 			}
 		};
 	}
+#pragma warning restore 618
 }

--- a/src/Tests/Search/Request/SuggestUsageTests.cs
+++ b/src/Tests/Search/Request/SuggestUsageTests.cs
@@ -50,9 +50,9 @@ namespace Tests.Search.Request
 						collate = new {
 						  query = new {
 							source = "{ \"match\": { \"{{field_name}}\": \"{{suggestion}}\" }}",
-							@params = new {
-						      field_name = "title"
-							}
+						  },
+						  @params = new {
+					        field_name = "title"
 						  },
 						  prune = true,
 						},
@@ -81,7 +81,8 @@ namespace Tests.Search.Request
 						suggest_mode = "always"
 					  },
 					  text = "hello world"
-					} }
+					  }
+					}
 				  }
 			};
 
@@ -123,8 +124,8 @@ namespace Tests.Search.Request
 					.Collate(c => c
 						.Query(q => q
 							.Source("{ \"match\": { \"{{field_name}}\": \"{{suggestion}}\" }}")
-							.Params(p => p.Add("field_name", "title"))
 						)
+						.Params(p => p.Add("field_name", "title"))
 						.Prune()
 					)
 					.Confidence(10.1)
@@ -190,13 +191,13 @@ namespace Tests.Search.Request
 						{
 							Collate = new PhraseSuggestCollate
 							{
-								Query = new TemplateQuery
+								Query = new PhraseSuggestCollateQuery
 								{
 									Source = "{ \"match\": { \"{{field_name}}\": \"{{suggestion}}\" }}",
-									Params = new Dictionary<string, object>
-									{
-										{ "field_name", "title" }
-									}
+								},
+								Params = new Dictionary<string, object>
+								{
+									{ "field_name", "title" }
 								},
 								Prune = true
 							},


### PR DESCRIPTION
Relates #2965 

This commit adds a Parameters dictionary to IPhraseSuggestCollate so that parameters are serialized to the correct query form and introduces a PhraseSuggestCollateQuery to specify the query.

Add XML documentation to indicate the usage of each property.

Closes #2849

(cherry-picked from commit f905270)