### PR TITLE
Obsolete IgnoreUnmapped on IGeoShape

### DIFF
--- a/src/Nest/QueryDsl/Geo/Shape/Circle/GeoShapeCircleQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Circle/GeoShapeCircleQuery.cs
@@ -22,7 +22,6 @@ namespace Nest
 #pragma warning disable 618
 				if (value?.IgnoreUnmapped != null)
 				{
-
 					IgnoreUnmapped = value.IgnoreUnmapped;
 					value.IgnoreUnmapped = null;
 				}

--- a/src/Nest/QueryDsl/Geo/Shape/Circle/GeoShapeCircleQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Circle/GeoShapeCircleQuery.cs
@@ -11,8 +11,25 @@ namespace Nest
 
 	public class GeoShapeCircleQuery : GeoShapeQueryBase, IGeoShapeCircleQuery
 	{
+		private ICircleGeoShape _shape;
 		protected override bool Conditionless => IsConditionless(this);
-		public ICircleGeoShape Shape { get; set; }
+
+		public ICircleGeoShape Shape
+		{
+			get => _shape;
+			set
+			{
+#pragma warning disable 618
+				if (value?.IgnoreUnmapped != null)
+				{
+
+					IgnoreUnmapped = value.IgnoreUnmapped;
+					value.IgnoreUnmapped = null;
+				}
+#pragma warning restore 618
+				_shape = value;
+			}
+		}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 
@@ -30,21 +47,21 @@ namespace Nest
 		{
 			a.Shape = a.Shape ?? new CircleGeoShape();
 			a.Shape.Coordinates = coordinates;
-			a.Shape.IgnoreUnmapped = ignoreUnmapped;
+			a.IgnoreUnmapped = ignoreUnmapped;
 		});
 
 		public GeoShapeCircleQueryDescriptor<T> Coordinates(double longitude, double latitude, bool? ignoreUnmapped = null) => Assign(a =>
 		{
 			a.Shape = a.Shape ?? new CircleGeoShape();
 			a.Shape.Coordinates = new GeoCoordinate(latitude, longitude);
-			a.Shape.IgnoreUnmapped = ignoreUnmapped;
+			a.IgnoreUnmapped = ignoreUnmapped;
 		});
 
 		public GeoShapeCircleQueryDescriptor<T> Radius(string radius, bool? ignoreUnmapped = null) => Assign(a =>
 		{
 			a.Shape = a.Shape ?? new CircleGeoShape();
 			a.Shape.Radius = radius;
-			a.Shape.IgnoreUnmapped = ignoreUnmapped;
+			a.IgnoreUnmapped = ignoreUnmapped;
 		});
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/Envelope/GeoShapeEnvelopeQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Envelope/GeoShapeEnvelopeQuery.cs
@@ -12,8 +12,25 @@ namespace Nest
 
 	public class GeoShapeEnvelopeQuery : GeoShapeQueryBase, IGeoShapeEnvelopeQuery
 	{
+		private IEnvelopeGeoShape _shape;
 		protected override bool Conditionless => IsConditionless(this);
-		public IEnvelopeGeoShape Shape { get; set; }
+
+		public IEnvelopeGeoShape Shape
+		{
+			get => _shape;
+			set
+			{
+#pragma warning disable 618
+				if (value?.IgnoreUnmapped != null)
+				{
+
+					IgnoreUnmapped = value.IgnoreUnmapped;
+					value.IgnoreUnmapped = null;
+				}
+#pragma warning restore 618
+				_shape = value;
+			}
+		}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 		internal static bool IsConditionless(IGeoShapeEnvelopeQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
@@ -30,7 +47,7 @@ namespace Nest
 		{
 			a.Shape = a.Shape ?? new EnvelopeGeoShape();
 			a.Shape.Coordinates = coordinates;
-			a.Shape.IgnoreUnmapped = ignoreUnmapped;
+			a.IgnoreUnmapped = ignoreUnmapped;
 		});
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/Envelope/GeoShapeEnvelopeQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Envelope/GeoShapeEnvelopeQuery.cs
@@ -23,7 +23,6 @@ namespace Nest
 #pragma warning disable 618
 				if (value?.IgnoreUnmapped != null)
 				{
-
 					IgnoreUnmapped = value.IgnoreUnmapped;
 					value.IgnoreUnmapped = null;
 				}

--- a/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
@@ -20,6 +20,7 @@ namespace Nest
 		/// This can be useful when querying multiple indexes which might have different mappings.
 		/// </summary>
 		[JsonProperty("ignore_unmapped")]
+		[Obsolete("Removed in NEST 7.x. Use IgnoreUnmapped on IGeoShapeQuery")]
 		bool? IgnoreUnmapped { get; set; }
 	}
 
