### PR TITLE
Fix synchronous HEAD request

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -75,7 +75,7 @@ namespace Elasticsearch.Net
 				statusCode = (int) responseMessage.StatusCode;
 
 				responseMessage.Headers.TryGetValues("Warning", out warnings);
-				mimeType = responseMessage.Content.Headers.ContentType.ToString();
+				mimeType = responseMessage.Content.Headers.ContentType?.MediaType;
 
 				if (responseMessage.Content != null)
 					responseStream = responseMessage.Content.ReadAsStreamAsync().GetAwaiter().GetResult();


### PR DESCRIPTION
When making a HEAD requests the response does not contain a ContentType. The Async version of `Request` already has this check, however the synchronous call fails with a NullReferenceException.