### PR TITLE
Update settings available for s3 repository plugin

### DIFF
--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
@@ -7,10 +7,7 @@ namespace Nest
 
 	public class S3Repository : IS3Repository
 	{
-		public S3Repository(S3RepositorySettings settings)
-		{
-			Settings = settings;
-		}
+		public S3Repository(IS3RepositorySettings settings) => Settings = settings;
 
 		public IS3RepositorySettings Settings { get; set; }
 		public string Type { get; } = "s3";
@@ -18,104 +15,143 @@ namespace Nest
 
 	public interface IS3RepositorySettings : IRepositorySettings
 	{
+		/// <summary>
+		/// The name of the bucket to be used for snapshots. This field is required
+		/// </summary>
 		[JsonProperty("bucket")]
 		string Bucket { get; set; }
 
+		/// <summary>
+		/// The name of the s3 client to use to connect to S3. Defaults to default.
+		/// </summary>
+		[JsonProperty("client")]
+		string Client { get; set; }
+
+		/// <summary>
+		/// Specifies the path within bucket to repository data.
+		/// Defaults to value of repositories.s3.base_path or to root directory if not set.
+		/// </summary>
 		[JsonProperty("base_path")]
 		string BasePath { get; set; }
 
-		[JsonProperty("access_key")]
-		string AccessKey { get; set; }
+		/// <summary>
+		/// Big files can be broken down into chunks during snapshotting if needed.
+		/// The chunk size can be specified in bytes or by using size value notation,
+		/// i.e. 1gb, 10mb, 5kb. Defaults to 1gb.
+		/// </summary>
+		[JsonProperty("chunk_size")]
+		string ChunkSize { get; set; }
 
-		[JsonProperty("secret_key")]
-		string SecretKey { get; set; }
-
+		/// <summary>
+		/// When set to true metadata files are stored in compressed format.
+		/// This setting doesn't affect index files that are already compressed by default.
+		/// Defaults to false.
+		/// </summary>
 		[JsonProperty("compress")]
 		bool? Compress { get; set; }
 
-		[JsonProperty("concurrent_streams")]
-		int? ConcurrentStreams { get; set; }
+		/// <summary>
+		/// When set to true files are encrypted on server side using AES256 algorithm.
+		/// Defaults to false.
+		/// </summary>
+		[JsonProperty("server_side_encryption")]
+		bool? ServerSideEncryption { get; set; }
 
-		[JsonProperty("chunk_size")]
-		string ChunkSize { get; set; }
+		/// <summary>
+		/// Minimum threshold below which the chunk is uploaded using a single request.
+		/// Beyond this threshold, the S3 repository will use the AWS Multipart Upload API to split the chunk into
+		/// several parts, each of buffer_size length, and to upload each part in its own request. Note that setting a
+		/// buffer size lower than 5mb is not allowed since it will prevent the use of the Multipart API and may result
+		/// in upload errors. It is also not possible to set a buffer size greater than 5gb as it is the maximum upload
+		/// size allowed by S3. Defaults to the minimum between 100mb and 5% of the heap size.
+		/// </summary>
+		[JsonProperty("buffer_size")]
+		string BufferSize { get; set; }
+
+		/// <summary>
+		/// Specify a canned ACL for the S3 bucket.
+		/// The S3 repository supports all S3 canned ACLs : private, public-read, public-read-write, authenticated-read,
+		/// log-delivery-write, bucket-owner-read, bucket-owner-full-control. Defaults to private.
+		/// </summary>
+		[JsonProperty("canned_acl")]
+		string CannedAcl { get; set; }
+
+		/// <summary>
+		/// Sets the S3 storage class type for the backup files. Values may be standard, reduced_redundancy, standard_ia.
+		/// Defaults to standard.
+		/// </summary>
+		[JsonProperty("storage_class")]
+		string StorageClass { get; set; }
 	}
 
 	public class S3RepositorySettings : IS3RepositorySettings
 	{
 		internal S3RepositorySettings() { }
 
-		public S3RepositorySettings(string bucket)
-		{
-			this.Bucket = bucket;
-		}
+		public S3RepositorySettings(string bucket) => this.Bucket = bucket;
 
+		/// <inheritdoc />
 		public string Bucket { get; set; }
+		/// <inheritdoc />
+		public string Client { get; set; }
+		/// <inheritdoc />
 		public string BasePath { get; set; }
-		public string AccessKey { get; set; }
-		public string SecretKey { get; set; }
-		public bool? Compress { get; set; }
-		public int? ConcurrentStreams { get; set; }
+		/// <inheritdoc />
 		public string ChunkSize { get; set; }
+		/// <inheritdoc />
+		public bool? Compress { get; set; }
+		/// <inheritdoc />
+		public bool? ServerSideEncryption { get; set; }
+		/// <inheritdoc />
+		public string BufferSize { get; set; }
+		/// <inheritdoc />
+		public string CannedAcl { get; set; }
+		/// <inheritdoc />
+		public string StorageClass { get; set; }
 	}
 
 	public class S3RepositorySettingsDescriptor
 		: DescriptorBase<S3RepositorySettingsDescriptor, IS3RepositorySettings>, IS3RepositorySettings
 	{
 		string IS3RepositorySettings.Bucket { get; set; }
+		string IS3RepositorySettings.Client { get; set; }
 		string IS3RepositorySettings.BasePath { get; set; }
-		string IS3RepositorySettings.AccessKey { get; set; }
-		string IS3RepositorySettings.SecretKey { get; set; }
 		bool? IS3RepositorySettings.Compress { get; set; }
-		int? IS3RepositorySettings.ConcurrentStreams { get; set; }
 		string IS3RepositorySettings.ChunkSize { get; set; }
+		bool? IS3RepositorySettings.ServerSideEncryption { get; set; }
+		string IS3RepositorySettings.BufferSize { get; set; }
+		string IS3RepositorySettings.CannedAcl { get; set; }
+		string IS3RepositorySettings.StorageClass { get; set; }
 
-		/// <summary>
-		/// The name of the bucket to be used for snapshots. (Mandatory)
-		/// </summary>
-		/// <param name="bucket"></param>
+		public S3RepositorySettingsDescriptor(string bucket) => Self.Bucket = bucket;
+
+		/// <inheritdoc cref="IS3RepositorySettings.Bucket"/>
 		public S3RepositorySettingsDescriptor Bucket(string bucket) => Assign(a => a.Bucket = bucket);
 
-		/// <summary>
-		/// Specifies the path within bucket to repository data. Defaults to root directory.
-		/// </summary>
-		/// <param name="basePath"></param>
-		/// <returns></returns>
+		/// <inheritdoc cref="IS3RepositorySettings.Client"/>
+		public S3RepositorySettingsDescriptor Client(string client) => Assign(a => a.Client = client);
+
+		/// <inheritdoc cref="IS3RepositorySettings.BasePath"/>
 		public S3RepositorySettingsDescriptor BasePath(string basePath) => Assign(a => a.BasePath = basePath);
 
-		/// <summary>
-		/// The access key to use for authentication. Defaults to value of cloud.aws.access_key.
-		/// </summary>
-		/// <param name="accessKey"></param>
-		/// <returns></returns>
-		public S3RepositorySettingsDescriptor AccessKey(string accessKey) => Assign(a => a.AccessKey = accessKey);
-
-		/// <summary>
-		/// The secret key to use for authentication. Defaults to value of cloud.aws.secret_key.
-		/// </summary>
-		/// <param name="secretKey"></param>
-		/// <returns></returns>
-		public S3RepositorySettingsDescriptor SecretKey(string secretKey) => Assign(a => a.SecretKey = secretKey);
-
-		/// <summary>
-		/// When set to true metadata files are stored in compressed format. This setting doesn't
-		/// affect index files that are already compressed by default. Defaults to false.
-		/// </summary>
-		/// <param name="compress"></param>
+		/// <inheritdoc cref="IS3RepositorySettings.Compress"/>
 		public S3RepositorySettingsDescriptor Compress(bool? compress = true) => Assign(a => a.Compress = compress);
 
-		/// <summary>
-		/// Throttles the number of streams (per node) preforming snapshot operation. Defaults to 5
-		/// </summary>
-		/// <param name="concurrentStreams"></param>
-		public S3RepositorySettingsDescriptor ConcurrentStreams(int? concurrentStreams) => Assign(a => a.ConcurrentStreams = concurrentStreams);
-
-		/// <summary>
-		///  Big files can be broken down into chunks during snapshotting if needed.
-		/// The chunk size can be specified in bytes or by using size value notation,
-		/// i.e. 1g, 10m, 5k. Defaults to 100m.
-		/// </summary>
-		/// <param name="chunkSize"></param>
+		/// <inheritdoc cref="IS3RepositorySettings.ChunkSize"/>
 		public S3RepositorySettingsDescriptor ChunkSize(string chunkSize) => Assign(a => a.ChunkSize = chunkSize);
+
+		/// <inheritdoc cref="IS3RepositorySettings.ServerSideEncryption"/>
+		public S3RepositorySettingsDescriptor ServerSideEncryption(bool? serverSideEncryption = true) =>
+			Assign(a => a.ServerSideEncryption = serverSideEncryption);
+
+		/// <inheritdoc cref="IS3RepositorySettings.BufferSize"/>
+		public S3RepositorySettingsDescriptor BufferSize(string bufferSize) => Assign(a => a.BufferSize = bufferSize);
+
+		/// <inheritdoc cref="IS3RepositorySettings.CannedAcl"/>
+		public S3RepositorySettingsDescriptor CannedAcl(string cannedAcl) => Assign(a => a.CannedAcl = cannedAcl);
+
+		/// <inheritdoc cref="IS3RepositorySettings.StorageClass"/>
+		public S3RepositorySettingsDescriptor StorageClass(string storageClass) => Assign(a => a.StorageClass = storageClass);
 	}
 
 	public class S3RepositoryDescriptor
@@ -125,6 +161,6 @@ namespace Nest
 		IS3RepositorySettings IRepository<IS3RepositorySettings>.Settings { get; set; }
 
 		public S3RepositoryDescriptor Settings(string bucket, Func<S3RepositorySettingsDescriptor, IS3RepositorySettings> settingsSelector = null) =>
-			Assign(a => a.Settings = settingsSelector.InvokeOrDefault(new S3RepositorySettingsDescriptor().Bucket(bucket)));
+			Assign(a => a.Settings = settingsSelector.InvokeOrDefault(new S3RepositorySettingsDescriptor(bucket)));
 	}
 }

