### PR TITLE
Split out Time into separate types for Time values and DateMath times

### DIFF
--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -19,7 +19,7 @@ The date type supports using date math expression when using it in a query/filte
 Whenever durations need to be specified, eg for a timeout parameter, the duration can be specified
 
 The expression starts with an "anchor" date, which can be either now or a date string (in the applicable format) ending with `||`.
-It can then follow by a math expression, supporting `+`, `-` and `/` (rounding).
+It can be followed by a math expression, supporting `+`, `-` and `/` (rounding).
 The units supported are
 
 * `y` (year)
@@ -35,8 +35,6 @@ The units supported are
 * `m` (minute)
 
 * `s` (second)
-
-as a whole number representing time in milliseconds, or as a time value like `2d` for 2 days.
 
 :datemath: {ref_current}/common-options.html#date-math
 
@@ -119,7 +117,7 @@ A rounding value can be chained to the end of the expression, after which no mor
 Expect("now+1d-1m/d").WhenSerializing(
     Nest.DateMath.Now.Add("1d")
         .Subtract(TimeSpan.FromMinutes(1))
-        .RoundTo(Nest.TimeUnit.Day));
+        .RoundTo(DateMathTimeUnit.Day));
 ----
 
 When anchoring dates, a `||` needs to be appended as clear separator between the anchor and ranges.
@@ -135,31 +133,105 @@ Expect("2015-05-05T00:00:00||+1d-1m").WhenSerializing(
 
 ==== Fractional times
 
-DateMath expressions do not support fractional numbers so unlike `Time` DateMath will
-pick the biggest integer unit it can represent
+Date math expressions within Elasticsearch do not support fractional numbers. To make working with Date math
+easier within NEST, conversions from `string`, `TimeSpan` and `double` will convert a fractional value to the
+largest whole number value and unit, rounded to the nearest second.
 
 [source,csharp]
 ----
-Expect("now+25h").WhenSerializing(
-    Nest.DateMath.Now.Add(TimeSpan.FromHours(25)));
-----
+Expect("now+1w").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromDays(7)));
 
-where as `Time` on its own serializes like this 
+Expect("now+1w").WhenSerializing(Nest.DateMath.Now.Add("1w"));
 
-[source,csharp]
-----
-Expect("1.04d").WhenSerializing(new Time(TimeSpan.FromHours(25)));
+Expect("now+1w").WhenSerializing(Nest.DateMath.Now.Add(604800000));
+
+Expect("now+7d").WhenSerializing(Nest.DateMath.Now.Add("7d"));
+
+Expect("now+30h").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromHours(30)));
+
+Expect("now+30h").WhenSerializing(Nest.DateMath.Now.Add("1.25d"));
 
 Expect("now+90001s").WhenSerializing(
     Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromSeconds(1))));
 
