### PR TITLE
rename InferMappingFor to DefaultsFor, falls inline with DefaultIndex…

### DIFF
--- a/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace Nest
 {
-	public interface IClrTypeDefault
+	public interface IClrTypeDefaults
 	{
 		/// <summary>
 		/// The CLR type the mapping relates to
@@ -26,13 +26,9 @@ namespace Nest
 		/// </summary>
 		string RelationName { get; set; }
 
-		/// <summary>
-		/// The default query to inject if constraint to
-		/// </summary>
-		QueryContainer Query { get; set; }
 	}
 
-	public interface IClrTypeDefaults<TDocument> : IClrTypeDefault where TDocument : class
+	public interface IClrTypeDefaults<TDocument> : IClrTypeDefaults where TDocument : class
 	{
 		/// <summary> Set a default Id property on CLR type <typeparamref name="TDocument" /> that NEST will evaluate </summary>
 		Expression<Func<TDocument, object>> IdProperty { get; set; }
@@ -46,7 +42,7 @@ namespace Nest
 		IList<IClrPropertyMapping<TDocument>> Properties { get; set; }
 	}
 
-	public class ClrTypeDefaults : IClrTypeDefault
+	public class ClrTypeDefaults : IClrTypeDefaults
 	{
 		/// <summary>
 		/// Initializes a new instance of <see cref="ClrTypeDefaults"/>
@@ -80,7 +76,7 @@ namespace Nest
 		public IList<IClrPropertyMapping<TDocument>> Properties { get; set; }
 	}
 
-	public class ClrTypeDefaultsDescriptor : DescriptorBase<ClrTypeDefaultsDescriptor,IClrTypeDefault> , IClrTypeDefault
+	public class ClrTypeDefaultsDescriptor : DescriptorBase<ClrTypeDefaultsDescriptor,IClrTypeDefaults> , IClrTypeDefaults
 	{
 		private readonly Type _type;
 
@@ -90,10 +86,10 @@ namespace Nest
 		/// <param name="type">The CLR type to map</param>
 		public ClrTypeDefaultsDescriptor(Type type) => _type = type;
 
-		Type IClrTypeDefault.ClrType => _type;
-		string IClrTypeDefault.IndexName { get; set; }
-		string IClrTypeDefault.TypeName { get; set; }
-		string IClrTypeDefault.RelationName { get; set; }
+		Type IClrTypeDefaults.ClrType => _type;
+		string IClrTypeDefaults.IndexName { get; set; }
+		string IClrTypeDefaults.TypeName { get; set; }
+		string IClrTypeDefaults.RelationName { get; set; }
 
 		/// <summary>
 		/// The default Elasticsearch index name for the CLR type
@@ -115,10 +111,10 @@ namespace Nest
 		: DescriptorBase<ClrTypeDefaultsDescriptor<TDocument>,IClrTypeDefaults<TDocument>>, IClrTypeDefaults<TDocument>
 		where TDocument : class
 	{
-		Type IClrTypeDefault.ClrType { get; } = typeof (TDocument);
-		string IClrTypeDefault.IndexName { get; set; }
-		string IClrTypeDefault.TypeName { get; set; }
-		string IClrTypeDefault.RelationName { get; set; }
+		Type IClrTypeDefaults.ClrType { get; } = typeof (TDocument);
+		string IClrTypeDefaults.IndexName { get; set; }
+		string IClrTypeDefaults.TypeName { get; set; }
+		string IClrTypeDefaults.RelationName { get; set; }
 		Expression<Func<TDocument, object>> IClrTypeDefaults<TDocument>.IdProperty { get; set; }
 		Expression<Func<TDocument, object>> IClrTypeDefaults<TDocument>.RoutingProperty { get; set; }
 		IList<IClrPropertyMapping<TDocument>> IClrTypeDefaults<TDocument>.Properties { get; set; } = new List<IClrPropertyMapping<TDocument>>();

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace Nest
 {
-	public interface IClrTypeDefaults
+	public interface IClrTypeMappings
 	{
 		/// <summary>
 		/// The CLR type the mapping relates to
@@ -28,7 +28,7 @@ namespace Nest
 
 	}
 
-	public interface IClrTypeDefaults<TDocument> : IClrTypeDefaults where TDocument : class
+	public interface IClrTypeMappings<TDocument> : IClrTypeMappings where TDocument : class
 	{
 		/// <summary> Set a default Id property on CLR type <typeparamref name="TDocument" /> that NEST will evaluate </summary>
 		Expression<Func<TDocument, object>> IdProperty { get; set; }
@@ -42,12 +42,12 @@ namespace Nest
 		IList<IClrPropertyMapping<TDocument>> Properties { get; set; }
 	}
 
-	public class ClrTypeDefaults : IClrTypeDefaults
+	public class ClrTypeMappings : IClrTypeMappings
 	{
 		/// <summary>
-		/// Initializes a new instance of <see cref="ClrTypeDefaults"/>
+		/// Initializes a new instance of <see cref="ClrTypeMappings"/>
 		/// </summary>
-		public ClrTypeDefaults(Type type) => ClrType = type;
+		public ClrTypeMappings(Type type) => ClrType = type;
 
 		/// <inheritdoc />
 		public Type ClrType { get; }
@@ -62,9 +62,9 @@ namespace Nest
 		public string RelationName { get; set; }
 
 	}
-	public class ClrTypeDefaults<TDocument> : ClrTypeDefaults, IClrTypeDefaults<TDocument> where TDocument : class
+	public class ClrTypeMappings<TDocument> : ClrTypeMappings, IClrTypeMappings<TDocument> where TDocument : class
 	{
-		public ClrTypeDefaults() : base(typeof(TDocument)) { }
+		public ClrTypeMappings() : base(typeof(TDocument)) { }
 
 		/// <inheritdoc />
 		public Expression<Func<TDocument, object>> IdProperty { get; set; }
@@ -76,82 +76,82 @@ namespace Nest
 		public IList<IClrPropertyMapping<TDocument>> Properties { get; set; }
 	}
 
-	public class ClrTypeDefaultsDescriptor : DescriptorBase<ClrTypeDefaultsDescriptor,IClrTypeDefaults> , IClrTypeDefaults
+	public class ClrTypeMappingsDescriptor : DescriptorBase<ClrTypeMappingsDescriptor,IClrTypeMappings> , IClrTypeMappings
 	{
 		private readonly Type _type;
 
 		/// <summary>
-		/// Instantiates a new instance of <see cref="ClrTypeDefaultsDescriptor"/>
+		/// Instantiates a new instance of <see cref="ClrTypeMappingsDescriptor"/>
 		/// </summary>
 		/// <param name="type">The CLR type to map</param>
-		public ClrTypeDefaultsDescriptor(Type type) => _type = type;
+		public ClrTypeMappingsDescriptor(Type type) => _type = type;
 
-		Type IClrTypeDefaults.ClrType => _type;
-		string IClrTypeDefaults.IndexName { get; set; }
-		string IClrTypeDefaults.TypeName { get; set; }
-		string IClrTypeDefaults.RelationName { get; set; }
+		Type IClrTypeMappings.ClrType => _type;
+		string IClrTypeMappings.IndexName { get; set; }
+		string IClrTypeMappings.TypeName { get; set; }
+		string IClrTypeMappings.RelationName { get; set; }
 
 		/// <summary>
 		/// The default Elasticsearch index name for the CLR type
 		/// </summary>
-		public ClrTypeDefaultsDescriptor IndexName(string indexName) => Assign(a => a.IndexName = indexName);
+		public ClrTypeMappingsDescriptor IndexName(string indexName) => Assign(a => a.IndexName = indexName);
 
 		/// <summary>
 		/// The default Elasticsearch type name for the CLR type
 		/// </summary>
-		public ClrTypeDefaultsDescriptor TypeName(string typeName) => Assign(a => a.TypeName = typeName);
+		public ClrTypeMappingsDescriptor TypeName(string typeName) => Assign(a => a.TypeName = typeName);
 
 		/// <summary>
 		/// The relation name for the CLR type to resolve to.
 		/// </summary>
-		public ClrTypeDefaultsDescriptor RelationName(string relationName) => Assign(a => a.RelationName = relationName);
+		public ClrTypeMappingsDescriptor RelationName(string relationName) => Assign(a => a.RelationName = relationName);
 	}
 
-	public class ClrTypeDefaultsDescriptor<TDocument>
-		: DescriptorBase<ClrTypeDefaultsDescriptor<TDocument>,IClrTypeDefaults<TDocument>>, IClrTypeDefaults<TDocument>
+	public class ClrTypeMappingsDescriptor<TDocument>
+		: DescriptorBase<ClrTypeMappingsDescriptor<TDocument>,IClrTypeMappings<TDocument>>, IClrTypeMappings<TDocument>
 		where TDocument : class
 	{
-		Type IClrTypeDefaults.ClrType { get; } = typeof (TDocument);
-		string IClrTypeDefaults.IndexName { get; set; }
-		string IClrTypeDefaults.TypeName { get; set; }
-		string IClrTypeDefaults.RelationName { get; set; }
-		Expression<Func<TDocument, object>> IClrTypeDefaults<TDocument>.IdProperty { get; set; }
-		Expression<Func<TDocument, object>> IClrTypeDefaults<TDocument>.RoutingProperty { get; set; }
-		IList<IClrPropertyMapping<TDocument>> IClrTypeDefaults<TDocument>.Properties { get; set; } = new List<IClrPropertyMapping<TDocument>>();
+		Type IClrTypeMappings.ClrType { get; } = typeof (TDocument);
+		string IClrTypeMappings.IndexName { get; set; }
+		string IClrTypeMappings.TypeName { get; set; }
+		string IClrTypeMappings.RelationName { get; set; }
+		Expression<Func<TDocument, object>> IClrTypeMappings<TDocument>.IdProperty { get; set; }
+		Expression<Func<TDocument, object>> IClrTypeMappings<TDocument>.RoutingProperty { get; set; }
+		IList<IClrPropertyMapping<TDocument>> IClrTypeMappings<TDocument>.Properties { get; set; } = new List<IClrPropertyMapping<TDocument>>();
 
 		/// <summary>
 		/// The default Elasticsearch index name for <typeparamref name="TDocument"/>
 		/// </summary>
-		public ClrTypeDefaultsDescriptor<TDocument> IndexName(string indexName) => Assign(a => a.IndexName = indexName);
+		public ClrTypeMappingsDescriptor<TDocument> IndexName(string indexName) => Assign(a => a.IndexName = indexName);
 
 		/// <summary>
 		/// The default Elasticsearch type name for <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeDefaultsDescriptor<TDocument> TypeName(string typeName) => Assign(a => a.TypeName = typeName);
+		public ClrTypeMappingsDescriptor<TDocument> TypeName(string typeName) => Assign(a => a.TypeName = typeName);
 
 		/// <summary>
 		/// The relation name for <typeparamref name="TDocument" /> to resolve to.
 		/// </summary>
-		public ClrTypeDefaultsDescriptor<TDocument> RelationName(string relationName) => Assign(a => a.RelationName = relationName);
+		public ClrTypeMappingsDescriptor<TDocument> RelationName(string relationName) => Assign(a => a.RelationName = relationName);
 
 		/// <summary>
 		/// Set a default Id property on CLR type <typeparamref name="TDocument" /> that NEST will evaluate
 		/// </summary>
-		public ClrTypeDefaultsDescriptor<TDocument> IdProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.IdProperty = property);
+		public ClrTypeMappingsDescriptor<TDocument> IdProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.IdProperty = property);
 
 		/// <summary> Provide a default routing parameter lookup based on <typeparamref name="TDocument" /> </summary>
-		public ClrTypeDefaultsDescriptor<TDocument> RoutingProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.RoutingProperty = property);
+		public ClrTypeMappingsDescriptor<TDocument> RoutingProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.RoutingProperty = property);
 
 		/// <summary>
 		/// Ignore <paramref name="property" /> on CLR type <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeDefaultsDescriptor<TDocument> Ignore(Expression<Func<TDocument, object>> property) =>
+		public ClrTypeMappingsDescriptor<TDocument> Ignore(Expression<Func<TDocument, object>> property) =>
 			Assign(a => a.Properties.Add(new IgnoreClrPropertyMapping<TDocument>(property)));
 
 		/// <summary>
 		/// Rename <paramref name="property" /> on CLR type <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeDefaultsDescriptor<TDocument> Rename(Expression<Func<TDocument, object>> property, string newName) =>
+		public ClrTypeMappingsDescriptor<TDocument> Rename(Expression<Func<TDocument, object>> property, string newName) =>
 			Assign(a => a.Properties.Add(new RenameClrPropertyMapping<TDocument>(property, newName)));
 
 	}

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace Nest
 {
-	public interface IClrTypeMappings
+	public interface IClrTypeMapping
 	{
 		/// <summary>
 		/// The CLR type the mapping relates to
@@ -28,7 +28,7 @@ namespace Nest
 
 	}
 
-	public interface IClrTypeMappings<TDocument> : IClrTypeMappings where TDocument : class
+	public interface IClrTypeMapping<TDocument> : IClrTypeMapping where TDocument : class
 	{
 		/// <summary> Set a default Id property on CLR type <typeparamref name="TDocument" /> that NEST will evaluate </summary>
 		Expression<Func<TDocument, object>> IdProperty { get; set; }
@@ -42,12 +42,12 @@ namespace Nest
 		IList<IClrPropertyMapping<TDocument>> Properties { get; set; }
 	}
 
-	public class ClrTypeMappings : IClrTypeMappings
+	public class ClrTypeMapping : IClrTypeMapping
 	{
 		/// <summary>
-		/// Initializes a new instance of <see cref="ClrTypeMappings"/>
+		/// Initializes a new instance of <see cref="ClrTypeMapping"/>
 		/// </summary>
-		public ClrTypeMappings(Type type) => ClrType = type;
+		public ClrTypeMapping(Type type) => ClrType = type;
 
 		/// <inheritdoc />
 		public Type ClrType { get; }
@@ -62,9 +62,9 @@ namespace Nest
 		public string RelationName { get; set; }
 
 	}
-	public class ClrTypeMappings<TDocument> : ClrTypeMappings, IClrTypeMappings<TDocument> where TDocument : class
+	public class ClrTypeMapping<TDocument> : ClrTypeMapping, IClrTypeMapping<TDocument> where TDocument : class
 	{
-		public ClrTypeMappings() : base(typeof(TDocument)) { }
+		public ClrTypeMapping() : base(typeof(TDocument)) { }
 
 		/// <inheritdoc />
 		public Expression<Func<TDocument, object>> IdProperty { get; set; }
@@ -76,82 +76,82 @@ namespace Nest
 		public IList<IClrPropertyMapping<TDocument>> Properties { get; set; }
 	}
 
-	public class ClrTypeMappingsDescriptor : DescriptorBase<ClrTypeMappingsDescriptor,IClrTypeMappings> , IClrTypeMappings
+	public class ClrTypeMappingDescriptor : DescriptorBase<ClrTypeMappingDescriptor,IClrTypeMapping> , IClrTypeMapping
 	{
 		private readonly Type _type;
 
 		/// <summary>
-		/// Instantiates a new instance of <see cref="ClrTypeMappingsDescriptor"/>
+		/// Instantiates a new instance of <see cref="ClrTypeMappingDescriptor"/>
 		/// </summary>
 		/// <param name="type">The CLR type to map</param>
-		public ClrTypeMappingsDescriptor(Type type) => _type = type;
+		public ClrTypeMappingDescriptor(Type type) => _type = type;
 
-		Type IClrTypeMappings.ClrType => _type;
-		string IClrTypeMappings.IndexName { get; set; }
-		string IClrTypeMappings.TypeName { get; set; }
-		string IClrTypeMappings.RelationName { get; set; }
+		Type IClrTypeMapping.ClrType => _type;
+		string IClrTypeMapping.IndexName { get; set; }
+		string IClrTypeMapping.TypeName { get; set; }
+		string IClrTypeMapping.RelationName { get; set; }
 
 		/// <summary>
 		/// The default Elasticsearch index name for the CLR type
 		/// </summary>
-		public ClrTypeMappingsDescriptor IndexName(string indexName) => Assign(a => a.IndexName = indexName);
+		public ClrTypeMappingDescriptor IndexName(string indexName) => Assign(a => a.IndexName = indexName);
 
 		/// <summary>
 		/// The default Elasticsearch type name for the CLR type
 		/// </summary>
-		public ClrTypeMappingsDescriptor TypeName(string typeName) => Assign(a => a.TypeName = typeName);
+		public ClrTypeMappingDescriptor TypeName(string typeName) => Assign(a => a.TypeName = typeName);
 
 		/// <summary>
 		/// The relation name for the CLR type to resolve to.
 		/// </summary>
-		public ClrTypeMappingsDescriptor RelationName(string relationName) => Assign(a => a.RelationName = relationName);
+		public ClrTypeMappingDescriptor RelationName(string relationName) => Assign(a => a.RelationName = relationName);
 	}
 
-	public class ClrTypeMappingsDescriptor<TDocument>
-		: DescriptorBase<ClrTypeMappingsDescriptor<TDocument>,IClrTypeMappings<TDocument>>, IClrTypeMappings<TDocument>
+	public class ClrTypeMappingDescriptor<TDocument>
+		: DescriptorBase<ClrTypeMappingDescriptor<TDocument>,IClrTypeMapping<TDocument>>, IClrTypeMapping<TDocument>
 		where TDocument : class
 	{
-		Type IClrTypeMappings.ClrType { get; } = typeof (TDocument);
-		string IClrTypeMappings.IndexName { get; set; }
-		string IClrTypeMappings.TypeName { get; set; }
-		string IClrTypeMappings.RelationName { get; set; }
-		Expression<Func<TDocument, object>> IClrTypeMappings<TDocument>.IdProperty { get; set; }
-		Expression<Func<TDocument, object>> IClrTypeMappings<TDocument>.RoutingProperty { get; set; }
-		IList<IClrPropertyMapping<TDocument>> IClrTypeMappings<TDocument>.Properties { get; set; } = new List<IClrPropertyMapping<TDocument>>();
+		Type IClrTypeMapping.ClrType { get; } = typeof (TDocument);
+		string IClrTypeMapping.IndexName { get; set; }
+		string IClrTypeMapping.TypeName { get; set; }
+		string IClrTypeMapping.RelationName { get; set; }
+		Expression<Func<TDocument, object>> IClrTypeMapping<TDocument>.IdProperty { get; set; }
+		Expression<Func<TDocument, object>> IClrTypeMapping<TDocument>.RoutingProperty { get; set; }
+		IList<IClrPropertyMapping<TDocument>> IClrTypeMapping<TDocument>.Properties { get; set; } = new List<IClrPropertyMapping<TDocument>>();
 
 		/// <summary>
 		/// The default Elasticsearch index name for <typeparamref name="TDocument"/>
 		/// </summary>
-		public ClrTypeMappingsDescriptor<TDocument> IndexName(string indexName) => Assign(a => a.IndexName = indexName);
+		public ClrTypeMappingDescriptor<TDocument> IndexName(string indexName) => Assign(a => a.IndexName = indexName);
 
 		/// <summary>
 		/// The default Elasticsearch type name for <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeMappingsDescriptor<TDocument> TypeName(string typeName) => Assign(a => a.TypeName = typeName);
+		public ClrTypeMappingDescriptor<TDocument> TypeName(string typeName) => Assign(a => a.TypeName = typeName);
 
 		/// <summary>
 		/// The relation name for <typeparamref name="TDocument" /> to resolve to.
 		/// </summary>
-		public ClrTypeMappingsDescriptor<TDocument> RelationName(string relationName) => Assign(a => a.RelationName = relationName);
+		public ClrTypeMappingDescriptor<TDocument> RelationName(string relationName) => Assign(a => a.RelationName = relationName);
 
 		/// <summary>
 		/// Set a default Id property on CLR type <typeparamref name="TDocument" /> that NEST will evaluate
 		/// </summary>
-		public ClrTypeMappingsDescriptor<TDocument> IdProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.IdProperty = property);
+		public ClrTypeMappingDescriptor<TDocument> IdProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.IdProperty = property);
 
 		/// <summary> Provide a default routing parameter lookup based on <typeparamref name="TDocument" /> </summary>
