### PR TITLE
Fix/contentbody verb

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -241,14 +241,16 @@ namespace Elasticsearch.Net
 					data.Write(stream, requestData.ConnectionSettings);
 				stream.Position = 0;
 			}
-			else
+			// HttpClient does not allow any Content for GET and HEAD requests
+			else if ((requestMessage.Method != System.Net.Http.HttpMethod.Get) && (requestMessage.Method != System.Net.Http.HttpMethod.Head))
 			{
 				// Set content in order to set a Content-Type header.
 				// Content gets diposed so can't be shared instance
 				requestMessage.Content = new ByteArrayContent(new byte[0]);
 			}
 
-			requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(requestData.RequestMimeType);
+			if (requestMessage.Content != null)
+				requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(requestData.RequestMimeType);
 
 			return requestMessage;
 		}

--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -242,7 +242,7 @@ namespace Elasticsearch.Net
 				stream.Position = 0;
 			}
 			// HttpClient does not allow any Content for GET and HEAD requests
-			else if ((requestMessage.Method != System.Net.Http.HttpMethod.Get) && (requestMessage.Method != System.Net.Http.HttpMethod.Head))
+			else if (requestMessage.Method != System.Net.Http.HttpMethod.Get && requestMessage.Method != System.Net.Http.HttpMethod.Head)
 			{
 				// Set content in order to set a Content-Type header.
 				// Content gets diposed so can't be shared instance


### PR DESCRIPTION
When sending a HEAD or GET message, the message does not contain any content. The used HttpClient class accepts no content at all using these type of verbs. The current implementation that creates an empty BytesArrayContent actually creates a message that will not be send by the HttpClient. A ProtocolViolationException will be thrown (see https://github.com/Microsoft/referencesource/blob/master/System/net/System/Net/HttpWebRequest.cs, private void CheckProtocol(bool onRequestStream)).
This small fixes leaves the Content of the requestMessage null, only for HEAD and GET messages for which no postdata is offered.

Unfortunately there are no tests available that I can update to validate the change. To verify the bug and it's fix, I've been using the StaticConnectionPool (actually through Serilog).