-Expect("now+90000001ms").WhenSerializing(
+Expect("now+90000s").WhenSerializing(
     Nest.DateMath.Now.Add(TimeSpan.FromHours(25).Add(TimeSpan.FromMilliseconds(1))));
 
-Expect("now+1y").WhenSerializing(
-    Nest.DateMath.Now.Add("1y"));
+Expect("now+1y").WhenSerializing(Nest.DateMath.Now.Add("1y"));
 
-Expect("now+52w").WhenSerializing(
-    Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+Expect("now+12M").WhenSerializing(Nest.DateMath.Now.Add("12M"));
+
+Expect("now+18M").WhenSerializing(Nest.DateMath.Now.Add("1.5y"));
+
+Expect("now+52w").WhenSerializing(Nest.DateMath.Now.Add(TimeSpan.FromDays(7 * 52)));
+----
+
+==== Rounding
+
+Rounding can be controlled using the constructor, and passing a value for rounding
+
+[source,csharp]
+----
+Expect("now+2s").WhenSerializing(
+    Nest.DateMath.Now.Add(new DateMathTime("2.5s", MidpointRounding.ToEven)));
+
+Expect("now+3s").WhenSerializing(
+    Nest.DateMath.Now.Add(new DateMathTime("2.5s", MidpointRounding.AwayFromZero)));
+
+Expect("now+0s").WhenSerializing(
+    Nest.DateMath.Now.Add(new DateMathTime(500, MidpointRounding.ToEven)));
+
+Expect("now+1s").WhenSerializing(
+    Nest.DateMath.Now.Add(new DateMathTime(500, MidpointRounding.AwayFromZero)));
+----
+
+==== Equality and Comparisons
+
+`DateMathTime` supports implements equality and comparison
+
+[source,csharp]
+----
+DateMathTime twoSeconds = new DateMathTime(2, DateMathTimeUnit.Second);
+DateMathTime twoSecondsFromString = "2s";
+DateMathTime twoSecondsFromTimeSpan = TimeSpan.FromSeconds(2);
+DateMathTime twoSecondsFromDouble = 2000;
+
+twoSeconds.Should().Be(twoSecondsFromString);
+twoSeconds.Should().Be(twoSecondsFromTimeSpan);
+twoSeconds.Should().Be(twoSecondsFromDouble);
+
+DateMathTime threeSecondsFromString = "3s";
+DateMathTime oneMinuteFromTimeSpan = TimeSpan.FromMinutes(1);
+
+(threeSecondsFromString > twoSecondsFromString).Should().BeTrue();
+(oneMinuteFromTimeSpan > threeSecondsFromString).Should().BeTrue();
+----
+
+Since years and months do not
+contain exact values
+
+* A year is approximated to 365 days
+
+* A month is approximated to (365 / 12) days
+
+[source,csharp]
+----
+DateMathTime oneYear = new DateMathTime(1, DateMathTimeUnit.Year);
+DateMathTime oneYearFromString = "1y";
+DateMathTime twelveMonths = new DateMathTime(12, DateMathTimeUnit.Month);
+DateMathTime twelveMonthsFromString = "12M";
+
+oneYear.Should().Be(oneYearFromString);
+oneYear.Should().Be(twelveMonths);
+twelveMonths.Should().Be(twelveMonthsFromString);
+
+DateMathTime thirteenMonths = new DateMathTime(13, DateMathTimeUnit.Month);
+DateMathTime thirteenMonthsFromString = "13M";
+DateMathTime fiftyTwoWeeks = "52w";
+
+(oneYear < thirteenMonths).Should().BeTrue();
+(oneYear < thirteenMonthsFromString).Should().BeTrue();
+(twelveMonths > fiftyTwoWeeks).Should().BeTrue();
+(oneYear > fiftyTwoWeeks).Should().BeTrue();
 ----
 

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -53,7 +53,7 @@ Expect("2d")
     .WhenSerializing(unitMilliseconds);
 ----
 
-The `Milliseconds` property on `Time` is calculated even when not using the constructor that takes a double
+The `Milliseconds` property on `Time` is calculated even when not using the constructor that takes a `double`
 
 [source,csharp]
 ----
@@ -65,68 +65,44 @@ unitString.Milliseconds.Should().Be(1000*60*60*24*2);
 
 ==== Implicit conversion
 
-Alternatively to using the constructor, `string`, `TimeSpan` and `double` can be implicitly converted to `Time`
+There are implicit conversions from `string`, `TimeSpan` and `double` to an instance of `Time`, making them
+easier to work with
 
 [source,csharp]
 ----
-Time oneAndHalfYear = "1.5y";
-Time twoWeeks = TimeSpan.FromDays(14);
+Time oneMinute = "1m";
+Time fourteenDays = TimeSpan.FromDays(14);
 Time twoDays = 1000*60*60*24*2;
 
-Expect("1.5y").WhenSerializing(oneAndHalfYear);
-Expect("2w").WhenSerializing(twoWeeks);
+Expect("1m").WhenSerializing(oneMinute);
+Expect("14d").WhenSerializing(fourteenDays);
 Expect("2d").WhenSerializing(twoDays);
+----
 
-Time oneAndHalfYear = "1.5y";
-Time twoWeeks = TimeSpan.FromDays(14);
+==== Equality and Comparison
+
+Comparisons on the expressions can be performed since Milliseconds are calculated
+even when values are not passed as `double` milliseconds
+
+[source,csharp]
+----
+Time fourteenDays = TimeSpan.FromDays(14);
+fourteenDays.Milliseconds.Should().Be(1209600000);
+
 Time twoDays = 1000*60*60*24*2;
-----
 
-Milliseconds are calculated even when values are not passed as long...
-
-[source,csharp]
-----
-twoWeeks.Milliseconds.Should().BeGreaterThan(1);
-----
-
-...**except** when dealing with years or months, whose millsecond value cannot
-be calculated *accurately*, since they are not fixed durations. For instance,
-30 vs 31 vs 28 days in a month, or 366 vs 365 days in a year.
-In this instance, Milliseconds will be -1.
-
-[source,csharp]
-----
-oneAndHalfYear.Milliseconds.Should().Be(-1);
-----
-
-This allows you to do comparisons on the expressions
-
-[source,csharp]
-----
-oneAndHalfYear.Should().BeGreaterThan(twoWeeks);
-(oneAndHalfYear > twoWeeks).Should().BeTrue();
-(oneAndHalfYear >= twoWeeks).Should().BeTrue();
+fourteenDays.Should().BeGreaterThan(twoDays);
+(fourteenDays > twoDays).Should().BeTrue();
 (twoDays != null).Should().BeTrue();
 (twoDays >= new Time("2d")).Should().BeTrue();
 
-twoDays.Should().BeLessThan(twoWeeks);
-(twoDays < twoWeeks).Should().BeTrue();
-(twoDays <= twoWeeks).Should().BeTrue();
+twoDays.Should().BeLessThan(fourteenDays);
+(twoDays < fourteenDays).Should().BeTrue();
+(twoDays <= fourteenDays).Should().BeTrue();
 (twoDays <= new Time("2d")).Should().BeTrue();
 ----
 
-Special Time values `0` and `-1` can be compared against each other
-and other Time values although admittingly this is a tad non-sensical.
-
-[source,csharp]
-----
-Time.MinusOne.Should().BeLessThan(Time.Zero);
-Time.Zero.Should().BeGreaterThan(Time.MinusOne);
-Time.Zero.Should().BeLessThan(twoDays);
-Time.MinusOne.Should().BeLessThan(twoDays);
-----
-
-And assert equality
+Equality can also be performed
 
 [source,csharp]
 ----
@@ -134,15 +110,78 @@ twoDays.Should().Be(new Time("2d"));
 (twoDays == new Time("2d")).Should().BeTrue();
 (twoDays != new Time("2.1d")).Should().BeTrue();
 (new Time("2.1d") == new Time(TimeSpan.FromDays(2.1))).Should().BeTrue();
-//the string "-1" is not the same as double -1 which is milliseconds
-(new Time("-1") == new Time(-1)).Should().BeFalse();
-(new Time("-1") == Time.MinusOne).Should().BeTrue();
+----
+
+Equality has down to 1/10 nanosecond precision
+
+[source,csharp]
+----
+Time oneNanosecond = new Time(1, Nest.TimeUnit.Nanoseconds);
+Time onePointNoughtNineNanoseconds = "1.09nanos";
+Time onePointOneNanoseconds = "1.1nanos";
+
+(oneNanosecond == onePointNoughtNineNanoseconds).Should().BeTrue();
+(oneNanosecond == onePointOneNanoseconds).Should().BeFalse();
+----
+
+==== Special Time values
+
+Elasticsearch has two special values that can sometimes be passed where a `Time` is accepted
+
+* `0` represented as `Time.Zero`
+
+* `-1` represented as `Time.MinusOne`
+
+The following are all equal to `Time.MinusOne`
+
+[source,csharp]
+----
+Time.MinusOne.Should().Be(Time.MinusOne);
+new Time("-1").Should().Be(Time.MinusOne);
+new Time(-1).Should().Be(Time.MinusOne);
+((Time) (-1)).Should().Be(Time.MinusOne);
+((Time) "-1").Should().Be(Time.MinusOne);
+((Time) (-1)).Should().Be((Time) "-1");
+----
+
+Similarly, the following are all equal to `Time.Zero`
+
+[source,csharp]
+----
+Time.Zero.Should().Be(Time.Zero);
+new Time("0").Should().Be(Time.Zero);
+new Time(0).Should().Be(Time.Zero);
+((Time) 0).Should().Be(Time.Zero);
+((Time) "0").Should().Be(Time.Zero);
+((Time) 0).Should().Be((Time) "0");
+----
+
+Special Time values `0` and `-1` can be compared against other Time values
+although admittedly, this is a tad nonsensical.
+
+[source,csharp]
+----
+var twoDays = new Time(2, Nest.TimeUnit.Day);
+Time.MinusOne.Should().BeLessThan(Time.Zero);
+Time.Zero.Should().BeGreaterThan(Time.MinusOne);
+Time.Zero.Should().BeLessThan(twoDays);
+Time.MinusOne.Should().BeLessThan(twoDays);
+----
+
+If there is a need to construct a time of -1ms or 0ms, use the constructor
+that accepts a factor and time unit, or specify a string with ms time units
+
+[source,csharp]
+----
+(new Time(-1, Nest.TimeUnit.Millisecond) == new Time("-1ms")).Should().BeTrue();
+(new Time(0, Nest.TimeUnit.Millisecond) == new Time("0ms")).Should().BeTrue();
 ----
 
 ==== Units of Time
 
-Units of `Time` are specified as a union of either a `DateInterval` or `Time`,
-both of which implicitly convert to the `Union` of these two.
+Where Units of Time can be specified as a union of either a `DateInterval` or `Time`,
+a `DateInterval` or `Time` may be passed which will be implicity converted to a`Union<DateInterval, Time>`, the serialized form of which represents the initial value
+passed
 
 [source,csharp]
 ----
@@ -156,6 +195,6 @@ Expect("week").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Week);
 Expect("year").WhenSerializing<Union<DateInterval, Time>>(DateInterval.Year);
 
 Expect("2d").WhenSerializing<Union<DateInterval, Time>>((Time)"2d");
-Expect("1.16w").WhenSerializing<Union<DateInterval, Time>>((Time)TimeSpan.FromDays(8.1));
+Expect("11664m").WhenSerializing<Union<DateInterval, Time>>((Time)TimeSpan.FromDays(8.1));
 ----
 

--- a/docs/query-dsl/term-level/range/date-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/date-range-query-usage.asciidoc
@@ -25,7 +25,7 @@ q
     .Boost(1.1)
     .Field(p => p.Description)
     .GreaterThan(FixedDate)
-    .GreaterThanOrEquals(DateMath.Anchored(FixedDate).RoundTo(TimeUnit.Month))
+    .GreaterThanOrEquals(DateMath.Anchored(FixedDate).RoundTo(DateMathTimeUnit.Month))
     .LessThan("01/01/2012")
     .LessThanOrEquals(DateMath.Now)
     .Format("dd/MM/yyyy||yyyy")
@@ -43,7 +43,7 @@ new DateRangeQuery
     Boost = 1.1,
     Field = "description",
     GreaterThan = FixedDate,
-    GreaterThanOrEqualTo = DateMath.Anchored(FixedDate).RoundTo(TimeUnit.Month),
+    GreaterThanOrEqualTo = DateMath.Anchored(FixedDate).RoundTo(DateMathTimeUnit.Month),
     LessThan = "01/01/2012",
     LessThanOrEqualTo = DateMath.Now,
     TimeZone = "+01:00",

--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -79,8 +79,7 @@ namespace Nest
 
 			var enumType = typeof(T);
 			var key = $"{enumType.Name}.{str}";
-			object value;
-			if (_enumCache.TryGetValue(key, out value))
+			if (_enumCache.TryGetValue(key, out var value))
 				return (T)value;
 
 			foreach (var name in Enum.GetNames(enumType))

--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/JsonConverterBase.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/JsonConverterBase.cs
@@ -17,10 +17,7 @@ namespace Nest
 
 		public abstract void WriteJson(JsonWriter writer, T value, JsonSerializer serializer);
 
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-		{
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) =>
 			throw new NotSupportedException();
-		}
-
 	}
 }

