### PR TITLE
Fix/geocentroid agg empty

### DIFF
--- a/build/scripts/Testing.fsx
+++ b/build/scripts/Testing.fsx
@@ -34,6 +34,7 @@ module Tests =
             let key = tokens.[0].ToUpper()
             let b = if tokens.Length = 1 then true else (bool.Parse (tokens.[1]))
             let v = sprintf "NEST_RANDOM_%s" key
+            printfn "%s = %O" v b
             setProcessEnvironVar v (if b then "true" else "false")
         ignore()
 

--- a/build/scripts/Testing.fsx
+++ b/build/scripts/Testing.fsx
@@ -34,7 +34,6 @@ module Tests =
             let key = tokens.[0].ToUpper()
             let b = if tokens.Length = 1 then true else (bool.Parse (tokens.[1]))
             let v = sprintf "NEST_RANDOM_%s" key
-            printfn "%s = %O" v b
             setProcessEnvironVar v (if b then "true" else "false")
         ignore()
 

--- a/src/Nest/Aggregations/AggregateDictionary.cs
+++ b/src/Nest/Aggregations/AggregateDictionary.cs
@@ -12,13 +12,6 @@ namespace Nest
 	[ContractJsonConverter(typeof(AggregateDictionaryConverter))]
 	public class AggregateDictionary : IsAReadOnlyDictionaryBase<string, IAggregate>
 	{
-		private static string TypedKeysTokens(string key)
-		{
-//typed_keys = true on results in aggregation keys being returned as "<type>#<name>"
-			var tokens = key.Split(TypedKeysSeparator, 2, StringSplitOptions.RemoveEmptyEntries);
-			return tokens.Length > 1 ? tokens[1] : tokens[0];
-		}
-
 		public static AggregateDictionary Default { get; } = new AggregateDictionary(EmptyReadOnly<string, IAggregate>.Dictionary);
 
 		public AggregateDictionary(IReadOnlyDictionary<string, IAggregate> backingDictionary) : base(backingDictionary) { }

--- a/src/Nest/Aggregations/AggregateDictionaryConverter.cs
+++ b/src/Nest/Aggregations/AggregateDictionaryConverter.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	internal class AggregateDictionaryConverter : VerbatimDictionaryKeysJsonConverter<string, IAggregate>
+	{
+		private static readonly AggregateJsonConverter OldSchoolHeuristicsParser = new AggregateJsonConverter();
+
+		public override bool CanRead => true;
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var dictionary = new Dictionary<string, IAggregate>();
+			if (reader.TokenType != JsonToken.StartObject)
+			{
+				reader.Skip();
+				return new AggregateDictionary(dictionary);
+			}
+
+			var depth = reader.Depth;
+			while (reader.Depth >= depth)
+			{
+				reader.Read();
+				var typedProperty = reader.Value as string;
+				if (typedProperty.IsNullOrEmpty()) break;
+				var tokens = AggregateDictionary.TypedKeyTokens(typedProperty);
+				if (tokens.Length == 1)
+					ParseAggregate(reader, serializer, tokens[0], dictionary);
+				else
+					ReadAggregate(reader, serializer, tokens, dictionary);
+			}
+
+			return new AggregateDictionary(dictionary);
+		}
+
+		private static void ReadAggregate(JsonReader r, JsonSerializer s, string[] tokens, Dictionary<string, IAggregate> d)
+		{
+			var name = tokens[1];
+			var type = tokens[0];
+			switch (type)
+			{
+				case "geo_centroid":
+					ReadAggregate<GeoCentroidAggregate>(r, s, d, name);
+					break;
+				default:
+					//still fall back to heuristics based parsed in case we do not know the key
+					ParseAggregate(r, s, name, d);
+					break;
+			}
+		}
+
+		private static void ReadAggregate<TAggregate>(JsonReader reader, JsonSerializer serializer, Dictionary<string, IAggregate> dictionary, string name)
+			where TAggregate : IAggregate
+		{
+			reader.Read();
+			var geoCentroid = serializer.Deserialize<TAggregate>(reader);
+			dictionary.Add(name, geoCentroid);
+		}
+
+		private static void ParseAggregate(JsonReader reader, JsonSerializer serializer, string name, Dictionary<string, IAggregate> dictionary)
+		{
+			reader.Read();
+			var aggregate = OldSchoolHeuristicsParser.ReadJson(reader, typeof(IAggregate), null, serializer) as IAggregate;
+			dictionary.Add(name, aggregate);
+		}
+	}
+}

