### PR TITLE
Update AsciiDocNet

### DIFF
--- a/docs/aggregations/writing-aggregations.asciidoc
+++ b/docs/aggregations/writing-aggregations.asciidoc
@@ -202,7 +202,7 @@ s => s
 
 An advanced scenario may involve an existing collection of aggregation functions that should be set as aggregations
 on the request. Using LINQ's `.Aggregate()` method, each function can be applied to the aggregation descriptor
-`childAggs` below) in turn, returning the descriptor after each function application.
+(`childAggs` below) in turn, returning the descriptor after each function application.
 
 [source,csharp]
 ----
@@ -228,6 +228,7 @@ return s => s
         );
 ----
 <1> a list of aggregation functions to apply
+
 <2> Using LINQ's `Aggregate()` function to accumulate/apply all of the aggregation functions
 
 [[handling-aggregate-response]]
@@ -271,5 +272,6 @@ var maxPerChild = childAggregation.Max("max_per_child");
 maxPerChild.Should().NotBeNull(); <2>
 ----
 <1> Do something with the average per child. Here we just assert it's not null
+
 <2> Do something with the max per child. Here we just assert it's not null
 

--- a/docs/client-concepts/certificates/working-with-certificates.asciidoc
+++ b/docs/client-concepts/certificates/working-with-certificates.asciidoc
@@ -21,7 +21,8 @@ that generated the certificate is trusted by the machine running the client code
 to the cluster over HTTPS with the client.
 
 If you are using your own CA which is not trusted however, .NET won't allow you to make HTTPS calls to that endpoint by default. With .NET,
-you can pre-empt this though a custom validation callback on the global static`ServicePointManager.ServerCertificateValidationCallback`. Most examples you will find doing this this will simply return `true` from the
+you can pre-empt this though a custom validation callback on the global static
+`ServicePointManager.ServerCertificateValidationCallback`. Most examples you will find doing this this will simply return `true` from the
 validation callback and merrily whistle off into the sunset. **This is not advisable** as it allows *any* HTTPS traffic through in the
 current `AppDomain` *without* any validation. Here's a concrete example:
 
@@ -39,8 +40,9 @@ validation will not be performed for HTTPS connections to *both* Elasticsearch *
 ==== Validation configuration
 
 It's possible to also set a callback per service endpoint with .NET, and both Elasticsearch.NET and NEST expose this through
-connection settings `ConnectionConfiguration` with Elasticsearch.Net and `ConnectionSettings` with NEST). You can do
-your own validation in that handler or use one of the baked in handlers that we ship with out of the box, on the static class`CertificateValidations`.
+connection settings (`ConnectionConfiguration` with Elasticsearch.Net and `ConnectionSettings` with NEST). You can do
+your own validation in that handler or use one of the baked in handlers that we ship with out of the box, on the static class
+`CertificateValidations`.
 
 The two most basic ones are `AllowAll` and `DenyAll`, which accept or deny all SSL traffic to our nodes, respectively. Here's
 a couple of examples.
@@ -80,8 +82,9 @@ public class AllowAllCertificatesCluster : SslAndKpiXPackCluster
 If your client application has access to the public CA certificate locally, Elasticsearch.NET and NEST ship with some handy helpers
 that can assert that a certificate the server presents is one that came from the local CA.
 
-If you use X-Pack's {ref_current}/certutil.html[+certutil+ tool] to generate SSL certificates, the generated node certificate
-does not include the CA in the certificate chain, in order to cut down on SSL handshake size. In those case you can use`CertificateValidations.AuthorityIsRoot` and pass it your local copy of the CA public key to assert that
+If you use X-Pack's {ref_current}/certutil.html[`certutil` tool] to generate SSL certificates, the generated node certificate
+does not include the CA in the certificate chain, in order to cut down on SSL handshake size. In those case you can use
+`CertificateValidations.AuthorityIsRoot` and pass it your local copy of the CA public key to assert that
 the certificate the server presented was generated using it
 
 [source,csharp]
@@ -115,31 +118,22 @@ the local CA certificate is part of the chain that was used to generate the serv
 ==== Client Certificates
 
 X-Pack also allows you to configure a {xpack_current}/pki-realm.html[PKI realm] to enable user authentication
-through client certificates. The {ref_current}/certutil.html[+certutil+ tool] included with X-Pack allows you to
+through client certificates. The {ref_current}/certutil.html[`certutil` tool] included with X-Pack allows you to
 generate client certificates as well and assign the distinguished name (DN) of the
 certificate to a user with a certain role.
 
-By default, the `certutil` tool only generates a public certificate `.cer`) and a private key `.key`. To authenticate with client certificates, you need to present both
+By default, the `certutil` tool only generates a public certificate (`.cer`) and a private key `.key`. To authenticate with client certificates, you need to present both
 as one certificate. The easiest way to do this is to generate a `pfx` or `p12` file from the `.cer` and `.key`
 and attach these to requests using `new X509Certificate(pathToPfx)`.
 
