### PR TITLE
when 'dotnet xunit' returns a non zero exit code forcefully fail the …

### DIFF
--- a/build/scripts/Testing.fsx
+++ b/build/scripts/Testing.fsx
@@ -1,4 +1,5 @@
 ﻿#I @"../../packages/build/FAKE/tools"
+open Fake.Core
 #r @"FakeLib.dll"
 
 #load @"Commandline.fsx"
@@ -48,7 +49,8 @@ module Tests =
             | _  -> p
 
         let dotnet = Tooling.BuildTooling("dotnet")
-        dotnet.ExecWithTimeoutIn "src/Tests" command (TimeSpan.FromMinutes 30.) |> ignore
+        let exitCode = dotnet.ExecWithTimeoutIn "src/Tests" command (TimeSpan.FromMinutes 30.) 
+        if exitCode > 0 then raise (Exception <| (sprintf "test finished with exitCode %d" exitCode))
 
     let RunReleaseUnitTests() =
         setLocalEnvVars()

--- a/src/Tests/Framework/Xunit/TestAssemblyRunner.cs
+++ b/src/Tests/Framework/Xunit/TestAssemblyRunner.cs
@@ -108,11 +108,21 @@ namespace Xunit
 				//in parallel
 				using (@group.Key ?? Disposable.Empty)
 				{
-					@group.Key?.Start();
+					try
+					{
+						@group.Key?.Start();
+					}
+					catch (Exception e)
+					{
+						messageBus.QueueMessage(new ErrorMessage(new ITestCase[] { }, e));
+						throw;
+					}
+
 					await @group.ForEachAsync(dop, async g => { await RunTestCollections(messageBus, ctx, g, testFilters); });
 				}
 				this.ClusterTotals[clusterName].Stop();
 			}
+
 
 			return new RunSummary()
 			{


### PR DESCRIPTION
…build, in cases where our xunit setup fails no tests will be run and will end up going unreported

cc @codebrain @russcam 