### PR TITLE
Change Fields to be optional on MultiMatchQuery

### DIFF
--- a/src/Nest/QueryDsl/FullText/MultiMatch/MultiMatchQuery.cs
+++ b/src/Nest/QueryDsl/FullText/MultiMatch/MultiMatchQuery.cs
@@ -142,7 +142,7 @@ namespace Nest
 		[JsonProperty("zero_terms_query")]
 		ZeroTermsQuery? ZeroTermsQuery { get; set; }
 
-    /// <summary></summary>
+    	/// <summary></summary>
 		[JsonProperty("auto_generate_synonyms_phrase_query")]
 		bool? AutoGenerateSynonymsPhraseQuery { get; set; }
 	}
@@ -185,11 +185,11 @@ namespace Nest
 		public ZeroTermsQuery? ZeroTermsQuery { get; set; }
 		/// <inheritdoc />
 		public bool? FuzzyTranspositions { get; set; }
-    /// <inheritdoc />
+    	/// <inheritdoc />
 		public bool? AutoGenerateSynonymsPhraseQuery { get; set; }
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.MultiMatch = this;
-		internal static bool IsConditionless(IMultiMatchQuery q) => q.Fields.IsConditionless() || q.Query.IsNullOrEmpty();
+		internal static bool IsConditionless(IMultiMatchQuery q) => q.Query.IsNullOrEmpty();
 	}
 
 	/// <inheritdoc cref="IMultiMatchQuery"/>
@@ -276,7 +276,7 @@ namespace Nest
 		/// <inheritdoc cref="IMultiMatchQuery.ZeroTermsQuery"/>
 		public MultiMatchQueryDescriptor<T> ZeroTermsQuery(ZeroTermsQuery? zeroTermsQuery) => Assign(a => a.ZeroTermsQuery = zeroTermsQuery);
 
-    /// <inheritdoc cref="IMultiMatchQuery.AutoGenerateSynonymsPhraseQuery"/>
+    	/// <inheritdoc cref="IMultiMatchQuery.AutoGenerateSynonymsPhraseQuery"/>
 		public MultiMatchQueryDescriptor<T> AutoGenerateSynonymsPhraseQuery(bool? autoGenerateSynonymsPhraseQuery = true) =>
 			Assign(a => a.AutoGenerateSynonymsPhraseQuery = autoGenerateSynonymsPhraseQuery);
 	}

--- a/src/Tests/QueryDsl/FullText/MultiMatch/MultiMatchUsageTests.cs
+++ b/src/Tests/QueryDsl/FullText/MultiMatch/MultiMatchUsageTests.cs
@@ -82,8 +82,7 @@ namespace Tests.QueryDsl.FullText.MultiMatch
 		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IMultiMatchQuery>(a => a.MultiMatch)
 		{
 			q => q.Query = null,
-			q => q.Query = string.Empty,
-			q => q.Fields = null
+			q => q.Query = string.Empty
 		};
 	}
 
@@ -115,6 +114,36 @@ namespace Tests.QueryDsl.FullText.MultiMatch
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
 			.MultiMatch(c => c
 				.Fields(Field<Project>(p=>p.Description, 2.2).And("myOtherField^0.3"))
+				.Query("hello world")
+			);
+	}
+
+	/**[float]
+	 * === Multi match with no fields specified
+	 *
+	 * Starting with Elasticsearch 6.1.0+, it's possible to send a Multi Match query without providing any fields.
+	 * When no fields are provided the Multi Match query will use the fields defined in the index setting `index.query.default_field`
+	 * (which in turns defaults to `*`).
+	 */
+	public class MultiMatchWithNoFieldsSpecifiedUsageTests : QueryDslUsageTestsBase
+	{
+		public MultiMatchWithNoFieldsSpecifiedUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object QueryJson => new
+		{
+			multi_match = new
+			{
+				query = "hello world"
+			}
+		};
+
+		protected override QueryContainer QueryInitializer => new MultiMatchQuery
+		{
+			Query = "hello world",
+		};
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.MultiMatch(c => c
 				.Query("hello world")
 			);
 	}


### PR DESCRIPTION
This commit adds the ability to send multi_match query without providing any fields.
When no fields are provided the multi_match query will use the fields
defined in the index setting index.query.default_field
(which in turns defaults to *).

Closes #3159