-If you do not have a way to run `openssl` or `Pvk2Pfx` to do this as part of your deployments the clients ships with a handy helper to generate one
-on the fly by passing the paths to the `.cer`  and `.key` files that `certutil` outputs. Sadly, this functonality is not available on .NET Core because
-the `PublicKey` property cannot be set on the crypto service provider that is used to generate the `pfx` file at runtime.
-
-You can set Client Certificates to use on all connections on `ConnectionSettings`
+You can pass a client certificate on `ConnectionSettings` for *all* requests.
 
 [source,csharp]
 ----
 public class PkiCluster : CertgenCaCluster
 {
     protected override ConnectionSettings Authenticate(ConnectionSettings s) => s <1>
-        .ClientCertificate(
-            ClientCertificate.LoadWithPrivateKey(
-                this.Node.FileSystem.ClientCertificate, <2>
-                this.Node.FileSystem.ClientPrivateKey, <3>
-                "") <4>
-        );
+        .ClientCertificate(new X509Certificate2(this.Node.FileSystem.ClientCertificate));
 
     //hide
     protected override string[] AdditionalServerSettings => base.AdditionalServerSettings.Concat(new[]
@@ -150,11 +144,8 @@ public class PkiCluster : CertgenCaCluster
 }
 ----
 <1> Set the client certificate on `ConnectionSettings`
-<2> The path to the `.cer` file
-<3> The path to the `.key` file
-<4> The password for the private key
 
-Or per request on `RequestConfiguration` which will take precedence over the ones defined on `ConnectionConfiguration`
+Or on a per request basis on `RequestConfiguration` which will take precedence over the ones defined on `ConnectionConfiguration`
 
 ==== Object Initializer syntax example 
 

--- a/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
@@ -20,10 +20,10 @@ NEST can use to issue client calls on.
 
 [IMPORTANT]
 --
-Despite the name, a connection pool in NEST is **not** like connection pooling that you may be familiar with from https://msdn.microsoft.com/en-us/library/bb399543(v=vs.110).aspx[interacting with a database using ADO.Net]; for example,
+Despite the name, a connection pool in NEST is **not** like connection pooling that you may be familiar with from
+https://msdn.microsoft.com/en-us/library/bb399543(v=vs.110).aspx[interacting with a database using ADO.Net]; for example,
 a connection pool in NEST is **not** responsible for managing an underlying pool of TCP connections to Elasticsearch,
-this is https://blogs.msdn.microsoft.com/adarshk/2005/01/02/understanding-system-net-connection-management-and-servicepointmanager/[handled by the ServicePointManager in Desktop CLR]
-and can be controlled by <<servicepoint-behaviour,changing the ServicePoint behaviour>> on `HttpConnection`.
+this is https://blogs.msdn.microsoft.com/adarshk/2005/01/02/understanding-system-net-connection-management-and-servicepointmanager/[handled by the ServicePointManager in Desktop CLR].
 
 --
 

--- a/docs/client-concepts/connection-pooling/building-blocks/request-pipelines.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/request-pipelines.asciidoc
@@ -101,7 +101,8 @@ sniffingPipeline.FirstPoolUsageNeedsSniffing.Should().BeFalse();
 
 ==== Wait for first sniff
 
-All threads wait for the sniff on startup to finish, waiting the request timeout period. A https://msdn.microsoft.com/en-us/library/system.threading.semaphoreslim(v=vs.110).aspx[`SemaphoreSlim`]
+All threads wait for the sniff on startup to finish, waiting the request timeout period. A
+https://msdn.microsoft.com/en-us/library/system.threading.semaphoreslim(v=vs.110).aspx[`SemaphoreSlim`]
 is used to block threads until the sniff finishes and waiting threads release the `SemaphoreSlim` appropriately.
 
 We can demonstrate this with the following example. First, let's configure

--- a/docs/client-concepts/connection-pooling/exceptions/unexpected-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unexpected-exceptions.asciidoc
@@ -58,8 +58,11 @@ audit = await audit.TraceUnexpectedException(
 );
 ----
 <1> set up a cluster with 10 nodes
+
 <2> where node 2 on port 9201 always throws an exception
+
 <3> The first call to 9200 returns a healthy response
+
 <4> ...but the second call, to 9201, returns a bad response
 
 Sometimes, an unexpected exception happens further down in the pipeline. In this scenario, we
@@ -74,11 +77,7 @@ Finally, we assert that we can still see the audit trail for the whole coordinat
 ----
 var audit = new Auditor(() => Framework.Cluster
     .Nodes(10)
-#if DOTNETCORE
-    .ClientCalls(r => r.OnPort(9200).FailAlways(new System.Net.Http.HttpRequestException("recover")))
-#else
-    .ClientCalls(r => r.OnPort(9200).FailAlways(new WebException("recover"))) <1>
-#endif
+    .ClientCalls(r => r.OnPort(9200).FailAlways(new System.Net.Http.HttpRequestException("recover"))) <1>
     .ClientCalls(r => r.OnPort(9201).FailAlways(new Exception("boom!"))) <2>
     .StaticConnectionPool()
     .Settings(s => s.DisablePing())
@@ -97,8 +96,10 @@ audit = await audit.TraceUnexpectedException(
     }
 );
 ----
-<1> calls on 9200 set up to throw a `WebException`
+<1> calls on 9200 set up to throw a `HttpRequestException`
+
 <2> calls on 9201 set up to throw an `Exception`
+
 <3> Assert that the audit trail for the client call includes the bad response from 9200 and 9201
 
 An unexpected hard exception on ping and sniff is something we *do* try to recover from and failover to retrying on the next node.
@@ -143,6 +144,8 @@ audit = await audit.TraceUnexpectedException(
 );
 ----
 <1> `InnerException` is the exception that brought the request down
+
 <2> The hard exception that happened on ping is still available though
+
 <3> An exception can be hard to relate back to a point in time, so the exception is also available on the audit trail
 

--- a/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
@@ -81,6 +81,7 @@ var audit = new Auditor(() => Framework.Cluster
 );
 ----
 <1> Always succeed on ping
+
 <2> ...but always fail on calls with a 401 Bad Authentication response
 
 Now, let's make a client call. We'll see that the first audit event is a successful ping
@@ -101,7 +102,9 @@ audit = await audit.TraceElasticsearchException(
 );
 ----
 <1> First call results in a successful ping
+
 <2> Second call results in a bad response
+
 <3> The reason for the bad response is Bad Authentication
 
 When a bad authentication response occurs, the client attempts to deserialize the response body returned;
@@ -135,6 +138,7 @@ audit = await audit.TraceElasticsearchException(
 );
 ----
 <1> Always return a 401 bad response with a HTML response on client calls
+
 <2> Assert that the response body bytes are null
 
 Now in this example, by turning on `DisableDirectStreaming()` on `ConnectionSettings`, we see the same behaviour exhibited
@@ -169,5 +173,6 @@ audit = await audit.TraceElasticsearchException(
 );
 ----
 <1> Response bytes are set on the response
+
 <2> Assert that the response contains `"nginx/"`
 

--- a/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
@@ -65,8 +65,11 @@ audit = await audit.TraceCalls(
 );
 ----
 <1> disable sniffing
+
 <2> first call is a successful ping
+
 <3> sniff on startup call happens here, on the second call
+
 <4> No sniff on startup again
 
 Now, let's disable pinging on the request 
@@ -90,6 +93,7 @@ audit = await audit.TraceCall(
 );
 ----
 <1> disable ping
+
 <2> No ping after sniffing
 
 Finally, let's demonstrate disabling both sniff and ping on the request 
@@ -111,5 +115,6 @@ audit = await audit.TraceCall(
 );
 ----
 <1> diable ping and sniff
+
 <2> no ping or sniff before the call
 

--- a/docs/client-concepts/connection-pooling/round-robin/skip-dead-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/round-robin/skip-dead-nodes.asciidoc
@@ -140,7 +140,9 @@ await audit.TraceCalls(
 );
 ----
 <1> The first call goes to 9200 which succeeds
+
 <2> The 2nd call does a ping on 9201 because its used for the first time. It fails so we wrap over to node 9202
+
 <3> The next call goes to 9203 which fails so we should wrap over
 
 A cluster with 2 nodes where the second node fails on ping 
@@ -190,5 +192,6 @@ await audit.TraceCalls(
 );
 ----
 <1> All the calls fail
+
 <2> After all our registered nodes are marked dead we want to sample a single dead node each time to quickly see if the cluster is back up. We do not want to retry all 4 nodes
 

--- a/docs/client-concepts/connection-pooling/sniffing/on-connection-failure.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-connection-failure.asciidoc
@@ -186,7 +186,7 @@ void SniffUrlAssert(Audit a, string host, int expectedPort)
     var sniffUri = new UriBuilder(a.Node.Uri)
     {
         Path = RequestPipeline.SniffPath,
-        Query = "?flat_settings=true&timeout=2s"
+        Query = "flat_settings=true&timeout=2s"
     }.Uri;
     sniffUri.PathEquals(a.Path, nameof(SniffUrlAssert));
 }