@@ -31,6 +32,7 @@ namespace Nest
 		public string Type { get; protected set; }
 
 		/// <inheritdoc />
+		[Obsolete("Removed in NEST 7.x. Use IgnoreUnmapped on IGeoShapeQuery")]
 		public bool? IgnoreUnmapped { get; set; }
 	}
 

--- a/src/Nest/QueryDsl/Geo/Shape/GeoShapeQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeoShapeQueryJsonConverter.cs
@@ -7,14 +7,15 @@ using Newtonsoft.Json.Linq;
 namespace Nest
 {
 	/// <summary>
-	/// Marks an instance where _name and boost do not exist as children of the variable field but as siblings
+	/// Marks an instance where _name, boost and ignore_unmapped do
+	/// not exist as children of the variable field but as siblings
 	/// </summary>
-	internal class GeoShapeQueryFieldNameConverter : FieldNameQueryJsonConverter<GeoShapeCircleQuery>
+	internal class GeoShapeQueryFieldNameConverter : ReserializeJsonConverter<GeoShapeCircleQuery, IGeoShapeQuery>
 	{
-		private static readonly string[] SkipProperties = {"boost", "_name"};
+		private static readonly string[] SkipProperties = {"boost", "_name", "ignore_unmapped"};
 		protected override bool SkipWriteProperty(string propertyName) => SkipProperties.Contains(propertyName);
 
-		protected override void SerializeJson(JsonWriter writer, object value, IFieldNameQuery castValue, JsonSerializer serializer)
+		protected override void SerializeJson(JsonWriter writer, object value, IGeoShapeQuery castValue, JsonSerializer serializer)
 		{
 			var fieldName = castValue.Field;
 			if (fieldName == null) return;
@@ -26,8 +27,10 @@ namespace Nest
 			writer.WriteStartObject();
 			var name = castValue.Name;
 			var boost = castValue.Boost;
+			var ignoreUnmapped = castValue.IgnoreUnmapped;
 			if (!name.IsNullOrEmpty()) writer.WriteProperty(serializer, "_name", name);
 			if (boost != null) writer.WriteProperty(serializer, "boost", boost);
+			if (ignoreUnmapped != null) writer.WriteProperty(serializer, "ignore_unmapped", ignoreUnmapped);
 			writer.WritePropertyName(field);
 			this.Reserialize(writer, value, serializer);
 			writer.WriteEndObject();
@@ -40,6 +43,14 @@ namespace Nest
 		public override bool CanRead => true;
 		public override bool CanWrite => false;
 
+		public virtual T GetCoordinates<T>(JToken shape, JsonSerializer serializer)
+		{
+			var coordinates = shape["coordinates"];
+			return coordinates != null
+				? coordinates.ToObject<T>(serializer)
+				: default(T);
+		}
+
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var j = JObject.Load(reader);
@@ -47,15 +58,21 @@ namespace Nest
 
 			double? boost = null;
 			string name  = null;
-			if (j.TryGetValue("boost", out var b) && (b.Type != JTokenType.Array && b.Type != JTokenType.Object))
+			bool? ignoreUnmapped = null;
+			if (j.TryGetValue("boost", out var boostToken) && (boostToken.Type != JTokenType.Array && boostToken.Type != JTokenType.Object))
 			{
 				j.Remove("boost");
-				boost = b.Value<double?>();
+				boost = boostToken.Value<double?>();
 			}
-			if (j.TryGetValue("_name", out var n) && n.Type == JTokenType.String)
+			if (j.TryGetValue("_name", out var nameToken) && nameToken.Type == JTokenType.String)
 			{
 				j.Remove("_name");
-				name = n.Value<string>();
+				name = nameToken.Value<string>();
+			}
+			if (j.TryGetValue("ignore_unmapped", out var ignoreUnmappedToken) && ignoreUnmappedToken.Type == JTokenType.Boolean)
+			{
+				j.Remove("ignore_unmapped");
+				ignoreUnmapped = ignoreUnmappedToken.Value<bool?>();
 			}
 			var firstProp = j.Properties().FirstOrDefault();
 			if (firstProp == null) return null;
@@ -77,6 +94,7 @@ namespace Nest
 			query.Name = name;
 			query.Field = field;
 			query.Relation = relation;
+			query.IgnoreUnmapped = ignoreUnmapped;
 			return query;
 		}
 
@@ -87,61 +105,27 @@ namespace Nest
 		{
 			var type = shape["type"];
 			var typeName = type?.Value<string>();
-			var ignoreUnmapped = shape["ignore_unmapped"]?.Value<bool?>();
-
 			var geometry = GeoShapeConverter.ReadJToken(shape, serializer);
-
 			switch (typeName)
 			{
 				case "circle":
-					return new GeoShapeCircleQuery
-					{
-						Shape = SetIgnoreUnmapped(geometry as ICircleGeoShape, ignoreUnmapped)
-					};
+					return new GeoShapeCircleQuery { Shape = geometry as ICircleGeoShape };
 				case "envelope":
-					return new GeoShapeEnvelopeQuery
-					{
-						Shape = SetIgnoreUnmapped(geometry as IEnvelopeGeoShape, ignoreUnmapped)
-					};
+					return new GeoShapeEnvelopeQuery { Shape = geometry as IEnvelopeGeoShape };
 				case "linestring":
-					return new GeoShapeLineStringQuery
-					{
-						Shape = SetIgnoreUnmapped(geometry as ILineStringGeoShape, ignoreUnmapped)
-					};
+					return new GeoShapeLineStringQuery { Shape = geometry as ILineStringGeoShape };
 				case "multilinestring":
-					return new GeoShapeMultiLineStringQuery
-					{
-						Shape = SetIgnoreUnmapped(geometry as IMultiLineStringGeoShape, ignoreUnmapped)
-					};
+					return new GeoShapeMultiLineStringQuery { Shape = geometry as IMultiLineStringGeoShape };
 				case "point":
-					return new GeoShapePointQuery
-					{
-						Shape = SetIgnoreUnmapped(geometry as IPointGeoShape, ignoreUnmapped)
-					};
+					return new GeoShapePointQuery { Shape = geometry as IPointGeoShape };
 				case "multipoint":
-					return new GeoShapeMultiPointQuery
-					{
-						Shape = SetIgnoreUnmapped(geometry as IMultiPointGeoShape, ignoreUnmapped)
-					};
+					return new GeoShapeMultiPointQuery { Shape = geometry as IMultiPointGeoShape };
 				case "polygon":
-					return new GeoShapePolygonQuery
-					{
-						Shape = SetIgnoreUnmapped(geometry as IPolygonGeoShape, ignoreUnmapped)
-					};
+					return new GeoShapePolygonQuery { Shape = geometry as IPolygonGeoShape };
 				case "multipolygon":
-					return new GeoShapeMultiPolygonQuery
-					{
-						Shape = SetIgnoreUnmapped(geometry as IMultiPolygonGeoShape, ignoreUnmapped)
-					};
+					return new GeoShapeMultiPolygonQuery { Shape = geometry as IMultiPolygonGeoShape };
 				case "geometrycollection":
-					var geometryCollection = geometry as IGeometryCollection;
-					if (geometryCollection != null)
-					{
-						foreach (var innerGeometry in geometryCollection.Geometries)
-							SetIgnoreUnmapped(innerGeometry, ignoreUnmapped);
-					}
-
-					return new GeoShapeGeometryCollectionQuery { Shape = geometryCollection };
+					return new GeoShapeGeometryCollectionQuery { Shape = geometry as IGeometryCollection };
 				default:
 					return null;
 			}
@@ -149,12 +133,5 @@ namespace Nest
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) =>
 			throw new NotSupportedException();
-
-		private static TShape SetIgnoreUnmapped<TShape>(TShape shape, bool? ignoreUnmapped) where TShape : IGeoShape
-		{
-			if (shape != null)
-				shape.IgnoreUnmapped = ignoreUnmapped;
-			return shape;
-		}
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/GeometryCollection/GeometryCollection.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeometryCollection/GeometryCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -33,6 +34,7 @@ namespace Nest
 		string IGeoShape.Type => this.Type;
 
 		/// <inheritdoc />
+		[Obsolete("Removed in NEST 7.x. Use IgnoreUnmapped on IGeoShapeQuery")]
 		public bool? IgnoreUnmapped { get; set; }
 
 		/// <inheritdoc />

--- a/src/Nest/QueryDsl/Geo/Shape/IGeoShapeQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/IGeoShapeQuery.cs
@@ -12,15 +12,21 @@ namespace Nest
 		[JsonProperty("relation")]
 		GeoShapeRelation? Relation { get; set; }
 
+		/// <summary>
+		/// Will ignore an unmapped field and will not match any documents for this query.
+		/// This can be useful when querying multiple indexes which might have different mappings.
+		/// </summary>
+		[JsonProperty("ignore_unmapped")]
+		bool? IgnoreUnmapped { get; set; }
 	}
 
 	public abstract class GeoShapeQueryBase : FieldNameQueryBase, IGeoShapeQuery
 	{
-		/// <summary>
-		/// Controls the spatial relation operator to use at search time.
-		/// </summary>
+		/// <inheritdoc />
 		public GeoShapeRelation? Relation { get; set; }
 
+		/// <inheritdoc />
+		public bool? IgnoreUnmapped { get; set; }
 	}
 
 	public abstract class GeoShapeQueryDescriptorBase<TDescriptor, TInterface, T>
@@ -30,16 +36,12 @@ namespace Nest
 		where T : class
 	{
 		GeoShapeRelation? IGeoShapeQuery.Relation { get; set; }
+		bool? IGeoShapeQuery.IgnoreUnmapped { get; set; }
 
-		/// <summary>
-		/// Controls the spatial relation operator to used at search time.
-		/// </summary>
+		/// <inheritdoc cref="IGeoShapeQuery.Relation"/>
 		public TDescriptor Relation(GeoShapeRelation? relation) => Assign(a => a.Relation = relation);
 
-//		/// <summary>
-//		/// Will ignore an unmapped field and will not match any documents for this query.
-//		/// This can be useful when querying multiple indexes which might have different mappings.
-//		/// </summary>
-//		public TDescriptor IgnoreUnmapped(bool? ignoreUnmapped = true) => Assign(a => a.IgnoreUnmapped = ignoreUnmapped);
+		/// <inheritdoc cref="IGeoShapeQuery.IgnoreUnmapped"/>
+		public TDescriptor IgnoreUnmapped(bool? ignoreUnmapped = true) => Assign(a => a.IgnoreUnmapped = ignoreUnmapped);
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/LineString/GeoShapeLineStringQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/LineString/GeoShapeLineStringQuery.cs
@@ -12,8 +12,25 @@ namespace Nest
 
 	public class GeoShapeLineStringQuery : GeoShapeQueryBase, IGeoShapeLineStringQuery
 	{
+		private ILineStringGeoShape _shape;
 		protected override bool Conditionless => IsConditionless(this);
-		public ILineStringGeoShape Shape { get; set; }
+
+		public ILineStringGeoShape Shape
+		{
+			get => _shape;
+			set
+			{
+#pragma warning disable 618
+				if (value?.IgnoreUnmapped != null)
+				{
+
+					IgnoreUnmapped = value.IgnoreUnmapped;
+					value.IgnoreUnmapped = null;
+				}
+#pragma warning restore 618
+				_shape = value;
+			}
+		}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 		internal static bool IsConditionless(IGeoShapeLineStringQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
@@ -30,7 +47,7 @@ namespace Nest
 		{
 			a.Shape = a.Shape ?? new LineStringGeoShape();
 			a.Shape.Coordinates = coordinates;
-			a.Shape.IgnoreUnmapped = ignoreUnmapped;
+			a.IgnoreUnmapped = ignoreUnmapped;
 		});
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/LineString/GeoShapeLineStringQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/LineString/GeoShapeLineStringQuery.cs
@@ -23,7 +23,6 @@ namespace Nest
 #pragma warning disable 618
 				if (value?.IgnoreUnmapped != null)
 				{
-
 					IgnoreUnmapped = value.IgnoreUnmapped;
 					value.IgnoreUnmapped = null;
 				}

--- a/src/Nest/QueryDsl/Geo/Shape/MultiLineString/GeoShapeMultiLineStringQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiLineString/GeoShapeMultiLineStringQuery.cs
@@ -23,7 +23,6 @@ namespace Nest
 #pragma warning disable 618
 				if (value?.IgnoreUnmapped != null)
 				{
-
 					IgnoreUnmapped = value.IgnoreUnmapped;
 					value.IgnoreUnmapped = null;
 				}

--- a/src/Nest/QueryDsl/Geo/Shape/MultiLineString/GeoShapeMultiLineStringQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiLineString/GeoShapeMultiLineStringQuery.cs
@@ -12,8 +12,25 @@ namespace Nest
 
 	public class GeoShapeMultiLineStringQuery : GeoShapeQueryBase, IGeoShapeMultiLineStringQuery
 	{
+		private IMultiLineStringGeoShape _shape;
 		protected override bool Conditionless => IsConditionless(this);
-		public IMultiLineStringGeoShape Shape { get; set; }
+
+		public IMultiLineStringGeoShape Shape
+		{
+			get => _shape;
+			set
+			{
+#pragma warning disable 618
+				if (value?.IgnoreUnmapped != null)
+				{
+
+					IgnoreUnmapped = value.IgnoreUnmapped;
+					value.IgnoreUnmapped = null;
+				}
+#pragma warning restore 618
+				_shape = value;
+			}
+		}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 		internal static bool IsConditionless(IGeoShapeMultiLineStringQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
@@ -30,7 +47,7 @@ namespace Nest
 		{
 			a.Shape = a.Shape ?? new MultiLineStringGeoShape();
 			a.Shape.Coordinates = coordinates;
-			a.Shape.IgnoreUnmapped = ignoreUnmapped;
+			a.IgnoreUnmapped = ignoreUnmapped;
 		});
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/MultiPoint/GeoShapeMultiPointQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiPoint/GeoShapeMultiPointQuery.cs
@@ -23,7 +23,6 @@ namespace Nest
 #pragma warning disable 618
 				if (value?.IgnoreUnmapped != null)
 				{
-
 					IgnoreUnmapped = value.IgnoreUnmapped;
 					value.IgnoreUnmapped = null;
 				}

--- a/src/Nest/QueryDsl/Geo/Shape/MultiPoint/GeoShapeMultiPointQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiPoint/GeoShapeMultiPointQuery.cs
@@ -12,8 +12,25 @@ namespace Nest
 
 	public class GeoShapeMultiPointQuery : GeoShapeQueryBase, IGeoShapeMultiPointQuery
 	{
+		private IMultiPointGeoShape _shape;
 		protected override bool Conditionless => IsConditionless(this);
-		public IMultiPointGeoShape Shape { get; set; }
+
+		public IMultiPointGeoShape Shape
+		{
+			get => _shape;
+			set
+			{
+#pragma warning disable 618
+				if (value?.IgnoreUnmapped != null)
+				{
+
+					IgnoreUnmapped = value.IgnoreUnmapped;
+					value.IgnoreUnmapped = null;
+				}
+#pragma warning restore 618
+				_shape = value;
+			}
+		}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 		internal static bool IsConditionless(IGeoShapeMultiPointQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
@@ -30,7 +47,7 @@ namespace Nest
 		{
 			a.Shape = a.Shape ?? new MultiPointGeoShape();
 			a.Shape.Coordinates = coordinates;
-			a.Shape.IgnoreUnmapped = ignoreUnmapped;
+			a.IgnoreUnmapped = ignoreUnmapped;
 		});
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/MultiPolygon/GeoShapeMultiPolygonQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiPolygon/GeoShapeMultiPolygonQuery.cs
@@ -23,7 +23,6 @@ namespace Nest
 #pragma warning disable 618
 				if (value?.IgnoreUnmapped != null)
 				{
-
 					IgnoreUnmapped = value.IgnoreUnmapped;
 					value.IgnoreUnmapped = null;
 				}

--- a/src/Nest/QueryDsl/Geo/Shape/MultiPolygon/GeoShapeMultiPolygonQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/MultiPolygon/GeoShapeMultiPolygonQuery.cs
@@ -12,8 +12,25 @@ namespace Nest
 
 	public class GeoShapeMultiPolygonQuery : GeoShapeQueryBase, IGeoShapeMultiPolygonQuery
 	{
+		private IMultiPolygonGeoShape _shape;
 		protected override bool Conditionless => IsConditionless(this);
-		public IMultiPolygonGeoShape Shape { get; set; }
+
+		public IMultiPolygonGeoShape Shape
+		{
+			get => _shape;
+			set
+			{
+#pragma warning disable 618
+				if (value?.IgnoreUnmapped != null)
+				{
+
+					IgnoreUnmapped = value.IgnoreUnmapped;
+					value.IgnoreUnmapped = null;
+				}
+#pragma warning restore 618
+				_shape = value;
+			}
+		}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 		internal static bool IsConditionless(IGeoShapeMultiPolygonQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
@@ -27,7 +44,12 @@ namespace Nest
 		IMultiPolygonGeoShape IGeoShapeMultiPolygonQuery.Shape { get; set; }
 
 		public GeoShapeMultiPolygonQueryDescriptor<T> Coordinates(IEnumerable<IEnumerable<IEnumerable<GeoCoordinate>>> coordinates, bool? ignoreUnmapped = null) =>
-			Assign(a => a.Shape = new MultiPolygonGeoShape { Coordinates = coordinates, IgnoreUnmapped = ignoreUnmapped});
+			Assign(a =>
+			{
+				a.Shape = a.Shape ?? new MultiPolygonGeoShape();
+				a.Shape.Coordinates = coordinates;
+				a.IgnoreUnmapped = ignoreUnmapped;
+			});
 
 
 	}

--- a/src/Nest/QueryDsl/Geo/Shape/Point/GeoShapePointQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Point/GeoShapePointQuery.cs
@@ -11,8 +11,25 @@ namespace Nest
 
 	public class GeoShapePointQuery : GeoShapeQueryBase, IGeoShapePointQuery
 	{
+		private IPointGeoShape _shape;
 		protected override bool Conditionless => IsConditionless(this);
-		public IPointGeoShape Shape { get; set; }
+
+		public IPointGeoShape Shape
+		{
+			get => _shape;
+			set
+			{
+#pragma warning disable 618
+				if (value?.IgnoreUnmapped != null)
+				{
+
+					IgnoreUnmapped = value.IgnoreUnmapped;
+					value.IgnoreUnmapped = null;
+				}
+#pragma warning restore 618
+				_shape = value;
+			}
+		}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 		internal static bool IsConditionless(IGeoShapePointQuery q) => q.Field.IsConditionless() || q.Shape?.Coordinates == null;
@@ -26,9 +43,19 @@ namespace Nest
 		IPointGeoShape IGeoShapePointQuery.Shape { get; set; }
 
 		public GeoShapePointQueryDescriptor<T> Coordinates(GeoCoordinate coordinates, bool? ignoreUnmapped = null) =>
-			Assign(a => a.Shape = new PointGeoShape { Coordinates = coordinates });
+			Assign(a =>
+			{
+				a.Shape = a.Shape ?? new PointGeoShape();
+				a.Shape.Coordinates = coordinates;
+				a.IgnoreUnmapped = ignoreUnmapped;
+			});
 
 		public GeoShapePointQueryDescriptor<T> Coordinates(double longitude, double latitude, bool? ignoreUnmapped = null) =>
-			Assign(a => a.Shape = new PointGeoShape { Coordinates = new GeoCoordinate(latitude, longitude), IgnoreUnmapped = ignoreUnmapped});
+			Assign(a =>
+			{
+				a.Shape = a.Shape ?? new PointGeoShape();
+				a.Shape.Coordinates = new GeoCoordinate(latitude, longitude);
+				a.IgnoreUnmapped = ignoreUnmapped;
+			});
 	}
 }

--- a/src/Nest/QueryDsl/Geo/Shape/Point/GeoShapePointQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Point/GeoShapePointQuery.cs
@@ -22,7 +22,6 @@ namespace Nest
 #pragma warning disable 618
 				if (value?.IgnoreUnmapped != null)
 				{
-
 					IgnoreUnmapped = value.IgnoreUnmapped;
 					value.IgnoreUnmapped = null;
 				}

--- a/src/Nest/QueryDsl/Geo/Shape/Polygon/GeoShapePolygonQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Polygon/GeoShapePolygonQuery.cs
@@ -23,7 +23,6 @@ namespace Nest
 #pragma warning disable 618
 				if (value?.IgnoreUnmapped != null)
 				{
-
 					IgnoreUnmapped = value.IgnoreUnmapped;
 					value.IgnoreUnmapped = null;
 				}

--- a/src/Nest/QueryDsl/Geo/Shape/Polygon/GeoShapePolygonQuery.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/Polygon/GeoShapePolygonQuery.cs
@@ -12,8 +12,25 @@ namespace Nest
 
 	public class GeoShapePolygonQuery : GeoShapeQueryBase, IGeoShapePolygonQuery
 	{
+		private IPolygonGeoShape _shape;
 		protected override bool Conditionless => IsConditionless(this);
-		public IPolygonGeoShape Shape { get; set; }
+
+		public IPolygonGeoShape Shape
+		{
+			get => _shape;
+			set
+			{
+#pragma warning disable 618
+				if (value?.IgnoreUnmapped != null)
+				{
+
+					IgnoreUnmapped = value.IgnoreUnmapped;
+					value.IgnoreUnmapped = null;
+				}
+#pragma warning restore 618
+				_shape = value;
+			}
+		}
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.GeoShape = this;
 		internal static bool IsConditionless(IGeoShapePolygonQuery q) => q.Field.IsConditionless() || q.Shape == null || !q.Shape.Coordinates.HasAny();
@@ -27,6 +44,11 @@ namespace Nest
 		IPolygonGeoShape IGeoShapePolygonQuery.Shape { get; set; }
 
 		public GeoShapePolygonQueryDescriptor<T> Coordinates(IEnumerable<IEnumerable<GeoCoordinate>> coordinates, bool? ignoreUnmapped = null) =>
-			Assign(a => a.Shape = new PolygonGeoShape { Coordinates = coordinates, IgnoreUnmapped = ignoreUnmapped });
+			Assign(a =>
+			{
+				a.Shape = a.Shape ?? new PolygonGeoShape();
+				a.Shape.Coordinates = coordinates;
+				a.IgnoreUnmapped = ignoreUnmapped;
+			});
 	}
 }

--- a/src/Tests/QueryDsl/Geo/GeoShapeQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/GeoShapeQueryUsageTests.cs
@@ -79,13 +79,13 @@ namespace Tests.QueryDsl.Geo
 				{
 					_name="named_query",
 					boost = 1.1,
+					ignore_unmapped = true,
 					envelope = new
 					{
 						relation = "intersects",
 						shape = new
 						{
 							type = "envelope",
-							ignore_unmapped = true,
 							coordinates = this._coordinates
 						}
 					}
@@ -105,8 +105,9 @@ namespace Tests.QueryDsl.Geo
 				Name = "named_query",
 				Boost = 1.1,
 				Field = Infer.Field<Framework.MockData.Shape>(p => p.Envelope),
-				Shape = new EnvelopeGeoShape(this._coordinates) { IgnoreUnmapped = true},
+				Shape = new EnvelopeGeoShape(this._coordinates),
 				Relation = GeoShapeRelation.Intersects,
+				IgnoreUnmapped = true
 			}
 		};
 
@@ -116,8 +117,9 @@ namespace Tests.QueryDsl.Geo
 					.Name("named_query")
 					.Boost(1.1)
 					.Field(p => p.Envelope)
-					.Coordinates(this._coordinates, ignoreUnmapped: true)
+					.Coordinates(this._coordinates)
 					.Relation(GeoShapeRelation.Intersects)
+					.IgnoreUnmapped()
 				)
 			);
 

--- a/src/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTestsBase.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTestsBase.cs
@@ -6,7 +6,7 @@ namespace Tests.QueryDsl
 {
 	public abstract class GeoShapeQueryUsageTestsBase : QueryDslUsageTestsBase
 	{
-		public GeoShapeQueryUsageTestsBase(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+		protected GeoShapeQueryUsageTestsBase(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
 		protected override object QueryJson => new
 		{

--- a/src/Tests/QueryDsl/Geo/Shape/Polygon/GeoShapePolygonQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/Geo/Shape/Polygon/GeoShapePolygonQueryUsageTests.cs
@@ -7,7 +7,7 @@ using static Nest.Infer;
 
 namespace Tests.QueryDsl.Geo.Shape.Polygon
 {
-	public class GeoShapePolygonQueryUsageTests : GeoShapeQueryUsageTestsBase
+	public class GeoShapePolygonQueryUsageTests : QueryDslUsageTestsBase
 	{
 		public GeoShapePolygonQueryUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
@@ -23,11 +23,23 @@ namespace Tests.QueryDsl.Geo.Shape.Polygon
 			}
 		};
 
-		protected override object ShapeJson => new
+		protected override object QueryJson => new
 		{
-			type = "polygon",
-			ignore_unmapped = true,
-			coordinates = this._coordinates
+			geo_shape = new
+			{
+				_name="named_query",
+				boost = 1.1,
+				ignore_unmapped = true,
+				location = new
+				{
+					relation = "intersects",
+					shape = new
+					{
+						type = "polygon",
+						coordinates = this._coordinates
+					}
+				}
+			}
 		};
 
 		protected override QueryContainer QueryInitializer => new GeoShapePolygonQuery
@@ -35,7 +47,9 @@ namespace Tests.QueryDsl.Geo.Shape.Polygon
 			Name = "named_query",
 			Boost = 1.1,
 			Field = Field<Project>(p => p.Location),
-			Shape = new PolygonGeoShape(this._coordinates) { IgnoreUnmapped = true},
+#pragma warning disable 618 // use of IgnoreUnmapped
+			Shape = new PolygonGeoShape(this._coordinates) { IgnoreUnmapped = true },
+#pragma warning restore 618
 			Relation = GeoShapeRelation.Intersects,
 		};
 


### PR DESCRIPTION
This commit deprecates IgnoreUnmapped on IGeoShape by applying Obsolete attribute.
IgnoreUnmapped exists at the same level as _name and boost on a geo_shape query.

Map IgnoreUnmapped from IGeoShape.IgnoreUnmapped to IGeoShapeQuery.IgnoreUnmapped if
assigned.