--- a/src/Nest/CommonOptions/DateMath/DateMathExpression.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMathExpression.cs
@@ -7,7 +7,7 @@ namespace Nest
 		public DateMathExpression(string anchor) { this.Anchor = anchor; }
 		public DateMathExpression(DateTime anchor) { this.Anchor = anchor; }
 
-		public DateMathExpression(Union<DateTime, string> anchor, Time range, DateMathOperation operation)
+		public DateMathExpression(Union<DateTime, string> anchor, DateMathTime range, DateMathOperation operation)
 		{
 			anchor.ThrowIfNull(nameof(anchor));
 			range.ThrowIfNull(nameof(range));
@@ -16,25 +16,25 @@ namespace Nest
 			Self.Ranges.Add(Tuple.Create(operation, range));
 		}
 
-		public DateMathExpression Add(Time expression)
+		public DateMathExpression Add(DateMathTime expression)
 		{
 			Self.Ranges.Add(Tuple.Create(DateMathOperation.Add, expression));
 			return this;
 		}
 
-		public DateMathExpression Subtract(Time expression)
+		public DateMathExpression Subtract(DateMathTime expression)
 		{
 			Self.Ranges.Add(Tuple.Create(DateMathOperation.Subtract, expression));
 			return this;
 		}
 
-		public DateMathExpression Operation(Time expression, DateMathOperation operation)
+		public DateMathExpression Operation(DateMathTime expression, DateMathOperation operation)
 		{
 			Self.Ranges.Add(Tuple.Create(operation, expression));
 			return this;
 		}
 
-		public DateMath RoundTo(TimeUnit round)
+		public DateMath RoundTo(DateMathTimeUnit round)
 		{
 			this.Round = round;
 			return this;

--- a/src/Nest/CommonOptions/DateMath/DateMathOperation.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMathOperation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -11,5 +12,23 @@ namespace Nest
 		Add,
 		[EnumMember(Value = "-")]
 		Subtract
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public static class DateMathOperationExtensions
+	{
+		public static string GetStringValue(this DateMathOperation value)
+		{
+			switch (value)
+			{
+				case DateMathOperation.Add:
+					return "+";
+				case DateMathOperation.Subtract:
+					return "-";
+				default:
+					throw new ArgumentOutOfRangeException(nameof(value), value, null);
+			}
+
+		}
 	}
 }

--- a/src/Nest/CommonOptions/DateMath/DateMathOperation.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMathOperation.cs
@@ -14,7 +14,6 @@ namespace Nest
 		Subtract
 	}
 
