### PR TITLE
Add significant terms aggregations to 6.x

### DIFF
--- a/src/Nest/Aggregations/AggregateDictionary.cs
+++ b/src/Nest/Aggregations/AggregateDictionary.cs
@@ -129,6 +129,20 @@ namespace Nest
 				};
 		}
 
+		public SignificantTermsAggregate SignificantText(string key)
+		{
+			var bucket = this.TryGet<BucketAggregate>(key);
+			return bucket == null
+				? null
+				: new SignificantTermsAggregate
+				{
+					BgCount = bucket.BgCount,
+					DocCount = bucket.DocCount,
+					Buckets = bucket.Items.OfType<SignificantTermsBucket>().ToList(),
+					Meta = bucket.Meta
+				};
+		}
+
 		public TermsAggregate<TKey> Terms<TKey>(string key)
 		{
 			var bucket = this.TryGet<BucketAggregate>(key);

--- a/src/Nest/Aggregations/AggregationContainer.cs
+++ b/src/Nest/Aggregations/AggregationContainer.cs
@@ -138,6 +138,9 @@ namespace Nest
 		[JsonProperty("significant_terms")]
 		ISignificantTermsAggregation SignificantTerms { get; set; }
 
+		[JsonProperty("significant_text")]
+		ISignificantTextAggregation SignificantText { get; set; }
+
 		[JsonProperty("value_count")]
 		IValueCountAggregation ValueCount { get; set; }
 
@@ -258,6 +261,8 @@ namespace Nest
 		public ITermsAggregation Terms { get; set; }
 
 		public ISignificantTermsAggregation SignificantTerms { get; set; }
+
+		public ISignificantTextAggregation SignificantText { get; set; }
 
 		public IPercentileRanksAggregation PercentileRanks { get; set; }
 
@@ -387,6 +392,8 @@ namespace Nest
 		IValueCountAggregation IAggregationContainer.ValueCount { get; set; }
 
 		ISignificantTermsAggregation IAggregationContainer.SignificantTerms { get; set; }
+
+		ISignificantTextAggregation IAggregationContainer.SignificantText { get; set; }
 
 		IPercentileRanksAggregation IAggregationContainer.PercentileRanks { get; set; }
 
@@ -533,6 +540,10 @@ namespace Nest
 		public AggregationContainerDescriptor<T> SignificantTerms(string name,
 			Func<SignificantTermsAggregationDescriptor<T>, ISignificantTermsAggregation> selector) =>
 			_SetInnerAggregation(name, selector, (a, d) => a.SignificantTerms = d);
+
+		public AggregationContainerDescriptor<T> SignificantText(string name,
+			Func<SignificantTextAggregationDescriptor<T>, ISignificantTextAggregation> selector) =>
+			_SetInnerAggregation(name, selector, (a, d) => a.SignificantText = d);
 
 		public AggregationContainerDescriptor<T> ValueCount(string name,
 			Func<ValueCountAggregationDescriptor<T>, IValueCountAggregation> selector) =>

--- a/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsIncludeExclude.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsIncludeExclude.cs
@@ -13,15 +13,9 @@ namespace Nest
 		[JsonIgnore]
 		public IEnumerable<string> Values { get; set; }
 
-		public SignificantTermsIncludeExclude(string pattern)
-		{
-			Pattern = pattern;
-		}
+		public SignificantTermsIncludeExclude(string pattern) => Pattern = pattern;
 
-		public SignificantTermsIncludeExclude(IEnumerable<string> values)
-		{
-			Values = values;
-		}
+		public SignificantTermsIncludeExclude(IEnumerable<string> values) => Values = values;
 	}
 
 	internal class SignificantTermsIncludeExcludeJsonConverter : JsonConverter

