### PR TITLE
fix #2875 unforeseen usage of using a query descriptor outside of the…

### DIFF
--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -16,7 +16,9 @@ namespace Nest
 			where TQuery : class, TQueryInterface, IQuery, new()
 			where TQueryInterface : class, IQuery
 		{
-			// The invocation of the create delegate has to happen first since it mutates the outer query.
+			// Invoke the create delegate before assigning container; the create delegate 
+			// may mutate the current QueryContainerDescriptor<T> instance such that it 
+			// contains a query. See https://github.com/elastic/elasticsearch-net/issues/2875
 			var query = create.InvokeOrDefault(new TQuery());
 
 			var container = this.ContainedQuery == null

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -16,11 +16,11 @@ namespace Nest
 			where TQuery : class, TQueryInterface, IQuery, new()
 			where TQueryInterface : class, IQuery
 		{
+			var query = create.InvokeOrDefault(new TQuery());
+
 			var container = this.ContainedQuery == null
 				? this
 				: new QueryContainerDescriptor<T>();
-
-			var query = create.InvokeOrDefault(new TQuery());
 
 			IQueryContainer c = container;
 			c.IsVerbatim = query.IsVerbatim;

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -16,6 +16,7 @@ namespace Nest
 			where TQuery : class, TQueryInterface, IQuery, new()
 			where TQueryInterface : class, IQuery
 		{
+			// The invocation of the create delegate has to happen first since it mutates the outer query.
 			var query = create.InvokeOrDefault(new TQuery());
 
 			var container = this.ContainedQuery == null

--- a/src/Tests/Reproduce/GithubIssue2875.cs
+++ b/src/Tests/Reproduce/GithubIssue2875.cs
@@ -1,0 +1,36 @@
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+using static Tests.Framework.RoundTripper;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue2875
+	{
+
+		[U] public void ReusingQueryDescriptorOutSideOfSelector()
+		{
+			Expect(new
+			{
+				query = new {
+					@bool = new
+					{
+						must = new []
+						{
+							new  { term = new { field = new { value = "value" } }}
+						}
+
+					}
+				}
+			}).FromRequest(ReuseQueryDescriptorUnexpected);
+		}
+
+		private static ISearchResponse<Project> ReuseQueryDescriptorUnexpected(IElasticClient client) => client.Search<Project>(s => s
+			.Query(q => q
+				.Bool(b => b
+					.Must(q.Term("field", "value"))
+				)
+			)
+		);
+	}
+}


### PR DESCRIPTION
… selector/lambda was not working because we did the ContainedQuery check before the create(), this worked in the advertized usage patterns but would yield an Exception of having already defined a query otherwise