### PR TITLE
Add response mime type to response

### DIFF
--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -75,6 +75,8 @@ namespace Elasticsearch.Net
 
 		public IEnumerable<string> DeprecationWarnings { get; internal set; } = Enumerable.Empty<string>();
 
+		public string ResponseMimeType { get; internal set; }
+
 		internal bool AllowAllStatusCodes { get; }
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -22,6 +22,7 @@ namespace Elasticsearch.Net
 		public Exception Exception { get; set; }
 		public int? StatusCode { get; set; }
 		public Stream Stream { get; set; }
+		public string ResponseMimeType { get; set; } = RequestData.MimeType;
 
 		public IEnumerable<string> DeprecationWarnings { get; set; }
 
@@ -61,6 +62,7 @@ namespace Elasticsearch.Net
 			response.HttpMethod = this._requestData.Method;
 			response.OriginalException = exception;
 			response.DeprecationWarnings = this.DeprecationWarnings ?? Enumerable.Empty<string>();
+			response.ResponseMimeType = this.ResponseMimeType;
 			return response;
 		}
 


### PR DESCRIPTION
This commit is a backport of #3188 that adds the response mime type to ElasticsearchResponse.