--- a/docs/client-concepts/connection-pooling/sniffing/role-detection.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/role-detection.asciidoc
@@ -138,6 +138,7 @@ var audit = new Auditor(() => Framework.Cluster
 };
 ----
 <1> Before the sniff, assert we only see three master only nodes
+
 <2> After the sniff, assert we now know about the existence of 20 nodes.
 
 After the sniff has happened on 9200 before the first API call, assert that the subsequent API
@@ -218,7 +219,9 @@ var audit = new Auditor(() => Framework.Cluster
 };
 ----
 <1> for testing simplicity, disable pings
+
 <2> We only want to execute API calls to nodes in rack_one
+
 <3> After sniffing on startup, assert that the pool of nodes that the client will execute API calls against only contains the three nodes that are in `rack_one`
 
 With the cluster set up, assert that the sniff happens on 9200 before the first API call
@@ -295,6 +298,8 @@ await audit.TraceUnexpectedElasticsearchException(new ClientCall
 });
 ----
 <1> The audit trail indicates a sniff for the very first time on startup
+
 <2> The sniff succeeds because the node predicate is ignored when sniffing
+
 <3> when trying to do an actual API call however, the predicate prevents any nodes from being attempted
 

--- a/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
@@ -56,7 +56,7 @@ We set up a cluster with 4 nodes all having a different rack id
 				our Sticky Sniffing Connection Pool gives the most weight to rack_2 and rack_11.
 				We initially only seed nodes `9200-9203` in racks 0 to 3. So we should be sticky on rack_2.
 				We setup node 9202 to fail after two client calls in which case we sniff and find nodes
-			 `9210-9213` in which case we should become sticky on rack_11.
+				`9210-9213` in which case we should become sticky on rack_11.
 
 [source,csharp]
 ----

--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -22,7 +22,8 @@ how the clients interact with Elasticsearch.
 
 ==== Options on ConnectionConfiguration
 
-The following is a list of available connection configuration options on `ConnectionConfiguration`; since`ConnectionSettings` derives from `ConnectionConfiguration`, these options are available for both
+The following is a list of available connection configuration options on `ConnectionConfiguration`; since
+`ConnectionSettings` derives from `ConnectionConfiguration`, these options are available for both
 Elasticsearch.Net and NEST:
 
 `BasicAuthentication`::

--- a/docs/client-concepts/connection/modifying-default-connection.asciidoc
+++ b/docs/client-concepts/connection/modifying-default-connection.asciidoc
@@ -29,7 +29,8 @@ The Desktop CLR implementation using `WebRequest` is the most mature implementat
 in production since the beginning of NEST. For this reason, we aren't quite ready to it give up in favour of
 a `HttpClient` implementation across all CLR versions.
 
-In addition to production usage, there are also a couple of important toggles that are easy to set against a`ServicePoint` that are not possible to set as yet on `HttpClient`.
+In addition to production usage, there are also a couple of important toggles that are easy to set against a
+`ServicePoint` that are not possible to set as yet on `HttpClient`.
 
 Finally, another limitation is that `HttpClient` has no synchronous code paths, so supporting these means
 doing hacky async patches which definitely need time to bake.
@@ -104,74 +105,4 @@ from our fixed `InMemoryConnection` response
 searchResponse.ShouldBeValid();
 searchResponse.Documents.Count.Should().Be(25);
 ----
-
-==== Changing HttpConnection
-
-There may be a need to change how the default `HttpConnection` works, for example, to add an X509 certificate
-to the request, change the maximum number of connections allowed to an endpoint, etc.
-
-By deriving from `HttpConnection`, it is possible to change the behaviour of the connection. The following
-provides some examples
-
-[[servicepoint-behaviour]]
-===== ServicePoint behaviour
-
-If you are running on the Desktop CLR you can override specific properties for the current `ServicePoint` easily
-by overriding `AlterServicePoint` on an `IConnection` implementation deriving from `HttpConnection`
-
-[source,csharp]
-----
-public class MyCustomHttpConnection : HttpConnection
-{
-    protected override void AlterServicePoint(ServicePoint requestServicePoint, RequestData requestData)
-    {
-        base.AlterServicePoint(requestServicePoint, requestData);
-        requestServicePoint.ConnectionLimit = 10000;
-        requestServicePoint.UseNagleAlgorithm = true;
-    }
-}
-
-var connection = new MyCustomHttpConnection();
-var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
-var settings = new ConnectionSettings(connectionPool, connection);
-var client = new ElasticClient(settings);
-----
-
-The Connection limit has been increased from the default 80 to much higher and https://en.wikipedia.org/wiki/Nagle's_algorithm[nagling] has been enabled, which is disabled by default in the client.
-
-NOTE: The client reuses TCP connections through .NET's internal connection pooling,
-so changing the connection limit to something really high should only be done with careful
-consideration and testing. It's demonstrated here only as an example.
-
-[[x509-certificates]]
-===== X.509 Certificates
-
-It is possible to add X509 certificates to each request from the client by overriding the `CreateHttpWebRequest`
-method in an `IConnection` implementation deriving from `HttpConnection`
-
-[source,csharp]
-----
-public class X509CertificateHttpConnection : HttpConnection
-{
-    protected override HttpWebRequest CreateHttpWebRequest(RequestData requestData)
-    {
-        var request = base.CreateHttpWebRequest(requestData);
-        request.ClientCertificates.Add(new X509Certificate("file_path_to_cert"));
-        return request;
-    }
-}
-----
-
-As before, a new instance of the custom connection is passed to `ConnectionSettings` in order to
-use
-
-[source,csharp]
-----
-var connection = new X509CertificateHttpConnection();
-var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
-var settings = new ConnectionSettings(connectionPool, connection);
-var client = new ElasticClient(settings);
-----
-
-See <<working-with-certificates, Working with certificates>> for further details.
 