--- a/src/Nest/Aggregations/Bucket/SignificantText/SignificantTextAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantText/SignificantTextAggregation.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// An aggregation that returns interesting or unusual occurrences of free-text terms in a set.
+	/// </summary>
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	[ContractJsonConverter(typeof(AggregationJsonConverter<SignificantTextAggregation>))]
+	public interface ISignificantTextAggregation : IBucketAggregation
+	{
+		/// <summary>
+		/// The field on which to run the aggregation
+		/// </summary>
+		[JsonProperty("field")]
+		Field Field { get; set; }
+
+		/// <summary>
+		/// Defines how many term buckets should be returned out of the overall
+		/// terms list
+		/// </summary>
+		[JsonProperty("size")]
+		int? Size { get; set; }
+
+		/// <summary>
+		/// Controls the number of candidate terms produced by each shard from which
+		/// the <see cref="Size"/> of terms is selected.
+		/// </summary>
+		[JsonProperty("shard_size")]
+		int? ShardSize { get; set; }
+
+		/// <summary>
+		/// Return only terms that match equal to or more than a configurable
+		/// number of hits
+		/// </summary>
+		[JsonProperty("min_doc_count")]
+		long? MinimumDocumentCount { get; set; }
+
+		/// <summary>
+		/// Regulates the certainty a shard has if the term should actually be added to the candidate
+		/// list or not with respect to the <see cref="MinimumDocumentCount"/>.
+		/// Terms will only be considered if their local shard frequency within
+		/// the set is higher than the <see cref="ShardMinimumDocumentCount"/>.
+		/// </summary>
+		[JsonProperty("shard_min_doc_count")]
+		long? ShardMinimumDocumentCount { get; set; }
+
+		/// <summary>
+		/// Determines the mechanism by which aggregations are executed
+		/// </summary>
+		[JsonProperty("execution_hint")]
+		TermsAggregationExecutionHint? ExecutionHint { get; set; }
+
+		/// <summary>
+		/// Include term values for which buckets will be created.
+		/// </summary>
+		[JsonProperty("include")]
+		SignificantTermsIncludeExclude Include { get; set; }
+
+		/// <summary>
+		/// Exclude term values for which buckets will be created.
+		/// </summary>
+		[JsonProperty("exclude")]
+		SignificantTermsIncludeExclude Exclude { get; set; }
+
+		/// <summary>
+		/// Use mutual information to calculate significance score
+		/// </summary>
+		[JsonProperty("mutual_information")]
+		IMutualInformationHeuristic MutualInformation { get; set; }
+
+		/// <summary>
+		/// Use chi square to calculate significance score
+		/// </summary>
+		[JsonProperty("chi_square")]
+		IChiSquareHeuristic ChiSquare { get; set; }
+
+		/// <summary>
+		/// Use Google normalized distance to calculate significance score
+		/// </summary>
+		[JsonProperty("gnd")]
+		IGoogleNormalizedDistanceHeuristic GoogleNormalizedDistance { get; set; }
+
+		/// <summary>
+		/// Use percentage to calculate significance score.
+		/// <para>A simple calculation of the number of documents in the foreground
+		/// sample with a term divided by the number of documents in the background
+		/// with the term. By default this produces a score greater than zero
+		///  and less than one.</para>
+		/// </summary>
+		[JsonProperty("percentage")]
+		IPercentageScoreHeuristic PercentageScore { get; set; }
+
+		/// <summary>
+		/// Use a script to calculate a custom significance score.
+		/// </summary>
+		[JsonProperty("script_heuristic")]
+		IScriptedHeuristic Script { get; set; }
+
+		/// <summary>
+		/// The default source of statistical information for background term
+		/// frequencies is the entire index. This scope can be narrowed
+		/// through the use of a background filter to focus in on significant
+		/// terms within a narrower context
+		/// </summary>
+		[JsonProperty("background_filter")]
+		QueryContainer BackgroundFilter { get; set; }
+
+		/// <summary>
+		/// Whether to filter out near-duplicate text
+		/// </summary>
+		[JsonProperty("filter_duplicate_text")]
+		bool? FilterDuplicateText { get; set; }
+
+		/// <summary>
+		/// Ordinarily the indexed field name and the original JSON field being
+		/// retrieved share the same name. However with more complex field
+		/// mappings using features like copy_to the source JSON field(s)
+		/// and the indexed field being aggregated can differ.
+		/// In these cases it is possible to list the JSON _source fields
+		/// from which text will be analyzed using <see cref="SourceFields"/>
+		/// </summary>
+		[JsonProperty("source_fields")]
+		Fields SourceFields { get; set; }
+	}
+
+	/// <inheritdoc cref="ISignificantTextAggregation"/>
+	public class SignificantTextAggregation : BucketAggregationBase, ISignificantTextAggregation
+	{
+		/// <inheritdoc />
+		public Field Field { get; set; }
+		/// <inheritdoc />
+		public int? Size { get; set; }
+		/// <inheritdoc />
+		public int? ShardSize { get; set; }
+		/// <inheritdoc />
+		public long? MinimumDocumentCount { get; set; }
+		/// <inheritdoc />
+		public long? ShardMinimumDocumentCount { get; set; }
+		/// <inheritdoc />
+		public TermsAggregationExecutionHint? ExecutionHint { get; set; }
+		/// <inheritdoc />
+		public SignificantTermsIncludeExclude Include { get; set; }
+		/// <inheritdoc />
+		public SignificantTermsIncludeExclude Exclude { get; set; }
+		/// <inheritdoc />
+		public IMutualInformationHeuristic MutualInformation { get; set; }
+		/// <inheritdoc />
+		public IChiSquareHeuristic ChiSquare { get; set; }
+		/// <inheritdoc />
+		public IGoogleNormalizedDistanceHeuristic GoogleNormalizedDistance { get; set; }
+		/// <inheritdoc />
+		public IPercentageScoreHeuristic PercentageScore { get; set; }
+		/// <inheritdoc />
+		public IScriptedHeuristic Script { get; set; }
+		/// <inheritdoc />
+		public QueryContainer BackgroundFilter { get; set; }
+		/// <inheritdoc />
+		public bool? FilterDuplicateText { get; set; }
+		/// <inheritdoc />
+		public Fields SourceFields { get; set; }
+
+		internal SignificantTextAggregation() { }
+
+		public SignificantTextAggregation(string name) : base(name) { }
+
+		internal override void WrapInContainer(AggregationContainer c) => c.SignificantText = this;
+	}
+
+	/// <inheritdoc cref="ISignificantTextAggregation"/>
+	public class SignificantTextAggregationDescriptor<T>
+		: BucketAggregationDescriptorBase<SignificantTextAggregationDescriptor<T>, ISignificantTextAggregation, T>
+			, ISignificantTextAggregation
+		where T : class
+	{
+		Field ISignificantTextAggregation.Field { get; set; }
+
+		int? ISignificantTextAggregation.Size { get; set; }
+
+		int? ISignificantTextAggregation.ShardSize { get; set; }
+
+		long? ISignificantTextAggregation.MinimumDocumentCount { get; set; }
+
+		long? ISignificantTextAggregation.ShardMinimumDocumentCount { get; set; }
+
+		TermsAggregationExecutionHint? ISignificantTextAggregation.ExecutionHint { get; set; }
+
+		SignificantTermsIncludeExclude ISignificantTextAggregation.Include { get; set; }
+
+		SignificantTermsIncludeExclude ISignificantTextAggregation.Exclude { get; set; }
+
+		IMutualInformationHeuristic ISignificantTextAggregation.MutualInformation { get; set; }
+
+		IChiSquareHeuristic ISignificantTextAggregation.ChiSquare { get; set; }
+
+		IGoogleNormalizedDistanceHeuristic ISignificantTextAggregation.GoogleNormalizedDistance { get; set; }
+
+		IPercentageScoreHeuristic ISignificantTextAggregation.PercentageScore { get; set; }
+
+		IScriptedHeuristic ISignificantTextAggregation.Script { get; set; }
+
+		QueryContainer ISignificantTextAggregation.BackgroundFilter { get; set; }
+
+		bool? ISignificantTextAggregation.FilterDuplicateText { get; set; }
+
+		Fields ISignificantTextAggregation.SourceFields { get; set; }
+
+		/// <inheritdoc cref="ISignificantTextAggregation.Field"/>
+		public SignificantTextAggregationDescriptor<T> Field(Field field) => Assign(a => a.Field = field);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.Field"/>
+		public SignificantTextAggregationDescriptor<T> Field(Expression<Func<T, object>> field) => Assign(a => a.Field = field);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.Size"/>
+		public SignificantTextAggregationDescriptor<T> Size(int? size) => Assign(a => a.Size = size);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.ExecutionHint"/>
+		public SignificantTextAggregationDescriptor<T> ExecutionHint(TermsAggregationExecutionHint? hint) => Assign(a => a.ExecutionHint = hint);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.Include"/>
+		public SignificantTextAggregationDescriptor<T> Include(string includePattern) =>
+			Assign(a => a.Include = new SignificantTermsIncludeExclude(includePattern));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.Include"/>
+		public SignificantTextAggregationDescriptor<T> Include(IEnumerable<string> values) =>
+			Assign(a => a.Include = new SignificantTermsIncludeExclude(values));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.Exclude"/>
+		public SignificantTextAggregationDescriptor<T> Exclude(string excludePattern) =>
+			Assign(a => a.Exclude = new SignificantTermsIncludeExclude(excludePattern));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.Exclude"/>
+		public SignificantTextAggregationDescriptor<T> Exclude(IEnumerable<string> values) =>
+			Assign(a => a.Exclude = new SignificantTermsIncludeExclude(values));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.ShardSize"/>
+		public SignificantTextAggregationDescriptor<T> ShardSize(int? shardSize) => Assign(a => a.ShardSize = shardSize);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.MinimumDocumentCount"/>
+		public SignificantTextAggregationDescriptor<T> MinimumDocumentCount(long? minimumDocumentCount) =>
+			Assign(a => a.MinimumDocumentCount = minimumDocumentCount);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.ShardMinimumDocumentCount"/>
+		public SignificantTextAggregationDescriptor<T> ShardMinimumDocumentCount(long? shardMinimumDocumentCount) =>
+			Assign(a => a.ShardMinimumDocumentCount = shardMinimumDocumentCount);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.MutualInformation"/>
+		public SignificantTextAggregationDescriptor<T> MutualInformation(Func<MutualInformationHeuristicDescriptor, IMutualInformationHeuristic> mutualInformationSelector = null) =>
+			Assign(a => a.MutualInformation = mutualInformationSelector.InvokeOrDefault(new MutualInformationHeuristicDescriptor()));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.ChiSquare"/>
+		public SignificantTextAggregationDescriptor<T> ChiSquare(Func<ChiSquareHeuristicDescriptor, IChiSquareHeuristic> chiSquareSelector) =>
+			Assign(a => a.ChiSquare = chiSquareSelector.InvokeOrDefault(new ChiSquareHeuristicDescriptor()));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.GoogleNormalizedDistance"/>
+		public SignificantTextAggregationDescriptor<T> GoogleNormalizedDistance(Func<GoogleNormalizedDistanceHeuristicDescriptor, IGoogleNormalizedDistanceHeuristic> gndSelector) =>
+			Assign(a => a.GoogleNormalizedDistance = gndSelector.InvokeOrDefault(new GoogleNormalizedDistanceHeuristicDescriptor()));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.PercentageScore"/>
+		public SignificantTextAggregationDescriptor<T> PercentageScore(Func<PercentageScoreHeuristicDescriptor, IPercentageScoreHeuristic> percentageScoreSelector) =>
+			Assign(a => a.PercentageScore = percentageScoreSelector.InvokeOrDefault(new PercentageScoreHeuristicDescriptor()));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.Script"/>
+		public SignificantTextAggregationDescriptor<T> Script(Func<ScriptedHeuristicDescriptor, IScriptedHeuristic> scriptSelector) =>
+			Assign(a => a.Script = scriptSelector?.Invoke(new ScriptedHeuristicDescriptor()));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.BackgroundFilter"/>
+		public SignificantTextAggregationDescriptor<T> BackgroundFilter(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
+			Assign(a => a.BackgroundFilter = selector?.Invoke(new QueryContainerDescriptor<T>()));
+
+		/// <inheritdoc cref="ISignificantTextAggregation.FilterDuplicateText"/>
+		public SignificantTextAggregationDescriptor<T> FilterDuplicateText(bool? filterDuplicateText = true) => Assign(a => a.FilterDuplicateText = filterDuplicateText);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.SourceFields"/>
+		public SignificantTextAggregationDescriptor<T> SourceFields(Func<FieldsDescriptor<T>, IPromise<Fields>> sourceFields) =>
+			Assign(a => a.SourceFields = sourceFields?.Invoke(new FieldsDescriptor<T>())?.Value);
+
+		/// <inheritdoc cref="ISignificantTextAggregation.SourceFields"/>
+		public SignificantTextAggregationDescriptor<T> SourceFields(Fields sourceFields) => Assign(a => a.SourceFields = sourceFields);
+
+	}
+}

