### PR TITLE
Update Parent/Child relationship documentation

### DIFF
--- a/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
+++ b/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
@@ -83,11 +83,10 @@ var createIndexResponse = client.CreateIndex("index", c => c
     .Index<MyDocument>()
     .Mappings(ms => ms
         .Map<MyDocument>(m => m
-            .RoutingField(r => r.Required()) <1>
-            .AutoMap<MyParent>() <2>
-            .AutoMap<MyChild>() <3>
+            .AutoMap<MyParent>() <1>
+            .AutoMap<MyChild>() <2>
             .Properties(props => props
-                .Join(j => j <4>
+                .Join(j => j <3>
                     .Name(p => p.MyJoinField)
                     .Relations(r => r
                         .Join<MyParent, MyChild>()
@@ -98,19 +97,19 @@ var createIndexResponse = client.CreateIndex("index", c => c
     )
 );
 ----
-<1> recommended to make the routing field mandatory so you can not accidentally forget
+<1> Map all of the `MyParent` properties
 
-<2> Map all of the `MyParent` properties
+<2> Map all of the `MyChild` properties
 
-<3> Map all of the `MyChild` properties
-
-<4> Additionally map the `JoinField` since it is not automatically mapped by `AutoMap()`
+<3> Additionally map the `JoinField` since it is not automatically mapped by `AutoMap()`
 
 We call `AutoMap()` for both types to discover properties of both .NET types. `AutoMap()` won't automatically setup the
 join field mapping though because NEST can not infer all the `Relations` that are required by your domain.
 
 In this case we setup `MyChild` to be child of `MyParent`. `.Join()` has many overloads so be sure to check them out if you
 need to map not one but multiple children.
+
+The resulting mapping request JSON looks as follows
 
 [source,javascript]
 ----

--- a/src/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
@@ -90,11 +90,10 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 				.Index<MyDocument>()
 				.Mappings(ms => ms
 					.Map<MyDocument>(m => m
-						.RoutingField(r => r.Required()) // <1> recommended to make the routing field mandatory so you can not accidentally forget
-						.AutoMap<MyParent>() // <2> Map all of the `MyParent` properties
-						.AutoMap<MyChild>() // <3> Map all of the `MyChild` properties
+						.AutoMap<MyParent>() // <1> Map all of the `MyParent` properties
+						.AutoMap<MyChild>() // <2> Map all of the `MyChild` properties
 						.Properties(props => props
-							.Join(j => j // <4> Additionally map the `JoinField` since it is not automatically mapped by `AutoMap()`
+							.Join(j => j // <3> Additionally map the `JoinField` since it is not automatically mapped by `AutoMap()`
 								.Name(p => p.MyJoinField)
 								.Relations(r => r
 									.Join<MyParent, MyChild>()
@@ -112,6 +111,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 			* In this case we setup `MyChild` to be child of `MyParent`. `.Join()` has many overloads so be sure to check them out if you
 			* need to map not one but multiple children.
 			*
+			* The resulting mapping request JSON looks as follows
 			*/
 
 			//json


### PR DESCRIPTION
Remove the recommendation to always set the _routing field as required. It is only needed for the child mapping, not the parent