### PR TITLE
Add segment attributes to the _segments API

### DIFF
--- a/src/Nest/Indices/Monitoring/IndicesSegments/Segment.cs
+++ b/src/Nest/Indices/Monitoring/IndicesSegments/Segment.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Nest
 {
@@ -15,15 +17,29 @@ namespace Nest
 		public long DeletedDocuments { get; internal set; }
 
 		[JsonProperty("size")]
+		[Obsolete("Unused. Will be removed in the next major release")]
 		public string Size { get; internal set; }
 
 		[JsonProperty("size_in_bytes")]
 		public double SizeInBytes { get; internal set; }
 
+		[JsonProperty("memory_in_bytes")]
+		public double MemoryInBytes { get; internal set; }
+
 		[JsonProperty("committed")]
 		public bool Committed { get; internal set; }
 
-		[JsonProperty("Search")]
+		[JsonProperty("search")]
 		public bool Search { get; internal set; }
+
+		[JsonProperty("version")]
+		public string Version { get; internal set; }
+
+		[JsonProperty("compound")]
+		public bool Compound { get; internal set; }
+
+		[JsonProperty("attributes")]
+		public IReadOnlyDictionary<string, string> Attributes { get; internal set; } =
+			EmptyReadOnly<string, string>.Dictionary;
 	}
 }

--- a/src/Tests/Indices/Monitoring/IndicesSegments/SegmentsApiTests.cs
+++ b/src/Tests/Indices/Monitoring/IndicesSegments/SegmentsApiTests.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Linq;
 using Elasticsearch.Net;
+using FluentAssertions;
 using Nest;
 using Tests.Framework;
 using Tests.Framework.Integration;
 using Tests.Framework.ManagedElasticsearch.Clusters;
-using Xunit;
+using static Tests.Framework.TestClient;
 
 namespace Tests.Indices.Monitoring.IndicesSegments
 {
@@ -27,5 +29,28 @@ namespace Tests.Indices.Monitoring.IndicesSegments
 		protected override Func<SegmentsDescriptor, ISegmentsRequest> Fluent => d => d;
 
 		protected override SegmentsRequest Initializer => new SegmentsRequest(Infer.AllIndices);
+
+		protected override void ExpectResponse(ISegmentsResponse response)
+		{
+			response.ShouldBeValid();
+
+			foreach (var indexShard in response.Indices.SelectMany(i => i.Value.Shards))
+			{
+				indexShard.Key.Should().NotBeNullOrEmpty();
+				foreach (var segment in indexShard.Value.Segments)
+				{
+					segment.Key.Should().NotBeNullOrEmpty();
+					var segmentValue = segment.Value;
+
+					segmentValue.Should().NotBeNull();
+					segmentValue.MemoryInBytes.Should().BeGreaterThan(0);
+					segmentValue.SizeInBytes.Should().BeGreaterThan(0);
+					segmentValue.Version.Should().NotBeNullOrEmpty();
+
+					if (VersionUnderTestSatisfiedBy(">=6.1.0"))
+						segmentValue.Attributes.Should().NotBeEmpty();
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This commit adds attributes to the Segments API.
Add memory_in_bytes, version and compound.
Deprecate size.

Closes #3160