### PR TITLE
Structural equals for infer and IUrlParameter types

### DIFF
--- a/src/Nest/CommonAbstractions/Extensions/Extensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/Extensions.cs
@@ -183,6 +183,13 @@ namespace Nest
 			return list != null && list.Any();
 		}
 
+		internal static bool IsEmpty<T>(this IEnumerable<T> list)
+		{
+			if (list == null) return true;
+			var enumerable = list as T[] ?? list.ToArray();
+			return !enumerable.Any() || enumerable.All(t => t == null);
+		}
+
 		internal static void ThrowIfNull<T>(this T value, string name, string message = null)
 		{
 			if (value == null && message.IsNullOrEmpty()) throw new ArgumentNullException(name);
@@ -192,6 +199,16 @@ namespace Nest
 		internal static bool IsNullOrEmpty(this string value)
 		{
 			return string.IsNullOrWhiteSpace(value);
+		}
+		internal static bool IsNullOrEmptyCommaSeparatedList(this string value, out string[] split)
+		{
+			split = null;
+			if (string.IsNullOrWhiteSpace(value)) return true;
+			split = value.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+				.Where(t=>!t.IsNullOrEmpty())
+				.Select(t=>t.Trim())
+				.ToArray();
+			return split.Length == 0;
 		}
 
 		internal static void ForEach<T>(this IEnumerable<T> enumerable, Action<T> handler)
@@ -282,5 +299,13 @@ namespace Nest
 				additionalRateLimiter?.Release();
 			}
 		}
