### PR TITLE
Set Body on low level response for BytesResponse

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -146,7 +146,7 @@ namespace Elasticsearch.Net
 
 			if (responseType == typeof(StringResponse))
 				cs = new StringResponse(bytes.Utf8String()) as TResponse;
-			else if (responseType == typeof(byte[]))
+			else if (responseType == typeof(BytesResponse))
 				cs = new BytesResponse(bytes) as TResponse;
 			else if (responseType == typeof(VoidResponse))
 				cs = StaticVoid as TResponse;

--- a/src/Tests/Reproduce/BytesResponseTests.cs
+++ b/src/Tests/Reproduce/BytesResponseTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using Tests.Framework.MockData;
+using Xunit;
+
+namespace Tests.Reproduce
+{
+	public class BytesResponseTests : IClusterFixture<ReadOnlyCluster>
+	{
+		private readonly ReadOnlyCluster _cluster;
+
+		public BytesResponseTests(ReadOnlyCluster cluster) => _cluster = cluster;
+
+		[I] public void NonNullBytesResponse()
+		{
+			var client = _cluster.Client;
+
+			var bytesResponse = client.LowLevel.Search<BytesResponse>("project", "project", PostData.Serializable(new { }));
+
+			bytesResponse.Body.Should().NotBeNull();
+			bytesResponse.Body.Should().BeEquivalentTo(bytesResponse.ResponseBodyInBytes);
+		}
+
+		[I] public void NonNullBytesLowLevelResponse()
+		{
+			var settings  = new ConnectionConfiguration(new Uri($"http://localhost:{_cluster.DesiredPort}"));
+			var lowLevelClient = new ElasticLowLevelClient(settings);
+
+			var bytesResponse = lowLevelClient.Search<BytesResponse>("project", "project", PostData.Serializable(new { }));
+
+			bytesResponse.Body.Should().NotBeNull();
+			bytesResponse.Body.Should().BeEquivalentTo(bytesResponse.ResponseBodyInBytes);
+		}
+	}
+}


### PR DESCRIPTION
This commit fixes a bug that was introduced when moving to typed
ElasticsearchResponse<T> responses from the low level client,
whereby the response.Body was not being set in the case of BytesResponse.