--- a/docs/client-concepts/high-level/analysis/writing-analyzers.asciidoc
+++ b/docs/client-concepts/high-level/analysis/writing-analyzers.asciidoc
@@ -73,7 +73,8 @@ var createIndexResponse = client.CreateIndex("my-index", c => c
 
 ==== Configuring a built-in analyzer
 
-Several built-in analyzers can be configured to alter their behaviour. For example, the`standard` analyzer can be configured to support a list of stop words with the stop word token filter
+Several built-in analyzers can be configured to alter their behaviour. For example, the
+`standard` analyzer can be configured to support a list of stop words with the stop word token filter
 it contains.
 
 Configuring a built-in analyzer requires creating an analyzer based on the built-in one
@@ -103,6 +104,7 @@ var createIndexResponse = client.CreateIndex("my-index", c => c
 );
 ----
 <1> Pre-defined list of English stopwords within Elasticsearch
+
 <2> Use the `standard_english` analyzer configured
 
 [source,javascript]
@@ -156,7 +158,9 @@ public class Question
 ----
 
 Based on our domain knowledge of programming languages, we would like to be able to search questions
-that contain `"C#"`, but using the `standard` analyzer, `"C#"` will be analyzed and produce the token`"c"`. This won't work for our use case as there will be no way to distinguish questions about`"C#"` from questions about another popular programming language, `"C"`.
+that contain `"C#"`, but using the `standard` analyzer, `"C#"` will be analyzed and produce the token
+`"c"`. This won't work for our use case as there will be no way to distinguish questions about
+`"C#"` from questions about another popular programming language, `"C"`.
 
 We can solve our issue with a custom analyzer
 
@@ -268,6 +272,7 @@ var createIndexResponse = client.CreateIndex("questions", c => c
 );
 ----
 <1> Use an analyzer at index time that strips HTML tags
+
 <2> Use an analyzer at search time that does not strip HTML tags
 
 With this in place, the text of a question body will be analyzed with the `index_question` analyzer

--- a/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
+++ b/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
@@ -21,7 +21,7 @@ Since types are removed in Elasticsearch 6.0 this feature is no longer supported
 now explicitly inject a serializer for user types only (_source, fields etcetera) please rely on a JsonConverter that
 can do this out of the box e.g `TypeNameHandling.All` from `Json.NET`
 
-https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm[]
+https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm
 
 [source,csharp]
 ----

--- a/docs/client-concepts/high-level/getting-started.asciidoc
+++ b/docs/client-concepts/high-level/getting-started.asciidoc
@@ -107,6 +107,7 @@ var indexResponse = client.IndexDocument(person); <1>
 var asyncIndexResponse = await client.IndexDocumentAsync(person); <2>
 ----
 <1> synchronous method that returns an `IIndexResponse`
+
 <2> asynchronous method that returns a `Task<IIndexResponse>` that can be awaited
 
 NOTE: All methods available within NEST are exposed as both synchronous and asynchronous versions,
@@ -141,7 +142,8 @@ var searchResponse = client.Search<Person>(s => s
 var people = searchResponse.Documents;
 ----
 
-`people` now holds the first ten people whose first name is Martijn. The search endpoint for this query is`/people/person/_search` and the index `"people"`) and type `"person"`) values has been determined from
+`people` now holds the first ten people whose first name is Martijn. The search endpoint for this query is
+`/people/person/_search` and the index (`"people"`) and type (`"person"`) values has been determined from
 
 . the default index on `ConnectionSettings`
 

--- a/docs/client-concepts/high-level/inference/document-paths.asciidoc
+++ b/docs/client-concepts/high-level/inference/document-paths.asciidoc
@@ -109,7 +109,8 @@ var request = new IndexRequest<Project>(2) { Document = project };
 request = new IndexRequest<Project>(project) { };
 ----
 
-when comparing with the full blown constructor and passing document manually,`DocumentPath<T>`'s benefits become apparent. Compare the following request that doesn't
+when comparing with the full blown constructor and passing document manually,
+`DocumentPath<T>`'s benefits become apparent. Compare the following request that doesn't
 use `DocumentPath<T>` with the former examples
 
 [source,csharp]

--- a/docs/client-concepts/high-level/inference/field-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/field-inference.asciidoc
@@ -39,7 +39,8 @@ Expect("name")
     .WhenSerializing(fieldProperty);
 ----
 
-When using the constructor and passing a value for `Name`, `Property` or `Expression`,`ComparisonValue` is also set on the `Field` instance; this is used when
+When using the constructor and passing a value for `Name`, `Property` or `Expression`,
+`ComparisonValue` is also set on the `Field` instance; this is used when
 
 * determining `Field` equality
 
@@ -472,10 +473,15 @@ class Precedence
 }
 ----
 <1> Even though this property has various attributes applied we provide an override on ConnectionSettings later that takes precedence.
+
 <2> Has a `TextAttribute`, `PropertyNameAttribute` and a `JsonPropertyAttribute` - the `TextAttribute` takes precedence.
+
 <3> Has both a `PropertyNameAttribute` and a `JsonPropertyAttribute` - the `PropertyNameAttribute` takes precedence.
+
 <4> `JsonPropertyAttribute` takes precedence.
+
 <5> This property we are going to hard code in our custom serializer to resolve to ask.
+
 <6> We are going to register a DefaultFieldNameInferrer on ConnectionSettings that will uppercase all properties.
 
 Here we create a custom serializer that renames any property named `AskSerializer` to `ask`

--- a/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
@@ -98,7 +98,8 @@ requestUri.LocalPath.Should().StartWith("/some-other-index/");
 <1> Provide the index name on the request
 
 When an index name is provided on a request, it **will take precedence** over the default
-index name and any index name specified for the POCO type using `.MapDefaultTypeIndices()` or`.DefaultMappingFor<T>()`
+index name and any index name specified for the POCO type using `.MapDefaultTypeIndices()` or
+`.DefaultMappingFor<T>()`
 
 [source,csharp]
 ----

--- a/docs/client-concepts/high-level/inference/indices-paths.asciidoc
+++ b/docs/client-concepts/high-level/inference/indices-paths.asciidoc
@@ -88,6 +88,7 @@ singleIndexFromIndexName.Match(
 );
 ----
 <1> `_all` will override any specific index names here
+
 <2> The `Project` type has been mapped to a specific index name using <<index-name-type-mapping,`.DefaultMappingFor<Project>`>>
 
 [[nest-indices]]