-	[JsonConverter(typeof(StringEnumConverter))]
 	public static class DateMathOperationExtensions
 	{
 		public static string GetStringValue(this DateMathOperation value)

--- a/src/Nest/CommonOptions/DateMath/DateMathTime.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMathTime.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A time representation for use within <see cref="DateMath"/> expressions.
+	/// </summary>
+	public class DateMathTime : IComparable<DateMathTime>, IEquatable<DateMathTime>
+	{
+		private const int MonthsInAYear = 12;
+		private const double MillisecondsInAYearApproximate = MillisecondsInADay * 365;
+		private const double MillisecondsInAMonthApproximate = MillisecondsInAYearApproximate / MonthsInAYear;
+		private const double MillisecondsInAWeek = MillisecondsInADay * 7;
+		private const double MillisecondsInADay = MillisecondsInAnHour * 24;
+		private const double MillisecondsInAnHour = MillisecondsInAMinute * 60;
+		private const double MillisecondsInAMinute = MillisecondsInASecond * 60;
+		private const double MillisecondsInASecond = 1000;
+
+		private static readonly Regex ExpressionRegex =
+			new Regex(@"^
+				(?<factor>[+\-]? # open factor capture, allowing optional +- signs
+					(?:(?#numeric)(?:\d+(?:\.\d*)?)|(?:\.\d+)) #a numeric in the forms: (N, N., .N, N.N)
+					(?:(?#exponent)e[+\-]?\d+)? #an optional exponential scientific component, E also matches here (IgnoreCase)
+				) # numeric and exponent fall under the factor capture
+				\s{0,10} #optional spaces (sanity checked for max 10 repetitions)
+				(?<interval>(?:y|w|d|h|m|s)) #interval indicator
+				$",
+				RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+
+		private double _approximateSeconds;
+
+		public int Factor { get; private set; }
+
+		public DateMathTimeUnit Interval { get; private set; }
+
+		public static implicit operator DateMathTime(TimeSpan span) => new DateMathTime(span);
+		public static implicit operator DateMathTime(double milliseconds) => new DateMathTime(milliseconds);
+		public static implicit operator DateMathTime(string expression) => new DateMathTime(expression);
+
+		public DateMathTime(TimeSpan timeSpan, MidpointRounding rounding = MidpointRounding.AwayFromZero)
+			: this(timeSpan.TotalMilliseconds, rounding) { }
+
+		public DateMathTime(double milliseconds, MidpointRounding rounding = MidpointRounding.AwayFromZero) =>
+			SetWholeFactorIntervalAndSeconds(milliseconds, rounding);
+
+		public DateMathTime(int factor, DateMathTimeUnit interval) =>
+			SetWholeFactorIntervalAndSeconds(factor, interval, MidpointRounding.AwayFromZero);
+
+		public DateMathTime(string timeUnit, MidpointRounding rounding = MidpointRounding.AwayFromZero)
+		{
+			if (timeUnit == null) throw new ArgumentNullException(nameof(timeUnit));
+			if (timeUnit.Length == 0) throw new ArgumentException("Expression string is empty", nameof(timeUnit));
+
+			var match = ExpressionRegex.Match(timeUnit);
+			if (!match.Success) throw new ArgumentException($"Expression '{timeUnit}' string is invalid", nameof(timeUnit));
+
+			var factor = match.Groups["factor"].Value;
+			if (!double.TryParse(factor, NumberStyles.Any ,CultureInfo.InvariantCulture, out double fraction))
+				throw new ArgumentException($"Expression '{timeUnit}' contains invalid factor: {factor}", nameof(timeUnit));
+
+			var intervalValue = match.Groups["interval"].Value;
+			DateMathTimeUnit interval;
+
+			switch (intervalValue)
+			{
+				case "M":
+					interval= DateMathTimeUnit.Month;
+					break;
+				case "m":
+					interval = DateMathTimeUnit.Minute;
+					break;
+				default:
+					interval = intervalValue.ToEnum<DateMathTimeUnit>().Value;
+					break;
+			}
+
+			SetWholeFactorIntervalAndSeconds(fraction, interval, rounding);
+		}
+
+		private void SetWholeFactorIntervalAndSeconds(double factor, DateMathTimeUnit interval, MidpointRounding rounding)
+		{
+			var fraction = factor;
+			double milliseconds;
+
+			// if the factor is already a whole number then use it
+			if (TryGetIntegerGreaterThanZero(fraction, out var whole))
+			{
+				this.Factor = whole;
+				this.Interval = interval;
+				switch (interval)
+				{
+					case DateMathTimeUnit.Second:
+						this._approximateSeconds = whole;
+						break;
+					case DateMathTimeUnit.Minute:
+						this._approximateSeconds = whole * (MillisecondsInAMinute / MillisecondsInASecond);
+						break;
+					case DateMathTimeUnit.Hour:
+						this._approximateSeconds = whole * (MillisecondsInAnHour / MillisecondsInASecond);
+						break;
+					case DateMathTimeUnit.Day:
+						this._approximateSeconds = whole * (MillisecondsInADay / MillisecondsInASecond);
+						break;
+					case DateMathTimeUnit.Week:
+						this._approximateSeconds = whole * (MillisecondsInAWeek / MillisecondsInASecond);
+						break;
+					case DateMathTimeUnit.Month:
+						this._approximateSeconds = whole * (MillisecondsInAMonthApproximate / MillisecondsInASecond);
+						break;
+					case DateMathTimeUnit.Year:
+						this._approximateSeconds = whole * (MillisecondsInAYearApproximate / MillisecondsInASecond);
+						break;
+					default:
+						throw new ArgumentOutOfRangeException(nameof(interval), interval, null);
+				}
+				return;
+			}
+
+			switch (interval)
+			{
+				case DateMathTimeUnit.Second:
+					milliseconds = factor * MillisecondsInASecond;
+					break;
+				case DateMathTimeUnit.Minute:
+					milliseconds = factor * MillisecondsInAMinute;
+					break;
+				case DateMathTimeUnit.Hour:
+					milliseconds = factor * MillisecondsInAnHour;
+					break;
+				case DateMathTimeUnit.Day:
+					milliseconds = factor * MillisecondsInADay;
+					break;
+				case DateMathTimeUnit.Week:
+					milliseconds = factor * MillisecondsInAWeek;
+					break;
+				case DateMathTimeUnit.Month:
+					if (TryGetIntegerGreaterThanZero(fraction, out whole))
+					{
+						this.Factor = whole;
+						this.Interval = interval;
+						this._approximateSeconds = whole * (MillisecondsInAMonthApproximate / MillisecondsInASecond);
+						return;
+					}
+
+					milliseconds = factor * MillisecondsInAMonthApproximate;
+					break;
+				case DateMathTimeUnit.Year:
+					if (TryGetIntegerGreaterThanZero(fraction, out whole))
+					{
+						this.Factor = whole;
+						this.Interval = interval;
+						this._approximateSeconds = whole * (MillisecondsInAYearApproximate / MillisecondsInASecond);
+						return;
+					}
+
+					fraction = fraction * MonthsInAYear;
+					if (TryGetIntegerGreaterThanZero(fraction, out whole))
+					{
+						this.Factor = whole;
+						this.Interval = DateMathTimeUnit.Month;
+						this._approximateSeconds = whole * (MillisecondsInAMonthApproximate / MillisecondsInASecond);
+						return;
+					}
+					milliseconds = factor * MillisecondsInAYearApproximate;
+					break;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(interval), interval, null);
+			}
+
+			SetWholeFactorIntervalAndSeconds(milliseconds, rounding);
+		}
+
+		private void SetWholeFactorIntervalAndSeconds(double milliseconds, MidpointRounding rounding)
+		{
+			double fraction;
+			int whole;
+
+			if (milliseconds >= MillisecondsInAWeek)
+			{
+				fraction = milliseconds / MillisecondsInAWeek;
+				if (TryGetIntegerGreaterThanZero(fraction, out whole))
+				{
+					this.Factor = whole;
+					this.Interval = DateMathTimeUnit.Week;
+					this._approximateSeconds = Factor * (MillisecondsInAWeek / MillisecondsInASecond);
+					return;
+				}
+			}
+			if (milliseconds >= MillisecondsInADay)
+			{
+				fraction = milliseconds / MillisecondsInADay;
+				if (TryGetIntegerGreaterThanZero(fraction, out whole))
+				{
+					this.Factor = whole;
+					this.Interval = DateMathTimeUnit.Day;
+					this._approximateSeconds = Factor * (MillisecondsInADay / MillisecondsInASecond);
+					return;
+				}
+			}
+			if (milliseconds >= MillisecondsInAnHour)
+			{
+				fraction = milliseconds / MillisecondsInAnHour;
+				if (TryGetIntegerGreaterThanZero(fraction, out whole))
+				{
+					this.Factor = whole;
+					this.Interval = DateMathTimeUnit.Hour;
+					this._approximateSeconds = Factor * (MillisecondsInAnHour / MillisecondsInASecond);
+					return;
+				}
+			}
+			if (milliseconds >= MillisecondsInAMinute)
+			{
+				fraction = milliseconds / MillisecondsInAMinute;
+				if (TryGetIntegerGreaterThanZero(fraction, out whole))
+				{
+					this.Factor = whole;
+					this.Interval = DateMathTimeUnit.Minute;
+					this._approximateSeconds = Factor * (MillisecondsInAMinute / MillisecondsInASecond);
+					return;
+				}
+			}
+			if (milliseconds >= MillisecondsInASecond)
+			{
+				fraction = milliseconds / MillisecondsInASecond;
+				if (TryGetIntegerGreaterThanZero(fraction, out whole))
+				{
+					this.Factor = whole;
+					this.Interval = DateMathTimeUnit.Second;
+					this._approximateSeconds = Factor;
+					return;
+				}
+			}
+
+			// round to nearest second, using specified rounding
+			this.Factor = Convert.ToInt32(Math.Round(milliseconds / MillisecondsInASecond, rounding));
+			this.Interval = DateMathTimeUnit.Second;
+			this._approximateSeconds = Factor;
+		}
+
+		public int CompareTo(DateMathTime other)
+		{
+			if (other == null) return 1;
+			if (this._approximateSeconds == other._approximateSeconds) return 0;
+			if (this._approximateSeconds < other._approximateSeconds) return -1;
+			return 1;
+		}
+
+		private static bool TryGetIntegerGreaterThanZero(double d, out int value)
+		{
+			if (Math.Abs(d % 1) < double.Epsilon)
+			{
+				value = Convert.ToInt32(d);
+				return true;
+			}
+
+			value = 0;
+			return false;
+		}
+
+		public static bool operator <(DateMathTime left, DateMathTime right) => left.CompareTo(right) < 0;
+		public static bool operator <=(DateMathTime left, DateMathTime right) => left.CompareTo(right) < 0 || left.Equals(right);
+
+		public static bool operator >(DateMathTime left, DateMathTime right) => left.CompareTo(right) > 0;
+		public static bool operator >=(DateMathTime left, DateMathTime right) => left.CompareTo(right) > 0 || left.Equals(right);
+
+		public static bool operator ==(DateMathTime left, DateMathTime right) =>
+			ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
+
+		public static bool operator !=(DateMathTime left, DateMathTime right) => !(left == right);
+
+		public override string ToString() => this.Factor + this.Interval.GetStringValue();
+
+		public bool Equals(DateMathTime other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+			return this._approximateSeconds == other._approximateSeconds;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((DateMathTime) obj);
+		}
+
+		public override int GetHashCode() => this._approximateSeconds.GetHashCode();
+	}
+}

--- a/src/Nest/CommonOptions/DateMath/DateMathTime.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMathTime.cs
@@ -33,23 +33,44 @@ namespace Nest
 
 		private double _approximateSeconds;
 
+		/// <summary>
+		/// The numeric time factor
+		/// </summary>
 		public int Factor { get; private set; }
 
+		/// <summary>
+		/// The time units
+		/// </summary>
 		public DateMathTimeUnit Interval { get; private set; }
 
 		public static implicit operator DateMathTime(TimeSpan span) => new DateMathTime(span);
 		public static implicit operator DateMathTime(double milliseconds) => new DateMathTime(milliseconds);
 		public static implicit operator DateMathTime(string expression) => new DateMathTime(expression);
 
+		/// <summary>
+		/// Instantiates a new instance of <see cref="DateMathTime"/> from a TimeSpan.
+		/// Rounding can be specified to determine how fractional second values should be rounded.
+		/// </summary>
 		public DateMathTime(TimeSpan timeSpan, MidpointRounding rounding = MidpointRounding.AwayFromZero)
 			: this(timeSpan.TotalMilliseconds, rounding) { }
 
+		/// <summary>
+		/// Instantiates a new instance of <see cref="DateMathTime"/> from a milliseconds value.
+		/// Rounding can be specified to determine how fractional second values should be rounded.
+		/// </summary>
 		public DateMathTime(double milliseconds, MidpointRounding rounding = MidpointRounding.AwayFromZero) =>
 			SetWholeFactorIntervalAndSeconds(milliseconds, rounding);
 
+		/// <summary>
+		/// Instantiates a new instance of <see cref="DateMathTime"/> from a factor and interval.
+		/// </summary>
 		public DateMathTime(int factor, DateMathTimeUnit interval) =>
 			SetWholeFactorIntervalAndSeconds(factor, interval, MidpointRounding.AwayFromZero);
 
+		/// <summary>
+		/// Instantiates a new instance of <see cref="DateMathTime"/> from the timeUnit string expression.
+		/// Rounding can be specified to determine how fractional second values should be rounded.
+		/// </summary>
 		public DateMathTime(string timeUnit, MidpointRounding rounding = MidpointRounding.AwayFromZero)
 		{
 			if (timeUnit == null) throw new ArgumentNullException(nameof(timeUnit));

--- a/src/Nest/CommonOptions/DateMath/DateMathTimeUnit.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMathTimeUnit.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	[JsonConverter(typeof(EnumMemberValueCasingJsonConverter<DateMathTimeUnit>))]
+	public enum DateMathTimeUnit
+	{
+		[EnumMember(Value = "s")]
+		Second,
+		[EnumMember(Value = "m")]
+		Minute,
+		[EnumMember(Value = "h")]
+		Hour,
+		[EnumMember(Value = "d")]
+		Day,
+		[EnumMember(Value = "w")]
+		Week,
+		[EnumMember(Value = "M")]
+		Month,
+		[EnumMember(Value = "y")]
+		Year
+	}
+
+	public static class DateMathTimeUnitExtensions
+	{
+		public static string GetStringValue(this DateMathTimeUnit value)
+		{
+			switch (value)
+			{
+				case DateMathTimeUnit.Second:
+					return "s";
+				case DateMathTimeUnit.Minute:
+					return "m";
+				case DateMathTimeUnit.Hour:
+					return "h";
+				case DateMathTimeUnit.Day:
+					return "d";
+				case DateMathTimeUnit.Week:
+					return "w";
+				case DateMathTimeUnit.Month:
+					return "M";
+				case DateMathTimeUnit.Year:
+					return "y";
+				default:
+					throw new ArgumentOutOfRangeException(nameof(value), value, null);
+			}
+		}
+	}
+}

--- a/src/Nest/CommonOptions/TimeUnit/Time.cs
+++ b/src/Nest/CommonOptions/TimeUnit/Time.cs
@@ -6,101 +6,96 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// Represents a time value
+	/// </summary>
 	[JsonConverter(typeof(TimeJsonConverter))]
 	public class Time : IComparable<Time>, IEquatable<Time>
 	{
-		private const double MillisecondsInAYearApproximate = MillisecondsInADay * 365;
-		private const double MillisecondsInAMonthApproximate = MillisecondsInADay * 30;
-		private const double MillisecondsInAWeek = MillisecondsInADay * 7;
 		private const double MillisecondsInADay = MillisecondsInAnHour * 24;
 		private const double MillisecondsInAnHour = MillisecondsInAMinute * 60;
 		private const double MillisecondsInAMinute = MillisecondsInASecond * 60;
 		private const double MillisecondsInASecond = 1000;
-		private const double NanosecondsInAMillisecond = 100;
-		private const double MicrosecondsInAMillisecond = 10;
+		private const double MillisecondsInAMillisecond = 1;
+		private const double MillisecondsInAMicrosecond = MillisecondsInAMillisecond / 1000;
+		private const double MillisecondsInANanosecond = MillisecondsInAMicrosecond / 1000;
+		private const double MicrosecondsInATick = 0.1; // 10 ticks = 1 microsecond
+		private const double NanosecondsInATick = 100; // 1 tick = 100 nanoseconds
+
+		private static double FLOAT_TOLERANCE = 1e-7; // less than 1 nanosecond
 
 		private static readonly Regex ExpressionRegex =
-			new Regex(@"^(?<factor>[-+]?\d+(?:\.\d+)?)\s*(?<interval>(?:y|w|d|h|m|s|ms|nanos|micros))?$",
-				RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
-
-		private static double FLOAT_TOLERANCE = 0.0000001;
+			new Regex(@"^
+				(?<factor>[+\-]? # open factor capture, allowing optional +- signs
+					(?:(?#numeric)(?:\d+(?:\.\d*)?)|(?:\.\d+)) #a numeric in the forms: (N, N., .N, N.N)
+					(?:(?#exponent)e[+\-]?\d+)? #an optional exponential scientific component, E also matches here (IgnoreCase)
+				) # numeric and exponent fall under the factor capture
+				\s{0,10} #optional spaces (sanity checked for max 10 repetitions)
+				(?<interval>(?:d|h|m|s|ms|nanos|micros))? #optional interval indicator
+				$",
+				RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
 		private int? StaticTimeValue { get; }
 
 		public double? Factor { get; private set; }
 
-		public double? Milliseconds { get; private set; }
-		private double ApproximateMilliseconds { get; set; }
-
 		public TimeUnit? Interval { get; private set; }
 
-		public static implicit operator Time(TimeSpan span) => new Time(span);
+		public double? Milliseconds { get; private set; }
 
-		public static implicit operator Time(double milliseconds)
-		{
-			if (Math.Abs(milliseconds - (-1)) < FLOAT_TOLERANCE) return Time.MinusOne;
-			if (Math.Abs(milliseconds) < FLOAT_TOLERANCE) return Time.Zero;
-			return new Time(milliseconds);
-		}
+		public static implicit operator Time(TimeSpan span) => new Time(span);
+		public static implicit operator Time(double milliseconds) => new Time(milliseconds);
 		public static implicit operator Time(string expression) => new Time(expression);
 
 		public static Time MinusOne { get; } = new Time(-1, true);
+
 		public static Time Zero { get; } = new Time(0, true);
 
-		protected Time(int specialFactor, bool specialValue)
+		private Time(int specialFactor, bool specialValue)
 		{
 			if (!specialValue) throw new ArgumentException("this constructor is only for static TimeValues");
 			this.StaticTimeValue = specialFactor;
 		}
 
-		public Time(TimeSpan timeSpan) { Reduce(timeSpan.TotalMilliseconds); }
+		public Time(TimeSpan timeSpan)
+			: this(timeSpan.TotalMilliseconds) { }
 
-		public Time(double milliseconds) { Reduce(milliseconds); }
+		public Time(double milliseconds)
+		{
+			if (Math.Abs(milliseconds - (-1)) < FLOAT_TOLERANCE) StaticTimeValue = -1;
+			else if (Math.Abs(milliseconds) < FLOAT_TOLERANCE) StaticTimeValue = 0;
+			else Reduce(milliseconds);
+		}
 
 		public Time(double factor, TimeUnit interval)
 		{
 			this.Factor = factor;
 			this.Interval = interval;
-			SetMilliseconds(this.Interval.Value, this.Factor.Value);
+			this.Milliseconds = GetExactMilliseconds(this.Factor.Value, this.Interval.Value);
 		}
 
 		public Time(string timeUnit)
 		{
-			if (timeUnit.IsNullOrEmpty()) throw new ArgumentException("Time expression string is empty", nameof(timeUnit));
-			if (timeUnit == "-1" || timeUnit == "0")
-			{
-				this.StaticTimeValue = int.Parse(timeUnit);
-				return;
-			}
-			ParseExpression(timeUnit);
+			if (timeUnit.IsNullOrEmpty()) throw new ArgumentException("Expression string is empty", nameof(timeUnit));
+			if (timeUnit == "-1" || timeUnit == "0") this.StaticTimeValue = int.Parse(timeUnit);
+			else ParseExpression(timeUnit);
 		}
 
 		private void ParseExpression(string timeUnit)
 		{
 			var match = ExpressionRegex.Match(timeUnit);
-			if (!match.Success) throw new ArgumentException($"Time expression '{timeUnit}' string is invalid", nameof(timeUnit));
+			if (!match.Success) throw new ArgumentException($"Expression '{timeUnit}' is invalid", nameof(timeUnit));
+			var factor = match.Groups["factor"].Value;
+			if (!double.TryParse(factor, NumberStyles.Any ,CultureInfo.InvariantCulture, out double f))
+				throw new ArgumentException($"Expression '{timeUnit}' contains invalid factor: {factor}", nameof(timeUnit));
 
-			this.Factor = double.Parse(match.Groups["factor"].Value, CultureInfo.InvariantCulture);
+			this.Factor = f;
 			var interval = match.Groups["interval"].Success ? match.Groups["interval"].Value : null;
-			switch (interval)
-			{
-				case null:
-					throw new ArgumentException($"Time expression '{timeUnit}' is missing an interval", nameof(timeUnit));
-				case "M":
-					this.Interval = TimeUnit.Month;
-					break;
-				case "m":
-					this.Interval = TimeUnit.Minute;
-					break;
-				default:
-					this.Interval = interval.ToEnum<TimeUnit>(StringComparison.OrdinalIgnoreCase);
-					break;
-			}
-
+			this.Interval = interval.ToEnum<TimeUnit>(StringComparison.OrdinalIgnoreCase);
 			if (!this.Interval.HasValue)
-				throw new ArgumentException($"Time expression '{timeUnit}' can not be parsed to an interval", nameof(timeUnit));
+				throw new ArgumentException($"Expression '{interval}' cannot be parsed to an interval", nameof(timeUnit));
 
-			SetMilliseconds(this.Interval.Value, this.Factor.Value);
+			this.Milliseconds = GetExactMilliseconds(this.Factor.Value, this.Interval.Value);
 		}
 
 		public int CompareTo(Time other)
@@ -117,43 +112,9 @@ namespace Nest
 				// ReSharper enable PossibleInvalidOperationException
 			};
 
-			if (this.ApproximateMilliseconds == other.ApproximateMilliseconds) return 0;
-			if (this.ApproximateMilliseconds < other.ApproximateMilliseconds) return -1;
+			if (Math.Abs(this.Milliseconds.Value - other.Milliseconds.Value) < FLOAT_TOLERANCE) return 0;
+			if (this.Milliseconds < other.Milliseconds) return -1;
 			return 1;
-		}
-
-		public static Time ToFirstUnitYieldingInteger(Time fractionalTime)
-		{
-			var fraction = fractionalTime.Factor.GetValueOrDefault(double.Epsilon);
-			if (IsIntegerGreaterThanZero(fraction)) return fractionalTime;
-
-			var ms = fractionalTime.ApproximateMilliseconds;
-			if (ms > MillisecondsInAWeek)
-			{
-				fraction = ms / MillisecondsInAWeek;
-				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Week);
-			}
-			if (ms > MillisecondsInADay)
-			{
-				fraction = ms / MillisecondsInADay;
-				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Day);
-			}
-			if (ms > MillisecondsInAnHour)
-			{
-				fraction = ms / MillisecondsInAnHour;
-				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Hour);
-			}
-			if (ms > MillisecondsInAMinute)
-			{
-				fraction = ms / MillisecondsInAMinute;
-				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Minute);
-			}
-			if (ms > MillisecondsInASecond)
-			{
-				fraction = ms / MillisecondsInASecond;
-				if (IsIntegerGreaterThanZero(fraction)) return new Time(fraction, TimeUnit.Second);
-			}
-			return new Time(ms, TimeUnit.Millisecond);
 		}
 
 		private static bool IsIntegerGreaterThanZero(double d) => Math.Abs(d % 1) < double.Epsilon;
@@ -169,24 +130,30 @@ namespace Nest
 
 		public static bool operator !=(Time left, Time right) => !(left == right);
 
+		/// <summary>
+		/// Converts this instance of <see cref="Time"/> to an instance of <see cref="TimeSpan"/>.
+		/// For values in <see cref="TimeUnit.Microseconds"/> and <see cref="TimeUnit.Nanoseconds"/>, value will be rounded to the nearest Tick.
+		/// All other values will be rounded to the nearest Millisecond.
+		/// </summary>
+		/// <exception cref="InvalidOperationException">
+		/// <para>special time values <see cref="MinusOne"/> and <see cref="Zero"/> do not have a <see cref="TimeSpan"/> representation.</para>
+		/// <para>instance of <see cref="Time"/> has no value for <see cref="Interval"/></para>
+		/// </exception>
 		public TimeSpan ToTimeSpan()
 		{
-			if (this.StaticTimeValue.HasValue) throw new Exception("Static time values like -1 or 0 have no logical TimeSpan representation");
-			//should not happen will throw in constructor
-			if (!this.Interval.HasValue) throw new Exception("TimeUnit has no interval so you can not call ToTimeStamp on it");
+			if (this.StaticTimeValue.HasValue)
+				throw new InvalidOperationException("Static time values like -1 or 0 have no logical TimeSpan representation");
+			if (!this.Interval.HasValue)
+				throw new InvalidOperationException($"Time has no value for Interval so you can not call {nameof(ToTimeSpan)} on it");
 
 			switch (this.Interval.Value)
 			{
 				case TimeUnit.Microseconds:
-					// ReSharper disable once PossibleInvalidOperationException
-					var microTicks	 = (long)this.Factor.Value * 10;
-					return new TimeSpan(microTicks);
+					return TimeSpan.FromTicks((long)(this.Factor.Value / MicrosecondsInATick));
 				case TimeUnit.Nanoseconds:
-					var nanoTicks = (long)this.Factor.Value / 100;
-					// ReSharper disable once PossibleInvalidOperationException
-					return new TimeSpan(nanoTicks);
+					return TimeSpan.FromTicks((long)(this.Factor.Value / NanosecondsInATick));
 				default:
-					return TimeSpan.FromMilliseconds(this.ApproximateMilliseconds);
+					return TimeSpan.FromMilliseconds(this.Milliseconds.Value);
 			}
 		}
 
@@ -196,8 +163,10 @@ namespace Nest
 				return this.StaticTimeValue.Value.ToString();
 			if (!this.Factor.HasValue)
 				return "<bad Time object should not happen>";
-			var factor = this.Factor.Value.ToString("0.##", CultureInfo.InvariantCulture);
-			return (this.Interval.HasValue) ? factor + this.Interval.Value.GetStringValue() : factor;
+
+			var mantissa = ExponentFormat(this.Factor.Value);
+			var factor = this.Factor.Value.ToString("0." + mantissa, CultureInfo.InvariantCulture);
+			return this.Interval.HasValue ? factor + this.Interval.Value.GetStringValue() : factor;
 		}
 
 		public bool Equals(Time other)
@@ -208,7 +177,7 @@ namespace Nest
 			if (!this.StaticTimeValue.HasValue && other.StaticTimeValue.HasValue) return false;
 			if (this.StaticTimeValue.HasValue && other.StaticTimeValue.HasValue)
 				return this.StaticTimeValue == other.StaticTimeValue;
-			return Math.Abs(this.ApproximateMilliseconds - other.ApproximateMilliseconds) < 0.00001;
+			return Math.Abs(this.Milliseconds.Value - other.Milliseconds.Value) < FLOAT_TOLERANCE;
 		}
 
 		public override bool Equals(object obj)
@@ -219,24 +188,79 @@ namespace Nest
 			return Equals((Time) obj);
 		}
 
-		public override int GetHashCode()
+		public override int GetHashCode() => this.StaticTimeValue.HasValue
+			? this.StaticTimeValue.Value.GetHashCode()
+			: this.Milliseconds.GetHashCode();
+
+		private void Reduce(double ms)
 		{
-			if (this.StaticTimeValue.HasValue) return this.StaticTimeValue.Value.GetHashCode();
-			return this.ApproximateMilliseconds.GetHashCode();
+			this.Milliseconds = ms;
+			double fraction;
+
+			if (ms >= MillisecondsInADay)
+			{
+				fraction = ms / MillisecondsInADay;
+				if (IsIntegerGreaterThanZero(fraction))
+				{
+					Factor = fraction;
+					Interval = TimeUnit.Day;
+					return;
+				}
+			}
+			if (ms >= MillisecondsInAnHour)
+			{
+				fraction = ms / MillisecondsInAnHour;
+				if (IsIntegerGreaterThanZero(fraction))
+				{
+					Factor = fraction;
+					Interval = TimeUnit.Hour;
+					return;
+				}
+			}
+			if (ms >= MillisecondsInAMinute)
+			{
+				fraction = ms / MillisecondsInAMinute;
+				if (IsIntegerGreaterThanZero(fraction))
+				{
+					Factor = fraction;
+					Interval = TimeUnit.Minute;
+					return;
+				}
+			}
+			if (ms >= MillisecondsInASecond)
+			{
+				fraction = ms / MillisecondsInASecond;
+				if (IsIntegerGreaterThanZero(fraction))
+				{
+					Factor = fraction;
+					Interval = TimeUnit.Second;
+					return;
+				}
+			}
+			if (IsIntegerGreaterThanZero(ms))
+			{
+				Factor = ms;
+				Interval = TimeUnit.Millisecond;
+				return;
+			}
+
+			fraction = ms / MillisecondsInAMicrosecond;
+			if (IsIntegerGreaterThanZero(fraction))
+			{
+				Factor = fraction;
+				Interval = TimeUnit.Microseconds;
+				return;
+			}
+
+			// expressed as fraction of nanoseconds
+			Factor = ms / MillisecondsInANanosecond;
+			Interval = TimeUnit.Nanoseconds;
 		}
 
-		private void SetMilliseconds(TimeUnit interval, double factor)
-		{
-			this.Milliseconds = GetExactMilliseconds(interval, factor) ;
-			this.ApproximateMilliseconds = GetApproximateMilliseconds(interval, factor, this.Milliseconds.Value);
-		}
-
-		private double GetExactMilliseconds(TimeUnit interval, double factor)
+		private static double GetExactMilliseconds(double factor, TimeUnit interval)
 		{
 			switch (interval)
 			{
-				case TimeUnit.Week:
-					return factor * MillisecondsInAWeek;
 				case TimeUnit.Day:
 					return factor * MillisecondsInADay;
 				case TimeUnit.Hour:
@@ -245,67 +269,24 @@ namespace Nest
 					return factor * MillisecondsInAMinute;
 				case TimeUnit.Second:
 					return factor * MillisecondsInASecond;
-				case TimeUnit.Microseconds:
-					return factor / MicrosecondsInAMillisecond;
-				case TimeUnit.Nanoseconds:
-					return factor / NanosecondsInAMillisecond;
-				case TimeUnit.Year:
-				case TimeUnit.Month:
-					// Cannot calculate exact milliseconds for non-fixed intervals
-					return -1;
-				default: // ms
+				case TimeUnit.Millisecond:
 					return factor;
-			}
-		}
-
-		private double GetApproximateMilliseconds(TimeUnit interval, double factor, double fallback)
-		{
-			switch (interval)
-			{
-				case TimeUnit.Year:
-					return factor * MillisecondsInAYearApproximate;
-				case TimeUnit.Month:
-					return factor * MillisecondsInAMonthApproximate;
+				case TimeUnit.Microseconds:
+					return factor * MillisecondsInAMicrosecond;
+				case TimeUnit.Nanoseconds:
+					return factor * MillisecondsInANanosecond;
 				default:
-					return fallback;
+					throw new ArgumentOutOfRangeException(nameof(interval), interval, null);
 			}
 		}
 
-		private void Reduce(double ms)
+		private static string ExponentFormat(double d)
 		{
-			this.Milliseconds = ms;
-			this.ApproximateMilliseconds = ms;
-
-			if (ms >= MillisecondsInAWeek)
-			{
-				Factor = ms / MillisecondsInAWeek;
-				Interval = TimeUnit.Week;
-			}
-			else if (ms >= MillisecondsInADay)
-			{
-				Factor = ms / MillisecondsInADay;
-				Interval = TimeUnit.Day;
-			}
-			else if (ms >= MillisecondsInAnHour)
-			{
-				Factor = ms / MillisecondsInAnHour;
-				Interval = TimeUnit.Hour;
-			}
-			else if (ms >= MillisecondsInAMinute)
-			{
-				Factor = ms / MillisecondsInAMinute;
-				Interval = TimeUnit.Minute;
-			}
-			else if (ms >= MillisecondsInASecond)
-			{
-				Factor = ms / MillisecondsInASecond;
-				Interval = TimeUnit.Second;
-			}
-			else
-			{
-				Factor = ms;
-				Interval = TimeUnit.Millisecond;
-			}
+			// Translate the double into sign, exponent and mantissa.
+			var bits = BitConverter.DoubleToInt64Bits(d);
+			// Note that the shift is sign-extended, hence the test against -1 not 1
+			var exponent = (int) ((bits >> 52) & 0x7ffL);
+			return new string('#', Math.Max(2, exponent));
 		}
 	}
 }

