### PR TITLE
DFI similarity type only exists on 2.3.0+ versions.

### DIFF
--- a/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
@@ -21,8 +21,8 @@ An aggregation that returns interesting or unusual occurrences of terms in a set
 
 [WARNING]
 --
-The significant_terms aggregation can be very heavy when run on large indices. Work is in progress 
-to provide more lightweight sampling techniques. 
+The significant_terms aggregation can be very heavy when run on large indices. Work is in progress
+to provide more lightweight sampling techniques.
 As a result, the API for this feature may change in non-backwards compatible ways
 
 --
@@ -37,7 +37,7 @@ s => s
 .Aggregations(a => a
     .SignificantTerms("significant_names", st => st
         .Field(p => p.Name)
-        .MinimumDocumentCount(10)
+        .MinimumDocumentCountAsLong(10)
         .MutualInformation(mi => mi
             .BackgroundIsSuperSet()
             .IncludeNegatives()
@@ -55,7 +55,7 @@ new SearchRequest<Project>
     Aggregations = new SignificantTermsAggregation("significant_names")
     {
         Field = Field<Project>(p => p.Name),
-        MinimumDocumentCount = 10,
+        MinimumDocumentCountAsLong = 10,
         MutualInformation = new MutualInformationHeuristic
         {
             BackgroundIsSuperSet = true,
@@ -108,7 +108,7 @@ s => s
 .Aggregations(a => a
     .SignificantTerms("significant_names", st => st
         .Field(p => p.Name)
-        .MinimumDocumentCount(10)
+        .MinimumDocumentCountAsLong(10)
         .MutualInformation(mi => mi
             .BackgroundIsSuperSet()
             .IncludeNegatives()
@@ -127,7 +127,7 @@ new SearchRequest<Project>
     Aggregations = new SignificantTermsAggregation("significant_names")
     {
         Field = Field<Project>(p => p.Name),
-        MinimumDocumentCount = 10,
+        MinimumDocumentCountAsLong = 10,
         MutualInformation = new MutualInformationHeuristic
         {
             BackgroundIsSuperSet = true,
@@ -182,7 +182,7 @@ s => s
 .Aggregations(a => a
     .SignificantTerms("significant_names", st => st
         .Field(p => p.Name)
-        .MinimumDocumentCount(10)
+        .MinimumDocumentCountAsLong(10)
         .MutualInformation(mi => mi
             .BackgroundIsSuperSet()
             .IncludeNegatives()
@@ -201,7 +201,7 @@ new SearchRequest<Project>
     Aggregations = new SignificantTermsAggregation("significant_names")
     {
         Field = Field<Project>(p => p.Name),
-        MinimumDocumentCount = 10,
+        MinimumDocumentCountAsLong = 10,
         MutualInformation = new MutualInformationHeuristic
         {
             BackgroundIsSuperSet = true,

--- a/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
@@ -35,7 +35,7 @@ s => s
                     .Script(ss => ss
                         .Type("number")
                         .Script(sss => sss
-                            .Inline("Math.sin(34*(double)doc['numberOfCommits'].value)")
+                            .Inline("sin(doc['numberOfCommits'].value)")
                             .Lang("groovy")
                         )
                         .Order(SortOrder.Descending)
@@ -91,7 +91,7 @@ new SearchRequest<Project>
                 new ScriptSort
                 {
                     Type = "number",
-                    Script = new InlineScript("Math.sin(34*(double)doc['numberOfCommits'].value)") { Lang = "groovy" },
+                    Script = new InlineScript("sin(doc['numberOfCommits'].value)") { Lang = "groovy" },
                     Order = SortOrder.Descending
                 },
             },
@@ -144,7 +144,7 @@ new SearchRequest<Project>
                   "type": "number",
                   "script": {
                     "lang": "groovy",
-                    "inline": "Math.sin(34*(double)doc['numberOfCommits'].value)"
+                    "inline": "sin(doc['numberOfCommits'].value)"
                   },
                   "order": "desc"
                 }


### PR DESCRIPTION
Fixes test with a SkipAttribute.
Update docs.