+
+		internal static bool NullOrEquals<T>(this T o, T other)
+		{
+			if (o == null && other == null) return true;
+			if (o == null || other == null) return false;
+			return o.Equals(other);
+		}
+
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/CategoryId/CategoryId.cs
+++ b/src/Nest/CommonAbstractions/Infer/CategoryId/CategoryId.cs
@@ -1,19 +1,38 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using Elasticsearch.Net;
 
 namespace Nest
 {
-	public class CategoryId : IUrlParameter
+	public class CategoryId : IUrlParameter, IEquatable<CategoryId>
 	{
-		private readonly long _categoryId;
+		internal readonly long Value;
 
-		public CategoryId(long categoryId)
-		{
-			_categoryId = categoryId;
-		}
+		public CategoryId(long value) => Value = value;
 
 		public static implicit operator CategoryId(long categoryId) => new CategoryId(categoryId);
+		public static implicit operator long(CategoryId categoryId) => categoryId.Value;
 
-		public string GetString(IConnectionConfigurationValues settings) => _categoryId.ToString(CultureInfo.InvariantCulture);
+		// ReSharper disable once ImpureMethodCallOnReadonlyValueField
+		public string GetString(IConnectionConfigurationValues settings) => Value.ToString(CultureInfo.InvariantCulture);
+
+		public bool Equals(CategoryId other) => this.Value == other.Value;
+
+		public override bool Equals(object obj)
+		{
+			switch (obj)
+			{
+				case int l: return this.Value == l;
+				case long l: return this.Value == l;
+				case CategoryId i: return this.Value == i.Value;
+				default: return false;
+			}
+		}
+
+		public override int GetHashCode() => this.Value.GetHashCode();
+
+		public static bool operator ==(CategoryId left, CategoryId right) => Equals(left, right);
+
+		public static bool operator !=(CategoryId left, CategoryId right) => !Equals(left, right);
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -96,8 +96,8 @@ namespace Nest
 		public bool Equals(Field other)
 		{
 			return _type != null
-				? other != null && _type == other._type && _comparisonValue.Equals(other._comparisonValue) && Boost.Equals(other.Boost)
-				: other != null && _comparisonValue.Equals(other._comparisonValue) && Boost.Equals(other.Boost);
+				? other != null && _type == other._type && _comparisonValue.Equals(other._comparisonValue)
+				: other != null && _comparisonValue.Equals(other._comparisonValue);
 		}
 
 		public override bool Equals(object obj)

--- a/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
@@ -11,32 +11,40 @@ namespace Nest
 {
 	[ContractJsonConverter(typeof(FieldsJsonConverter))]
 	[DebuggerDisplay("{DebugDisplay,nq}")]
-	public class Fields : IUrlParameter, IEnumerable<Field>
+	public class Fields : IUrlParameter, IEnumerable<Field>, IEquatable<Fields>
 	{
 		internal readonly List<Field> ListOfFields;
 
-		string IUrlParameter.GetString(IConnectionConfigurationValues settings) =>
-			string.Join(",", ListOfFields.Select(f => ((IUrlParameter)f).GetString(settings)));
+		string IUrlParameter.GetString(IConnectionConfigurationValues settings)
+		{
+			if (!(settings is IConnectionSettingsValues nestSettings))
+				throw new ArgumentNullException(nameof(settings), $"Can not resolve {nameof(Fields)} if no {nameof(IConnectionSettingsValues)} is provided");
+
+			return string.Join(",", ListOfFields.Where(f => f != null).Select(f => ((IUrlParameter)f).GetString(nestSettings)));
+		}
 
 		private string DebugDisplay =>
-			$"Count: {ListOfFields.Count} [" + string.Join(",", ListOfFields.Select((t, i) => $"({i + 1}: {t.DebugDisplay})")) + "]";
-
+			$"Count: {ListOfFields.Count} [" + string.Join(",", ListOfFields.Select((t, i) => $"({i + 1}: {t?.DebugDisplay ?? "NULL"})")) + "]";
 
 		internal Fields() { this.ListOfFields = new List<Field>(); }
 		internal Fields(IEnumerable<Field> fieldNames) { this.ListOfFields = fieldNames.ToList(); }
 
-		public static implicit operator Fields(string[] fields) => new Fields(fields.Select(f => (Field)f));
+		public static implicit operator Fields(string[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f => (Field)f));
 
-		public static implicit operator Fields(string field) =>
-			new Fields(field.Split(new [] {','}, StringSplitOptions.RemoveEmptyEntries).Select(f=>(Field)f));
+		public static implicit operator Fields(string field) => field.IsNullOrEmptyCommaSeparatedList(out var split)
+			? null : new Fields(split.Select(f=>(Field)f));
 
-		public static implicit operator Fields(Expression[] fields) => new Fields(fields.Select(f => (Field)f));
+		public static implicit operator Fields(Expression[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f => (Field)f));
 
-		public static implicit operator Fields(Expression field) => new Fields(new [] { (Field)field });
+		public static implicit operator Fields(Expression field) => field == null ? null : new Fields(new [] { (Field)field });
 
-		public static implicit operator Fields(Field field) => new Fields(new[] { field });
+		public static implicit operator Fields(Field field) => field == null ? null : new Fields(new[] { field });
 
-		public static implicit operator Fields(Field[] fields) => new Fields(fields);
+		public static implicit operator Fields(PropertyInfo field) => field == null ? null : new Fields(new Field[] { field });
+
+		public static implicit operator Fields(PropertyInfo[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f=>(Field)f));
+
+		public static implicit operator Fields(Field[] fields) => fields.IsEmpty() ? null : new Fields(fields);
 
 		public Fields And<T>(Expression<Func<T, object>> field, double? boost = null) where T : class
 		{
@@ -80,14 +88,38 @@ namespace Nest
 			return this;
 		}
 
-		public IEnumerator<Field> GetEnumerator()
+		public IEnumerator<Field> GetEnumerator() => this.ListOfFields.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+		public static bool operator ==(Fields left, Fields right) => Equals(left, right);
+
+		public static bool operator !=(Fields left, Fields right) => !Equals(left, right);
+
+		public bool Equals(Fields other) => EqualsAllFields(this.ListOfFields, other.ListOfFields);
+
+		public override bool Equals(object obj)
 		{
-			return this.ListOfFields.GetEnumerator();
+			switch (obj)
+			{
+				case Fields f: return Equals(f);
+				case string s: return Equals(s);
+				case Field fn: return Equals(fn);
+				case Field[] fns: return Equals(fns);
+				case Expression e: return Equals(e);
+				case Expression[] es: return Equals(es);
+				default: return false;
+			}
 		}
 
-		IEnumerator IEnumerable.GetEnumerator()
+		private static bool EqualsAllFields(IReadOnlyList<Field> thisTypes, IReadOnlyList<Field> otherTypes)
 		{
-			return this.GetEnumerator();
+			if (thisTypes == null && otherTypes == null) return true;
+			if (thisTypes == null || otherTypes == null) return false;
+			if (thisTypes.Count != otherTypes.Count) return false;
+			return thisTypes.Count == otherTypes.Count && !thisTypes.Except(otherTypes).Any();
 		}
+
+		public override int GetHashCode() => this.ListOfFields.GetHashCode();
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/Id/IdExtensions.cs
+++ b/src/Nest/CommonAbstractions/Infer/Id/IdExtensions.cs
@@ -9,7 +9,7 @@ namespace Nest
     {
 		internal static bool IsConditionless(this Id id)
 		{
-			return id == null || (id.Value == null && id.Document == null);
+			return id == null || (id.StringOrLongValue == null && id.Document == null);
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/Id/IdJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/Id/IdJsonConverter.cs
@@ -30,7 +30,8 @@ namespace Nest
 				var documentId = settings.Inferrer.Id(id.Document.GetType(), id.Document);
 				writer.WriteValue(documentId);
 			}
-			else writer.WriteValue(id.Value);
+			else if (id.LongValue != null) writer.WriteValue(id.LongValue);
+			else writer.WriteValue(id.StringValue);
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/IndexName/IndexName.cs
+++ b/src/Nest/CommonAbstractions/Infer/IndexName/IndexName.cs
@@ -19,24 +19,25 @@ namespace Nest
 
 		private IndexName(string index, string cluster = null)
 		{
-			this.Name = index?.Trim();
-			this.Cluster = cluster?.Trim();
+			this.Name = index;
+			this.Cluster = cluster;
 		}
 		private IndexName(Type type, string cluster = null)
 		{
 			this.Type = type;
-			this.Cluster = cluster?.Trim();
+			this.Cluster = cluster;
 		}
 		private IndexName(string index, Type type, string cluster = null)
 		{
 			this.Name = index;
 			this.Type = type;
-			this.Cluster = cluster?.Trim();
+			this.Cluster = cluster;
 		}
 
 		public static IndexName From<T>() => typeof(T);
 		public static IndexName From<T>(string clusterName) => From(typeof(T), clusterName);
 		private static IndexName From(Type t, string clusterName) => new IndexName(t, clusterName);
+		// TODO private?
 		public static IndexName Rebuild(string index, Type t, string clusterName = null) => new IndexName(index, t, clusterName);
 
 		public Indices And<T>() => new Indices(new[] { this, typeof(T) });
@@ -57,13 +58,7 @@ namespace Nest
 
 		bool IEquatable<IndexName>.Equals(IndexName other) => EqualsMarker(other);
 
-		public override bool Equals(object obj)
-		{
-			var s = obj as string;
-			if (!s.IsNullOrEmpty()) return this.EqualsString(s);
-			var pp = obj as IndexName;
-			return EqualsMarker(pp);
-		}
+		public override bool Equals(object obj) => obj is string s ? this.EqualsString(s) : obj is IndexName i && EqualsMarker(i);
 
 		public override int GetHashCode()
 		{
@@ -76,6 +71,10 @@ namespace Nest
 			}
 		}
 
+		public static bool operator ==(IndexName left, IndexName right) => Equals(left, right);
+
+		public static bool operator !=(IndexName left, IndexName right) => !Equals(left, right);
+
 		public override string ToString()
 		{
 			if (!this.Name.IsNullOrEmpty())
@@ -85,10 +84,7 @@ namespace Nest
 		private string PrefixClusterName(string name) => PrefixClusterName(this, name);
 		private static string PrefixClusterName(IndexName i, string name) => i.Cluster.IsNullOrEmpty() ? name : $"{i.Cluster}:{name}";
 
-		private bool EqualsString(string other)
-		{
-			return !other.IsNullOrEmpty() && other == PrefixClusterName(this.Name);
-		}
+		private bool EqualsString(string other) => !other.IsNullOrEmpty() && other == PrefixClusterName(this.Name);
 
 		private bool EqualsMarker(IndexName other)
 		{

--- a/src/Nest/CommonAbstractions/Infer/Indices/Indices.cs
+++ b/src/Nest/CommonAbstractions/Infer/Indices/Indices.cs
@@ -50,18 +50,16 @@ namespace Nest
 
 		public static Indices Parse(string indicesString)
 		{
-			if (indicesString.IsNullOrEmpty()) throw new Exception("can not parse an empty string to Indices");
-			var indices = indicesString.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
-			if (indices.Contains("_all")) return Indices.All;
-			return Index(indices.Select(i => (IndexName)i));
+			if (indicesString.IsNullOrEmptyCommaSeparatedList(out var indices)) return null;
+			return indices.Contains("_all") ? All : Index(indices.Select(i => (IndexName)i));
 		}
 
 		public static implicit operator Indices(string indicesString) => Parse(indicesString);
-		public static implicit operator Indices(ManyIndices many) => new Indices(many);
-		public static implicit operator Indices(string[] many) => new ManyIndices(many);
-		public static implicit operator Indices(IndexName[] many) => new ManyIndices(many);
-		public static implicit operator Indices(IndexName index) => new ManyIndices(new[] { index });
-		public static implicit operator Indices(Type type) => new ManyIndices(new IndexName[] { type });
+		public static implicit operator Indices(ManyIndices many) => many == null ? null : new Indices(many);
+		public static implicit operator Indices(string[] many) => many.IsEmpty() ? null : new ManyIndices(many);
+		public static implicit operator Indices(IndexName[] many) => many.IsEmpty()? null : new ManyIndices(many);
+		public static implicit operator Indices(IndexName index) => index == null ? null : new ManyIndices(new[] { index });
+		public static implicit operator Indices(Type type) => type == null ? null : new ManyIndices(new IndexName[] { type });
 
 		private string DebugDisplay => this.Match(
 			all => "_all",

--- a/src/Nest/CommonAbstractions/Infer/JoinFieldRouting/Routing.cs
+++ b/src/Nest/CommonAbstractions/Infer/JoinFieldRouting/Routing.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
 
@@ -9,24 +11,48 @@ namespace Nest
 	[DebuggerDisplay("{DebugDisplay,nq}")]
 	public class Routing : IEquatable<Routing>, IUrlParameter
 	{
-		internal object Value { get; set; }
+		internal string StringValue { get; }
+		internal long? LongValue { get; }
+		internal string StringOrLongValue => this.StringValue ?? this.LongValue?.ToString(CultureInfo.InvariantCulture);
+
 		internal object Document { get; }
 		internal Func<object> DocumentGetter { get; }
 
-		internal Routing(Func<object> documentGetter) { DocumentGetter = documentGetter; }
-		public Routing(string routing) { Value = routing; }
-		public Routing(long routing) { Value = routing; }
-		public Routing(object document) { Document = document; }
+		internal int Tag { get; }
 
-		public static implicit operator Routing(string routing) => new Routing(routing);
-		public static implicit operator Routing(string[] routing) => new Routing(string.Join(",", routing));
+		internal Routing(Func<object> documentGetter)
+		{
+			Tag = 0;
+			DocumentGetter = documentGetter;
+		}
+
+		public Routing(string routing)
+		{
+			Tag = 1;
+			StringValue = routing;
+		}
+
+		public Routing(long routing)
+		{
+			Tag = 2;
+			LongValue = routing;
+		}
+
+		public Routing(object document)
+		{
+			Tag = 4;
+			Document = document;
+		}
+
+		public static implicit operator Routing(string routing) => routing.IsNullOrEmptyCommaSeparatedList(out _) ? null : new Routing(routing);
+		public static implicit operator Routing(string[] routing) => routing.IsEmpty() ? null : new Routing(string.Join(",", routing));
 		public static implicit operator Routing(long routing) => new Routing(routing);
 		public static implicit operator Routing(Guid routing) => new Routing(routing.ToString("D"));
 
 		/// <summary> Use the inferred routing from <paramref name="document"/> </summary>
 		public static Routing From<T>(T document) where T : class => new Routing(document);
 
-		private string DebugDisplay => Value?.ToString() ?? "Routing from instance typeof: " + Document?.GetType().Name;
+		private string DebugDisplay => this.StringOrLongValue ?? "Routing from instance typeof: " + Document?.GetType().Name;
 
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings)
 		{
@@ -36,48 +62,85 @@ namespace Nest
 
 		private string GetString(IConnectionSettingsValues nestSettings)
 		{
+			string value = null;
 			if (this.DocumentGetter != null)
 			{
 				var doc = this.DocumentGetter();
-				Value = nestSettings.Inferrer.Routing(doc);
+				value = nestSettings.Inferrer.Routing(doc);
 			}
 			else if (this.Document != null)
-				Value = nestSettings.Inferrer.Routing(this.Document);
+				value = nestSettings.Inferrer.Routing(this.Document);
 
-			var s = Value as string;
-			return s ?? this.Value?.ToString();
+			return value ?? this.StringOrLongValue;
 		}
+
+		public static bool operator ==(Routing left, Routing right) => Equals(left, right);
+
+		public static bool operator !=(Routing left, Routing right) => !Equals(left, right);
 
 		public bool Equals(Routing other)
 		{
-			if (ReferenceEquals(null, other)) return false;
-			if (ReferenceEquals(this, other)) return true;
-			return Equals(Value, other.Value) && Equals(Document, other.Document);
+			if (this.Tag == other.Tag)
+			{
+				switch (this.Tag)
+				{
+					case 0:
+						var t = this.DocumentGetter();
+						var o = other.DocumentGetter();
+						return t?.Equals(o) ?? false;
+					case 4: return this.Document?.Equals(other.Document) ?? false;
+					default:
+						return StringEquals(this.StringOrLongValue, other.StringOrLongValue);
+				}
+			}
+			else if (this.Tag + other.Tag == 3)
+				return StringEquals(this.StringOrLongValue, other.StringOrLongValue);
+			else
+				return false;
+		}
+
+		private static readonly char[] Separator = {','};
+
+		private static bool StringEquals(string left, string right)
+		{
+			if (left == null && right == null) return true;
+			else if (left == null || right == null)
+				return false;
+			if (!left.Contains(",") || !right.Contains(",")) return left == right;
+
+			var l1 = left.Split(Separator, StringSplitOptions.RemoveEmptyEntries).Select(v=>v.Trim()).ToList();
+			var l2 = right.Split(Separator, StringSplitOptions.RemoveEmptyEntries).Select(v=>v.Trim()).ToList();
+			if (l1.Count != l2.Count) return false;
+			return l1.Count == l2.Count && !l1.Except(l2).Any();
+
 		}
 
 		public override bool Equals(object obj)
 		{
-			if (ReferenceEquals(null, obj)) return false;
-			if (ReferenceEquals(this, obj)) return true;
-			return obj.GetType() == this.GetType() && Equals((Routing)obj);
+			switch (obj)
+			{
+				case Routing r: return Equals(r);
+				case string s: return Equals(s);
+				case int l: return Equals(l);
+				case long l: return Equals(l);
+				case Guid g: return Equals(g);
+			}
+
+			return Equals(new Routing(obj));
 		}
 
+		private static int TypeHashCode { get; } = typeof(Routing).GetHashCode();
 		public override int GetHashCode()
 		{
 			unchecked
 			{
-				return ((Value?.GetHashCode() ?? 0) * 397) ^ (Document?.GetHashCode() ?? 0);
+				var result = TypeHashCode;
+				result = (result * 397) ^ (this.StringValue?.GetHashCode() ?? 0);
+				result = (result * 397) ^ (this.LongValue?.GetHashCode() ?? 0);
+				result = (result * 397) ^ (this.DocumentGetter?.GetHashCode() ?? 0);
+				result = (result * 397) ^ (this.Document?.GetHashCode() ?? 0);
+				return result;
 			}
-		}
-
-		public static bool operator ==(Routing left, Routing right)
-		{
-			return Equals(left, right);
-		}
-
-		public static bool operator !=(Routing left, Routing right)
-		{
-			return !Equals(left, right);
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/JoinFieldRouting/RoutingJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/JoinFieldRouting/RoutingJsonConverter.cs
@@ -23,14 +23,22 @@ namespace Nest
 				return;
 			}
 
-			var id = (Routing)value;
-			if (id.Document != null)
+			var routing = (Routing)value;
+			if (routing.Document != null)
 			{
 				var settings = serializer.GetConnectionSettings();
-				var documentId = settings.Inferrer.Routing(id.Document.GetType(), id.Document);
+				var documentId = settings.Inferrer.Routing(routing.Document.GetType(), routing.Document);
 				writer.WriteValue(documentId);
 			}
-			else writer.WriteValue(id.Value);
+			else if (routing.DocumentGetter != null)
+			{
+				var settings = serializer.GetConnectionSettings();
+				var doc = routing.DocumentGetter();
+				var documentId = settings.Inferrer.Routing(doc.GetType(), doc);
+				writer.WriteValue(documentId);
+			}
+			else if (routing.LongValue != null) writer.WriteValue(routing.LongValue);
+			else writer.WriteValue(routing.StringValue);
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/JoinFieldRouting/RoutingResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/JoinFieldRouting/RoutingResolver.cs
@@ -62,13 +62,8 @@ namespace Nest
 			return true;
 		}
 
-		private string ResolveId(Id id, IConnectionSettingsValues nestSettings)
-		{
-			if (id.Document != null) return nestSettings.Inferrer.Id(id.Document);
-
-			var s = id.Value as string;
-			return s ?? id.Value?.ToString();
-		}
+		private string ResolveId(Id id, IConnectionSettingsValues nestSettings) =>
+			id.Document != null ? nestSettings.Inferrer.Id(id.Document) : id.StringOrLongValue;
 
 		private static JoinField GetJoinFieldFromObject(Type type, object @object)
 		{

--- a/src/Nest/CommonAbstractions/Infer/Metrics/IndexMetrics.cs
+++ b/src/Nest/CommonAbstractions/Infer/Metrics/IndexMetrics.cs
@@ -3,13 +3,25 @@ using Elasticsearch.Net;
 
 namespace Nest
 {
-	public class IndexMetrics : IUrlParameter
+	public class IndexMetrics : IEquatable<IndexMetrics>, IUrlParameter
 	{
 		private readonly NodesStatsIndexMetric _enumValue;
+		internal Enum Value => _enumValue;
 
 		public string GetString(IConnectionConfigurationValues settings) => this._enumValue.GetStringValue();
 		internal IndexMetrics(NodesStatsIndexMetric metric) { _enumValue = metric; }
 
 		public static implicit operator IndexMetrics(NodesStatsIndexMetric metric) => new IndexMetrics(metric);
+
+		public bool Equals(Enum other) => this.Value.Equals(other);
+		public bool Equals(IndexMetrics other) => this.Value.Equals(other.Value);
+
+		public override bool Equals(object obj) => obj is Enum e ? Equals(e) : obj is IndexMetrics m && Equals(m.Value);
+
+		public override int GetHashCode() => (_enumValue.GetHashCode());
+
+		public static bool operator ==(IndexMetrics left, IndexMetrics right) => Equals(left, right);
+
+		public static bool operator !=(IndexMetrics left, IndexMetrics right) => !Equals(left, right);
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/Metrics/Metrics.cs
+++ b/src/Nest/CommonAbstractions/Infer/Metrics/Metrics.cs
@@ -3,9 +3,10 @@ using Elasticsearch.Net;
 
 namespace Nest
 {
-	public class Metrics : IUrlParameter
+	public class Metrics : IEquatable<Metrics>, IUrlParameter
 	{
 		private readonly Enum _enumValue;
+		internal Enum Value => _enumValue;
 
 		public string GetString(IConnectionConfigurationValues settings) => this._enumValue.GetStringValue();
 		internal Metrics(IndicesStatsMetric metric) { _enumValue = metric; }
@@ -21,5 +22,16 @@ namespace Nest
 		public static implicit operator Metrics(ClusterStateMetric metric) => new Metrics(metric);
 		public static implicit operator Metrics(WatcherStatsMetric metric) => new Metrics(metric);
 		public static implicit operator Metrics(NodesUsageMetric metric) => new Metrics(metric);
+
+		public bool Equals(Enum other) => this.Value.Equals(other);
+		public bool Equals(Metrics other) => this.Value.Equals(other.Value);
+
+		public override bool Equals(object obj) => obj is Enum e ? Equals(e) : obj is Metrics m && Equals(m.Value);
+
+		public override int GetHashCode() => (_enumValue != null ? _enumValue.GetHashCode() : 0);
+
+		public static bool operator ==(Metrics left, Metrics right) => Equals(left, right);
+
+		public static bool operator !=(Metrics left, Metrics right) => !Equals(left, right);
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/Name/Name.cs
+++ b/src/Nest/CommonAbstractions/Infer/Name/Name.cs
@@ -1,18 +1,42 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using Elasticsearch.Net;
 
 namespace Nest
 {
 	[DebuggerDisplay("{DebugDisplay,nq}")]
-	public class Name : IUrlParameter
+	public class Name : IEquatable<Name>, IUrlParameter
 	{
 		private readonly string _name;
-		public Name(string name) { this._name = name; }
+		internal string Value => _name;
+		private string DebugDisplay => _name;
+
+		public Name(string name) => this._name = name?.Trim();
 
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings) => _name;
 
-		private string DebugDisplay => _name;
+		public static implicit operator Name(string name) => name.IsNullOrEmpty() ? null : new Name(name);
 
-		public static implicit operator Name(string name) => new Name(name);
+		public static bool operator ==(Name left, Name right) => Equals(left, right);
+
+		public static bool operator !=(Name left, Name right) => !Equals(left, right);
+
+		public bool Equals(Name other) => EqualsString(other?.Value);
+
+		public override bool Equals(object obj) =>
+			obj is string s ? this.EqualsString(s) : (obj is Name i) && this.EqualsString(i.Value);
+
+		private bool EqualsString(string other) => !other.IsNullOrEmpty() && other.Trim() == this.Value;
+
+		private static int TypeHashCode { get; } = typeof(Name).GetHashCode();
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				var result = TypeHashCode;
+				result = (result * 397) ^ (this.Value?.GetHashCode() ?? 0);
+				return result;
+			}
+		}
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/Name/Names.cs
+++ b/src/Nest/CommonAbstractions/Infer/Name/Names.cs
@@ -7,32 +7,49 @@ using Elasticsearch.Net;
 namespace Nest
 {
 	[DebuggerDisplay("{DebugDisplay,nq}")]
-	public class Names : IUrlParameter
+	public class Names : IEquatable<Names>, IUrlParameter
 	{
-		private readonly IEnumerable<Name> _names;
+		private readonly IList<Name> _names;
+		internal IList<Name> Value => _names;
 
-		public Names(IEnumerable<string> names)
+		public Names(IEnumerable<string> names) : this(names?.Select(n=>(Name)n).ToList()) { }
+
+		public Names(IEnumerable<Name> names)
 		{
-			if (!names.HasAny()) throw new ArgumentException("can not create Names on an empty enumerable of string", nameof(names));
-			this._names = names.Select(n => (Name)n);
+			this._names = names?.ToList();
+			if (!this._names.HasAny())
+				throw new ArgumentException($"can not create {nameof(Names)} on an empty enumerable of ", nameof(names));
 		}
 
-		public Names(IEnumerable<Name> names) { this._names = names; }
-
-		public static Names Parse(string names)
-		{
-			if (names.IsNullOrEmpty()) throw new ArgumentException("can not create Names on an empty enumerable of string", nameof(names));
-			var nameList = names.Split(new [] { "," }, StringSplitOptions.RemoveEmptyEntries).Select(s=>s.Trim());
-			return new Names(nameList);
-		}
+		public static Names Parse(string names) => names.IsNullOrEmptyCommaSeparatedList(out var list) ? null : new Names(list);
 
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings) =>
 			string.Join(",", this._names.Cast<IUrlParameter>().Select(n => n.GetString(settings)));
 
 		private string DebugDisplay => ((IUrlParameter)this).GetString(null);
 
-		public static implicit operator Names(Name name) => new Names(new[] { name });
+		public static implicit operator Names(Name name) => name == null ? null : new Names(new[] { name });
 
 		public static implicit operator Names(string names) => Parse(names);
+
+		public static implicit operator Names(string[] names) => names.IsEmpty() ? null : new Names(names);
+
+		public static bool operator ==(Names left, Names right) => Equals(left, right);
+
+		public static bool operator !=(Names left, Names right) => !Equals(left, right);
+
+		public bool Equals(Names other) => EqualsAllIds(this.Value, other.Value);
+
+		private static bool EqualsAllIds(ICollection<Name> thisIds, ICollection<Name> otherIds)
+		{
+			if (thisIds == null && otherIds == null) return true;
+			if (thisIds == null || otherIds == null) return false;
+			if (thisIds.Count != otherIds.Count) return false;
+			return thisIds.Count == otherIds.Count && !thisIds.Except(otherIds).Any();
+		}
+
+		public override bool Equals(object obj) => obj is string s ? this.Equals(Parse(s)) : (obj is Names i) && this.Equals(i);
+
+		public override int GetHashCode() => this._names.GetHashCode();
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/NodeId/NodeIds.cs
+++ b/src/Nest/CommonAbstractions/Infer/NodeId/NodeIds.cs
@@ -7,23 +7,43 @@ using Elasticsearch.Net;
 namespace Nest
 {
 	[DebuggerDisplay("{DebugDisplay,nq}")]
-	public class NodeIds : IUrlParameter
+	public class NodeIds : IEquatable<NodeIds>, IUrlParameter
 	{
-		private readonly IEnumerable<string> _nodeIds;
+		private readonly IList<string> _nodeIds;
+		internal IList<string> Value => _nodeIds;
 
-		public NodeIds(IEnumerable<string> nodeIds) { this._nodeIds = nodeIds; }
+		public NodeIds(IEnumerable<string> nodeIds)
+		{
+			this._nodeIds = nodeIds?.ToList();
+			if (!this._nodeIds.HasAny())
+				throw new ArgumentException($"can not create {nameof(NodeIds )} on an empty enumerable of ", nameof(nodeIds));
+		}
 
 		private string DebugDisplay => ((IUrlParameter)this).GetString(null);
 
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings) => string.Join(",", this._nodeIds);
 
-		public static NodeIds Parse(string nodeIds)
-		{
-			if (nodeIds.IsNullOrEmpty()) throw new ArgumentException("can not create NodeIds on an empty enumerable of ", nameof(nodeIds));
-			var nodes = nodeIds.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).Select(s=>s.Trim());
-			return new NodeIds(nodes);
-		}
+		public static NodeIds Parse(string nodeIds) => nodeIds.IsNullOrEmptyCommaSeparatedList(out var nodes) ? null : new NodeIds(nodes);
 
 		public static implicit operator NodeIds(string nodes) => Parse(nodes);
+		public static implicit operator NodeIds(string[] nodes) => nodes.IsEmpty() ? null : new NodeIds(nodes);
+
+		public static bool operator ==(NodeIds left, NodeIds right) => Equals(left, right);
+
+		public static bool operator !=(NodeIds left, NodeIds right) => !Equals(left, right);
+
+		public bool Equals(NodeIds other) => EqualsAllIds(this.Value, other.Value);
+
+		private static bool EqualsAllIds(ICollection<string> thisIds, ICollection<string> otherIds)
+		{
+			if (thisIds == null && otherIds == null) return true;
+			if (thisIds == null || otherIds == null) return false;
+			if (thisIds.Count != otherIds.Count) return false;
+			return thisIds.Count == otherIds.Count && !thisIds.Except(otherIds).Any();
+		}
+
+		public override bool Equals(object obj) => obj is string s ? this.Equals(Parse(s)) : (obj is NodeIds i) && this.Equals(i);
+
+		public override int GetHashCode() => this._nodeIds.GetHashCode();
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/RelationName/RelationName.cs
+++ b/src/Nest/CommonAbstractions/Infer/RelationName/RelationName.cs
@@ -9,22 +9,16 @@ namespace Nest
 	[DebuggerDisplay("{DebugDisplay,nq}")]
 	public class RelationName : IEquatable<RelationName>, IUrlParameter
 	{
-		private static int TypeHashCode { get; } = typeof(RelationName).GetHashCode();
 
 		public string Name { get; }
 		public Type Type { get; }
 
-		private RelationName(string type)
-		{
-			this.Name = type;
-		}
-
-		private RelationName(Type type)
-		{
-			this.Type = type;
-		}
+		private RelationName(string type) => this.Name = type;
+		private RelationName(Type type) => this.Type = type;
 
 		internal string DebugDisplay => Type == null ? Name : $"{nameof(RelationName)} for typeof: {Type?.Name}";
+
+		public static RelationName From<T>() => typeof(T);
 
 		public static RelationName Create(Type type) => GetRelationNameForType(type);
 
@@ -32,11 +26,11 @@ namespace Nest
 
 		private static RelationName GetRelationNameForType(Type type) => new RelationName(type);
 
-		public static implicit operator RelationName(string typeName) =>
-			typeName == null ? null : new RelationName(typeName);
+		public static implicit operator RelationName(string typeName) => typeName.IsNullOrEmpty() ? null : new RelationName(typeName);
 
 		public static implicit operator RelationName(Type type) => type == null ? null : new RelationName(type);
 
+		private static int TypeHashCode { get; } = typeof(RelationName).GetHashCode();
 		public override int GetHashCode()
 		{
 			unchecked
@@ -47,22 +41,14 @@ namespace Nest
 			}
 		}
 
-		bool IEquatable<RelationName>.Equals(RelationName other) => Equals(other);
+		public static bool operator ==(RelationName left, RelationName right) => Equals(left, right);
 
-		public override bool Equals(object obj)
-		{
-			var s = obj as string;
-			if (!s.IsNullOrEmpty()) return this.EqualsString(s);
-			if (obj is RelationName pp) return this.EqualsMarker(pp);
-			return base.Equals(obj);
-		}
+		public static bool operator !=(RelationName left, RelationName right) => !Equals(left, right);
 
-		public override string ToString()
-		{
-			if (!this.Name.IsNullOrEmpty())
-				return this.Name;
-			return this.Type != null ? this.Type.Name : string.Empty;
-		}
+		public bool Equals(RelationName other) => EqualsMarker(other);
+
+		public override bool Equals(object obj) =>
+			obj is string s ? this.EqualsString(s) : (obj is RelationName r) && this.EqualsMarker(r);
 
 		public bool EqualsMarker(RelationName other)
 		{
@@ -73,20 +59,21 @@ namespace Nest
 			return false;
 		}
 
-		public bool EqualsString(string other)
+		private bool EqualsString(string other) => !other.IsNullOrEmpty() && other == this.Name;
+
+		public override string ToString()
 		{
-			return !other.IsNullOrEmpty() && other == this.Name;
+			if (!this.Name.IsNullOrEmpty()) return this.Name;
+			return this.Type != null ? this.Type.Name : string.Empty;
 		}
 
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings)
 		{
-			var nestSettings = settings as IConnectionSettingsValues;
-			if (nestSettings == null)
-				throw new Exception("Tried to pass type name on querystring but it could not be resolved because no nest settings are available");
+			if (!(settings is IConnectionSettingsValues nestSettings))
+				throw new ArgumentNullException(nameof(settings), $"Can not resolve {nameof(RelationName)} if no {nameof(IConnectionSettingsValues)} is provided");
 
 			return nestSettings.Inferrer.RelationName(this);
 		}
 
-		public static RelationName From<T>() => typeof(T);
 	}
 }

--- a/src/Nest/CommonAbstractions/Infer/TypeName/TypeName.cs
+++ b/src/Nest/CommonAbstractions/Infer/TypeName/TypeName.cs
@@ -14,14 +14,9 @@ namespace Nest
 		public string Name { get; }
 		public Type Type { get; }
 
-		private TypeName(string type)
-		{
-			this.Name = type;
-		}
-		private TypeName(Type type)
-		{
-			this.Type = type;
-		}
+		private TypeName(string type) => this.Name = type;
+
+		private TypeName(Type type) => this.Type = type;
 
 		internal string DebugDisplay => Type == null ? Name : $"{nameof(TypeName)} for typeof: {Type?.Name}";
 
@@ -31,7 +26,7 @@ namespace Nest
 
 		private static TypeName GetTypeNameForType(Type type) => new TypeName(type);
 
-		public static implicit operator TypeName(string typeName) => typeName == null ? null : new TypeName(typeName);
+		public static implicit operator TypeName(string typeName) => typeName.IsNullOrEmpty() ? null : new TypeName(typeName);
 
 		public static implicit operator TypeName(Type type) => type == null ? null : new TypeName(type);
 
@@ -44,8 +39,11 @@ namespace Nest
 				return result;
 			}
 		}
+		public static bool operator ==(TypeName left, TypeName right) => Equals(left, right);
 
-		bool IEquatable<TypeName>.Equals(TypeName other) => Equals(other);
+		public static bool operator !=(TypeName left, TypeName right) => !Equals(left, right);
+
+		public bool Equals(TypeName other) => EqualsMarker(other);
 
 		public override bool Equals(object obj)
 		{
@@ -78,9 +76,8 @@ namespace Nest
 
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings)
 		{
-			var nestSettings = settings as IConnectionSettingsValues;
-			if (nestSettings == null)
-				throw new Exception("Tried to pass type name on querystring but it could not be resolved because no nest settings are available");
+			if (!(settings is IConnectionSettingsValues nestSettings))
+				throw new ArgumentNullException(nameof(settings), $"Can not resolve {nameof(TypeName)} if no {nameof(IConnectionSettingsValues)} is provided");
 
 			return nestSettings.Inferrer.TypeName(this);
 		}

--- a/src/Nest/Document/Single/Index/IndexRequest.cs
+++ b/src/Nest/Document/Single/Index/IndexRequest.cs
@@ -19,9 +19,10 @@ namespace Nest
 
 		protected override HttpMethod HttpMethod => GetHttpMethod(this);
 
-		internal static HttpMethod GetHttpMethod(IIndexRequest<TDocument> request) => request.Id?.Value != null ? HttpMethod.PUT : HttpMethod.POST;
+		internal static HttpMethod GetHttpMethod(IIndexRequest<TDocument> request) => request.Id.IsConditionless() ? HttpMethod.POST : HttpMethod.PUT;
 
 		partial void DocumentFromPath(TDocument document) => this.Document = document;
+
 		private TDocument AutoRouteDocument() => Self.Document;
 
 		void IProxyRequest.WriteJson(IElasticsearchSerializer sourceSerializer, Stream stream, SerializationFormatting formatting) =>

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/ActionIdsEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/ActionIdsEqualityTests.cs
@@ -1,0 +1,37 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class NamesEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Names types = "foo,bar";
+			Names[] equal = {"foo,bar", "bar,foo", "foo,  bar", "bar,  foo   "};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			Names types = "foo,bar";
+			Names[] notEqual = {"foo,bar,x", "foo" };
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+		[U] public void Null()
+		{
+			Names types = "foo,bar";
+			(types == null).Should().BeFalse();
+			(null == types).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/CategoryIdEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/CategoryIdEqualityTests.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class CategoryIdEqualityTests
+	{
+		[U] public void Eq()
+		{
+			CategoryId types = 2;
+			CategoryId[] equal = {2L, 2};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+
+			CategoryId l1 = 2, l2 = 2;
+			(l1 == l2).ShouldBeTrue(l2);
+			(l1 == 2).ShouldBeTrue(l1);
+			l1.Should().Be(l2);
+			l1.Should().Be(2);
+		}
+
+		[U] public void NotEq()
+		{
+			CategoryId types = 3;
+			CategoryId[] notEqual = {4L, 4};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+			CategoryId l1 = 2, l2 = 3;
+			(l1 != l2).ShouldBeTrue(l2);
+			(l1 != 3).ShouldBeTrue(l1);
+			l1.Should().NotBe(l2);
+			l1.Should().NotBe(3);
+		}
+
+		[U] public void Null()
+		{
+			CategoryId c = 10;
+			(c == null).Should().BeFalse();
+			(null == c).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/DocumentPathEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/DocumentPathEqualityTests.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class DocumentPathEqualityTests
+	{
+		[U] public void Eq()
+		{
+			var project = new Project {Name = "x"};
+			DocumentPath<Project> path = project;
+			DocumentPath<Project> pathOther = project;
+			(pathOther == path).Should().BeTrue();
+			pathOther.Should().Be(path);
+
+			path = new DocumentPath<Project>(2);
+			pathOther = new DocumentPath<Project>(2);
+			(pathOther == path).Should().BeTrue();
+			pathOther.Should().Be(path);
+		}
+
+		[U] public void NotEq()
+		{
+			var project = new Project {Name = "x"};
+			DocumentPath<Project> path = project;
+			DocumentPath<Project> pathOther = new Project {Name = "x"};
+			(pathOther != path).Should().BeTrue();
+			pathOther.Should().NotBe(path);
+
+			path = new DocumentPath<Project>(2);
+			pathOther = new DocumentPath<Project>(2).Index("x");
+			(pathOther != path).Should().BeTrue();
+			pathOther.Should().NotBe(path);
+
+			path = new DocumentPath<Project>(2);
+			pathOther = new DocumentPath<Project>(2).Type("x");
+			(pathOther != path).Should().BeTrue();
+			pathOther.Should().NotBe(path);
+		}
+		[U] public void Null()
+		{
+			var value = new DocumentPath<Project>(2);
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldEqualityTests.cs
@@ -1,0 +1,69 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class FieldEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Field name = "foo";
+			Field[] equal = {"foo"};
+			foreach (var t in equal)
+			{
+				(t == name).ShouldBeTrue(t);
+				t.Should().Be(name);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			Field name = "foo";
+			Field[] notEqual = {"bar", "x", "", "   ", " foo ", Infer.Field<Project>(p=>p.Name)};
+			foreach (var t in notEqual)
+			{
+				(t != name).ShouldBeTrue(t);
+				t.Should().NotBe(name);
+			}
+		}
+
+		[U] public void TypedEq()
+		{
+			Field t1 = Infer.Field<Project>(p => p.Name), t2 = Infer.Field<Project>(p => p.Name);
+			(t1 == t2).ShouldBeTrue(t2);
+			t1.Should().Be(t2);
+		}
+
+		[U] public void TypedNotEq()
+		{
+			Field t1 = Infer.Field<Developer>(p => p.Id), t2 = Infer.Field<CommitActivity>(p => p.Id);
+			(t1 != t2).ShouldBeTrue(t2);
+			t1.Should().NotBe(t2);
+		}
+
+		[U] public void ReflectedEq()
+		{
+			Field t1 = typeof(Project).GetProperty(nameof(Project.Name)),
+				  t2 = typeof(Project).GetProperty(nameof(Project.Name));
+			(t1 == t2).ShouldBeTrue(t2);
+			t1.Should().Be(t2);
+		}
+
+		[U] public void ReflectedNotEq()
+		{
+			Field t1 = typeof(CommitActivity).GetProperty(nameof(CommitActivity.Id)),
+				  t2 = typeof(Developer).GetProperty(nameof(Developer.Id));
+			(t1 != t2).ShouldBeTrue(t2);
+			t1.Should().NotBe(t2);
+		}
+
+		[U] public void Null()
+		{
+			Field value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldsEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldsEqualityTests.cs
@@ -1,0 +1,81 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class FieldsEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Fields name = "foo, bar";
+			Fields[] equal = {"foo, bar", "  foo,   bar", "bar, foo", "   bar  ,   foo  "};
+			foreach (var t in equal)
+			{
+				(t == name).ShouldBeTrue(t);
+				t.Should().BeEquivalentTo(name);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			Fields name = "foo, bar";
+			Fields[] notEqual = {"bar", "foo, bar, x", "", "   ", " foo ", Infer.Field<Project>(p=>p.Name)};
+			foreach (var t in notEqual)
+			{
+				(t != name).ShouldBeTrue(t);
+				if (t != null) t.Should().NotBeEquivalentTo(name);
+			}
+		}
+
+		[U] public void TypedEq()
+		{
+			Fields t1 = Infer.Field<Project>(p => p.Name), t2 = Infer.Field<Project>(p => p.Name);
+			(t1 == t2).ShouldBeTrue(t2);
+			t1.Should().BeEquivalentTo(t2);
+
+			t1 = Infer.Field<Project>(p => p.Name, 1.1); t2 = Infer.Field<Project>(p => p.Name, 1.1);
+			(t1 == t2).ShouldBeTrue(t2);
+			t1.Should().BeEquivalentTo(t2);
+		}
+
+		[U] public void TypedNotEq()
+		{
+			Fields t1 = Infer.Field<Developer>(p => p.Id), t2 = Infer.Field<CommitActivity>(p => p.Id);
+			(t1 != t2).ShouldBeTrue(t2);
+			t1.Should().NotBeEquivalentTo(t2);
+
+			t1 = Infer.Field<Project>(p => p.Name); t2 = Infer.Field<Project>(p => p.Name, 2.0);
+			(t1 != t2).ShouldBeTrue(t2);
+			t1.Should().NotBeEquivalentTo(t2);
+
+			t1 = Infer.Field<Project>(p => p.Name, 1.0); t2 = Infer.Field<Project>(p => p.Name, 2.0);
+			(t1 != t2).ShouldBeTrue(t2);
+			t1.Should().NotBeEquivalentTo(t2);
+		}
+
+		[U] public void ReflectedEq()
+		{
+			Fields t1 = typeof(Project).GetProperty(nameof(Project.Name)),
+				  t2 = typeof(Project).GetProperty(nameof(Project.Name));
+			(t1 == t2).ShouldBeTrue(t2);
+			t1.Should().BeEquivalentTo(t2);
+		}
+
+		[U] public void ReflectedNotEq()
+		{
+			Fields t1 = typeof(CommitActivity).GetProperty(nameof(CommitActivity.Id)),
+				  t2 = typeof(Developer).GetProperty(nameof(Developer.Id));
+			(t1 != t2).ShouldBeTrue(t2);
+			t1.Should().NotBeEquivalentTo(t2);
+		}
+
+		[U] public void Null()
+		{
+			Fields value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldsEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldsEqualityTests.cs
@@ -38,6 +38,16 @@ namespace Tests.ClientConcepts.HighLevel.Inference.Equality
 			t1 = Infer.Field<Project>(p => p.Name, 1.1); t2 = Infer.Field<Project>(p => p.Name, 1.1);
 			(t1 == t2).ShouldBeTrue(t2);
 			t1.Should().BeEquivalentTo(t2);
+
+			// boost factor is not taken into account when comparing fields
+			t1 = Infer.Field<Project>(p => p.Name, 2.1); t2 = Infer.Field<Project>(p => p.Name, 1.1);
+			(t1 == t2).ShouldBeTrue(t2);
+			t1.Should().BeEquivalentTo(t2);
+
+			// boost factor is not taken into account when comparing fields
+			t1 = Infer.Field<Project>(p => p.Name); t2 = Infer.Field<Project>(p => p.Name, 1.1);
+			(t1 == t2).ShouldBeTrue(t2);
+			t1.Should().BeEquivalentTo(t2);
 		}
 
 		[U] public void TypedNotEq()
@@ -46,11 +56,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference.Equality
 			(t1 != t2).ShouldBeTrue(t2);
 			t1.Should().NotBeEquivalentTo(t2);
 
-			t1 = Infer.Field<Project>(p => p.Name); t2 = Infer.Field<Project>(p => p.Name, 2.0);
-			(t1 != t2).ShouldBeTrue(t2);
-			t1.Should().NotBeEquivalentTo(t2);
-
-			t1 = Infer.Field<Project>(p => p.Name, 1.0); t2 = Infer.Field<Project>(p => p.Name, 2.0);
+			t1 = Infer.Field<Project>(p => p.Name, 1.0); t2 = Infer.Field<Project>(p => p.Location, 1.0);
 			(t1 != t2).ShouldBeTrue(t2);
 			t1.Should().NotBeEquivalentTo(t2);
 		}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/IdEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/IdEqualityTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class IdEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Id types = "foo";
+			Id[] equal = {"foo"};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+
+			Id l1 = 2, l2 = 2;
+			(l1 == l2).ShouldBeTrue(l2);
+			(l1 == 2).ShouldBeTrue(l1);
+			(l1 == "2").ShouldBeTrue(l1);
+			l1.Should().Be(l2);
+			l1.Should().Be("2");
+			l1.Should().Be(2);
+
+			var g = Guid.NewGuid();
+			l1 = g; l2 = g;
+			(l1 == l2).ShouldBeTrue(l2);
+			l1.Should().Be(l2);
+
+			var project = new Project {Name = "x"};
+			l1 = Id.From(project); l2 = Id.From(project);
+			(l1 == l2).ShouldBeTrue(l2);
+			l1.Should().Be(l2);
+
+		}
+
+		[U] public void NotEq()
+		{
+			Id types = "foo";
+			Id[] notEqual = {"bar", "" , "foo  "};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+			Id l1 = 2, l2 = 3;
+			(l1 != l2).ShouldBeTrue(l2);
+			(l1 != 3).ShouldBeTrue(l1);
+			(l1 != "3").ShouldBeTrue(l1);
+			l1.Should().NotBe(l2);
+			l1.Should().NotBe(3);
+			l1.Should().NotBe("3");
+
+			l1 = Guid.NewGuid(); l2 = Guid.NewGuid();
+			(l1 != l2).ShouldBeTrue(l2);
+			l1.Should().NotBe(l2);
+
+			//when comparing objects we can only do referential equality. Project does not have its own Equals implementation.
+			l1 = Id.From(new Project {Name = "x"}); l2 = Id.From(new Project {Name = "x"});
+			(l1 != l2).ShouldBeTrue(l2);
+			l1.Should().NotBe(l2);
+		}
+
+		[U] public void Null()
+		{
+			Id value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/IndexMetricsEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/IndexMetricsEqualityTests.cs
@@ -1,0 +1,41 @@
+﻿using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class IndexMetricsEqualityTests
+	{
+		[U] public void Eq()
+		{
+			IndexMetrics metrics = NodesStatsIndexMetric.All;
+			IndexMetrics[] equal = {NodesStatsIndexMetric.All};
+			foreach (var t in equal)
+			{
+				(t == metrics).ShouldBeTrue(t);
+				t.Should().Be(metrics);
+			}
+			metrics.Should().Be(NodesStatsIndexMetric.All);
+		}
+
+		[U] public void NotEq()
+		{
+			IndexMetrics metrics = NodesStatsIndexMetric.All;
+			IndexMetrics[] notEqual = {NodesStatsIndexMetric.Flush};
+			foreach (var t in notEqual)
+			{
+				(t != metrics).ShouldBeTrue(t);
+				t.Should().NotBe(metrics);
+			}
+			metrics.Should().NotBe(NodesStatsMetric.All);
+		}
+
+		[U] public void Null()
+		{
+			IndexMetrics value = NodesStatsIndexMetric.All;
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/IndexNameEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/IndexNameEqualityTests.cs
@@ -1,0 +1,72 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class IndexNameEqualityTests
+	{
+		[U] public void Eq()
+		{
+			IndexName types = "foo";
+			IndexName[] equal = {"foo"};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			IndexName types = "foo";
+			IndexName[] notEqual = {"bar", "foo  ", "  foo   ", "x", "", "   ", typeof(Project)};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+		[U] public void EqCluster()
+		{
+			IndexName types = "c:foo";
+			IndexName[] equal = {"c:foo"};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+		[U] public void NotEqCluster()
+		{
+			IndexName types = "c:foo";
+			IndexName[] notEqual = {"c1:bar", "c:foo  ", "  c:foo   ", "c:foo1", "x", "", "   ", typeof(Project) };
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+
+		[U] public void IndexdEq()
+		{
+			IndexName t1 = typeof(Project), t2 = typeof(Project);
+			(t1 == t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void IndexdNotEq()
+		{
+			IndexName t1 = typeof(Project), t2 = typeof(CommitActivity);
+			(t1 != t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void Null()
+		{
+			IndexName value = typeof(Project);
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/IndicesEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/IndicesEqualityTests.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class IndicesEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Nest.Indices types = "foo,bar";
+			Nest.Indices[] equal = {"foo,bar", "bar,foo", "foo,  bar", "bar,  foo   "};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+
+			(Nest.Indices.All == "_all").Should().BeTrue();
+		}
+
+
+		[U] public void NotEq()
+		{
+			Nest.Indices types = "foo,bar";
+			Nest.Indices[] notEqual = {"foo,bar,x", "foo", typeof(Project)};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+
+		[U] public void TypedEq()
+		{
+			Nest.Indices t1 = typeof(Project), t2 = typeof(Project);
+			(t1 == t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void TypedNotEq()
+		{
+			Nest.Indices t1 = typeof(Project), t2 = typeof(CommitActivity);
+			(t1 != t2).ShouldBeTrue(t2);
+		}
+		[U] public void Null()
+		{
+			Nest.Indices value = typeof(Project);
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/MetricsEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/MetricsEqualityTests.cs
@@ -1,0 +1,40 @@
+﻿using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class MetricsEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Metrics metrics = IndicesStatsMetric.All;
+			Metrics[] equal = {IndicesStatsMetric.All};
+			foreach (var t in equal)
+			{
+				(t == metrics).ShouldBeTrue(t);
+				t.Should().Be(metrics);
+			}
+			metrics.Should().Be(IndicesStatsMetric.All);
+		}
+
+		[U] public void NotEq()
+		{
+			Metrics metrics = IndicesStatsMetric.All;
+			Metrics[] notEqual = {IndicesStatsMetric.Completion, ClusterStateMetric.All};
+			foreach (var t in notEqual)
+			{
+				(t != metrics).ShouldBeTrue(t);
+				t.Should().NotBe(metrics);
+			}
+			metrics.Should().NotBe(ClusterStateMetric.All);
+		}
+		[U] public void Null()
+		{
+			Metrics value = IndicesStatsMetric.All;
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/NameEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/NameEqualityTests.cs
@@ -1,0 +1,38 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class NameEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Name types = "foo";
+			Name[] equal = {"foo", "  foo", "foo   "};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			Name types = "foo";
+			Name[] notEqual = {"bar", "" };
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+
+		[U] public void Null()
+		{
+			Name value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/NamesEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/NamesEqualityTests.cs
@@ -1,0 +1,38 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class ActionIdsEqualityTests
+	{
+		[U] public void Eq()
+		{
+			ActionIds types = "foo,bar";
+			ActionIds[] equal = {"foo,bar", "bar,foo", "foo,  bar", "bar,  foo   "};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			ActionIds types = "foo,bar";
+			ActionIds[] notEqual = {"foo,bar,x", "foo" };
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+
+		[U] public void Null()
+		{
+			Names value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/NodeIdsEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/NodeIdsEqualityTests.cs
@@ -1,0 +1,38 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class NodeIdsEqualityTests
+	{
+		[U] public void Eq()
+		{
+			NodeIds types = "foo,bar";
+			NodeIds[] equal = {"foo,bar", "bar,foo", "foo,  bar", "bar,  foo   "};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			NodeIds types = "foo,bar";
+			NodeIds[] notEqual = {"foo,bar,x", "foo"};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+
+		[U] public void Null()
+		{
+			NodeIds value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/PropertyNameEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/PropertyNameEqualityTests.cs
@@ -1,0 +1,51 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class PropertyNameEqualityTests
+	{
+		[U] public void Eq()
+		{
+			PropertyName name = "foo";
+			PropertyName[] equal = {"foo"};
+			foreach (var t in equal)
+			{
+				(t == name).ShouldBeTrue(t);
+				t.Should().Be(name);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			PropertyName name = "foo";
+			PropertyName[] notEqual = {"bar", "foo  ", "  foo   ", "x", "", "   ", Infer.Property<Project>(p=>p.Name)};
+			foreach (var t in notEqual)
+			{
+				(t != name).ShouldBeTrue(t);
+				t.Should().NotBe(name);
+			}
+		}
+
+		[U] public void TypedEq()
+		{
+			PropertyName t1 = Infer.Property<Project>(p => p.Name), t2 = Infer.Property<Project>(p => p.Name);
+			(t1 == t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void TypedNotEq()
+		{
+			PropertyName t1 = Infer.Property<Developer>(p => p.Id), t2 = Infer.Property<CommitActivity>(p => p.Id);
+			(t1 != t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void Null()
+		{
+			PropertyName value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/RelationNameEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/RelationNameEqualityTests.cs
@@ -1,0 +1,50 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class RelationNameEqualityTests
+	{
+		[U] public void Eq()
+		{
+			RelationName name = "foo";
+			RelationName[] equal = {"foo"};
+			foreach (var t in equal)
+			{
+				(t == name).ShouldBeTrue(t);
+				t.Should().Be(name);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			RelationName name = "foo";
+			RelationName[] notEqual = {"bar", "foo  ", "  foo   ", "x", "", "   ", typeof(Project)};
+			foreach (var t in notEqual)
+			{
+				(t != name).ShouldBeTrue(t);
+				t.Should().NotBe(name);
+			}
+		}
+
+		[U] public void TypedEq()
+		{
+			RelationName t1 = typeof(Project), t2 = typeof(Project);
+			(t1 == t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void TypedNotEq()
+		{
+			RelationName t1 = typeof(Project), t2 = typeof(CommitActivity);
+			(t1 != t2).ShouldBeTrue(t2);
+		}
+		[U] public void Null()
+		{
+			RelationName value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/RoutingEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/RoutingEqualityTests.cs
@@ -1,0 +1,66 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class RoutingEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Routing types = "foo";
+			Routing[] equal = {"foo"};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+
+			Routing l1 = 2, l2 = 2;
+			(l1 == l2).ShouldBeTrue(l2);
+			(l1 == 2).ShouldBeTrue(l1);
+			(l1 == "2").ShouldBeTrue(l1);
+			l1.Should().Be(l2);
+			l1.Should().Be("2");
+			l1.Should().Be(2);
+
+			l1 = "foo, bar"; l2 = "bar,   foo";
+			(l1 == l2).ShouldBeTrue(l2);
+			l1.Should().Be(l2);
+
+		}
+
+		[U] public void NotEq()
+		{
+			Routing types = "foo";
+			Routing[] notEqual = {"bar", "" , "foo  "};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+			Routing l1 = 2, l2 = 3;
+			(l1 != l2).ShouldBeTrue(l2);
+			(l1 != 3).ShouldBeTrue(l1);
+			(l1 != "3").ShouldBeTrue(l1);
+			l1.Should().NotBe(l2);
+			l1.Should().NotBe(3);
+			l1.Should().NotBe("3");
+
+			l1 = "foo, bar"; l2 = "bar,   foo, x";
+			(l1 != l2).ShouldBeTrue(l2);
+			l1.Should().NotBe(l2);
+
+			l1 = "foo, bar"; l2 = "bar";
+			(l1 != l2).ShouldBeTrue(l2);
+			l1.Should().NotBe(l2);
+		}
+
+		[U] public void Null()
+		{
+			Routing value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/TaskIdEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/TaskIdEqualityTests.cs
@@ -1,0 +1,38 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class TaskIdEqualityTests
+	{
+		[U] public void Eq()
+		{
+			TaskId types = "node:1337";
+			TaskId[] equal = {"node:1337"};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			TaskId types = "node:1337";
+			TaskId[] notEqual = {"node:1338", "  node:1337", "node:1337   ", "node:133", "node2:1337"};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+
+		[U] public void Null()
+		{
+			TaskId value = "node:1339";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/TypeNameEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/TypeNameEqualityTests.cs
@@ -1,0 +1,51 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class TypeNameEqualityTests
+	{
+		[U] public void Eq()
+		{
+			TypeName types = "foo";
+			TypeName[] equal = {"foo"};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+		[U] public void NotEq()
+		{
+			TypeName types = "foo";
+			TypeName[] notEqual = {"bar", "foo  ", "  foo   ", "x", "", "   ", typeof(Project)};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+
+		[U] public void TypedEq()
+		{
+			TypeName t1 = typeof(Project), t2 = typeof(Project);
+			(t1 == t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void TypedNotEq()
+		{
+			TypeName t1 = typeof(Project), t2 = typeof(CommitActivity);
+			(t1 != t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void Null()
+		{
+			TypeName value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/Equality/TypesEqualityTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/Equality/TypesEqualityTests.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference.Equality
+{
+	public class TypesEqualityTests
+	{
+		[U] public void Eq()
+		{
+			Types types = "foo,bar";
+			Types[] equal = {"foo,bar", "bar,foo", "foo,  bar", "bar,  foo   "};
+			foreach (var t in equal)
+			{
+				(t == types).ShouldBeTrue(t);
+				t.Should().Be(types);
+			}
+		}
+
+
+		[U] public void NotEq()
+		{
+			Types types = "foo,bar";
+			Types[] notEqual = {"foo,bar,x", "foo", "", "   ", typeof(Project)};
+			foreach (var t in notEqual)
+			{
+				(t != types).ShouldBeTrue(t);
+				t.Should().NotBe(types);
+			}
+		}
+
+		[U] public void TypedEq()
+		{
+			Types t1 = typeof(Project), t2 = typeof(Project);
+			(t1 == t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void TypedNotEq()
+		{
+			Types t1 = typeof(Project), t2 = typeof(CommitActivity);
+			(t1 != t2).ShouldBeTrue(t2);
+		}
+
+		[U] public void Null()
+		{
+			Types value = "foo";
+			(value == null).Should().BeFalse();
+			(null == value).Should().BeFalse();
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
@@ -54,8 +54,6 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			*
 			* - determining `Field` equality
 			* - getting the hash code for a `Field` instance
-			*
-			* IMPORTANT: Boost values are **not** taken into account when determining equality.
 			*/
 			var fieldStringWithBoostTwo = new Field("name^2");
 			var fieldStringWithBoostThree = new Field("name^3");
@@ -70,7 +68,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			fieldExpression.GetHashCode().Should().NotBe(0);
 			fieldProperty.GetHashCode().Should().NotBe(0);
 
-			fieldStringWithBoostTwo.Should().Be(fieldStringWithBoostThree); //<1> <<field-name-with-boost,Fields can constructed with a name that contains a boost>>
+			fieldStringWithBoostTwo.Should().Be(fieldStringWithBoostTwo); //<1> <<field-name-with-boost,Fields can constructed with a name that contains a boost>>
 		}
 
 		/**

--- a/src/Tests/ClientConcepts/HighLevel/Inference/ImplicitConversionTests.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/ImplicitConversionTests.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.MockData;
+
+namespace Tests.ClientConcepts.HighLevel.Inference
+{
+	public class ImplicitConversionTests
+	{
+		private static T Implicit<T>(T i) => i;
+
+		[U] public void ActionIds()
+		{
+			Implicit<ActionIds>(null).Should().BeNull();
+			Implicit<ActionIds>("").Should().BeNull();
+			Implicit<ActionIds>("   ").Should().BeNull();
+			Implicit<ActionIds>(",, ,,").Should().BeNull();
+			Implicit<ActionIds>(new string[] {}).Should().BeNull();
+			Implicit<ActionIds>(new string[] {null, null}).Should().BeNull();
+		}
+
+		[U] public void CategoryId()
+		{
+			Implicit<CategoryId>(null).Should().BeNull();
+		}
+
+		[U] public void DocumentPath()
+		{
+			Implicit<DocumentPath<Project>>((Project)null).Should().BeNull();
+			Implicit<DocumentPath<Project>>((Id)null).Should().BeNull();
+			Implicit<DocumentPath<Project>>((string)null).Should().BeNull();
+			Implicit<DocumentPath<Project>>("").Should().BeNull();
+			Implicit<DocumentPath<Project>>("   ").Should().BeNull();
+		}
+
+		[U] public void Field()
+		{
+			Implicit<Field>((string)null).Should().BeNull();
+			Implicit<Field>((Expression)null).Should().BeNull();
+			Implicit<Field>((PropertyInfo)null).Should().BeNull();
+			Implicit<Field>("").Should().BeNull();
+			Implicit<Field>("   ").Should().BeNull();
+		}
+
+		[U] public void Fields()
+		{
+			Implicit<Fields>((Expression)null).Should().BeNull();
+			Implicit<Fields>((Field)null).Should().BeNull();
+			Implicit<Fields>((string)null).Should().BeNull();
+			Implicit<Fields>((PropertyInfo)null).Should().BeNull();
+			Implicit<Fields>((string[])null).Should().BeNull();
+			Implicit<Fields>((Expression[])null).Should().BeNull();
+			Implicit<Fields>((PropertyInfo[])null).Should().BeNull();
+			Implicit<Fields>((Field[])null).Should().BeNull();
+			Implicit<Fields>("").Should().BeNull();
+			Implicit<Fields>("   ").Should().BeNull();
+			Implicit<Fields>(new string[] {}).Should().BeNull();
+			Implicit<Fields>(new Expression[] {}).Should().BeNull();
+			Implicit<Fields>(new PropertyInfo[] {}).Should().BeNull();
+			Implicit<Fields>(new Field[] {}).Should().BeNull();
+			Implicit<Fields>(new Expression[] {null, null}).Should().BeNull();
+			Implicit<Fields>(new PropertyInfo[] {null, null}).Should().BeNull();
+			Implicit<Fields>(new Field[] {null, null}).Should().BeNull();
+		}
+
+		[U] public void Id()
+		{
+			Implicit<Id>(null).Should().BeNull();
+			Implicit<Id>("").Should().BeNull();
+			Implicit<Id>("   ").Should().BeNull();
+		}
+
+		[U] public void IndexName()
+		{
+			Implicit<IndexName>((string)null).Should().BeNull();
+			Implicit<IndexName>((Type)null).Should().BeNull();
+			Implicit<IndexName>("").Should().BeNull();
+			Implicit<IndexName>("   ").Should().BeNull();
+		}
+
+		[U] public void Indices()
+		{
+			Implicit<Nest.Indices>((string)null).Should().BeNull();
+			Implicit<Nest.Indices>((Nest.Indices.ManyIndices)null).Should().BeNull();
+			Implicit<Nest.Indices>((string[])null).Should().BeNull();
+			Implicit<Nest.Indices>((IndexName)null).Should().BeNull();
+			Implicit<Nest.Indices>((IndexName[])null).Should().BeNull();
+			Implicit<Nest.Indices>((IndexName)null).Should().BeNull();
+			Implicit<Nest.Indices>("").Should().BeNull();
+			Implicit<Nest.Indices>("    ").Should().BeNull();
+			Implicit<Nest.Indices>(",, ,,    ").Should().BeNull();
+			Implicit<Nest.Indices>(new string[] {}).Should().BeNull();
+			Implicit<Nest.Indices>(new IndexName[] {}).Should().BeNull();
+			Implicit<Nest.Indices>(new string[] {null, null}).Should().BeNull();
+			Implicit<Nest.Indices>(new IndexName[] {null, null}).Should().BeNull();
+		}
+
+		[U] public void Names()
+		{
+			Implicit<Names>((string)null).Should().BeNull();
+			Implicit<Names>((string[])null).Should().BeNull();
+			Implicit<Names>("").Should().BeNull();
+			Implicit<Names>(",,").Should().BeNull();
+			Implicit<Names>(",   ,").Should().BeNull();
+			Implicit<Names>("   ").Should().BeNull();
+			Implicit<Names>(new string[] {}).Should().BeNull();
+			Implicit<Names>(new string[] {null, null}).Should().BeNull();
+		}
+
+		[U] public void Routing()
+		{
+			Implicit<Routing>((string)null).Should().BeNull();
+			Implicit<Routing>((string[])null).Should().BeNull();
+			Implicit<Routing>("").Should().BeNull();
+			Implicit<Routing>(",,").Should().BeNull();
+			Implicit<Routing>(",   ,").Should().BeNull();
+			Implicit<Routing>("   ").Should().BeNull();
+			Implicit<Routing>(new string[] {}).Should().BeNull();
+			Implicit<Routing>(new string[] {null, null}).Should().BeNull();
+		}
+
+		[U] public void Metrics()
+		{
+			Implicit<Metrics>(null).Should().BeNull();
+		}
+
+		[U] public void IndexMetrics()
+		{
+			Implicit<IndexMetrics>(null).Should().BeNull();
+		}
+
+		[U] public void Name()
+		{
+			Implicit<Name>(null).Should().BeNull();
+			Implicit<Name>("").Should().BeNull();
+			Implicit<Name>("   ").Should().BeNull();
+		}
+
+		[U] public void NodeId()
+		{
+			Implicit<NodeIds>((string)null).Should().BeNull();
+			Implicit<NodeIds>((string[])null).Should().BeNull();
+			Implicit<NodeIds>("").Should().BeNull();
+			Implicit<NodeIds>("  ").Should().BeNull();
+			Implicit<NodeIds>("  ,, , ,,").Should().BeNull();
+			Implicit<NodeIds>(new string[] {}).Should().BeNull();
+			Implicit<NodeIds>(new string[] {null, null}).Should().BeNull();
+		}
+
+		[U] public void PropertyName()
+		{
+			Implicit<PropertyName>((Expression)null).Should().BeNull();
+			Implicit<PropertyName>((PropertyInfo)null).Should().BeNull();
+			Implicit<PropertyName>((string)null).Should().BeNull();
+			Implicit<PropertyName>("").Should().BeNull();
+			Implicit<PropertyName>("  ").Should().BeNull();
+		}
+
+		[U] public void RelationName()
+		{
+			Implicit<RelationName>((string)null).Should().BeNull();
+			Implicit<RelationName>((Type)null).Should().BeNull();
+			Implicit<RelationName>("   ").Should().BeNull();
+		}
+
+		[U] public void TaskId()
+		{
+			Implicit<TaskId>((string)null).Should().BeNull();
+			Implicit<TaskId>("    ").Should().BeNull();
+			Implicit<TaskId>("").Should().BeNull();
+		}
+
+		[U] public void TypeName()
+		{
+			Implicit<TypeName>((Type)null).Should().BeNull();
+			Implicit<TypeName>((string)null).Should().BeNull();
+			Implicit<TypeName>("").Should().BeNull();
+			Implicit<TypeName>("   ").Should().BeNull();
+		}
+
+		[U] public void Types()
+		{
+			Implicit<Types>((TypeName)null).Should().BeNull();
+			Implicit<Types>((Type)null).Should().BeNull();
+			Implicit<Types>((Types.ManyTypes)null).Should().BeNull();
+			Implicit<Types>((Types.AllTypesMarker)null).Should().BeNull();
+			Implicit<Types>((string)null).Should().BeNull();
+			Implicit<Types>("").Should().BeNull();
+			Implicit<Types>(" ,,, ").Should().BeNull();
+			Implicit<Types>("  ").Should().BeNull();
+			Implicit<Types>(new string[] {}).Should().BeNull();
+			Implicit<Types>(new TypeName[] {}).Should().BeNull();
+			Implicit<Types>(new string[] {null, null}).Should().BeNull();
+			Implicit<Types>(new TypeName[] {null, null}).Should().BeNull();
+		}
+
+
+	}
+}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs
@@ -154,8 +154,8 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		[U] public void ImplicitConversionReadsCluster()
 		{
 			var i = (IndexName)"cluster_one  :  project  ";
-			i.Cluster.Should().Be("cluster_one");
-			i.Name.Should().Be("project");
+			i.Cluster.Should().Be("cluster_one  ");
+			i.Name.Should().Be("  project  ");
 
 			i = (IndexName)"cluster_one:project";
 			i.Cluster.Should().Be("cluster_one");

--- a/src/Tests/Document/Single/Index/IndexUrlTests.cs
+++ b/src/Tests/Document/Single/Index/IndexUrlTests.cs
@@ -23,10 +23,14 @@ namespace Tests.Document.Single.Index
 					Document = project
 				}));
 
-			await POST("/project/doc")
+			//no explit ID is provided and none can be inferred on the anonymous object so this falls back to a PUT to /index/type
+			await PUT("/project/doc")
 				.Fluent(c => c.Index(new { }, i => i.Index(typeof(Project)).Type(typeof(Project))))
+				.FluentAsync(c => c.IndexAsync(new { }, i => i.Index(typeof(Project)).Type(typeof(Project))));
+
+			//no explit ID is provided and document is not fed into DocumentPath using explicit OIS.
+			await POST("/project/doc")
 				.Request(c => c.Index(new IndexRequest<object>("project", "doc") {Document = new { }}))
-				.FluentAsync(c => c.IndexAsync(new { }, i => i.Index(typeof(Project)).Type(typeof(Project))))
 				.RequestAsync(c => c.IndexAsync(new IndexRequest<object>(typeof(Project), TypeName.From<Project>())
 				{
 					Document = new { }

--- a/src/Tests/Framework/Extensions/ShouldExtensions.cs
+++ b/src/Tests/Framework/Extensions/ShouldExtensions.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using Elasticsearch.Net;
+using FluentAssertions;
 using Nest;
 using Tests.Framework.MockData;
 
@@ -29,5 +30,8 @@ namespace Tests.Framework
 			project.SourceOnly.NotWrittenByDefaultSerializer.Should().Be("written");
 			project.SourceOnly.NotReadByDefaultSerializer.Should().Be("read");
 		}
+
+		public static void ShouldBeTrue(this bool b, IUrlParameter p) =>
+			b.Should().BeTrue(p?.GetString(TestClient.GlobalDefaultSettings) ?? "NULL");
 	}
 }


### PR DESCRIPTION
All `IUrlParameter` and `Infer` types now implement a structural `Equals()` and not a referential `Equals()`

* Trim() is bad on singular types, removed this from them as it only hides bugs. Moved the trim to plural type parsing of multi valued comma separated strings.
* Made sure all implementations implement `IEquatable<>`
* Made sure implicit conversion from null/empty string/empty comma separated string all behave the same (return null) for IUrlParameters and Infer types.
* Made sure null flows through all the Equals implementations and fixed existing tests that failed due to the updated implementation

`Field` now takes boost value into account, this was previously explicitly documented as desired behaviour but I can remember why this was the case, @russcam  any ideas?