--- a/src/Nest/CommonOptions/TimeUnit/TimeUnit.cs
+++ b/src/Nest/CommonOptions/TimeUnit/TimeUnit.cs
@@ -21,13 +21,7 @@ namespace Nest
 		[EnumMember(Value = "h")]
 		Hour,
 		[EnumMember(Value = "d")]
-		Day,
-		[EnumMember(Value = "w")]
-		Week,
-		[EnumMember(Value = "M")]
-		Month,
-		[EnumMember(Value = "y")]
-		Year
+		Day
 	}
 
 	public static class TimeUnitExtensions
@@ -50,12 +44,6 @@ namespace Nest
 					return "h";
 				case TimeUnit.Day:
 					return "d";
-				case TimeUnit.Week:
-					return "w";
-				case TimeUnit.Month:
-					return "M";
-				case TimeUnit.Year:
-					return "y";
 				default:
 					throw new ArgumentOutOfRangeException(nameof(value), value, null);
 			}

--- a/src/Nest/CommonOptions/TimeUnit/TimeUnit.cs
+++ b/src/Nest/CommonOptions/TimeUnit/TimeUnit.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
-	[JsonConverter(typeof(EnumMemberValueCasingJsonConverter<TimeUnit>))]
+	[JsonConverter(typeof(StringEnumConverter))]
 	public enum TimeUnit
 	{
 		[EnumMember(Value = "nanos")]

--- a/src/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs
@@ -50,7 +50,7 @@ namespace Tests.Aggregations.Bucket.DateRange
 				.Field(p => p.StartedOn)
 				.Ranges(
 					r => r.From(DateMath.Anchored(FixedDate).Add("2d")).To(DateMath.Now),
-					r => r.To(DateMath.Now.Add(TimeSpan.FromDays(1)).Subtract("30m").RoundTo(TimeUnit.Hour)),
+					r => r.To(DateMath.Now.Add(TimeSpan.FromDays(1)).Subtract("30m").RoundTo(DateMathTimeUnit.Hour)),
 					r => r.From(DateMath.Anchored("2012-05-05").Add(TimeSpan.FromDays(1)).Subtract("1m"))
 				)
 				.TimeZone("CET")
@@ -66,7 +66,7 @@ namespace Tests.Aggregations.Bucket.DateRange
 				Ranges = new List<DateRangeExpression>
 				{
 					new DateRangeExpression {From = DateMath.Anchored(FixedDate).Add("2d"), To = DateMath.Now},
-					new DateRangeExpression {To = DateMath.Now.Add(TimeSpan.FromDays(1)).Subtract("30m").RoundTo(TimeUnit.Hour)},
+					new DateRangeExpression {To = DateMath.Now.Add(TimeSpan.FromDays(1)).Subtract("30m").RoundTo(DateMathTimeUnit.Hour)},
 					new DateRangeExpression {From = DateMath.Anchored("2012-05-05").Add(TimeSpan.FromDays(1)).Subtract("1m")}
 				},
 				TimeZone = "CET",

--- a/src/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RequestTimeoutsOverrides.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RequestTimeoutsOverrides.doc.cs
@@ -53,11 +53,11 @@ namespace Tests.ClientConcepts.ConnectionPooling.RequestOverrides
 
 		}
 
