### PR TITLE
Deserialize aggregation metadata to Dictionary<string,object>

### DIFF
--- a/src/Nest/Aggregations/AggregateJsonConverter.cs
+++ b/src/Nest/Aggregations/AggregateJsonConverter.cs
@@ -108,7 +108,7 @@ namespace Nest
 				aggregate = GetPercentilesAggregate(reader, serializer, oldFormat: true);
 
 			var meta = propertyName == Parser.Meta
-				? GetMetadata(reader)
+				? GetMetadata(serializer, reader)
 				: null;
 
 			if (aggregate != null)
@@ -189,19 +189,12 @@ namespace Nest
 			return item;
 		}
 
-		private Dictionary<string, object> GetMetadata(JsonReader reader)
+		private Dictionary<string, object> GetMetadata(JsonSerializer serializer, JsonReader reader)
 		{
-			var meta = new Dictionary<string, object>();
+			// read past "meta" property name to start of object
 			reader.Read();
-			reader.Read();
-			while (reader.TokenType != JsonToken.EndObject)
-			{
-				var key = (string) reader.Value;
-				reader.Read();
-				var value = reader.Value;
-				meta.Add(key, value);
-				reader.Read();
-			}
+			var meta = serializer.Deserialize<Dictionary<string, object>>(reader);
+			// read past the closing end object of "meta" object
 			reader.Read();
 			return meta;
 		}

--- a/src/Tests/Aggregations/AggregationMetaUsageTests.cs
+++ b/src/Tests/Aggregations/AggregationMetaUsageTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using Tests.Framework.MockData;
+
+namespace Tests.Aggregations
+{
+	/**
+	*=== Aggregation Metadata
+	* Metadata can be provided per aggregation, and will be returned in the aggregation response
+	*/
+	public class AggregationMetaUsageTests : AggregationUsageTestBase
+	{
+		public AggregationMetaUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object AggregationJson => new
+		{
+			min_last_activity = new
+			{
+				min = new
+				{
+					field = "lastActivity",
+					meta = new
+					{
+						meta_1 = "value_1",
+						meta_2 = 2,
+						meta_3 = new
+						{
+							meta_3 = "value_3"
+						}
+					}
+				}
+			}
+		};
+
+		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
+			.Min("min_last_activity", m => m
+				.Field(p => p.LastActivity)
+				.Meta(d => d
+					.Add("meta_1", "value_1")
+					.Add("meta_2", 2)
+					.Add("meta_3", new { meta_3 = "value_3" })
+				)
+			);
+
+		protected override AggregationDictionary InitializerAggs =>
+			new MinAggregation("min_last_activity", Infer.Field<Project>(p => p.LastActivity))
+			{
+				Meta = new Dictionary<string,object>
+				{
+					{ "meta_1", "value_1" },
+					{ "meta_2", 2 },
+					{ "meta_3", new { meta_3 = "value_3" } }
+				}
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.ShouldBeValid();
+			var min = response.Aggregations.Min("min_last_activity");
+			min.Meta.Should().NotBeNull().And.ContainKeys("meta_1", "meta_2", "meta_3");
+		}
+	}
+}


### PR DESCRIPTION
This commit uses the JsonSerializer to deserialize the aggregation metadata to a Dictionary<string,object> from the JsonReader.
Add integration test to assert behaviour.

Closes #3072