--- a/src/Nest/Aggregations/Metric/GeoCentroid/GeoCentroidAggregate.cs
+++ b/src/Nest/Aggregations/Metric/GeoCentroid/GeoCentroidAggregate.cs
@@ -1,8 +1,12 @@
-﻿namespace Nest
+﻿using Newtonsoft.Json;
+
+namespace Nest
 {
 	public class GeoCentroidAggregate : MetricAggregateBase
 	{
+		[JsonProperty("location")]
 		public GeoLocation Location { get; set; }
+		[JsonProperty("count")]
 		public long Count { get; set; }
 	}
 }

--- a/src/Nest/Aggregations/Metric/MetricAggregate.cs
+++ b/src/Nest/Aggregations/Metric/MetricAggregate.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Nest
 {
 	public abstract class MetricAggregateBase : IAggregate
 	{
+		[JsonProperty("meta")]
 		public IReadOnlyDictionary<string, object> Meta { get;  set; } = EmptyReadOnly<string, object>.Dictionary;
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/RelationName/RelationNameJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/RelationName/RelationNameJsonConverter.cs
@@ -33,6 +33,5 @@ namespace Nest
 			}
 			return null;
 		}
-
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
@@ -36,28 +36,4 @@ namespace Nest
 	{
 		public override SerializationFormatting? ForceFormatting { get; } = None;
 	}
-	internal class SourceValueWriteConverter : JsonConverter
-	{
-		public override bool CanRead => false;
-		public override bool CanWrite => true;
-		public override bool CanConvert(Type objectType) => true;
-
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-		{
-			Write(writer, value, serializer);
-		}
-
-		public static void Write(JsonWriter writer, object value, JsonSerializer serializer)
-		{
-			var sourceSerializer = serializer.GetConnectionSettings().SourceSerializer;
-			var f = writer.Formatting == Formatting.Indented ? Indented : None;
-			var v = sourceSerializer.SerializeToString(value, f);
-			writer.WriteRawValue(v);
-		}
-
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-		{
-			throw new NotImplementedException("CanRead is false so this is not expected to be called");
-		}
-	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SourceValueWriteConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SourceValueWriteConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using Elasticsearch.Net;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	internal class SourceValueWriteConverter : JsonConverter
+	{
+		public override bool CanRead => false;
+		public override bool CanWrite => true;
+		public override bool CanConvert(Type objectType) => true;
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			Write(writer, value, serializer);
+		}
+
+		public static void Write(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var nativeType = value.GetType().Assembly() == typeof(SourceValueWriteConverter).Assembly();
+
+			var settings = serializer.GetConnectionSettings();
+			var s = nativeType ? settings.RequestResponseSerializer : settings.SourceSerializer;
+			var f = writer.Formatting == Formatting.Indented ? SerializationFormatting.Indented : SerializationFormatting.None;
+			var v = s.SerializeToString(value, f);
+			writer.WriteRawValue(v);
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			throw new NotImplementedException("CanRead is false so this is not expected to be called");
+		}
+	}
+}

--- a/src/Nest/CrossPlatform/TypeExtensions.cs
+++ b/src/Nest/CrossPlatform/TypeExtensions.cs
@@ -17,6 +17,15 @@ namespace Nest
 #endif
 		}
 
+		internal static Assembly Assembly(this Type type)
+		{
+#if DOTNETCORE
+			return type.GetTypeInfo().Assembly;
+#else
+			return type.Assembly;
+#endif
+		}
+
 		internal static bool IsGenericDictionary(this Type type)
 		{
 			return type.GetInterfaces().Any(t =>

--- a/src/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs
@@ -119,6 +119,7 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 		}
 	}
 
+	[NeedsTypedKeys]
 	public class GeoCentroidNoResultsAggregationUsageTests : AggregationUsageTestBase
 	{
 		public GeoCentroidNoResultsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }

--- a/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
@@ -39,13 +39,18 @@ namespace Tests.Framework.Configuration
 
 			this.Random = new RandomConfiguration
 			{
-				SourceSerializer = BoolConfig("SOURCESERIALIZER", randomizer),
-				TypedKeys = BoolConfig("TYPEDKEYS", randomizer),
+				SourceSerializer = RandomBoolConfig("SOURCESERIALIZER", randomizer),
+				TypedKeys = RandomBoolConfig("TYPEDKEYS", randomizer),
 			};
 		}
 
