### PR TITLE
GetMapping helpers to get the TypeMapping for a type.

### DIFF
--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -128,6 +128,10 @@ namespace Nest
 		{
 			return value == null || value.GetHashCode() == 0;
 		}
+		internal static bool IsNullOrEmpty(this IndexName value)
+		{
+			return value == null || value.GetHashCode() == 0;
+		}
 		internal static bool IsValueType(this Type type)
 		{
 #if DOTNETCORE

--- a/src/Nest/CommonAbstractions/Response/ResolvableDictionaryProxy.cs
+++ b/src/Nest/CommonAbstractions/Response/ResolvableDictionaryProxy.cs
@@ -28,7 +28,7 @@ namespace Nest
 			this.BackingDictionary = dictionary;
 		}
 
-		private string Sanitize(TKey key) => key.GetString(_connectionSettings);
+		private string Sanitize(TKey key) => key?.GetString(_connectionSettings);
 
 		IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() =>
 			this.Original.GetEnumerator();

--- a/src/Nest/CommonAbstractions/Response/ResolvableDictionaryProxy.cs
+++ b/src/Nest/CommonAbstractions/Response/ResolvableDictionaryProxy.cs
@@ -42,8 +42,8 @@ namespace Nest
 		public bool TryGetValue(TKey key, out TValue value) =>
 			this.BackingDictionary.TryGetValue(Sanitize(key), out value);
 
-		public TValue this[TKey key] => this.BackingDictionary[Sanitize(key)];
-		public TValue this[string key] => this.BackingDictionary[key];
+		public TValue this[TKey key] => this.BackingDictionary.TryGetValue(Sanitize(key), out var v) ? v : default(TValue);
+		public TValue this[string key] => this.BackingDictionary.TryGetValue(key, out var v) ? v : default(TValue);
 
 		public IEnumerable<TKey> Keys => this.Original.Keys;
 		public IEnumerable<string> ResolvedKeys => this.BackingDictionary.Keys;