-		public ClrTypeMappingsDescriptor<TDocument> RoutingProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.RoutingProperty = property);
+		public ClrTypeMappingDescriptor<TDocument> RoutingProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.RoutingProperty = property);
 
 		/// <summary>
 		/// Ignore <paramref name="property" /> on CLR type <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeMappingsDescriptor<TDocument> Ignore(Expression<Func<TDocument, object>> property) =>
+		public ClrTypeMappingDescriptor<TDocument> Ignore(Expression<Func<TDocument, object>> property) =>
 			Assign(a => a.Properties.Add(new IgnoreClrPropertyMapping<TDocument>(property)));
 
 		/// <summary>
 		/// Rename <paramref name="property" /> on CLR type <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeMappingsDescriptor<TDocument> Rename(Expression<Func<TDocument, object>> property, string newName) =>
+		public ClrTypeMappingDescriptor<TDocument> Rename(Expression<Func<TDocument, object>> property, string newName) =>
 			Assign(a => a.Properties.Add(new RenameClrPropertyMapping<TDocument>(property, newName)));
 
 	}

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace Nest
 {
-	public interface IClrTypeMapping
+	public interface IClrTypeDefault
 	{
 		/// <summary>
 		/// The CLR type the mapping relates to
@@ -25,9 +25,14 @@ namespace Nest
 		/// The relation name for <see cref="ClrType"/> to resolve to.
 		/// </summary>
 		string RelationName { get; set; }
+
+		/// <summary>
+		/// The default query to inject if constraint to
+		/// </summary>
+		QueryContainer Query { get; set; }
 	}
 
-	public interface IClrTypeMapping<TDocument> : IClrTypeMapping where TDocument : class
+	public interface IClrTypeDefaults<TDocument> : IClrTypeDefault where TDocument : class
 	{
 		/// <summary> Set a default Id property on CLR type <typeparamref name="TDocument" /> that NEST will evaluate </summary>
 		Expression<Func<TDocument, object>> IdProperty { get; set; }
@@ -41,12 +46,12 @@ namespace Nest
 		IList<IClrPropertyMapping<TDocument>> Properties { get; set; }
 	}
 
-	public class ClrTypeMapping : IClrTypeMapping
+	public class ClrTypeDefaults : IClrTypeDefault
 	{
 		/// <summary>
-		/// Initializes a new instance of <see cref="ClrTypeMapping"/>
+		/// Initializes a new instance of <see cref="ClrTypeDefaults"/>
 		/// </summary>
-		public ClrTypeMapping(Type type) => ClrType = type;
+		public ClrTypeDefaults(Type type) => ClrType = type;
 
 		/// <inheritdoc />
 		public Type ClrType { get; }
@@ -61,9 +66,9 @@ namespace Nest
 		public string RelationName { get; set; }
 
 	}
-	public class ClrTypeMapping<TDocument> : ClrTypeMapping, IClrTypeMapping<TDocument> where TDocument : class
+	public class ClrTypeDefaults<TDocument> : ClrTypeDefaults, IClrTypeDefaults<TDocument> where TDocument : class
 	{
-		public ClrTypeMapping() : base(typeof(TDocument)) { }
+		public ClrTypeDefaults() : base(typeof(TDocument)) { }
 
 		/// <inheritdoc />
 		public Expression<Func<TDocument, object>> IdProperty { get; set; }
@@ -75,82 +80,82 @@ namespace Nest
 		public IList<IClrPropertyMapping<TDocument>> Properties { get; set; }
 	}
 
-	public class ClrTypeMappingDescriptor : DescriptorBase<ClrTypeMappingDescriptor,IClrTypeMapping> , IClrTypeMapping
+	public class ClrTypeDefaultsDescriptor : DescriptorBase<ClrTypeDefaultsDescriptor,IClrTypeDefault> , IClrTypeDefault
 	{
 		private readonly Type _type;
 
 		/// <summary>
-		/// Instantiates a new instance of <see cref="ClrTypeMappingDescriptor"/>
+		/// Instantiates a new instance of <see cref="ClrTypeDefaultsDescriptor"/>
 		/// </summary>
 		/// <param name="type">The CLR type to map</param>
-		public ClrTypeMappingDescriptor(Type type) => _type = type;
+		public ClrTypeDefaultsDescriptor(Type type) => _type = type;
 
-		Type IClrTypeMapping.ClrType => _type;
-		string IClrTypeMapping.IndexName { get; set; }
-		string IClrTypeMapping.TypeName { get; set; }
-		string IClrTypeMapping.RelationName { get; set; }
+		Type IClrTypeDefault.ClrType => _type;
+		string IClrTypeDefault.IndexName { get; set; }
+		string IClrTypeDefault.TypeName { get; set; }
+		string IClrTypeDefault.RelationName { get; set; }
 
 		/// <summary>
 		/// The default Elasticsearch index name for the CLR type
 		/// </summary>
-		public ClrTypeMappingDescriptor IndexName(string indexName) => Assign(a => a.IndexName = indexName);
+		public ClrTypeDefaultsDescriptor IndexName(string indexName) => Assign(a => a.IndexName = indexName);
 
 		/// <summary>
 		/// The default Elasticsearch type name for the CLR type
 		/// </summary>
-		public ClrTypeMappingDescriptor TypeName(string typeName) => Assign(a => a.TypeName = typeName);
+		public ClrTypeDefaultsDescriptor TypeName(string typeName) => Assign(a => a.TypeName = typeName);
 
 		/// <summary>
 		/// The relation name for the CLR type to resolve to.
 		/// </summary>
-		public ClrTypeMappingDescriptor RelationName(string relationName) => Assign(a => a.RelationName = relationName);
+		public ClrTypeDefaultsDescriptor RelationName(string relationName) => Assign(a => a.RelationName = relationName);
 	}
 
-	public class ClrTypeMappingDescriptor<TDocument>
-		: DescriptorBase<ClrTypeMappingDescriptor<TDocument>,IClrTypeMapping<TDocument>>, IClrTypeMapping<TDocument>
+	public class ClrTypeDefaultsDescriptor<TDocument>
+		: DescriptorBase<ClrTypeDefaultsDescriptor<TDocument>,IClrTypeDefaults<TDocument>>, IClrTypeDefaults<TDocument>
 		where TDocument : class
 	{
-		Type IClrTypeMapping.ClrType { get; } = typeof (TDocument);
-		string IClrTypeMapping.IndexName { get; set; }
-		string IClrTypeMapping.TypeName { get; set; }
-		string IClrTypeMapping.RelationName { get; set; }
-		Expression<Func<TDocument, object>> IClrTypeMapping<TDocument>.IdProperty { get; set; }
-		Expression<Func<TDocument, object>> IClrTypeMapping<TDocument>.RoutingProperty { get; set; }
-		IList<IClrPropertyMapping<TDocument>> IClrTypeMapping<TDocument>.Properties { get; set; } = new List<IClrPropertyMapping<TDocument>>();
+		Type IClrTypeDefault.ClrType { get; } = typeof (TDocument);
+		string IClrTypeDefault.IndexName { get; set; }
+		string IClrTypeDefault.TypeName { get; set; }
+		string IClrTypeDefault.RelationName { get; set; }
+		Expression<Func<TDocument, object>> IClrTypeDefaults<TDocument>.IdProperty { get; set; }
+		Expression<Func<TDocument, object>> IClrTypeDefaults<TDocument>.RoutingProperty { get; set; }
+		IList<IClrPropertyMapping<TDocument>> IClrTypeDefaults<TDocument>.Properties { get; set; } = new List<IClrPropertyMapping<TDocument>>();
 
 		/// <summary>
 		/// The default Elasticsearch index name for <typeparamref name="TDocument"/>
 		/// </summary>
-		public ClrTypeMappingDescriptor<TDocument> IndexName(string indexName) => Assign(a => a.IndexName = indexName);
+		public ClrTypeDefaultsDescriptor<TDocument> IndexName(string indexName) => Assign(a => a.IndexName = indexName);
 
 		/// <summary>
 		/// The default Elasticsearch type name for <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeMappingDescriptor<TDocument> TypeName(string typeName) => Assign(a => a.TypeName = typeName);
+		public ClrTypeDefaultsDescriptor<TDocument> TypeName(string typeName) => Assign(a => a.TypeName = typeName);
 
 		/// <summary>
 		/// The relation name for <typeparamref name="TDocument" /> to resolve to.
 		/// </summary>
-		public ClrTypeMappingDescriptor<TDocument> RelationName(string relationName) => Assign(a => a.RelationName = relationName);
+		public ClrTypeDefaultsDescriptor<TDocument> RelationName(string relationName) => Assign(a => a.RelationName = relationName);
 
 		/// <summary>
 		/// Set a default Id property on CLR type <typeparamref name="TDocument" /> that NEST will evaluate
 		/// </summary>
-		public ClrTypeMappingDescriptor<TDocument> IdProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.IdProperty = property);
+		public ClrTypeDefaultsDescriptor<TDocument> IdProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.IdProperty = property);
 
 		/// <summary> Provide a default routing parameter lookup based on <typeparamref name="TDocument" /> </summary>