--- a/src/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryApiTests.cs
+++ b/src/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryApiTests.cs
@@ -252,12 +252,14 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.CreateRepository
 			type = "s3",
 			settings = new {
 				bucket = "foobucket",
+				client = "default",
 				base_path = "some/path",
-				access_key = "fooaccess",
-				secret_key = "foosecret",
 				compress = true,
-				concurrent_streams = 5,
-				chunk_size = "64mb"
+				chunk_size = "64mb",
+				server_side_encryption = true,
+				buffer_size = "100mb",
+				canned_acl = "authenticated-read",
+				storage_class = "standard"
 			}
 		};
 
@@ -267,11 +269,13 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.CreateRepository
 			.S3(fs => fs
 				.Settings("foobucket", s => s
 					.BasePath("some/path")
-					.AccessKey("fooaccess")
-					.SecretKey("foosecret")
+					.Client("default")
 					.Compress()
-					.ConcurrentStreams(5)
 					.ChunkSize("64mb")
+					.ServerSideEncryption()
+					.BufferSize("100mb")
+					.CannedAcl("authenticated-read")
+					.StorageClass("standard")
 				)
 			);
 
@@ -280,11 +284,13 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.CreateRepository
 			Repository = new S3Repository(new S3RepositorySettings("foobucket")
 			{
 				BasePath = "some/path",
-				AccessKey = "fooaccess",
-				SecretKey = "foosecret",
+				Client = "default",
 				Compress = true,
-				ConcurrentStreams = 5,
-				ChunkSize = "64mb"
+				ChunkSize = "64mb",
+				ServerSideEncryption = true,
+				BufferSize = "100mb",
+				CannedAcl = "authenticated-read",
+				StorageClass = "standard"
 			})
 		};
 	}


### PR DESCRIPTION
This commit updates the settings available for the s3 repository
plugin.
Add client,buffer_size,canned_acl,storage_class,server_side_encryption
Remove access_key,secret_key. Now specified in elasticsearch keystore.
Remove concurrent_streams.

Closes #3141