@@ -120,7 +121,9 @@ ISearchRequest singleTypedRequest = new SearchDescriptor<Project>().Index(single
 var invalidSingleString = Index("name1, name2"); <3>
 ----
 <1> specifying a single index using a string
+
 <2> specifying a single index using a type
+
 <3> an **invalid** single index name
 
 ===== Multiple indices
@@ -146,7 +149,9 @@ manyStringRequest = new SearchDescriptor<Project>().Type(new[] { "name1", "name2
 ((IUrlParameter)manyStringRequest.Type).GetString(this.Client.ConnectionSettings).Should().Be("name1,name2");
 ----
 <1> specifying multiple indices using strings
+
 <2> specifying multiple indices using types
+
 <3> The index names here come from the Connection Settings passed to `TestClient`. See the documentation on <<index-name-inference, Index Name Inference>> for more details.
 
 ===== All Indices
@@ -155,7 +160,8 @@ Elasticsearch allows searching across multiple indices using the special `_all` 
 
 NEST exposes the `_all` marker with `Indices.All` and `Indices.AllIndices`. Why expose it in two ways, you ask?
 Well, you may be using both `Nest.Indices` and `Nest.Types` in the same file and you may also be using C#6
-static imports too; in this scenario, the `All` property becomes ambiguous between `Indices.All` and `Types.All`, so the`_all` marker for indices is exposed as `Indices.AllIndices`, to alleviate this ambiguity
+static imports too; in this scenario, the `All` property becomes ambiguous between `Indices.All` and `Types.All`, so the
+`_all` marker for indices is exposed as `Indices.AllIndices`, to alleviate this ambiguity
 
 [source,csharp]
 ----

--- a/docs/client-concepts/high-level/mapping/auto-map.asciidoc
+++ b/docs/client-concepts/high-level/mapping/auto-map.asciidoc
@@ -204,7 +204,7 @@ In this example,
 
 * Birthday is mapped as a `date`,
 
-* Hours is mapped as a `long` `TimeSpan` ticks)
+* Hours is mapped as a `long` (`TimeSpan` ticks)
 
 * IsManager is mapped as a `boolean`,
 

--- a/docs/client-concepts/high-level/mapping/fluent-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/fluent-mapping.asciidoc
@@ -132,7 +132,8 @@ In this case, it's possible to use `.AutoMap()` in conjunction with explicitly m
 
 Here we are using `.AutoMap()` to automatically infer the mapping of our `Company` type from the
 CLR property types, but then we're overriding the `Employees` property to make it a
-{ref_current}/nested.html[nested datatype], since by default `.AutoMap()` will infer the`List<Employee>` property as an `object` datatype
+{ref_current}/nested.html[nested datatype], since by default `.AutoMap()` will infer the
+`List<Employee>` property as an `object` datatype
 
 [source,csharp]
 ----
@@ -284,8 +285,11 @@ var createIndexResponse = client.CreateIndex("myindex", c => c
             );
 ----
 <1> Automap company
+
 <2> Override company inferred mappings
+
 <3> Auto map employee
+
 <4> Override employee inferred mappings
 
 [source,javascript]
@@ -388,7 +392,8 @@ You may have noticed in the <<auto-map-with-overrides, Automap with fluent overr
 that the properties of the `Employees` property on `Company` were not mapped. This is because the automapping
 was applied only at the root level of the `Company` mapping.
 
-By calling `.AutoMap()` inside of the `.Nested<Employee>` mapping, it is possible to auto map the`Employee` nested properties and again, override any inferred mapping from the automapping process,
+By calling `.AutoMap()` inside of the `.Nested<Employee>` mapping, it is possible to auto map the
+`Employee` nested properties and again, override any inferred mapping from the automapping process,
 through manual mapping
 
 [source,csharp]
@@ -419,8 +424,11 @@ var createIndexResponse = client.CreateIndex("myindex", c => c
             );
 ----
 <1> Automap `Company`
+
 <2> Override specific `Company` mappings
+
 <3> Automap `Employees` property
+
 <4> Override specific `Employee` properties
 
 [source,javascript]

--- a/docs/client-concepts/high-level/mapping/ignoring-properties.asciidoc
+++ b/docs/client-concepts/high-level/mapping/ignoring-properties.asciidoc
@@ -27,8 +27,10 @@ selector)` on `ConnectionSettings`
 the `IElasticsearchSerializer` used, and inspected inside of the `CreatePropertyMapping()` on
 the serializer. Using the builtin `SourceSerializer` this would be the `IgnoreProperty`
 
-This example demonstrates all ways, using the `Ignore` property on the attribute to ignore the property`PropertyToIgnore`, the infer mapping to ignore the property `AnotherPropertyToIgnore` and the
-json serializer specific attribute  to ignore the property either `IgnoreProperty` or `JsonIgnoredProperty` depending on which`SourceSerializer` we configured.
+This example demonstrates all ways, using the `Ignore` property on the attribute to ignore the property
+`PropertyToIgnore`, the infer mapping to ignore the property `AnotherPropertyToIgnore` and the
+json serializer specific attribute  to ignore the property either `IgnoreProperty` or `JsonIgnoredProperty` depending on which
+`SourceSerializer` we configured.
 
 [source,csharp]
 ----
@@ -68,6 +70,7 @@ var createIndexResponse = client.CreateIndex("myindex", c => c
 );
 ----
 <1> we're using an in-memory connection, but in your application, you'll want to use an `IConnection` that actually sends a request.
+
 <2> we disable direct streaming here to capture the request and response bytes. In your application however, you'll like not want to do this in production.
 
 The JSON output for the mapping does not contain the ignored properties

--- a/docs/client-concepts/high-level/mapping/multi-fields.asciidoc
+++ b/docs/client-concepts/high-level/mapping/multi-fields.asciidoc
@@ -16,7 +16,8 @@ please modify the original csharp file found at the link and submit the PR with 
 === Multi fields
 
 It is often useful to index the same field in Elasticsearch in different ways, to
-serve different purposes, for example, mapping a POCO `string` property as a`text` datatype for full text search as well as mapping as a `keyword` datatype for
+serve different purposes, for example, mapping a POCO `string` property as a
+`text` datatype for full text search as well as mapping as a `keyword` datatype for
 structured search, sorting and aggregations. Another example is mapping a POCO `string`
 property to use different analyzers, to serve different full text search needs.
 
@@ -162,7 +163,9 @@ var createIndexResponse = client.CreateIndex("myindex", c => c
             );
 ----
 <1> Use the stop analyzer on this sub field
+
 <2> Use a custom analyzer named "named_shingles" that is configured in the index
+
 <3> Index as not analyzed
 
 [source,javascript]

--- a/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
+++ b/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
@@ -16,7 +16,8 @@ please modify the original csharp file found at the link and submit the PR with 
 === Parent/Child relationships
 
 Prior to Elasticsearch 6.x you could have multiple types in a single index. Through the special `_parent` field mapping of a given type,
-one could create 1 to N relationships of parent => children documents. This worked because when indexing children, you passed a`_parent` id which acted as the routing key, ensuring a parent, its children and any ancestors all lived on the same shard.
+one could create 1 to N relationships of parent => children documents. This worked because when indexing children, you passed a
+`_parent` id which acted as the routing key, ensuring a parent, its children and any ancestors all lived on the same shard.
 
 Starting with 6.x indices, multiple types are no longer suppported in a single index. One reason for this is that if for instance
 two types have the same `name` property, this property needed to be mapped exactly the same for both types, but all the APIs act as if you can map
@@ -99,8 +100,11 @@ var createIndexResponse = client.CreateIndex("index", c => c
 );
 ----
 <1> recommended to make the routing field mandatory so you can not accidentally forget
+
 <2> Map all of the `MyParent` properties
+
 <3> Map all of the `MyChild` properties
+
 <4> Additionally map the `JoinField` since it is not automatically mapped by `AutoMap()`
 
 We call `AutoMap()` for both types to discover properties of both .NET types. `AutoMap()` won't automatically setup the
@@ -176,6 +180,7 @@ parentDocument = new MyParent
 var indexParent = client.IndexDocument<MyDocument>(parentDocument);
 ----
 <1> this lets the join data type know this is a root document of type `myparent`
+
 <2> this lets the join data type know this is a root document of type `myparent`
 
 [source,javascript]

--- a/docs/client-concepts/high-level/mapping/visitor-pattern-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/visitor-pattern-mapping.asciidoc
@@ -71,6 +71,7 @@ public class DisableDocValuesPropertyVisitor : NoopPropertyVisitor
 }
 ----
 <1> Override the `Visit` method on `INumberProperty` and set `DocValues = false`
+
 <2> Similarily, override the `Visit` method on `IBooleanProperty` and set `DocValues = false`
 
 Now we can pass an instance of our custom visitor to `.AutoMap()` 
@@ -142,7 +143,7 @@ disables {ref_current}/doc-values.html[doc_values].
 You can even take the visitor approach a step further, and instead of visiting on `IProperty` types, visit
 directly on your POCO reflected `PropertyInfo` properties.
 
-As an example, let's create a visitor that maps all CLR types to an Elasticsearch text datatype `ITextProperty`).
+As an example, let's create a visitor that maps all CLR types to an Elasticsearch text datatype (`ITextProperty`).
 
 [source,csharp]
 ----

--- a/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
+++ b/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
@@ -25,12 +25,14 @@ NEST heavily relied on the fact that the `IContractResolver` used by the configu
 an instance of `ElasticContractResolver`, so if you wanted to deserialize your `_source` or `_fields`
 using your own resolver, you were out of luck. In addition, continued improvements to NEST's serialization pipeline
 was stymied by this dependency and as client authors, we wanted to unhinder ourselves from this in order to explore the myriad
-of exciting developments happening in the .NET ecosystem around performance with the likes of `Span<T>`,`ArrayPool<T>` and a more compact UTF-8 string representation.
+of exciting developments happening in the .NET ecosystem around performance with the likes of `Span<T>`,
+`ArrayPool<T>` and a more compact UTF-8 string representation.
 
 So what did we do in 6.x and how does it affect you?
 
 The `NEST` nuget package from 6.0.0 onwards will use the internal Json.NET serializer and will in effect, behave the same
-as it did in previous releases. If you previously relied on custom Json.NET serialization and configuration with custom`JsonSerializerSettings` and `JsonConverter` types for example, things have changed a bit. The following section explains
+as it did in previous releases. If you previously relied on custom Json.NET serialization and configuration with custom
+`JsonSerializerSettings` and `JsonConverter` types for example, things have changed a bit. The following section explains
 how to continue working with these with NEST 6.x.
 
 [float]
@@ -106,7 +108,8 @@ back to NEST's built-in serializer.
 ==== JsonNetSerializer
 
 We ship a separate {nuget}/NEST.JsonNetSerializer[NEST.JsonNetSerializer] package that helps in composing a custom `SourceSerializer`
-using `Json.NET`, that is smart enough to delegate the serialization of known NEST types back to the built-in`RequestResponseSerializer`. This package is also useful if you want to control how your documents and values are stored
+using `Json.NET`, that is smart enough to delegate the serialization of known NEST types back to the built-in
+`RequestResponseSerializer`. This package is also useful if you want to control how your documents and values are stored
 and retreived from Elasticsearch using `Json.NET`, without intervering with the way NEST uses `Json.NET` internally.
 
 The easiest way to hook this custom source serializer is as follows

--- a/docs/client-concepts/low-level/getting-started.asciidoc
+++ b/docs/client-concepts/low-level/getting-started.asciidoc
@@ -106,6 +106,7 @@ var asyncIndexResponse = await lowlevelClient.IndexAsync<StringResponse>("people
 string responseString = asyncIndexResponse.Body;
 ----
 <1> synchronous method that returns an `IIndexResponse`
+
 <2> asynchronous method that returns a `Task<IIndexResponse>` that can be awaited
 
 NOTE: All available methods within Elasticsearch.Net are exposed as both synchronous and asynchronous versions,
@@ -186,7 +187,8 @@ var successful = searchResponse.Success;
 var responseJson = searchResponse.Body;
 ----
 
-`responseJson` now holds a JSON string for the response. The search endpoint for this query is`/people/person/_search` and it's possible to search over multiple indices and types by changing the arguments
+`responseJson` now holds a JSON string for the response. The search endpoint for this query is
+`/people/person/_search` and it's possible to search over multiple indices and types by changing the arguments
 supplied in the request for `index` and `type`, respectively.
 
 Strings can also be used to express the request
@@ -241,7 +243,9 @@ var successOrKnownError = searchResponse.SuccessOrKnownError; <2>
 var exception = searchResponse.OriginalException; <3>
 ----
 <1> Response is in the 200 range, or an expected response for the given request
+
 <2> Response is successful, or has a response code between 400-599 that indicates the request cannot be retried.
+
 <3> If the response is unsuccessful, will hold the original exception.
 
 Using these details, it is possible to make decisions around what should be done in your application.
@@ -256,7 +260,8 @@ var settings = new ConnectionConfiguration(new Uri("http://example.com:9200"))
 var lowlevelClient = new ElasticLowLevelClient(settings);
 ----
 
-And if more fine grained control is required, custom exceptions can be thrown using `.OnRequestCompleted()` on`ConnectionConfiguration`
+And if more fine grained control is required, custom exceptions can be thrown using `.OnRequestCompleted()` on
+`ConnectionConfiguration`
 
 [source,csharp]
 ----

--- a/docs/client-concepts/troubleshooting/logging-with-on-request-completed.asciidoc
+++ b/docs/client-concepts/troubleshooting/logging-with-on-request-completed.asciidoc
@@ -15,7 +15,8 @@ please modify the original csharp file found at the link and submit the PR with 
 [[logging-with-on-request-completed]]
 === Logging with OnRequestCompleted
 
-When constructing the connection settings to pass to the client, you can pass a callback of type`Action<IApiCallDetails>` to the `OnRequestCompleted` method that can eavesdrop every time a
+When constructing the connection settings to pass to the client, you can pass a callback of type
+`Action<IApiCallDetails>` to the `OnRequestCompleted` method that can eavesdrop every time a
 response(good or bad) is received.
 
 If you have complex logging needs this is a good place to add that in
@@ -37,7 +38,9 @@ await client.RootNodeInfoAsync(); <3>
 counter.Should().Be(2);
 ----
 <1> Construct a client
+
 <2> Make a synchronous call and assert the counter is incremented
+
 <3> Make an asynchronous call and assert the counter is incremented
 
 `OnRequestCompleted` is called even when an exception is thrown, so it can be used even if the client is
@@ -61,7 +64,9 @@ await Assert.ThrowsAsync<ElasticsearchClientException>(async () => await client.
 counter.Should().Be(2);
 ----
 <1> Configure a client with a connection that **always returns a HTTP 500 response
+
 <2> Always throw exceptions when a call results in an exception
+
 <3> Assert an exception is thrown and the counter is incremented
 
 Here's an example using `OnRequestCompleted()` for more complex logging
@@ -142,10 +147,15 @@ list.ShouldAllBeEquivalentTo(new[] <6>
 });
 ----
 <1> Here we use `InMemoryConnection` but in a real application, you'd use an `IConnection` that _actually_ sends the request, such as `HttpConnection`
+
 <2> Disable direct streaming so we can capture the request and response bytes
+
 <3> Perform some action when a request completes. Here, we're just adding to a list, but in your application you may be logging to a file.
+
 <4> Make a synchronous call
+
 <5> Make an asynchronous call
+
 <6> Assert the list contains the contents written in the delegate passed to `OnRequestCompleted`
 
 When running an application in production, you probably don't want to disable direct streaming for _all_
@@ -225,7 +235,10 @@ list.ShouldAllBeEquivalentTo(new[]
 });
 ----
 <1> Make a synchronous call where the request and response bytes will not be buffered
+
 <2> Make an asynchronous call where `DisableDirectStreaming()` is enabled
+
 <3> Only the method and url for the first request is captured
+
 <4> the body of the second request is captured
 

--- a/docs/code-standards/naming-conventions.asciidoc
+++ b/docs/code-standards/naming-conventions.asciidoc
@@ -145,10 +145,8 @@ var exceptions = new List<Type>
 {
     nestAssembly.GetType("System.AssemblyVersionInformation", throwOnError: false),
     nestAssembly.GetType("System.Runtime.Serialization.Formatters.FormatterAssemblyStyle", throwOnError: false),
-#if DOTNETCORE
     typeof(SynchronizedCollection<>),
     nestAssembly.GetType("System.ComponentModel.Browsable", throwOnError: false)
-#endif
 };
 
 var types = nestAssembly.GetTypes();
@@ -177,9 +175,7 @@ var exceptions = new List<Type>
     elasticsearchNetAssembly.GetType("Purify.Purifier+PurifierDotNet"),
     elasticsearchNetAssembly.GetType("Purify.Purifier+PurifierMono"),
     elasticsearchNetAssembly.GetType("Purify.Purifier+UriInfo"),
-#if DOTNETCORE
     elasticsearchNetAssembly.GetType("System.ComponentModel.Browsable")
-#endif
 };
 
 var types = elasticsearchNetAssembly.GetTypes();
@@ -198,11 +194,7 @@ if (value.Length == 0)
 for (int index = 0; index < value.Length; ++index)
 {
     var character = value[index];
-#if DOTNETCORE
     var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(character);
-#else
-    var unicodeCategory = char.GetUnicodeCategory(character);
-#endif
     switch (unicodeCategory)
     {
         case UnicodeCategory.UppercaseLetter:

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -180,7 +180,8 @@ that accepts a factor and time unit, or specify a string with ms time units
 ==== Units of Time
 
 Where Units of Time can be specified as a union of either a `DateInterval` or `Time`,
-a `DateInterval` or `Time` may be passed which will be implicity converted to a`Union<DateInterval, Time>`, the serialized form of which represents the initial value
+a `DateInterval` or `Time` may be passed which will be implicity converted to a
+`Union<DateInterval, Time>`, the serialized form of which represents the initial value
 passed
 
 [source,csharp]

--- a/docs/query-dsl/bool-dsl/bool-dsl.asciidoc
+++ b/docs/query-dsl/bool-dsl/bool-dsl.asciidoc
@@ -470,7 +470,8 @@ bool
 ....
 
 Why is this? Well, when a `bool` query has **only** `should` clauses, **__at least one__** of them must match.
-However, when that `bool` query also has a `must` clause, the `should` clauses instead now act as a_boost_ factor, meaning none of them have to match but if they do, the relevancy score for that document
+However, when that `bool` query also has a `must` clause, the `should` clauses instead now act as a
+_boost_ factor, meaning none of them have to match but if they do, the relevancy score for that document
 will be boosted and thus appear higher in the results. The semantics for how `should` clauses behave then
 changes based on the presence of the `must` clause.
 
@@ -510,7 +511,8 @@ TIP: *Add parentheses to force evaluation order*
 Using `should` clauses as boost factors can be a really powerful construct when building
 search queries, and remember, you can mix and match an actual `bool` query with NEST's operator overloading.
 
-There is another subtle situation where NEST will not blindly merge two `bool` queries with only`should` clauses. Consider the following
+There is another subtle situation where NEST will not blindly merge two `bool` queries with only
+`should` clauses. Consider the following
 
 [source,sh]
 ----

--- a/docs/search/returned-fields.asciidoc
+++ b/docs/search/returned-fields.asciidoc
@@ -48,7 +48,8 @@ Seriously consider whether disabling source is what you really want to do for yo
 
 --
 
-When storing fields in this manner, the individual field values to return can be specified using`.StoredFields` on the search request
+When storing fields in this manner, the individual field values to return can be specified using
+`.StoredFields` on the search request
 
 [source,csharp]
 ----
@@ -111,7 +112,9 @@ var searchResponse = client.Search<Project>(s => s
 );
 ----
 <1> **Include** the following fields
+
 <2> **Exclude** the following fields
+
 <3> Fields can be included or excluded through patterns
 
 With source filtering specified on the request, `.Documents` will

--- a/docs/search/writing-queries.asciidoc
+++ b/docs/search/writing-queries.asciidoc
@@ -277,7 +277,9 @@ var searchResponse = client.Search<Project>(s => s
 );
 ----
 <1> match documents where lead developer first name contains Russ
+
 <2> ...and where the lead developer last name contains Cam
+
 <3> ...and where the project started in 2017
 
 which yields the following query JSON
@@ -328,7 +330,8 @@ the relevancy score calculated, since both queries are running in a query contex
 so no score is calculated for matching documents (all documents have the same score
 of 1.0 for this query).
 
-Because `bool` queries are so common, NEST overloads operators on queries to make forming`bool` queries much more succinct. The previous `bool` query can be more concisely
+Because `bool` queries are so common, NEST overloads operators on queries to make forming
+`bool` queries much more succinct. The previous `bool` query can be more concisely
 expressed as
 
 [source,csharp]
@@ -352,6 +355,7 @@ searchResponse = client.Search<Project>(s => s
 );
 ----
 <1> combine queries using the binary `&&` operator
+
 <2> wrap a query in a `bool` query filter clause using the unary `+` operator and combine using the binary `&&` operator
 
 Take a look at the dedicated section on <<bool-queries, writing `bool` queries>> for more detail

--- a/src/CodeGeneration/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
+++ b/src/CodeGeneration/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
@@ -53,7 +53,7 @@ namespace DocGenerator.AsciiDoc
 			return _newDocument;
 		}
 
-		public override void Visit(Document document)
+		public override void VisitDocument(Document document)
 		{
 			_newDocument = new Document
 			{
@@ -127,10 +127,10 @@ namespace DocGenerator.AsciiDoc
 				}
 			}
 
-			base.Visit(document);
+			base.VisitDocument(document);
 		}
 
-		public override void Visit(Container elements)
+		public override void VisitContainer(Container elements)
 		{
 			if (_topLevel)
 			{
@@ -207,10 +207,10 @@ namespace DocGenerator.AsciiDoc
 				}
 			}
 
-			base.Visit(elements);
+			base.VisitContainer(elements);
 		}
 
-		public override void Visit(Source source)
+		public override void VisitSource(Source source)
 		{
 			// remove method attributes as the elastic doc generation doesn't like them; it
 			// expects a linenumbering in the index 2 position of a source block
@@ -224,10 +224,10 @@ namespace DocGenerator.AsciiDoc
 			// (elastic docs generation does not like this callout format)
 			source.Text = Regex.Replace(source.Text.Replace("\t", "    "), @"//[ \t]*\<(\d+)\>.*", "<$1>");
 
-			base.Visit(source);
+			base.VisitSource(source);
 		}
 
-		public override void Visit(SectionTitle sectionTitle)
+		public override void VisitSectionTitle(SectionTitle sectionTitle)
 		{
 			// Generate an anchor for all top level section titles
 			if (this._document.IndexOf(sectionTitle) == 0 && !sectionTitle.Attributes.HasAnchor)
@@ -235,7 +235,7 @@ namespace DocGenerator.AsciiDoc
 				var builder = new StringBuilder();
 				using (var writer = new AsciiDocVisitor(new StringWriter(builder)))
 				{
-					writer.Visit((InlineContainer) sectionTitle);
+					writer.VisitInlineContainer(sectionTitle);
 				}
 
 				var title = builder.ToString().PascalToHyphen();
@@ -254,10 +254,10 @@ namespace DocGenerator.AsciiDoc
 				Ids.Add(key, _destination.FullName);
 			}
 
-			base.Visit(sectionTitle);
+			base.VisitSectionTitle(sectionTitle);
 		}
 
-		public override void Visit(AttributeEntry attributeEntry)
+		public override void VisitAttributeEntry(AttributeEntry attributeEntry)
 		{
 			if (attributeEntry.Name != "xml-docs") return;
 			//true when running from the IDE, build/output might have not been created
@@ -281,7 +281,7 @@ namespace DocGenerator.AsciiDoc
 
 			if (string.IsNullOrEmpty(value))
 			{
-				base.Visit(attributeEntry);
+				base.VisitAttributeEntry(attributeEntry);
 				return;
 			}
 
@@ -373,7 +373,7 @@ namespace DocGenerator.AsciiDoc
 				var builder = new StringBuilder();
 				using (var visitor = new AsciiDocVisitor(new StringWriter(builder)))
 				{
-					visitor.Visit((InlineContainer) lastSectionTitle);
+					visitor.VisitInlineContainer(lastSectionTitle);
 				}
 
 				return predicate(builder.ToString());

--- a/src/CodeGeneration/DocGenerator/AsciiDoc/RawAsciidocVisitor.cs
+++ b/src/CodeGeneration/DocGenerator/AsciiDoc/RawAsciidocVisitor.cs
@@ -22,7 +22,7 @@ namespace DocGenerator.AsciiDoc
 			_destination = destination;
 		}
 
-		public override void Visit(Document document)
+		public override void VisitDocument(Document document)
 		{
 			_document = document;
 
@@ -42,10 +42,10 @@ namespace DocGenerator.AsciiDoc
 					   "please modify the original csharp file found at the link and submit the PR with that change. Thanks!"
 			});
 
-			base.Visit(document);
+			base.VisitDocument(document);
 		}
 
-		public override void Visit(AttributeEntry attributeEntry)
+		public override void VisitAttributeEntry(AttributeEntry attributeEntry)
 		{
 			if (attributeEntry.Name == "includes-from-dirs")
 			{
@@ -106,7 +106,7 @@ namespace DocGenerator.AsciiDoc
 				}
 			}
 
-			base.Visit(attributeEntry);
+			base.VisitAttributeEntry(attributeEntry);
 		}
 	}
 }

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -8,9 +8,9 @@
     <NoWarn>NU1701,NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
-    <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha5" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.2" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.3.409" />

--- a/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -19,8 +19,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
          * Despite the name, a connection pool in NEST is **not** like connection pooling that you may be familiar with from
          * https://msdn.microsoft.com/en-us/library/bb399543(v=vs.110).aspx[interacting with a database using ADO.Net]; for example,
          * a connection pool in NEST is **not** responsible for managing an underlying pool of TCP connections to Elasticsearch,
-         * this is https://blogs.msdn.microsoft.com/adarshk/2005/01/02/understanding-system-net-connection-management-and-servicepointmanager/[handled by the ServicePointManager in Desktop CLR]
-         * and can be controlled by <<servicepoint-behaviour,changing the ServicePoint behaviour>> on `HttpConnection`.
+         * this is https://blogs.msdn.microsoft.com/adarshk/2005/01/02/understanding-system-net-connection-management-and-servicepointmanager/[handled by the ServicePointManager in Desktop CLR].
          * --
          *
          * So, what is a connection pool in NEST responsible for? It is responsible for managing the nodes in an Elasticsearch

--- a/src/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnexpectedExceptions.doc.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnexpectedExceptions.doc.cs
@@ -68,7 +68,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Exceptions
 		{
 			var audit = new Auditor(() => Framework.Cluster
 				.Nodes(10)
-				.ClientCalls(r => r.OnPort(9200).FailAlways(new System.Net.Http.HttpRequestException("recover")))
+				.ClientCalls(r => r.OnPort(9200).FailAlways(new System.Net.Http.HttpRequestException("recover"))) // <1> calls on 9200 set up to throw a `HttpRequestException`
 				.ClientCalls(r => r.OnPort(9201).FailAlways(new Exception("boom!"))) // <2> calls on 9201 set up to throw an `Exception`
 				.StaticConnectionPool()
 				.Settings(s => s.DisablePing())


### PR DESCRIPTION
Fixes link attribute parsing in working with certificates documentation, as well as some other minor parsing issues.