--- a/src/Nest/Indices/MappingManagement/GetMapping/GetMappingResponse.cs
+++ b/src/Nest/Indices/MappingManagement/GetMapping/GetMappingResponse.cs
@@ -41,15 +41,17 @@ namespace Nest
 	{
 		[JsonIgnore]
 		public IReadOnlyDictionary<IndexName, IndexMappings> Indices => Self.BackingDictionary;
+		
 		[JsonIgnore]
+		[Obsolete("Renamed to Indices, will be deleted from NEST 7.x")]
 		public IReadOnlyDictionary<IndexName, IndexMappings> Mappings => Indices;
 
 		[Obsolete("Use GetMappingFor explicitly instead this is a leaky abstraction that returns the mapping of the first index's first type on the response")]
-		public TypeMapping Mapping => this.Indices.FirstOrDefault().Value?.Mappings?.FirstOrDefault().Value;
+		public ITypeMapping Mapping => this.Indices.FirstOrDefault().Value?.Mappings?.FirstOrDefault().Value;
 
-		public TypeMapping GetMappingFor<T>() => this.Indices[typeof(T)]?[typeof(T)];
-		public TypeMapping GetMappingFor(string index, string type) => this.Indices[index]?[type];
-		public TypeMapping GetMappingFor(string index) => this.Indices[index]?.Mappings?.FirstOrDefault().Value;
+		public ITypeMapping GetMappingFor<T>() => this.Indices[typeof(T)]?[typeof(T)];
+		public ITypeMapping GetMappingFor(string index, string type) => this.Indices[index]?[type];
+		public ITypeMapping GetMappingFor(string index) => this.Indices[index]?.Mappings?.FirstOrDefault().Value;
 
 		public void Accept(IMappingVisitor visitor)
 		{

--- a/src/Nest/Indices/MappingManagement/GetMapping/GetMappingResponse.cs
+++ b/src/Nest/Indices/MappingManagement/GetMapping/GetMappingResponse.cs
@@ -44,6 +44,13 @@ namespace Nest
 		[JsonIgnore]
 		public IReadOnlyDictionary<IndexName, IndexMappings> Mappings => Indices;
 
+		[Obsolete("Use GetMappingFor explicitly instead this is a leaky abstraction that returns the mapping of the first index's first type on the response")]
+		public TypeMapping Mapping => this.Indices.FirstOrDefault().Value?.Mappings?.FirstOrDefault().Value;
+
+		public TypeMapping GetMappingFor<T>() => this.Indices[typeof(T)]?[typeof(T)];
+		public TypeMapping GetMappingFor(string index, string type) => this.Indices[index]?[type];
+		public TypeMapping GetMappingFor(string index) => this.Indices[index]?.Mappings?.FirstOrDefault().Value;
+
 		public void Accept(IMappingVisitor visitor)
 		{
 			var walker = new MappingWalker(visitor);

--- a/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -43,10 +43,6 @@ namespace Tests.Indices.MappingManagement.GetMapping
 		{
 			response.ShouldBeValid();
 
-			var visitor = new TestVisitor();
-			response.Accept(visitor);
-			var b = TestClient.Configuration.Random.SourceSerializer;
-
 			response.Indices["project"]["doc"].Properties.Should().NotBeEmpty();
 			response.Indices[Index<Project>()].Mappings[Type<Project>()].Properties.Should().NotBeEmpty();
 			response.Indices[Index<Project>()][Type<Project>()].Properties.Should().NotBeEmpty();
@@ -55,6 +51,25 @@ namespace Tests.Indices.MappingManagement.GetMapping
 			var leadDev = properties[Property<Project>(p => p.LeadDeveloper)];
 			leadDev.Should().NotBeNull();
 
+			//hide
+			AssertBadDictionaryAccess(response);
+
+			//hide
+			AssertVisitedProperies(response);
+		}
+
+		//hide
+		private static void AssertBadDictionaryAccess(IGetMappingResponse response)
+		{
+			response.Indices[null].Should().BeNull();
+
+		}
+		//hide
+		private static void AssertVisitedProperies(IGetMappingResponse response)
+		{
+			var visitor = new TestVisitor();
+			var b = TestClient.Configuration.Random.SourceSerializer;
+			response.Accept(visitor);
 			visitor.CountsShouldContainKeyAndCountBe("type", 1);
 			visitor.CountsShouldContainKeyAndCountBe("text", b ? 19 : 18);
 			visitor.CountsShouldContainKeyAndCountBe("keyword", b ? 19 : 18);

--- a/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -51,17 +51,31 @@ namespace Tests.Indices.MappingManagement.GetMapping
 			var leadDev = properties[Property<Project>(p => p.LeadDeveloper)];
 			leadDev.Should().NotBeNull();
 
+			var props = response.Indices["x"]?["y"].Properties;
+			props.Should().BeNull();
+
 			//hide
-			AssertBadDictionaryAccess(response);
+			AssertExtensionMethods(response);
 
 			//hide
 			AssertVisitedProperies(response);
 		}
 
 		//hide
-		private static void AssertBadDictionaryAccess(IGetMappingResponse response)
+		private static void AssertExtensionMethods(IGetMappingResponse response)
 		{
-			response.Indices[null].Should().BeNull();
+			/** The `GetMappingFor` extension method can be used to get a type mapping easily and safely */
+			response.GetMappingFor<Project>().Should().NotBeNull();
+			response.GetMappingFor(typeof(Project), typeof(Project)).Should().NotBeNull();
+			response.GetMappingFor(typeof(Project)).Should().NotBeNull();
+
+			/** The following should all return a `null` because we had asked for the mapping of type `doc` in index `project` */
+			response.GetMappingFor<Developer>().Should().BeNull();
+			response.GetMappingFor("dev", "dev").Should().BeNull();
+			response.GetMappingFor(typeof(Project), "x").Should().BeNull();
+			response.GetMappingFor("dev").Should().BeNull();
+
+
 
 		}
 		//hide


### PR DESCRIPTION
We used to have a Mapping property which returns the first index's first type's mapping. Since folks typically call get mapping to only return a single mapping. We removed this because its a leaky abstraction but it might be hard for folks to figure out the best way now. Introduced GetMappingFor helpers and reintroduced the Mapping property with an obsolete to guide folks during upgrade.

cc @niemyjski 