-		/**[float] 
+		/**[float]
         * === Connect timeouts
-        * 
-		* Connect timeouts can be overridden on a per request basis. 
-        * 
+        *
+		* Connect timeouts can be overridden on a per request basis.
+        *
         * Whilst the underlying `WebRequest` in the case of Desktop CLR
 		* and `HttpClient` in the case of Core CLR cannot distinguish between connect and retry timeouts,
 		* we use a separate configuration value for ping requests to allow ping to be configured
@@ -88,7 +88,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.RequestOverrides
 					{ MaxTimeoutReached }
 				},
 				/**
-				* On the second request we set a request ping timeout override of 2seconds
+				* On the second request we set a request ping timeout override of 2 seconds
 				* We should now see more nodes being tried before the request timeout is hit.
 				*/
 				new ClientCall(r => r.PingTimeout(TimeSpan.FromSeconds(2)))

--- a/src/Tests/QueryDsl/TermLevel/Range/DateRangeQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Range/DateRangeQueryUsageTests.cs
@@ -33,7 +33,7 @@ namespace Tests.QueryDsl.TermLevel.Range
 			Boost = 1.1,
 			Field = "description",
 			GreaterThan = FixedDate,
-			GreaterThanOrEqualTo = DateMath.Anchored(FixedDate).RoundTo(TimeUnit.Month),
+			GreaterThanOrEqualTo = DateMath.Anchored(FixedDate).RoundTo(DateMathTimeUnit.Month),
 			LessThan = "01/01/2012",
 			LessThanOrEqualTo = DateMath.Now,
 			TimeZone = "+01:00",