--- a/src/Nest/Aggregations/Visitor/AggregationVisitor.cs
+++ b/src/Nest/Aggregations/Visitor/AggregationVisitor.cs
@@ -54,6 +54,7 @@ namespace Nest
 		void Visit(IRangeAggregation aggregation);
 		void Visit(ITermsAggregation aggregation);
 		void Visit(ISignificantTermsAggregation aggregation);
+		void Visit(ISignificantTextAggregation aggregation);
 		void Visit(IPercentileRanksAggregation aggregation);
 		void Visit(ITopHitsAggregation aggregation);
 		void Visit(IChildrenAggregation aggregation);
@@ -127,6 +128,10 @@ namespace Nest
 		}
 
 		public virtual void Visit(ITermsAggregation aggregation)
+		{
+		}
+
+		public void Visit(ISignificantTextAggregation aggregation)
 		{
 		}
 

--- a/src/Nest/Aggregations/Visitor/AggregationWalker.cs
+++ b/src/Nest/Aggregations/Visitor/AggregationWalker.cs
@@ -71,6 +71,7 @@ namespace Nest
 			AcceptAggregation(aggregation.ScriptedMetric, visitor, (v, d) => v.Visit(d));
 			AcceptAggregation(aggregation.SerialDifferencing, visitor, (v, d) => v.Visit(d));
 			AcceptAggregation(aggregation.SignificantTerms, visitor, (v, d) => { v.Visit(d); this.Accept(v, d.Aggregations); });
