### PR TITLE
Honour JsonConverters added in JsonSerializerSettings

### DIFF
--- a/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
+++ b/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
@@ -110,9 +110,9 @@ back to NEST's built-in serializer.
 We ship a separate {nuget}/NEST.JsonNetSerializer[NEST.JsonNetSerializer] package that helps in composing a custom `SourceSerializer`
 using `Json.NET`, that is smart enough to delegate the serialization of known NEST types back to the built-in
 `RequestResponseSerializer`. This package is also useful if you want to control how your documents and values are stored
-and retreived from Elasticsearch using `Json.NET`, without intervering with the way NEST uses `Json.NET` internally.
+and retrieved from Elasticsearch using `Json.NET`, without interfering with the way NEST uses `Json.NET` internally.
 
-The easiest way to hook this custom source serializer is as follows
+The easiest way to hook this custom source serializer up is as follows
 
 [source,csharp]
 ----

--- a/src/Serializers/Nest.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.Serializer.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.Serializer.cs
@@ -54,7 +54,9 @@ namespace Nest.JsonNetSerializer
 			var contract = CreateContractResolver();
 			s.Formatting = formatting == SerializationFormatting.Indented ? Formatting.Indented : Formatting.None;
 			s.ContractResolver = contract;
-			s.Converters = converters.Concat(this.Converters).ToList();
+			foreach (var converter in converters.Concat(this.Converters))
+				s.Converters.Add(converter);
+
 			return JsonSerializer.Create(s);
 		}
 

--- a/src/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs
@@ -112,9 +112,9 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 		 * We ship a separate {nuget}/NEST.JsonNetSerializer[NEST.JsonNetSerializer] package that helps in composing a custom `SourceSerializer`
 		 * using `Json.NET`, that is smart enough to delegate the serialization of known NEST types back to the built-in
 		 * `RequestResponseSerializer`. This package is also useful if you want to control how your documents and values are stored
-		 * and retreived from Elasticsearch using `Json.NET`, without intervering with the way NEST uses `Json.NET` internally.
+		 * and retrieved from Elasticsearch using `Json.NET`, without interfering with the way NEST uses `Json.NET` internally.
 		 *
-		 * The easiest way to hook this custom source serializer is as follows
+		 * The easiest way to hook this custom source serializer up is as follows
 		 */
 		public void DefaultJsonNetSerializer()
 		{

--- a/src/Tests/Reproduce/JsonNetSerializerConverters.cs
+++ b/src/Tests/Reproduce/JsonNetSerializerConverters.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Nest.JsonNetSerializer;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Tests.Framework;
+
+namespace Tests.Reproduce
+{
+	// from https://stackoverflow.com/questions/49224866/elasticsearch-nest-6-storing-enums-as-string
+	public class JsonNetSerializerConverters
+	{
+		[U] public void JsonConvertersInJsonSerializerSettingsAreHonoured()
+		{
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(pool, new InMemoryConnection(), (builtin, settings) =>
+				new JsonNetSerializer(builtin, settings,
+					() => new JsonSerializerSettings
+					{
+						Converters = new List<JsonConverter> { new StringEnumConverter() }
+					})).DisableDirectStreaming();
+
+			var client = new ElasticClient(connectionSettings);
+
+			var indexResponse = client.Index(new Product { ProductType = ProductType.Example }, i => i.Index("examples"));
+			Encoding.UTF8.GetString(indexResponse.ApiCall.RequestBodyInBytes).Should().Contain("\"productType\":\"Example\"");
+		}
+
+		public class Product
+		{
+			public ProductType ProductType { get; set; }
+		}
+
+		public enum ProductType
+		{
+			Example
+		}
+	}
+}


### PR DESCRIPTION
This commit honours the addition of JsonConverters to the JsonSerializerSettings
constructed from the Func<JsonSerializerSettings> passed to JsonNetSerializer.

JsonSerializerSettings is always instantiated with an instance of List<JsonConverter>
for its Converters property.

Closes #3161