-		public ClrTypeMappingDescriptor<TDocument> RoutingProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.RoutingProperty = property);
+		public ClrTypeDefaultsDescriptor<TDocument> RoutingProperty(Expression<Func<TDocument, object>> property) => Assign(a => a.RoutingProperty = property);
 
 		/// <summary>
 		/// Ignore <paramref name="property" /> on CLR type <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeMappingDescriptor<TDocument> Ignore(Expression<Func<TDocument, object>> property) =>
+		public ClrTypeDefaultsDescriptor<TDocument> Ignore(Expression<Func<TDocument, object>> property) =>
 			Assign(a => a.Properties.Add(new IgnoreClrPropertyMapping<TDocument>(property)));
 
 		/// <summary>
 		/// Rename <paramref name="property" /> on CLR type <typeparamref name="TDocument" />
 		/// </summary>
-		public ClrTypeMappingDescriptor<TDocument> Rename(Expression<Func<TDocument, object>> property, string newName) =>
+		public ClrTypeDefaultsDescriptor<TDocument> Rename(Expression<Func<TDocument, object>> property, string newName) =>
 			Assign(a => a.Properties.Add(new RenameClrPropertyMapping<TDocument>(property, newName)));
 
 	}

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -274,7 +274,7 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings DefaultsFor(Type documentType, Func<ClrTypeDefaultsDescriptor, IClrTypeDefault> selector)
+		public TConnectionSettings DefaultsFor(Type documentType, Func<ClrTypeDefaultsDescriptor, IClrTypeDefaults> selector)
 		{
 			var inferMapping = selector(new ClrTypeDefaultsDescriptor(documentType));
 			if (!inferMapping.IndexName.IsNullOrEmpty())

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -240,14 +240,14 @@ namespace Nest
 		/// <typeparam name="TDocument">The type of the document.</typeparam>
 		/// <param name="selector">The selector.</param>
 		[Obsolete("Please use DefaultsFor")]
-		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeDefaultsDescriptor<TDocument>, IClrTypeDefaults<TDocument>> selector)
+		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeMappingsDescriptor<TDocument>, IClrTypeMappings<TDocument>> selector)
 			where TDocument : class =>
 			DefaultsFor<TDocument>(selector);
 
