### PR TITLE
Fix #3115 bump json.net to version 11.x [2.x clients]

### DIFF
--- a/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
+++ b/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
@@ -6,7 +6,7 @@
     <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="RazorMachine" Version="2.6.1" />
     <!-- TODO the following packages prevent us to jump to netcoreapp1.0 -->
     <PackageReference Include="CsQuery" Version="1.3.4" />

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.409" />
     <PackageReference Include="NuDoq" Version="1.2.5" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
   <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elasticsearch.Net\Elasticsearch.Net.csproj" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'!='netstandard1.3'">
     <Reference Include="System.ServiceModel" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Nest\Nest.csproj" />
     <PackageReference Include="Bogus" Version="21.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
     <PackageReference Include="SemanticVersioning" Version="0.7.6" />


### PR DESCRIPTION
Keeps the strict dependency range because a major upgrade of JSON.NET might break NEST's own types serialization.