### PR TITLE
ProperyNameJsonConverter and field resolver for propertyname was new'…

### DIFF
--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -19,6 +19,13 @@ namespace Nest
 		public ConnectionSettings(Uri uri = null)
 			: this(new SingleNodeConnectionPool(uri ?? new Uri("http://localhost:9200"))) { }
 
+		/// <summary>
+		/// Instantiate connection settings using a <see cref="SingleNodeConnectionPool"/> using the provided
+		/// <see cref="InMemoryConnection"/> that never uses any IO.
+		/// </summary>
+		public ConnectionSettings(InMemoryConnection connection)
+			: this(new SingleNodeConnectionPool(new Uri("http://localhost:9200")), connection) { }
+
 		public ConnectionSettings(IConnectionPool connectionPool) : this(connectionPool, null, null) { }
 
 		public ConnectionSettings(IConnectionPool connectionPool, SourceSerializerFactory sourceSerializer)

--- a/src/Nest/CommonAbstractions/Extensions/ExpressionExtensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/ExpressionExtensions.cs
@@ -24,11 +24,11 @@ namespace Nest
 		/// </summary>
 		private class SuffixExpressionVisitor : ExpressionVisitor
 		{
-			private readonly string suffix;
+			private readonly string _suffix;
 
 			public SuffixExpressionVisitor(string suffix)
 			{
-				this.suffix = suffix;
+				this._suffix = suffix;
 			}
 
 			public override Expression Visit(Expression node)
@@ -38,13 +38,10 @@ namespace Nest
 					nameof(SuffixExtensions.Suffix),
 					null,
 					node,
-					Expression.Constant(suffix));
+					Expression.Constant(_suffix));
 			}
 
-			protected override Expression VisitUnary(UnaryExpression node)
-			{
-				return node;
-			}
+			protected override Expression VisitUnary(UnaryExpression node) => node;
 		}
 
 		private static readonly Regex ExpressionRegex = new Regex(@"^\s*(.*)\s*\=\>\s*\1\.");
@@ -56,14 +53,12 @@ namespace Nest
 
 			if (expression == null) return null;
 
-			var lambda = expression as LambdaExpression;
-			if (lambda == null)
+			if (!(expression is LambdaExpression lambda))
 				return ExpressionRegex.Replace(expression.ToString(), string.Empty);
 
 			type = lambda.Parameters.FirstOrDefault()?.Type;
 
-			var memberExpression = lambda.Body as MemberExpression;
-			return memberExpression != null
+			return lambda.Body is MemberExpression memberExpression
 				? MemberExpressionRegex.Replace(memberExpression.ToString(), string.Empty)
 				: ExpressionRegex.Replace(expression.ToString(), string.Empty);
 		}

--- a/src/Nest/CommonAbstractions/Infer/Field/FieldExpressionVisitor.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/FieldExpressionVisitor.cs
@@ -151,8 +151,7 @@ namespace Nest
 		private static void VisitConstantOrVariable(MethodCallExpression methodCall, Stack<string> stack)
 		{
 			var lastArg = methodCall.Arguments.Last();
-			var constantExpression = lastArg as ConstantExpression;
-			var value = constantExpression != null
+			var value = lastArg is ConstantExpression constantExpression
 				? constantExpression.Value.ToString()
 				: Expression.Lambda(lastArg).Compile().DynamicInvoke().ToString();
 			stack.Push(value);

--- a/src/Nest/CommonAbstractions/Infer/Field/FieldResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/FieldResolver.cs
@@ -42,8 +42,7 @@ namespace Nest
 				return this.Resolve(field.Expression, field.Property);
 			}
 
-			string fieldName;
-			if (this.Fields.TryGetValue(field, out fieldName))
+			if (this.Fields.TryGetValue(field, out var fieldName))
 				return fieldName;
 
 			fieldName = this.Resolve(field.Expression, field.Property);
@@ -61,8 +60,7 @@ namespace Nest
 				return this.Resolve(property.Expression, property.Property);
 			}
 
-			string propertyName;
-			if (this.Properties.TryGetValue(property, out propertyName))
+			if (this.Properties.TryGetValue(property, out var propertyName))
 				return propertyName;
 
 			propertyName = this.Resolve(property.Expression, property.Property, true);

--- a/src/Nest/CommonAbstractions/Infer/PropertyName/PropertyName.cs
+++ b/src/Nest/CommonAbstractions/Infer/PropertyName/PropertyName.cs
@@ -33,10 +33,9 @@ namespace Nest
 
 		public PropertyName(Expression expression)
 		{
-			Type type;
 			Expression = expression;
 			CacheableExpression = !new HasVariableExpressionVisitor(expression).Found;
-			_comparisonValue = expression.ComparisonValueFromExpression(out type);
+			_comparisonValue = expression.ComparisonValueFromExpression(out var type);
 			_type = type;
 		}
 
@@ -86,10 +85,8 @@ namespace Nest
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings)
 		{
 			var nestSettings = settings as IConnectionSettingsValues;
-			if (nestSettings == null)
-				throw new Exception("Tried to pass field name on querysting but it could not be resolved because no nest settings are available");
-			var infer = new Inferrer(nestSettings);
-			return infer.PropertyName(this);
+
+			return nestSettings?.Inferrer.PropertyName(this);
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/PropertyName/PropertyNameJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/PropertyName/PropertyNameJsonConverter.cs
@@ -19,7 +19,8 @@ namespace Nest
 				writer.WriteNull();
 				return;
 			}
-			writer.WriteValue(new Inferrer(serializer.GetConnectionSettings()).PropertyName(property));
+			var infer = serializer.GetConnectionSettings().Inferrer;
+			writer.WriteValue(infer.PropertyName(property));
 		}
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{


### PR DESCRIPTION
…ing an Inferrer

`Run` creates a new `PropertyName` each time `RunCreateOnce` only once than does the inferrence a whole bunch of times.

Before 

```
        Method |         Mean |     Error |     StdDev |      Gen 0 |    Allocated |
-------------- |-------------:|----------:|-----------:|-----------:|-------------:|
           Run | 1,001.777 ms | 77.603 ms | 20.1571 ms | 62000.0000 | 192203.37 KB |
 RunCreateOnce |     8.501 ms |  1.670 ms |  0.4338 ms |          - |      4.57 KB |
```

After

```
        Method |        Mean |      Error |     StdDev |      Gen 0 |    Allocated |
-------------- |------------:|-----------:|-----------:|-----------:|-------------:|
           Run | 1,147.55 ms | 172.197 ms | 44.7275 ms | 62000.0000 | 192203.37 KB |
 RunCreateOnce |    10.58 ms |   3.117 ms |  0.8096 ms |          - |      4.57 KB |
```

Since the caches are per `ConnectionSettings` and not per `Inferrer` this has no noticable performance boost nor implications for `5.x` but is still cleaner.
