### PR TITLE
[DOCS] Fixed doc build errors

### DIFF
--- a/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs.
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
@@ -28,7 +28,8 @@ Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregat
 === Handling responses
 
 Using the `.Aggs` aggregation helper on `ISearchResponse<T>`, we can fetch our aggregation results easily
-in the correct type. <<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
+in the correct type.
+//<<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
 
 ==== Handling Responses
 
@@ -54,4 +55,3 @@ foreach (var item in dateHistogram.Buckets)
     nestedTerms.Buckets.Count.Should().BeGreaterThan(0);
 }
 ----
-

--- a/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs.
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
@@ -26,7 +26,8 @@ Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregat
 === Handling Responses
 
 Using the `.Agg` aggregation helper we can fetch our aggregation results easily
-in the correct type. <<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
+in the correct type.
+//<<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
 
 ==== Handling Responses
 
@@ -39,7 +40,7 @@ dateHistogram.Should().NotBeNull();
 dateHistogram.Buckets.Should().NotBeNull();
 ----
 
-We specified three ranges so we expect to have three of them in the response 
+We specified three ranges so we expect to have three of them in the response
 
 [source,csharp]
 ----
@@ -49,4 +50,3 @@ foreach (var item in dateHistogram.Buckets)
     item.DocCount.Should().BeGreaterThan(0);
 }
 ----
-

--- a/docs/aggregations/bucket/filter/filter-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/filter/filter-aggregation-usage.asciidoc
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/Filter/FilterAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/Filter/FilterAggregationUsageTests.cs.
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
@@ -23,7 +23,8 @@ Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregat
 === Handling Responses
 
 Using the `.Aggs` aggregation helper we can fetch our aggregation results easily
-in the correct type. <<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
+in the correct type.
+//<<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
 
 ==== Handling Responses
 
@@ -55,4 +56,3 @@ response.ShouldNotBeValid();
 response.ShouldBeValid();
 response.Aggregations.Filter(_aggName).DocCount.Should().BeGreaterThan(0);
 ----
-

--- a/docs/aggregations/bucket/filters/filters-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/filters/filters-aggregation-usage.asciidoc
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/Filters/FiltersAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/Filters/FiltersAggregationUsageTests.cs.
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
@@ -27,7 +27,8 @@ Be sure to read the Elasticsearch documentation {ref_current}/search-aggregation
 ==== Handling Responses
 
 Using the `.Agg` aggregation helper we can fetch our aggregation results easily
-in the correct type. <<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
+in the correct type.
+//<<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
 
 [source,csharp]
 ----
@@ -59,7 +60,8 @@ namedResult.DocCount.Should().Be(0);
 ==== Handling Responses
 
 Using the `.Agg` aggregation helper we can fetch our aggregation results easily
-in the correct type. <<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
+in the correct type.
+//<<aggs-vs-aggregations, Be sure to read more about .Aggs vs .Aggregations>>
 
 [source,csharp]
 ----
@@ -89,11 +91,10 @@ response.Aggregations.Filters("empty_filters").Buckets.Should().BeEmpty();
 ----
 
 [float]
-=== Conditionless Filters 
+=== Conditionless Filters
 
 [source,csharp]
 ----
 response.ShouldBeValid();
 response.Aggregations.Filters("conditionless_filters").Buckets.Should().BeEmpty();
 ----
-


### PR DESCRIPTION
The "aggs-vs-aggregations" section anchor was removed in https://github.com/elastic/elasticsearch-net/commit/e78688efbf4f408f0bd769d6a66b8426942dfa6c so this PR removes broken links to that section. 