### PR TITLE
Fix #3115 bump json.net to version 11

### DIFF
--- a/build/NEST.JsonNetSerializer.nuspec
+++ b/build/NEST.JsonNetSerializer.nuspec
@@ -19,7 +19,7 @@
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="[1.6.0, )" />
 				<dependency id="NEST" version="[$version$, $nextMajorVersion$)" />
-				<dependency id="Newtonsoft.Json" version="[$jsonDotNetCurrentVersion$, $jsonDotNetNextVersion$)" />
+				<dependency id="Newtonsoft.Json" version="$jsonDotNetCurrentVersion$" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,12 +10,12 @@
   <ItemGroup>
     <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.2" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.3.409" />
     <PackageReference Include="NuDoq" Version="1.2.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
   <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elasticsearch.Net\Elasticsearch.Net.csproj" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />

--- a/src/Serializers/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
+++ b/src/Serializers/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
   <Import Project="..\..\outputpath.props" />
 </Project>


### PR DESCRIPTION
This also removes the +1 major exclusive restriction on the dependency range.

I am OK with folks upgrading at their own risk given that we internalize our own `JSON.NET` now.