+			AcceptAggregation(aggregation.SignificantText, visitor, (v, d) => { v.Visit(d); this.Accept(v, d.Aggregations); });
 			AcceptAggregation(aggregation.Stats, visitor, (v, d) => v.Visit(d));
 			AcceptAggregation(aggregation.Sum, visitor, (v, d) => v.Visit(d));
 			AcceptAggregation(aggregation.SumBucket, visitor, (v, d) => v.Visit(d));

--- a/src/Tests/Aggregations/Bucket/SignificantText/SignificantTextAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Bucket/SignificantText/SignificantTextAggregationUsageTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using Tests.Framework.MockData;
+
+namespace Tests.Aggregations.Bucket.SignificantText
+{
+	/**
+	 * An aggregation that returns interesting or unusual occurrences of free-text
+	 * terms in a set. It is like the significant terms aggregation but differs in that:
+	 *
+	 * . It is specifically designed for use on type text fields
+	 * . It does not require field data or doc-values
+	 * . It re-analyzes text content on-the-fly meaning it can also filter duplicate sections of noisy text that otherwise tend to skew statistics.
+	 *
+	 * WARNING
+	 * --
+	 * Re-analyzing large result sets will require a lot of time and memory.
+	 * It is recommended that the significant_text aggregation is used
+	 * as a child of either the sampler or diversified sampler aggregation to
+	 * limit the analysis to a small selection of top-matching documents
+	 * e.g. 200. This will typically improve speed, memory use and quality
+	 * of results.
+	 * --
+	 *
+	 * See the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-significanttext-aggregation.html[significant text aggregation] for more detail.
+	 */
+	public class SignificantTextAggregationUsageTests : AggregationUsageTestBase
+	{
+		public SignificantTextAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		private readonly string _firstTenDescriptions =
+			string.Join(" ", Project.First.Description.Split(' ').Distinct().Take(1024));
+
+		protected override object AggregationJson => new
+		{
+			significant_descriptions = new
+			{
+				significant_text = new
+				{
+					field = "description",
+					filter_duplicate_text = true
+				}
+			}
+		};
+
+		protected override object QueryScopeJson => new
+		{
+			match = new
+			{
+				description = new
+				{
+					query = _firstTenDescriptions
+				}
+			}
+		};
+
+		protected override QueryContainer QueryScope => new MatchQuery
+		{
+			Field = Infer.Field<Project>(p => p.Description),
+			Query = _firstTenDescriptions
+		};
+
+		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
+			.SignificantText("significant_descriptions", st => st
+				.Field(p => p.Description)
+				.FilterDuplicateText()
+			);
+
+		protected override AggregationDictionary InitializerAggs =>
+			new SignificantTextAggregation("significant_descriptions")
+			{
+				Field = Infer.Field<Project>(p => p.Description),
+				FilterDuplicateText = true
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.ShouldBeValid();
+			var sigNames = response.Aggregations.SignificantText("significant_descriptions");
+			sigNames.Should().NotBeNull();
+			sigNames.DocCount.Should().BeGreaterThan(0);
+			foreach (var bucket in sigNames.Buckets)
+			{
+				bucket.Key.Should().NotBeNullOrEmpty();
+				bucket.BgCount.Should().BeGreaterThan(0);
+				bucket.DocCount.Should().BeGreaterThan(0);
+				bucket.Score.Should().BeGreaterThan(0);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Backport of #3200

Preserves type name of `SignificantTermsIncludeExclude` instead of newly named `IncludeExclude`