### PR TITLE
Fix indentation in the tweet example (readme.md)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,7 +142,7 @@ Indexing a document is as simple as (with 6.x):
 ```csharp
 var tweet = new Tweet
 {
-	Id = 1,
+    Id = 1,
     User = "kimchy",
     PostDate = new DateTime(2009, 11, 15),
     Message = "Trying out NEST, so far so good?"


### PR DESCRIPTION
Hi 

It seems that the indentation in the tweet example (Readme.md) is broken. I believe that this file is not autogenerated, so probably it's a correct place to fix it.

This change will make it consistent with the indentation in other lines.