### PR TITLE
can now do integration tests against build candidates (hash:version) …

### DIFF
--- a/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs
@@ -355,7 +355,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 		{
 			get
 			{
-				var es = this.Node.Version > ElasticsearchVersion.GetOrAdd("5.0.0-alpha2") ? "" : "es.";
+				var es = this.Node.Version > ElasticsearchVersion.Create("5.0.0-alpha2") ? "" : "es.";
 
 				return new[]
 				{

--- a/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
@@ -27,7 +27,7 @@ namespace Tests.Framework.Configuration
 			var version = Environment.GetEnvironmentVariable("NEST_INTEGRATION_VERSION");
 			if (!string.IsNullOrEmpty(version)) Mode = TestMode.Integration;
 
-			this.ElasticsearchVersion = ElasticsearchVersion.GetOrAdd(string.IsNullOrWhiteSpace(version) ? DefaultVersion : version);
+			this.ElasticsearchVersion = ElasticsearchVersion.Create(string.IsNullOrWhiteSpace(version) ? DefaultVersion : version);
 			this.ClusterFilter = Environment.GetEnvironmentVariable("NEST_INTEGRATION_CLUSTER");
 			this.TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
 

--- a/src/Tests/Framework/Configuration/Versions/ElasticsearchVersionResolver.cs
+++ b/src/Tests/Framework/Configuration/Versions/ElasticsearchVersionResolver.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Xml.Linq;
+using Version = SemVer.Version;
+
+namespace Tests.Framework.Versions
+{
+	public class ElasticsearchVersionResolver
+	{
+		private static readonly object _lock = new { };
+
+		public const string SonaTypeUrl = "https://oss.sonatype.org/content/repositories/snapshots/org/elasticsearch/distribution/zip/elasticsearch";
+
+		//public virtual string LatestVersion
+
+		public static readonly ElasticsearchVersionResolver Default = new ElasticsearchVersionResolver();
+
+		public virtual string LatestVersion => _latestVersion.Value;
+		public virtual string LatestSnapshot => _latestSnapshot.Value;
+
+		private static readonly ConcurrentDictionary<string, string> SnapshotVersions = new ConcurrentDictionary<string, string>();
+
+		public virtual string SnapshotZipFilename(string version)
+		{
+			lock (_lock)
+			{
+				if (SnapshotVersions.TryGetValue(version, out var zipLocation))
+					return zipLocation;
+
+				zipLocation = ResolveLatestSnapshotFor(version);
+				SnapshotVersions.TryAdd(version, zipLocation);
+				return zipLocation;
+			}
+		}
+
+		private readonly Lazy<string> _latestSnapshot = new Lazy<string>(ResolveLatestSnapshot, LazyThreadSafetyMode.ExecutionAndPublication);
+		private static string ResolveLatestSnapshot()
+		{
+			var version = Default.LatestVersion;
+			return ResolveLatestSnapshotFor(version);
+		}
+
+		private static string ResolveLatestSnapshotFor(string version)
+		{
+			var url = $"{SonaTypeUrl}/{version}/maven-metadata.xml";
+			try
+			{
+				using (var httpclient = new HttpClient())
+				{
+					var response = httpclient.GetAsync(url).Result;
+					var mavenMetadata = XElement.Load(response.Content.ReadAsStreamAsync().Result);
+					var snapshot = mavenMetadata.Descendants("versioning").Descendants("snapshot").FirstOrDefault();
+					var snapshotTimestamp = snapshot.Descendants("timestamp").FirstOrDefault().Value;
+					var snapshotBuildNumber = snapshot.Descendants("buildNumber").FirstOrDefault().Value;
+					var identifier = $"{snapshotTimestamp}-{snapshotBuildNumber}";
+					var zip = $"elasticsearch-{version.Replace("SNAPSHOT", "")}{identifier}.zip";
+					return zip;
+				}
+
+			}
+			catch (Exception e)
+			{
+				throw new Exception($"Can not download maven data from {url}", e);
+			}
+		}
+
+		private readonly Lazy<string> _latestVersion = new Lazy<string>(ResolveLatestVersion, LazyThreadSafetyMode.ExecutionAndPublication);
+		private static string ResolveLatestVersion()
+		{
+			var url = $"{SonaTypeUrl}/maven-metadata.xml";
+			try
+			{
+				using(var httpclient = new HttpClient())
+				{
+					var response = httpclient.GetAsync(url).Result;
+					var xml = XElement.Load(response.Content.ReadAsStreamAsync().Result);
+					var versions = xml
+						.Descendants("version")
+						.Select(n => new Version(n.Value))
+						.OrderByDescending(n => n);
+					return versions.First().ToString();
+				}
+			}
+			catch (Exception e)
+			{
+				throw new Exception($"Can not download maven data from {url}", e);
+			}
+		}
+	}
+}

--- a/src/Tests/Framework/Configuration/YamlConfiguration.cs
+++ b/src/Tests/Framework/Configuration/YamlConfiguration.cs
@@ -27,7 +27,7 @@ namespace Tests.Framework.Configuration
 				.ToDictionary(ConfigName, ConfigValue);
 
 			this.Mode = GetTestMode(_config["mode"]);
-			this.ElasticsearchVersion = ElasticsearchVersion.GetOrAdd(_config["elasticsearch_version"]);
+			this.ElasticsearchVersion = ElasticsearchVersion.Create(_config["elasticsearch_version"]);
 			this.ForceReseed = BoolConfig("force_reseed", false);
 			this.TestAgainstAlreadyRunningElasticsearch = BoolConfig("test_against_already_running_elasticsearch", false);
 			this.ClusterFilter = _config.ContainsKey("cluster_filter") ? _config["cluster_filter"] : null;

--- a/src/Tests/Framework/ElasticsearchVersionTests.cs
+++ b/src/Tests/Framework/ElasticsearchVersionTests.cs
@@ -1,0 +1,53 @@
+﻿using FluentAssertions;
+using Tests.Framework.Versions;
+
+namespace Tests.Framework
+{
+	public class MockElasticsearchVersionResolver : ElasticsearchVersionResolver
+	{
+		public MockElasticsearchVersionResolver()
+		{
+
+		}
+
+		public override string LatestSnapshot => "7.3.1-SNAPSHOT";
+		public override string LatestVersion => "7.3.1";
+		public override string SnapshotZipFilename(string version)
+		{
+			return $"{version}.zip";
+		}
+	}
+
+
+
+	public class ElasticsearchVersionTests
+	{
+		public ElasticsearchVersion Create(string version) => ElasticsearchVersion.Create(version, new MockElasticsearchVersionResolver());
+
+		[U] public void ReleaseVersion()
+		{
+			var v = Create("7.6.0");
+			v.State.Should().Be(ElasticsearchVersion.ReleaseState.Released);
+		}
+		[U] public void BuildCandidate()
+		{
+			var v = Create("0527a3c4:7.6.0");
+			v.State.Should().Be(ElasticsearchVersion.ReleaseState.BuildCandidate);
+			v.LocalFolderName.Should().Be("7.6.0-bc+0527a3c4");
+		}
+		[U] public void Snapshot()
+		{
+			var v = Create("7.6.0-SNAPSHOT");
+			v.State.Should().Be(ElasticsearchVersion.ReleaseState.Snapshot);
+			v.LocalFolderName.Should().Be("7.6.0-SNAPSHOT");
+		}
+		[U] public void Latest()
+		{
+			var v = Create("latest");
+			v.State.Should().Be(ElasticsearchVersion.ReleaseState.Released);
+			v.Version.Should().Be("7.3.1");
+			v.LocalFolderName.Should().Be("7.3.1");
+		}
+
+	}
+}

--- a/src/Tests/Framework/ManagedElasticsearch/Nodes/ElasticsearchNode.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Nodes/ElasticsearchNode.cs
@@ -157,7 +157,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 
 			if (this.ProcessId == null && consoleOut.TryParseNodeInfo(out version, out pid))
 			{
-				var startedVersion = ElasticsearchVersion.GetOrAdd(version);
+				var startedVersion = ElasticsearchVersion.Create(version);
 				this.ProcessId = pid;
 				if (this.Version != startedVersion)
 					throw new Exception($"Booted elasticsearch is version {startedVersion} but the test config dictates {this.Version}");

--- a/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeConfiguration.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeConfiguration.cs
@@ -60,9 +60,9 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 			this.DesiredPort = cluster.DesiredPort;
 
 			var attr = v.Major >= 5 ? "attr." : "";
-			var indexedOrStored = v > ElasticsearchVersion.GetOrAdd("5.0.0-alpha1") ? "stored" : "indexed";
-			var shieldOrSecurity = v > ElasticsearchVersion.GetOrAdd("5.0.0-alpha1") ? "xpack.security" : "shield";
-			var es = v > ElasticsearchVersion.GetOrAdd("5.0.0-alpha2") ? "" : "es.";
+			var indexedOrStored = v > ElasticsearchVersion.Create("5.0.0-alpha1") ? "stored" : "indexed";
+			var shieldOrSecurity = v > ElasticsearchVersion.Create("5.0.0-alpha1") ? "xpack.security" : "shield";
+			var es = v > ElasticsearchVersion.Create("5.0.0-alpha2") ? "" : "es.";
 			var b = this.XPackEnabled.ToString().ToLowerInvariant();
 			var sslEnabled = this.EnableSsl.ToString().ToLowerInvariant();
 			this.DefaultNodeSettings = new List<string>
@@ -80,12 +80,12 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 				$"{es}search.remote.connect=true"
 			};
 			//script.max_compilations_rate
-			if (v < ElasticsearchVersion.GetOrAdd("6.0.0-rc1"))
+			if (v < ElasticsearchVersion.Create("6.0.0-rc1"))
 				this.DefaultNodeSettings.Add($"{es}script.max_compilations_per_minute=10000");
 			else
 				this.DefaultNodeSettings.Add($"{es}script.max_compilations_rate=10000/1m");
 
-			if (v < ElasticsearchVersion.GetOrAdd("5.5.0"))
+			if (v < ElasticsearchVersion.Create("5.5.0"))
 			{
 				this.DefaultNodeSettings.AddRange(new [] {
 					$"{es}script.inline=true",

--- a/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeFileSystem.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Nodes/NodeFileSystem.cs
@@ -25,7 +25,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 
 		public string RoamingFolder { get; }
 		public string AnalysisFolder => Path.Combine(this.ConfigPath, "analysis");
-		public string DownloadZipLocation => Path.Combine(this.RoamingFolder, this._version.Zip);
+		public string DownloadZipLocation => Path.Combine(this.RoamingFolder, this._version.ZipFilename);
 		public string TaskRunnerFile => Path.Combine(this.RoamingFolder, "taskrunner.log");
 
 
@@ -55,7 +55,7 @@ namespace Tests.Framework.ManagedElasticsearch.Nodes
 			this._clusterName = clusterName;
 
 			var appData = GetApplicationDataDirectory() ?? "/tmp/NEST";
-			this.RoamingFolder = Path.Combine(appData, "NEST", this._version.FullyQualifiedVersion);
+			this.RoamingFolder = Path.Combine(appData, "NEST", this._version.LocalFolderName);
 			this.ElasticsearchHome = Path.Combine(this.RoamingFolder, this._version.FolderInZip);
 		}
 

--- a/src/Tests/Framework/ManagedElasticsearch/Plugins/ElasticsearchPluginCollection.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Plugins/ElasticsearchPluginCollection.cs
@@ -8,11 +8,11 @@ namespace Tests.Framework.ManagedElasticsearch.Plugins
 		public static ElasticsearchPluginCollection Supported { get; } =
 			new ElasticsearchPluginCollection
 			{
-				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.DeleteByQuery, version => version < ElasticsearchVersion.GetOrAdd("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.DeleteByQuery, version => version < ElasticsearchVersion.Create("5.0.0-alpha3")),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.MapperMurmer3),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.XPack),
-				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestGeoIp, version => version >= ElasticsearchVersion.GetOrAdd("5.0.0-alpha3")),
-				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestAttachment, version => version >= ElasticsearchVersion.GetOrAdd("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestGeoIp, version => version >= ElasticsearchVersion.Create("5.0.0-alpha3")),
+				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.IngestAttachment, version => version >= ElasticsearchVersion.Create("5.0.0-alpha3")),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.AnalysisKuromoji),
 				new ElasticsearchPluginConfiguration(ElasticsearchPlugin.AnalysisIcu)
 			};

--- a/src/Tests/Framework/ManagedElasticsearch/Plugins/ElasticsearchPluginConfiguration.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Plugins/ElasticsearchPluginConfiguration.cs
@@ -31,9 +31,8 @@ namespace Tests.Framework.ManagedElasticsearch.Plugins
 
 		public bool IsValid(ElasticsearchVersion version) => _isValid(version);
 
-		public string SnapshotDownloadUrl(ElasticsearchVersion version)  =>
-			$"https://snapshots.elastic.co/downloads/elasticsearch-plugins/{Moniker}/{SnapshotZip(version)}";
+		public string DownloadUrl(ElasticsearchVersion version)  => version.PluginDownloadUrl(this.Moniker);
 
-		public string SnapshotZip(ElasticsearchVersion version) => $"{Moniker}-{version.Version}.zip";
+
 	}
 }

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/DownloadCurrentElasticsearchDistribution.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/DownloadCurrentElasticsearchDistribution.cs
@@ -11,7 +11,7 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks.InstallationTasks
 		public override void Run(NodeConfiguration config, NodeFileSystem fileSystem)
 		{
 			var v = config.ElasticsearchVersion;
-			var from = v.DownloadUrl;
+			var from = v.ElasticsearchDownloadUrl;
 			var to = fileSystem.DownloadZipLocation;
 			if (File.Exists(to)) return;
 			Console.WriteLine($"Download elasticsearch: {v} from {from}");

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/ValidationTasks/ValidatePluginsTask.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/ValidationTasks/ValidatePluginsTask.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Linq;
-using Elasticsearch.Net;
 using Nest;
-using Tests.Framework.Configuration;
-using Tests.Framework.Integration;
 using Tests.Framework.ManagedElasticsearch.Nodes;
 using Tests.Framework.ManagedElasticsearch.Plugins;
 
@@ -14,9 +11,6 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks.ValidationTasks
 		public override void Validate(IElasticClient client, NodeConfiguration configuration)
 		{
 			var v = configuration.ElasticsearchVersion;
-			//if the version we are running against is a s snapshot version we do not validate plugins
-			//because we can not reliably install plugins against snapshots
-			if (v.IsSnapshot) return;
 
 			var requiredMonikers = ElasticsearchPluginCollection.Supported
 				.Where(plugin => plugin.IsValid(v) && configuration.RequiredPlugins.Contains(plugin.Plugin))

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/ValidationTasks/ValidateRunningVersion.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/ValidationTasks/ValidateRunningVersion.cs
@@ -17,8 +17,8 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks.ValidationTasks
 			if (!alreadyUp.IsValid) return;
 			var v = configuration.ElasticsearchVersion;
 
-			var alreadyUpVersion = ElasticsearchVersion.GetOrAdd(alreadyUp.Version.Number);
-			var alreadyUpSnapshotVersion = ElasticsearchVersion.GetOrAdd(alreadyUp.Version.Number + "-SNAPSHOT");
+			var alreadyUpVersion = ElasticsearchVersion.Create(alreadyUp.Version.Number);
+			var alreadyUpSnapshotVersion = ElasticsearchVersion.Create(alreadyUp.Version.Number + "-SNAPSHOT");
 			if (v != alreadyUpVersion && v != alreadyUpSnapshotVersion)
 				throw new Exception($"running elasticsearch is version {alreadyUpVersion} but the test config dictates {v}");
 		}

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -104,7 +104,7 @@ namespace Tests.Framework
 			})
 			.OnRequestDataCreated(data => data.Headers.Add("TestMethod", ExpensiveTestNameForIntegrationTests()));
 
-		public static string PercolatorType => Configuration.ElasticsearchVersion <= ElasticsearchVersion.GetOrAdd("5.0.0-alpha1")
+		public static string PercolatorType => Configuration.ElasticsearchVersion <= ElasticsearchVersion.Create("5.0.0-alpha1")
 			? ".percolator"
 			: "query";
 
@@ -112,7 +112,9 @@ namespace Tests.Framework
 		{
 			var versionRange = new SemVer.Range(range);
 			var satisfied = versionRange.IsSatisfied(version.Version);
-			if (!version.IsSnapshot || satisfied) return satisfied;
+			if (version.State != ElasticsearchVersion.ReleaseState.Released || satisfied)
+				return satisfied;
+
 			//Semver can only match snapshot version with ranges on the same major and minor
 			//anything else fails but we want to know e.g 2.4.5-SNAPSHOT satisfied by <5.0.0;
 			var wholeVersion = $"{version.Major}.{version.Minor}.{version.Patch}";


### PR DESCRIPTION
…and restored support for `latest` and snapshot versions in integration tests as well