### PR TITLE
Fix for #3084, the default internal serializer tried to mimic json.ne…

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -10,7 +10,7 @@ namespace Elasticsearch.Net
 {
 	public static class ResponseBuilder
 	{
-		private const int BufferSize = 81920;
+		public const int BufferSize = 81920;
 
 		public static TResponse ToResponse<TResponse>(
 			RequestData requestData,

--- a/src/Tests/Reproduce/GithubIssue3084.cs
+++ b/src/Tests/Reproduce/GithubIssue3084.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using Tests.Framework.MockData;
+using Xunit;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3084 : IClusterFixture<WritableCluster>
+	{
+		private readonly WritableCluster _cluster;
+
+		public GithubIssue3084(WritableCluster cluster) => _cluster = cluster;
+
+		protected static string RandomString() => Guid.NewGuid().ToString("N").Substring(0, 8);
+
+		public class ObjectVersion1
+		{
+			public int Id { get; set; }
+			public double Numeric { get; set; }
+		}
+		public class ObjectVersion2
+		{
+			public int Id { get; set; }
+			public int Numeric { get; set; }
+		}
+
+
+		[I]
+		public void DeserializeErrorIsTheSameForAsync()
+		{
+			var client = _cluster.Client;
+			var index = $"gh3084-{RandomString()}";
+			var document = new ObjectVersion1 {Id = 1, Numeric = 0};
+
+			var indexResult = client.Index(document, i => i.Index(index).Type("doc"));
+			indexResult.ShouldBeValid();
+
+			Action getDoc = () =>client.Get<ObjectVersion2>(new GetRequest(index, "doc", 1));
+			Func<Task<IGetResponse<ObjectVersion2>>> getDocAsync = async () => await client.GetAsync<ObjectVersion2>(new GetRequest(index, "doc", 1));
+
+			getDoc.ShouldThrow<Exception>("synchonous code path should throw");
+			getDocAsync.ShouldThrow<Exception>("async code path should throw");
+		}
+	}
+}


### PR DESCRIPTION
…t deserialize() behaviour for empty streams with a bazooka try catch around JToken.LoadAsync which ended up hiding real deserialization errors, **sigh**