### PR TITLE
Automatically skip parameters already found in _common.json but still…

### DIFF
--- a/src/CodeGeneration/ApiGenerator/ApiGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/ApiGenerator.cs
@@ -71,7 +71,7 @@ namespace ApiGenerator
 					.Where(f => f.EndsWith(".json") && !IgnoredApis.Contains(new FileInfo(f).Name))
 					.ToList()
 				);
-				var commonFile = Path.Combine(CodeConfiguration.RestSpecificationFolder, "Core", "_common") + ".json";
+				var commonFile = Path.Combine(CodeConfiguration.RestSpecificationFolder, "Core", "_common.json");
 				if (!File.Exists(commonFile)) throw new Exception($"Expected to find {commonFile}");
 				RestApiSpec.CommonApiQueryParameters = CreateCommonApiQueryParameters(commonFile);
 

--- a/src/CodeGeneration/ApiGenerator/ApiGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/ApiGenerator.cs
@@ -71,13 +71,17 @@ namespace ApiGenerator
 					.Where(f => f.EndsWith(".json") && !IgnoredApis.Contains(new FileInfo(f).Name))
 					.ToList()
 				);
+				var commonFile = Path.Combine(CodeConfiguration.RestSpecificationFolder, "Core", "_common") + ".json";
+				if (!File.Exists(commonFile)) throw new Exception($"Expected to find {commonFile}");
+				RestApiSpec.CommonApiQueryParameters = CreateCommonApiQueryParameters(commonFile);
+
 				foreach (var jsonFiles in folderFiles)
 				{
 					using (var fileProgress = pbar.Spawn(jsonFiles.Count, $"Listing {jsonFiles.Count} files", new ProgressBarOptions { ProgressCharacter = '─', BackgroundColor = ConsoleColor.DarkGray }))
 					{
 						foreach (var file in jsonFiles)
 						{
-							if (file.EndsWith("_common.json")) RestApiSpec.CommonApiQueryParameters = CreateCommonApiQueryParameters(file);
+							if (file.EndsWith("_common.json")) continue;
 							else if (file.EndsWith(".obsolete.json")) continue;
 							else if (file.EndsWith(".patch.json")) continue;
 							else if (file.EndsWith(".replace.json")) continue;
@@ -139,7 +143,7 @@ namespace ApiGenerator
 			var json = File.ReadAllText(jsonFile);
 			var jobject = JObject.Parse(json);
 			var commonParameters = jobject.Property("params").Value.ToObject<Dictionary<string, ApiQueryParameters>>();
-			return ApiQueryParametersPatcher.Patch(commonParameters, null);
+			return ApiQueryParametersPatcher.Patch(commonParameters, null, checkCommon: false);
 		}
 
 		private static string CreateMethodName(string apiEndpointKey)

--- a/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParametersPatcher.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParametersPatcher.cs
@@ -11,7 +11,8 @@ namespace ApiGenerator.Domain
 
 		public static Dictionary<string, ApiQueryParameters> Patch(
 			IDictionary<string, ApiQueryParameters> source,
-			IEndpointOverrides overrides)
+			IEndpointOverrides overrides,
+			bool checkCommon = true)
 		{
 			if (source == null) return null;
 
@@ -24,10 +25,17 @@ namespace ApiGenerator.Domain
 			var obsoleteLookup = CreateObsoleteLookup(globalOverrides, overrides, declaredKeys);
 
 			var patchedParams = new Dictionary<string, ApiQueryParameters>();
+			var name = overrides?.GetType().Name ?? "unkown";
 			foreach (var kv in source)
 			{
 				var queryStringKey = kv.Key;
 				kv.Value.QueryStringKey = queryStringKey;
+
+				if (checkCommon && RestApiSpec.CommonApiQueryParameters.Keys.Contains(queryStringKey))
+				{
+					ApiGenerator.Warnings.Add($"key '{queryStringKey}' in {name} is already declared in _common.json");
+					continue;
+				}
 
 				if (!renameLookup.TryGetValue(queryStringKey, out var preferredName)) preferredName = kv.Key;
 				kv.Value.ClsName = CreateCSharpName(preferredName);

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -1789,8 +1789,6 @@ namespace Elasticsearch.Net
 	public class NodesUsageRequestParameters : RequestParameters<NodesUsageRequestParameters> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
-		///<summary>Whether to return time and byte values in human-readable format.</summary>
-		public bool? Human { get => Q<bool?>("human"); set => Q("human", value); }
 		///<summary>Explicit operation timeout</summary>
 		public TimeSpan Timeout { get => Q<TimeSpan>("timeout"); set => Q("timeout", value.ToTimeUnit()); }
 	}
@@ -2285,8 +2283,6 @@ namespace Elasticsearch.Net
 	public class XPackInfoRequestParameters : RequestParameters<XPackInfoRequestParameters> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
-		///<summary>Presents additional info for humans (feature descriptions and X-Pack tagline)</summary>
-		public bool? Human { get => Q<bool?>("human"); set => Q("human", value); }
 		///<summary>Comma-separated list of info categories. Can be any of: build, license, features</summary>
 		public string[] Categories { get => Q<string[]>("categories"); set => Q("categories", value); }
 	}

--- a/src/Nest/_Generated/_Descriptors.generated.cs
+++ b/src/Nest/_Generated/_Descriptors.generated.cs
@@ -2959,8 +2959,6 @@ namespace Nest
 		public NodesUsageDescriptor NodeId(NodeIds nodeId) => Assign(a=>a.RouteValues.Optional("node_id", nodeId));
 
 		// Request parameters
-		///<summary>Whether to return time and byte values in human-readable format.</summary>
-		public NodesUsageDescriptor Human(bool? human = true) => Qs("human", human);
 		///<summary>Explicit operation timeout</summary>
 		public NodesUsageDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	
@@ -3767,8 +3765,6 @@ namespace Nest
 		// values part of the url path
 
 		// Request parameters
-		///<summary>Presents additional info for humans (feature descriptions and X-Pack tagline)</summary>
-		public XPackInfoDescriptor Human(bool? human = true) => Qs("human", human);
 		///<summary>Comma-separated list of info categories. Can be any of: build, license, features</summary>
 		public XPackInfoDescriptor Categories(params string[] categories) => Qs("categories", categories);
 	

--- a/src/Nest/_Generated/_Requests.generated.cs
+++ b/src/Nest/_Generated/_Requests.generated.cs
@@ -4234,8 +4234,6 @@ namespace Nest
 		NodeIds INodesUsageRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 
 		// Request parameters
-		///<summary>Whether to return time and byte values in human-readable format.</summary>
-		public bool? Human { get => Q<bool?>("human"); set => Q("human", value); }
 		///<summary>Explicit operation timeout</summary>
 		public Time Timeout { get => Q<Time>("timeout"); set => Q("timeout", value.ToString()); }
 	}
@@ -6518,8 +6516,6 @@ namespace Nest
 		// values part of the url path
 
 		// Request parameters
-		///<summary>Presents additional info for humans (feature descriptions and X-Pack tagline)</summary>
-		public bool? Human { get => Q<bool?>("human"); set => Q("human", value); }
 		///<summary>Comma-separated list of info categories. Can be any of: build, license, features</summary>
 		public string[] Categories { get => Q<string[]>("categories"); set => Q("categories", value); }
 	}


### PR DESCRIPTION
… warn about them

This fixes compiler warnings because `Human` is generated on the base class and implementation.