### PR TITLE
Update UnexpectedElasticsearchClientException.cs

### DIFF
--- a/src/Elasticsearch.Net/Exceptions/UnexpectedElasticsearchClientException.cs
+++ b/src/Elasticsearch.Net/Exceptions/UnexpectedElasticsearchClientException.cs
@@ -8,7 +8,7 @@ namespace Elasticsearch.Net
 		public List<PipelineException> SeenExceptions { get; set; }
 
 		public UnexpectedElasticsearchClientException(Exception killerException, List<PipelineException> seenExceptions)
-			: base(PipelineFailure.Unexpected, killerException?.Message ?? "An unexpected exception occured.", killerException)
+			: base(PipelineFailure.Unexpected, killerException?.Message ?? "An unexpected exception occurred.", killerException)
 		{
 			this.SeenExceptions = seenExceptions;
 		}


### PR DESCRIPTION
fixed spelling of "occured" to "occurred".