-		private static bool BoolConfig(string key, Randomizer randomizer) =>
-			(TryGetEnv("NEST_RANDOM_" + key, out var source) && bool.Parse(source)) || randomizer.Bool();
+		private static bool RandomBoolConfig(string key, Randomizer randomizer)
+		{
+			if (TryGetEnv("NEST_RANDOM_" + key, out var source) && bool.TryParse(source, out var b))
+				return b;
+			return randomizer.Bool();
+		}
+
 
 		private static bool TryGetEnv(string key, out string value)
 		{

--- a/src/Tests/Framework/XUnitPlumbing/IntegrationTestDiscoverer.cs
+++ b/src/Tests/Framework/XUnitPlumbing/IntegrationTestDiscoverer.cs
@@ -21,7 +21,8 @@ namespace Tests.Framework
 
 			return TypeSkipVersionAttributeSatisfies(classOfMethod)
 			       || MethodSkipVersionAttributeSatisfies(method)
-			       || SkipWhenRunOnTeamCity(classOfMethod, method);
+			       || SkipWhenRunOnTeamCity(classOfMethod, method)
+			       || SkipWhenNeedingTypedKeys(classOfMethod);
 		}
 
 		private bool SkipWhenRunOnTeamCity(Type classOfMethod, MethodInfo info)

--- a/src/Tests/Framework/XUnitPlumbing/NeedsTypedKeysAttribute.cs
+++ b/src/Tests/Framework/XUnitPlumbing/NeedsTypedKeysAttribute.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace Tests.Framework
+{
+	public class NeedsTypedKeysAttribute : Attribute { }
+}

--- a/src/Tests/Framework/XUnitPlumbing/NestTestDiscoverer.cs
+++ b/src/Tests/Framework/XUnitPlumbing/NestTestDiscoverer.cs
@@ -25,5 +25,8 @@ namespace Tests.Framework
 				? Enumerable.Empty<IXunitTestCase>()
 				: new[] { new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
 
+		protected static bool SkipWhenNeedingTypedKeys(Type classOfMethod) =>
+			(!TestClient.Configuration.Random.TypedKeys && classOfMethod.GetAttributes<NeedsTypedKeysAttribute>().Any());
+
 	}
 }

--- a/src/Tests/Framework/XUnitPlumbing/UnitTestDiscoverer.cs
+++ b/src/Tests/Framework/XUnitPlumbing/UnitTestDiscoverer.cs
@@ -16,8 +16,10 @@ namespace Tests.Framework
 			var classOfMethod = Type.GetType(testMethod.TestClass.Class.Name, true, true);
 			return !TestClient.Configuration.RunUnitTests
 			       || ClassShouldSkipWhenPackageReference(classOfMethod)
-			       || ClassIsIntegrationOnly(classOfMethod);
+			       || ClassIsIntegrationOnly(classOfMethod)
+			       || SkipWhenNeedingTypedKeys(classOfMethod);
 		}
+
 
 		private static bool ClassShouldSkipWhenPackageReference(Type classOfMethod)
 		{

--- a/src/Tests/tests.default.yaml
+++ b/src/Tests/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: i
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 6.0.0


### PR DESCRIPTION
fix for #3000 

It relies on `typed_keys=true` being send to the server so the aggregation names return `type#name` which all search request already do by default in the `6.x` client.

`AggregateDictionaryJsonConverter` now inspects the `type` portion. We only do it for `geo_centroid` for now but it should be easy to start adding all the others over the course of 6.x and support new ones like composite aggs #2902. `typed_keys=true` is a requirement from 6.x onwards. The fact that the old heuristics parser works in 98% of the cases is not good enough. 

Test classes can be marked with `[NeedsTypedKeys]` so that they don't run when the test configuration sets typed keys to false randomly. 

Can be tested with:

```
$  build integrate 6.0.0 "readonly" "aggregation" random:typedkeys
```

```
$  build integrate 6.0.0 "readonly" "aggregation" random:typedkeys:false
```

This PR also fixes an issue where this random value was not fed to the aggregation tests correctly.