-		public TConnectionSettings DefaultsFor<TDocument>(Func<ClrTypeDefaultsDescriptor<TDocument>, IClrTypeDefaults<TDocument>> selector)
+		public TConnectionSettings DefaultsFor<TDocument>(Func<ClrTypeMappingsDescriptor<TDocument>, IClrTypeMappings<TDocument>> selector)
 			where TDocument : class
 		{
-			var inferMapping = selector(new ClrTypeDefaultsDescriptor<TDocument>());
+			var inferMapping = selector(new ClrTypeMappingsDescriptor<TDocument>());
 			if (!inferMapping.IndexName.IsNullOrEmpty())
 				this._defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
 
@@ -274,9 +274,9 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings DefaultsFor(Type documentType, Func<ClrTypeDefaultsDescriptor, IClrTypeDefaults> selector)
+		public TConnectionSettings DefaultsFor(Type documentType, Func<ClrTypeMappingsDescriptor, IClrTypeMappings> selector)
 		{
-			var inferMapping = selector(new ClrTypeDefaultsDescriptor(documentType));
+			var inferMapping = selector(new ClrTypeMappingsDescriptor(documentType));
 			if (!inferMapping.IndexName.IsNullOrEmpty())
 				this._defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
 
@@ -294,7 +294,7 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings DefaultsFor(IEnumerable<ClrTypeDefaults> typeMappings)
+		public TConnectionSettings DefaultsFor(IEnumerable<ClrTypeMappings> typeMappings)
 		{
 			if (typeMappings == null) return (TConnectionSettings) this;
 			foreach (var inferMapping in typeMappings)

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -239,12 +239,12 @@ namespace Nest
 		/// </summary>
 		/// <typeparam name="TDocument">The type of the document.</typeparam>
 		/// <param name="selector">The selector.</param>
-		[Obsolete("Please use DefaultsFor")]
+		[Obsolete("Please use DefaultMappingFor")]
 		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeMappingsDescriptor<TDocument>, IClrTypeMappings<TDocument>> selector)
 			where TDocument : class =>
-			DefaultsFor<TDocument>(selector);
+			DefaultMappingFor<TDocument>(selector);
 
-		public TConnectionSettings DefaultsFor<TDocument>(Func<ClrTypeMappingsDescriptor<TDocument>, IClrTypeMappings<TDocument>> selector)
+		public TConnectionSettings DefaultMappingFor<TDocument>(Func<ClrTypeMappingsDescriptor<TDocument>, IClrTypeMappings<TDocument>> selector)
 			where TDocument : class
 		{
 			var inferMapping = selector(new ClrTypeMappingsDescriptor<TDocument>());
@@ -274,7 +274,7 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings DefaultsFor(Type documentType, Func<ClrTypeMappingsDescriptor, IClrTypeMappings> selector)
+		public TConnectionSettings DefaultMappingFor(Type documentType, Func<ClrTypeMappingsDescriptor, IClrTypeMappings> selector)
 		{
 			var inferMapping = selector(new ClrTypeMappingsDescriptor(documentType));
 			if (!inferMapping.IndexName.IsNullOrEmpty())
@@ -294,7 +294,7 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings DefaultsFor(IEnumerable<ClrTypeMappings> typeMappings)
+		public TConnectionSettings DefaultMappingFor(IEnumerable<ClrTypeMappings> typeMappings)
 		{
 			if (typeMappings == null) return (TConnectionSettings) this;
 			foreach (var inferMapping in typeMappings)

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -240,14 +240,14 @@ namespace Nest
 		/// <typeparam name="TDocument">The type of the document.</typeparam>
 		/// <param name="selector">The selector.</param>
 		[Obsolete("Please use DefaultMappingFor")]
-		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeMappingsDescriptor<TDocument>, IClrTypeMappings<TDocument>> selector)
+		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeMappingDescriptor<TDocument>, IClrTypeMapping<TDocument>> selector)
 			where TDocument : class =>
 			DefaultMappingFor<TDocument>(selector);
 
-		public TConnectionSettings DefaultMappingFor<TDocument>(Func<ClrTypeMappingsDescriptor<TDocument>, IClrTypeMappings<TDocument>> selector)
+		public TConnectionSettings DefaultMappingFor<TDocument>(Func<ClrTypeMappingDescriptor<TDocument>, IClrTypeMapping<TDocument>> selector)
 			where TDocument : class
 		{
-			var inferMapping = selector(new ClrTypeMappingsDescriptor<TDocument>());
+			var inferMapping = selector(new ClrTypeMappingDescriptor<TDocument>());
 			if (!inferMapping.IndexName.IsNullOrEmpty())
 				this._defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
 
@@ -274,9 +274,9 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings DefaultMappingFor(Type documentType, Func<ClrTypeMappingsDescriptor, IClrTypeMappings> selector)
+		public TConnectionSettings DefaultMappingFor(Type documentType, Func<ClrTypeMappingDescriptor, IClrTypeMapping> selector)
 		{
-			var inferMapping = selector(new ClrTypeMappingsDescriptor(documentType));
+			var inferMapping = selector(new ClrTypeMappingDescriptor(documentType));
 			if (!inferMapping.IndexName.IsNullOrEmpty())
 				this._defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
 
@@ -294,7 +294,7 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings DefaultMappingFor(IEnumerable<ClrTypeMappings> typeMappings)
+		public TConnectionSettings DefaultMappingFor(IEnumerable<ClrTypeMapping> typeMappings)
 		{
 			if (typeMappings == null) return (TConnectionSettings) this;
 			foreach (var inferMapping in typeMappings)

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -241,9 +241,8 @@ namespace Nest
 		/// <param name="selector">The selector.</param>
 		[Obsolete("Please use DefaultsFor")]
 		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeDefaultsDescriptor<TDocument>, IClrTypeDefaults<TDocument>> selector)
-		{
-			return DefaultsFor<TDocument>(selector);
-		}
+			where TDocument : class =>
+			DefaultsFor<TDocument>(selector);
 
 		public TConnectionSettings DefaultsFor<TDocument>(Func<ClrTypeDefaultsDescriptor<TDocument>, IClrTypeDefaults<TDocument>> selector)
 			where TDocument : class
@@ -275,7 +274,7 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings InferMappingFor(Type documentType, Func<ClrTypeDefaultsDescriptor, IClrTypeDefault> selector)
+		public TConnectionSettings DefaultsFor(Type documentType, Func<ClrTypeDefaultsDescriptor, IClrTypeDefault> selector)
 		{
 			var inferMapping = selector(new ClrTypeDefaultsDescriptor(documentType));
 			if (!inferMapping.IndexName.IsNullOrEmpty())
@@ -295,7 +294,7 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings InferMappings(IEnumerable<ClrTypeDefaults> typeMappings)
+		public TConnectionSettings DefaultsFor(IEnumerable<ClrTypeDefaults> typeMappings)
 		{
 			if (typeMappings == null) return (TConnectionSettings) this;
 			foreach (var inferMapping in typeMappings)

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -239,10 +239,16 @@ namespace Nest
 		/// </summary>
 		/// <typeparam name="TDocument">The type of the document.</typeparam>
 		/// <param name="selector">The selector.</param>
-		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeMappingDescriptor<TDocument>, IClrTypeMapping<TDocument>> selector)
+		[Obsolete("Please use DefaultsFor")]
+		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeDefaultsDescriptor<TDocument>, IClrTypeDefaults<TDocument>> selector)
+		{
+			return DefaultsFor<TDocument>(selector);
+		}
+
+		public TConnectionSettings DefaultsFor<TDocument>(Func<ClrTypeDefaultsDescriptor<TDocument>, IClrTypeDefaults<TDocument>> selector)
 			where TDocument : class
 		{
-			var inferMapping = selector(new ClrTypeMappingDescriptor<TDocument>());
+			var inferMapping = selector(new ClrTypeDefaultsDescriptor<TDocument>());
 			if (!inferMapping.IndexName.IsNullOrEmpty())
 				this._defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
 
@@ -269,9 +275,9 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings InferMappingFor(Type documentType, Func<ClrTypeMappingDescriptor, IClrTypeMapping> selector)
+		public TConnectionSettings InferMappingFor(Type documentType, Func<ClrTypeDefaultsDescriptor, IClrTypeDefault> selector)
 		{
-			var inferMapping = selector(new ClrTypeMappingDescriptor(documentType));
+			var inferMapping = selector(new ClrTypeDefaultsDescriptor(documentType));
 			if (!inferMapping.IndexName.IsNullOrEmpty())
 				this._defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
 
@@ -289,7 +295,7 @@ namespace Nest
 		/// </summary>
 		/// <param name="documentType">The type of the POCO you wish to configure</param>
 		/// <param name="selector">describe the POCO configuration</param>
-		public TConnectionSettings InferMappings(IEnumerable<ClrTypeMapping> typeMappings)
+		public TConnectionSettings InferMappings(IEnumerable<ClrTypeDefaults> typeMappings)
 		{
 			if (typeMappings == null) return (TConnectionSettings) this;
 			foreach (var inferMapping in typeMappings)

--- a/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/IndexName/IndexNameResolver.cs
@@ -42,7 +42,7 @@ namespace Nest
 			if (string.IsNullOrWhiteSpace(indexName))
 				throw new ArgumentException(
 					"Index name is null for the given type and no default index is set. "
-					+ "Map an index name using ConnectionSettings.MapDefaultTypeIndices(), ConnectionSettings.InferMappingFor<TDocument>() "
+					+ "Map an index name using ConnectionSettings.MapDefaultTypeIndices(), ConnectionSettings.DefaultsFor<TDocument>() "
 					+ "or set a default index using ConnectionSettings.DefaultIndex()."
 				);
 		}

--- a/src/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
+++ b/src/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
@@ -52,7 +52,7 @@ namespace Tests.ClientConcepts.Connection
 			 * And with the high level client
 			 */
 			var connectionSettings = new ConnectionSettings()
-				.DefaultsFor<Project>(i => i
+				.DefaultMappingFor<Project>(i => i
 					.IndexName("my-projects")
 					.TypeName("project")
 				)

--- a/src/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
+++ b/src/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
@@ -52,7 +52,7 @@ namespace Tests.ClientConcepts.Connection
 			 * And with the high level client
 			 */
 			var connectionSettings = new ConnectionSettings()
-				.InferMappingFor<Project>(i => i
+				.DefaultsFor<Project>(i => i
 					.IndexName("my-projects")
 					.TypeName("project")
 				)

--- a/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
@@ -376,7 +376,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* for property `C` on `B`
 			*/
 			var newConnectionSettings = TestClient.CreateSettings(modifySettings: s => s
-				.DefaultsFor<A>(m => m
+				.DefaultMappingFor<A>(m => m
 					.Rename(p => p.C, "d")
 				)
 			);
@@ -448,7 +448,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			*/
 			var usingSettings = WithConnectionSettings(s => s
 
-				.DefaultsFor<Precedence>(m => m
+				.DefaultMappingFor<Precedence>(m => m
 					.Rename(p => p.RenamedOnConnectionSettings, "renamed")
 				)
 				.DefaultFieldNameInferrer(p => p.ToUpperInvariant())
@@ -492,7 +492,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		{
 			/** Inherited properties can be ignored and renamed just as one would expect */
 			var usingSettings = WithConnectionSettings(s => s
-				.DefaultsFor<Child>(m => m
+				.DefaultMappingFor<Child>(m => m
 					.Rename(p => p.Description, "desc")
 					.Ignore(p => p.IgnoreMe)
 				)

--- a/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
@@ -376,7 +376,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* for property `C` on `B`
 			*/
 			var newConnectionSettings = TestClient.CreateSettings(modifySettings: s => s
-				.InferMappingFor<A>(m => m
+				.DefaultsFor<A>(m => m
 					.Rename(p => p.C, "d")
 				)
 			);
@@ -448,7 +448,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			*/
 			var usingSettings = WithConnectionSettings(s => s
 
-				.InferMappingFor<Precedence>(m => m
+				.DefaultsFor<Precedence>(m => m
 					.Rename(p => p.RenamedOnConnectionSettings, "renamed")
 				)
 				.DefaultFieldNameInferrer(p => p.ToUpperInvariant())
@@ -492,7 +492,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		{
 			/** Inherited properties can be ignored and renamed just as one would expect */
 			var usingSettings = WithConnectionSettings(s => s
-				.InferMappingFor<Child>(m => m
+				.DefaultsFor<Child>(m => m
 					.Rename(p => p.Description, "desc")
 					.Ignore(p => p.IgnoreMe)
 				)

--- a/src/Tests/ClientConcepts/HighLevel/Inference/IdsInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/IdsInference.doc.cs
@@ -69,7 +69,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* Here we instruct NEST to infer the Id for `MyDTO` based on its `Name` property
 			*/
 			WithConnectionSettings(x => x
-				.DefaultsFor<MyDTO>(m => m
+				.DefaultMappingFor<MyDTO>(m => m
 					.IdProperty(p => p.Name)
 				)
 			).Expect("x").WhenInferringIdOn(dto);
@@ -80,7 +80,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* with different inference rules
 			*/
 			WithConnectionSettings(x => x
-				.DefaultsFor<MyDTO>(m => m
+				.DefaultMappingFor<MyDTO>(m => m
 					.IdProperty(p => p.OtherName)
 				)
 			).Expect("y").WhenInferringIdOn(dto);
@@ -120,7 +120,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* that will infer the document id from the property `OtherName`:
 			*/
 			WithConnectionSettings(x => x
-				.DefaultsFor<MyOtherDTO>(m => m
+				.DefaultMappingFor<MyOtherDTO>(m => m
 					.IdProperty(p => p.OtherName)
 				)
 			).Expect("y").WhenInferringIdOn(dto);

--- a/src/Tests/ClientConcepts/HighLevel/Inference/IdsInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/IdsInference.doc.cs
@@ -69,7 +69,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* Here we instruct NEST to infer the Id for `MyDTO` based on its `Name` property
 			*/
 			WithConnectionSettings(x => x
-				.InferMappingFor<MyDTO>(m => m
+				.DefaultsFor<MyDTO>(m => m
 					.IdProperty(p => p.Name)
 				)
 			).Expect("x").WhenInferringIdOn(dto);
@@ -80,7 +80,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* with different inference rules
 			*/
 			WithConnectionSettings(x => x
-				.InferMappingFor<MyDTO>(m => m
+				.DefaultsFor<MyDTO>(m => m
 					.IdProperty(p => p.OtherName)
 				)
 			).Expect("y").WhenInferringIdOn(dto);
@@ -120,7 +120,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* that will infer the document id from the property `OtherName`:
 			*/
 			WithConnectionSettings(x => x
-				.InferMappingFor<MyOtherDTO>(m => m
+				.DefaultsFor<MyOtherDTO>(m => m
 					.IdProperty(p => p.OtherName)
 				)
 			).Expect("y").WhenInferringIdOn(dto);

--- a/src/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
@@ -41,7 +41,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		[U] public void ExplicitMappingIsInferredUsingMapDefaultTypeIndices()
 		{
 			var settings = new ConnectionSettings()
-				.InferMappingFor<Project>(m => m
+				.DefaultsFor<Project>(m => m
 					.IndexName("projects")
 				);
 			var resolver = new IndexNameResolver(settings);
@@ -50,14 +50,14 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		}
 
 		/**
-		 * `.InferMappingFor<T>()` can also be used to specify the index name, as well as be used
+		 * `.DefaultsFor<T>()` can also be used to specify the index name, as well as be used
 		 * to specify the type name and POCO property that should be used as the id for the document
 		 */
 		[U]
-		public void ExplicitMappingIsInferredUsingInferMappingFor()
+		public void ExplicitMappingIsInferredUsingDefaultsFor()
 		{
 			var settings = new ConnectionSettings()
-				.InferMappingFor<Project>(m => m
+				.DefaultsFor<Project>(m => m
 					.IndexName("projects")
 				);
 			var resolver = new IndexNameResolver(settings);
@@ -65,7 +65,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			index.Should().Be("projects");
 		}
 
-		/** An index name for a POCO provided using `.MapDefaultTypeIndices()` or `.InferMappingFor<T>()` **will take precedence** over
+		/** An index name for a POCO provided using `.MapDefaultTypeIndices()` or `.DefaultsFor<T>()` **will take precedence** over
 		* the default index name set on `ConnectionSettings`. This way, the client can be configured with a default index to use if no
 		* index is specified, and a specific index to use for different POCO types.
 		*/
@@ -73,7 +73,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		{
 			var settings = new ConnectionSettings()
 				.DefaultIndex("defaultindex")
-				.InferMappingFor<Project>(m => m
+				.DefaultsFor<Project>(m => m
 					.IndexName("projects")
 				);
 			var resolver = new IndexNameResolver(settings);
@@ -99,14 +99,14 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 
 		/** When an index name is provided on a request, it **will take precedence** over the default
 		* index name and any index name specified for the POCO type using `.MapDefaultTypeIndices()` or
-		* `.InferMappingFor<T>()`
+		* `.DefaultsFor<T>()`
 		*/
 		[U] public void ExplicitIndexOnRequestTakesPrecedence()
 		{
 			var client = TestClient.GetInMemoryClient(s=>
 				new ConnectionSettings()
 					.DefaultIndex("defaultindex")
-					.InferMappingFor<Project>(m => m
+					.DefaultsFor<Project>(m => m
 						.IndexName("projects")
 					)
 			);
@@ -120,7 +120,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		/** In summary, the order of precedence for determining the index name for a request is
 		 *
 		 * . Index name specified  on the request
-		 * . Index name specified for the generic type parameter in the request using `.MapDefaultTypeIndices()` or `.InferMappingFor<T>()`
+		 * . Index name specified for the generic type parameter in the request using `.MapDefaultTypeIndices()` or `.DefaultsFor<T>()`
 		 * . Default index name specified on `ConnectionSettings`
 		 */
 

--- a/src/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
@@ -41,7 +41,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		[U] public void ExplicitMappingIsInferredUsingMapDefaultTypeIndices()
 		{
 			var settings = new ConnectionSettings()
-				.DefaultsFor<Project>(m => m
+				.DefaultMappingFor<Project>(m => m
 					.IndexName("projects")
 				);
 			var resolver = new IndexNameResolver(settings);
@@ -57,7 +57,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		public void ExplicitMappingIsInferredUsingDefaultsFor()
 		{
 			var settings = new ConnectionSettings()
-				.DefaultsFor<Project>(m => m
+				.DefaultMappingFor<Project>(m => m
 					.IndexName("projects")
 				);
 			var resolver = new IndexNameResolver(settings);
@@ -73,7 +73,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		{
 			var settings = new ConnectionSettings()
 				.DefaultIndex("defaultindex")
-				.DefaultsFor<Project>(m => m
+				.DefaultMappingFor<Project>(m => m
 					.IndexName("projects")
 				);
 			var resolver = new IndexNameResolver(settings);
@@ -106,7 +106,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			var client = TestClient.GetInMemoryClient(s=>
 				new ConnectionSettings()
 					.DefaultIndex("defaultindex")
-					.DefaultsFor<Project>(m => m
+					.DefaultMappingFor<Project>(m => m
 						.IndexName("projects")
 					)
 			);

--- a/src/Tests/ClientConcepts/HighLevel/Inference/IndicesPaths.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/IndicesPaths.doc.cs
@@ -40,7 +40,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 
 			Nest.Indices allWithOthersFromString = "_all, name2"; //<1> `_all` will override any specific index names here
 
-			Nest.Indices singleIndexFromType = typeof(Project); //<2> The `Project` type has been mapped to a specific index name using <<index-name-type-mapping,`.InferMappingFor<Project>`>>
+			Nest.Indices singleIndexFromType = typeof(Project); //<2> The `Project` type has been mapped to a specific index name using <<index-name-type-mapping,`.DefaultsFor<Project>`>>
 
 			Nest.Indices singleIndexFromIndexName = IndexName.From<Project>();
 

--- a/src/Tests/ClientConcepts/HighLevel/Inference/RoutingInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/RoutingInference.doc.cs
@@ -67,7 +67,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* Here we instruct NEST to infer the Routing for `MyDTO` based on its `Name` property
 			*/
 			WithConnectionSettings(x => x
-				.InferMappingFor<MyDTO>(m => m
+				.DefaultsFor<MyDTO>(m => m
 					.RoutingProperty(p => p.Name)
 				)
 			).Expect("x").WhenInferringRoutingOn(dto);
@@ -78,7 +78,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* with different inference rules
 			*/
 			WithConnectionSettings(x => x
-				.InferMappingFor<MyDTO>(m => m
+				.DefaultsFor<MyDTO>(m => m
 					.RoutingProperty(p => p.OtherName)
 				)
 			).Expect("y").WhenInferringRoutingOn(dto);
@@ -132,7 +132,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			*
 			*/
 			WithConnectionSettings(x => x
-				.InferMappingFor<MyOtherDTO>(m => m
+				.DefaultsFor<MyOtherDTO>(m => m
 					.RoutingProperty(p => p.OtherName)
 				)
 			).Expect("y").WhenInferringRoutingOn(dto);
@@ -159,7 +159,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 
 			/** unless you configure the ConnectionSettings to use an alternate property: */
 			WithConnectionSettings(x => x
-				.InferMappingFor<BadDTO>(m => m
+				.DefaultsFor<BadDTO>(m => m
 					.RoutingProperty(p => p.ParentName)
 				)
 			).Expect("my-parent").WhenInferringRoutingOn(dto);

--- a/src/Tests/ClientConcepts/HighLevel/Inference/RoutingInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/RoutingInference.doc.cs
@@ -67,7 +67,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* Here we instruct NEST to infer the Routing for `MyDTO` based on its `Name` property
 			*/
 			WithConnectionSettings(x => x
-				.DefaultsFor<MyDTO>(m => m
+				.DefaultMappingFor<MyDTO>(m => m
 					.RoutingProperty(p => p.Name)
 				)
 			).Expect("x").WhenInferringRoutingOn(dto);
@@ -78,7 +78,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			* with different inference rules
 			*/
 			WithConnectionSettings(x => x
-				.DefaultsFor<MyDTO>(m => m
+				.DefaultMappingFor<MyDTO>(m => m
 					.RoutingProperty(p => p.OtherName)
 				)
 			).Expect("y").WhenInferringRoutingOn(dto);
@@ -132,7 +132,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			*
 			*/
 			WithConnectionSettings(x => x
-				.DefaultsFor<MyOtherDTO>(m => m
+				.DefaultMappingFor<MyOtherDTO>(m => m
 					.RoutingProperty(p => p.OtherName)
 				)
 			).Expect("y").WhenInferringRoutingOn(dto);
@@ -159,7 +159,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 
 			/** unless you configure the ConnectionSettings to use an alternate property: */
 			WithConnectionSettings(x => x
-				.DefaultsFor<BadDTO>(m => m
+				.DefaultMappingFor<BadDTO>(m => m
 					.RoutingProperty(p => p.ParentName)
 				)
 			).Expect("my-parent").WhenInferringRoutingOn(dto);

--- a/src/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs
@@ -73,12 +73,12 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		[U] public void RelationNameConfiguration()
 		{
 			var settings = new ConnectionSettings()
-				.InferMappingFor<CommitActivity>(m => m
+				.DefaultsFor<CommitActivity>(m => m
 					.IndexName("projects-and-commits")
 					.TypeName("doc")
 					.RelationName("commits")
 				)
-				.InferMappingFor<Project>(m => m
+				.DefaultsFor<Project>(m => m
 					.IndexName("projects-and-commits")
 					.TypeName("doc")
 					.RelationName("projects")
@@ -101,7 +101,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		[U] public void TypeNameExplicitConfigurationDoesNotAffectRelationName()
 		{
 			var settings = new ConnectionSettings()
-				.InferMappingFor<Project>(m => m
+				.DefaultsFor<Project>(m => m
 					.IndexName("projects-and-commits")
 					.TypeName("doc")
 				);

--- a/src/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs
@@ -73,12 +73,12 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		[U] public void RelationNameConfiguration()
 		{
 			var settings = new ConnectionSettings()
-				.DefaultsFor<CommitActivity>(m => m
+				.DefaultMappingFor<CommitActivity>(m => m
 					.IndexName("projects-and-commits")
 					.TypeName("doc")
 					.RelationName("commits")
 				)
-				.DefaultsFor<Project>(m => m
+				.DefaultMappingFor<Project>(m => m
 					.IndexName("projects-and-commits")
 					.TypeName("doc")
 					.RelationName("projects")
@@ -101,7 +101,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		[U] public void TypeNameExplicitConfigurationDoesNotAffectRelationName()
 		{
 			var settings = new ConnectionSettings()
-				.DefaultsFor<Project>(m => m
+				.DefaultMappingFor<Project>(m => m
 					.IndexName("projects-and-commits")
 					.TypeName("doc")
 				);

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
@@ -186,7 +186,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 			};
 
 			var settings = WithConnectionSettings(s => s
-				.DefaultsFor<ParentWithStringId>(m => m
+				.DefaultMappingFor<ParentWithStringId>(m => m
 					.TypeName("parent")
 					.Ignore(p => p.Description)
 					.Ignore(p => p.IgnoreMe)

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
@@ -186,7 +186,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 			};
 
 			var settings = WithConnectionSettings(s => s
-				.InferMappingFor<ParentWithStringId>(m => m
+				.DefaultsFor<ParentWithStringId>(m => m
 					.TypeName("parent")
 					.Ignore(p => p.Description)
 					.Ignore(p => p.IgnoreMe)

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/IgnoringProperties.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/IgnoringProperties.doc.cs
@@ -15,7 +15,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
     * - Using the `Ignore` property on a derived `ElasticsearchPropertyAttribute` type applied to
     * the property that should be ignored on the POCO
     *
-    * - Using the `.InferMappingFor<TDocument>(Func<ClrTypeMappingDescriptor<TDocument>, IClrTypeMapping<TDocument>>
+    * - Using the `.DefaultsFor<TDocument>(Func<ClrTypeMappingDescriptor<TDocument>, IClrTypeMapping<TDocument>>
     * selector)` on `ConnectionSettings`
     *
     * - Using an ignore attribute applied to the POCO property that is understood by
@@ -55,7 +55,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 				);
 
             var settings = WithConnectionSettings(s => s
-                .InferMappingFor<CompanyWithAttributesAndPropertiesToIgnore>(i => i
+                .DefaultsFor<CompanyWithAttributesAndPropertiesToIgnore>(i => i
                     .Ignore(p => p.AnotherPropertyToIgnore)
                 )
             );
@@ -119,7 +119,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 				);
 
             var settings = WithConnectionSettings(s => s
-                .InferMappingFor<Child>(m => m
+                .DefaultsFor<Child>(m => m
                     .Rename(p => p.Description, "desc")
                     .Ignore(p => p.IgnoreMe)
                 )

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/IgnoringProperties.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/IgnoringProperties.doc.cs
@@ -55,7 +55,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 				);
 
             var settings = WithConnectionSettings(s => s
-                .DefaultsFor<CompanyWithAttributesAndPropertiesToIgnore>(i => i
+                .DefaultMappingFor<CompanyWithAttributesAndPropertiesToIgnore>(i => i
                     .Ignore(p => p.AnotherPropertyToIgnore)
                 )
             );
@@ -119,7 +119,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 				);
 
             var settings = WithConnectionSettings(s => s
-                .DefaultsFor<Child>(m => m
+                .DefaultMappingFor<Child>(m => m
                     .Rename(p => p.Description, "desc")
                     .Ignore(p => p.IgnoreMe)
                 )

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
@@ -63,7 +63,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 		* ==== Parent And Child mapping
 		*
 		* In the following example we setup our client and give our types prefered index and type names.  Starting with NEST 6.x we can
-		* also give a type a preferred `RelationName` as can be seen on the `InferMappingFor<MyParent>`.
+		* also give a type a preferred `RelationName` as can be seen on the `DefaultsFor<MyParent>`.
 		*
 		* Also note that we give `MyChild` and `MyParent` the same default `doc` type name to make sure they end up in the same index
 		* under the same type.
@@ -74,9 +74,9 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 		{
 			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 			var connectionSettings = new ConnectionSettings(connectionPool, new InMemoryConnection()) // <1> for the purposes of this example, an in memory connection is used which doesn't actually send a request. In your application, you'd use the default connection or your own implementation that actually sends a request.
-				.InferMappingFor<MyDocument>(m => m.IndexName("index").TypeName("doc"))
-				.InferMappingFor<MyChild>(m => m.IndexName("index").TypeName("doc"))
-				.InferMappingFor<MyParent>(m => m.IndexName("index").TypeName("doc").RelationName("parent"));
+				.DefaultsFor<MyDocument>(m => m.IndexName("index").TypeName("doc"))
+				.DefaultsFor<MyChild>(m => m.IndexName("index").TypeName("doc"))
+				.DefaultsFor<MyParent>(m => m.IndexName("index").TypeName("doc").RelationName("parent"));
 
 			var client = new ElasticClient(connectionSettings);
 

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
@@ -74,9 +74,9 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 		{
 			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 			var connectionSettings = new ConnectionSettings(connectionPool, new InMemoryConnection()) // <1> for the purposes of this example, an in memory connection is used which doesn't actually send a request. In your application, you'd use the default connection or your own implementation that actually sends a request.
-				.DefaultsFor<MyDocument>(m => m.IndexName("index").TypeName("doc"))
-				.DefaultsFor<MyChild>(m => m.IndexName("index").TypeName("doc"))
-				.DefaultsFor<MyParent>(m => m.IndexName("index").TypeName("doc").RelationName("parent"));
+				.DefaultMappingFor<MyDocument>(m => m.IndexName("index").TypeName("doc"))
+				.DefaultMappingFor<MyChild>(m => m.IndexName("index").TypeName("doc"))
+				.DefaultMappingFor<MyParent>(m => m.IndexName("index").TypeName("doc").RelationName("parent"));
 
 			var client = new ElasticClient(connectionSettings);
 

--- a/src/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
+++ b/src/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
@@ -38,7 +38,7 @@ namespace Tests.ClientConcepts.Troubleshooting
 			 */
 			var pool = new SniffingConnectionPool(new []{ new Uri($"http://{TestClient.DefaultHost}:9200") });
 		    var connectionSettings = new ConnectionSettings(pool)
-				.InferMappingFor<Project>(i => i
+				.DefaultsFor<Project>(i => i
 					.IndexName("project")
 				);
 

--- a/src/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
+++ b/src/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
@@ -38,7 +38,7 @@ namespace Tests.ClientConcepts.Troubleshooting
 			 */
 			var pool = new SniffingConnectionPool(new []{ new Uri($"http://{TestClient.DefaultHost}:9200") });
 		    var connectionSettings = new ConnectionSettings(pool)
-				.DefaultsFor<Project>(i => i
+				.DefaultMappingFor<Project>(i => i
 					.IndexName("project")
 				);
 

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -67,27 +67,27 @@ namespace Tests.Framework
 
 		private static ConnectionSettings DefaultSettings(ConnectionSettings settings) => settings
 			.DefaultIndex("default-index")
-			.DefaultsFor<Project>(map => map
+			.DefaultMappingFor<Project>(map => map
 				.IndexName(DefaultSeeder.ProjectsIndex)
 				.IdProperty(p => p.Name)
 				.RelationName("project")
 				.TypeName("doc")
 			)
-			.DefaultsFor<CommitActivity>(map => map
+			.DefaultMappingFor<CommitActivity>(map => map
 				.IndexName(DefaultSeeder.ProjectsIndex)
 				.RelationName("commits")
 				.TypeName("doc")
 			)
-			.DefaultsFor<Developer>(map => map
+			.DefaultMappingFor<Developer>(map => map
 				.IndexName("devs")
 				.Ignore(p => p.PrivateValue)
 				.Rename(p => p.OnlineHandle, "nickname")
 			)
-			.DefaultsFor<ProjectPercolation>(map => map
+			.DefaultMappingFor<ProjectPercolation>(map => map
 				.IndexName("queries")
 				.TypeName(PercolatorType)
 			)
-			.DefaultsFor<Metric>(map => map
+			.DefaultMappingFor<Metric>(map => map
 				.IndexName("server-metrics")
 				.TypeName("metric")
 			)

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -67,27 +67,27 @@ namespace Tests.Framework
 
 		private static ConnectionSettings DefaultSettings(ConnectionSettings settings) => settings
 			.DefaultIndex("default-index")
-			.InferMappingFor<Project>(map => map
+			.DefaultsFor<Project>(map => map
 				.IndexName(DefaultSeeder.ProjectsIndex)
 				.IdProperty(p => p.Name)
 				.RelationName("project")
 				.TypeName("doc")
 			)
-			.InferMappingFor<CommitActivity>(map => map
+			.DefaultsFor<CommitActivity>(map => map
 				.IndexName(DefaultSeeder.ProjectsIndex)
 				.RelationName("commits")
 				.TypeName("doc")
 			)
-			.InferMappingFor<Developer>(map => map
+			.DefaultsFor<Developer>(map => map
 				.IndexName("devs")
 				.Ignore(p => p.PrivateValue)
 				.Rename(p => p.OnlineHandle, "nickname")
 			)
-			.InferMappingFor<ProjectPercolation>(map => map
+			.DefaultsFor<ProjectPercolation>(map => map
 				.IndexName("queries")
 				.TypeName(PercolatorType)
 			)
-			.InferMappingFor<Metric>(map => map
+			.DefaultsFor<Metric>(map => map
 				.IndexName("server-metrics")
 				.TypeName("metric")
 			)


### PR DESCRIPTION
… and DefaultType(NameInferrer)

Ignore the branch name, POC'd what it would take to add default queries for `T` but while feasible it ended up more confusing.