@@ -46,7 +46,7 @@ namespace Tests.QueryDsl.TermLevel.Range
 				.Boost(1.1)
 				.Field(p => p.Description)
 				.GreaterThan(FixedDate)
-				.GreaterThanOrEquals(DateMath.Anchored(FixedDate).RoundTo(TimeUnit.Month))
+				.GreaterThanOrEquals(DateMath.Anchored(FixedDate).RoundTo(DateMathTimeUnit.Month))
 				.LessThan("01/01/2012")
 				.LessThanOrEquals(DateMath.Now)
 				.Format("dd/MM/yyyy||yyyy")


### PR DESCRIPTION
The Time type has historically been used to represent both Elasticsearch's TimeValue and time within Date Math expressions. This is slightly misleading because

1. TimeValue accepts units from nanos -> seconds
2. Date Math expressions with time accept units from seconds -> years

In both cases, Elasticsearch accepts only whole numbers in addition to a unit of measure.

This commit introduces a new DateMathTime type to represent times within DateMath expressions, with a DateMathTimeUnit enum to represent the valid units for this type. There are implicit conversions from string, TimeSpan and double such that implicit conversion usage in users upgrading from 5.x -> 6.x will not be affected by the change. The constructors that accept string, TimeSpan and double accept fractional numbers to make the type easier to work with, and the fractional number will be converted to the largest whole number and unit that can be represented, with rounding to the nearest second for fractional seconds. An optional rounding argument to determine how to round mid points can be passed to the constructors that accept TimeSpan, double and string.

The DateMathTime type implements equality and comparison members, comparing the seconds representation. An approximation of seconds is used in the case of years and months, with 365 * seconds in a day for years, and (365 / 12)  * seconds in a day for months, allowing for comparisons between months and years.

Remove support for units above a day from the Time type.

Closes #2983