### PR TITLE
Add Visit methods for *_range properties

### DIFF
--- a/src/Nest/Mapping/Visitor/IMappingVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IMappingVisitor.cs
@@ -26,6 +26,7 @@ namespace Nest
 		void Visit(ILongRangeProperty property);
 		void Visit(IDoubleRangeProperty property);
 		void Visit(IDateRangeProperty property);
+		void Visit(IIpRangeProperty property);
 		void Visit(IJoinProperty property);
 	}
 
@@ -74,6 +75,8 @@ namespace Nest
 		public virtual void Visit(IDoubleRangeProperty property) { }
 
 		public virtual void Visit(IDateRangeProperty property) { }
+
+		public virtual void Visit(IIpRangeProperty property) { }
 
 		public virtual void Visit(IJoinProperty property) { }
 	}

--- a/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
@@ -18,6 +18,14 @@ namespace Nest
 		void Visit(IIpProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 		void Visit(IMurmur3HashProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 		void Visit(ITokenCountProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(IPercolatorProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(IIntegerRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(IFloatRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(ILongRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(IDoubleRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(IDateRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(IIpRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(IJoinProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		void Visit(IProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 

--- a/src/Nest/Mapping/Visitor/MappingWalker.cs
+++ b/src/Nest/Mapping/Visitor/MappingWalker.cs
@@ -201,6 +201,13 @@ namespace Nest
 							this.Accept(t.Fields);
 						});
 						break;
+					case FieldType.IpRange:
+						Visit<IIpRangeProperty>(field, t =>
+						{
+							this._visitor.Visit(t);
+							this.Accept(t.Fields);
+						});
+						break;
 					case FieldType.Join:
 						Visit<IJoinProperty>(field, t =>
 						{

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -32,6 +32,38 @@ namespace Nest
 		{
 		}
 
+		public void Visit(IPercolatorProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		{
+		}
+
+		public void Visit(IIntegerRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		{
+		}
+
+		public void Visit(IFloatRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		{
+		}
+
+		public void Visit(ILongRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		{
+		}
+
+		public void Visit(IDoubleRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		{
+		}
+
+		public void Visit(IDateRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		{
+		}
+
+		public void Visit(IIpRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		{
+		}
+
+		public void Visit(IJoinProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		{
+		}
+
 		public virtual void Visit(IIpProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
 		{
 		}
@@ -66,47 +98,75 @@ namespace Nest
 
 		public void Visit(IProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
 		{
-			if (type is INestedProperty nestedType)
-				Visit(nestedType, propertyInfo, attribute);
-
-			if (type is IObjectProperty objectType)
-				Visit(objectType, propertyInfo, attribute);
-
-			if (type is IBinaryProperty binaryType)
-				Visit(binaryType, propertyInfo, attribute);
-
-			if (type is IBooleanProperty booleanType)
-				Visit(booleanType, propertyInfo, attribute);
-
-			if (type is IDateProperty dateType)
-				Visit(dateType, propertyInfo, attribute);
-
-			if (type is INumberProperty numberType)
-				Visit(numberType, propertyInfo, attribute);
-
-			if (type is ITextProperty textType)
-				Visit(textType, propertyInfo, attribute);
-
-			if (type is IKeywordProperty keywordType)
-				Visit(keywordType, propertyInfo, attribute);
-
-			if (type is IGeoShapeProperty geoShapeType)
-				Visit(geoShapeType, propertyInfo, attribute);
-
-			if (type is IGeoPointProperty geoPointType)
-				Visit(geoPointType, propertyInfo, attribute);
-
-			if (type is ICompletionProperty completionType)
-				Visit(completionType, propertyInfo, attribute);
-
-			if (type is IIpProperty ipType)
-				Visit(ipType, propertyInfo, attribute);
-
-			if (type is IMurmur3HashProperty murmurType)
-				Visit(murmurType, propertyInfo, attribute);
-
-			if (type is ITokenCountProperty tokenCountType)
-				Visit(tokenCountType, propertyInfo, attribute);
+			switch (type)
+			{
+				case INestedProperty nestedType:
+					Visit(nestedType, propertyInfo, attribute);
+					break;
+				case IObjectProperty objectType:
+					Visit(objectType, propertyInfo, attribute);
+					break;
+				case IBinaryProperty binaryType:
+					Visit(binaryType, propertyInfo, attribute);
+					break;
+				case IBooleanProperty booleanType:
+					Visit(booleanType, propertyInfo, attribute);
+					break;
+				case IDateProperty dateType:
+					Visit(dateType, propertyInfo, attribute);
+					break;
+				case INumberProperty numberType:
+					Visit(numberType, propertyInfo, attribute);
+					break;
+				case ITextProperty textType:
+					Visit(textType, propertyInfo, attribute);
+					break;
+				case IKeywordProperty keywordType:
+					Visit(keywordType, propertyInfo, attribute);
+					break;
+				case IGeoShapeProperty geoShapeType:
+					Visit(geoShapeType, propertyInfo, attribute);
+					break;
+				case IGeoPointProperty geoPointType:
+					Visit(geoPointType, propertyInfo, attribute);
+					break;
+				case ICompletionProperty completionType:
+					Visit(completionType, propertyInfo, attribute);
+					break;
+				case IIpProperty ipType:
+					Visit(ipType, propertyInfo, attribute);
+					break;
+				case IMurmur3HashProperty murmurType:
+					Visit(murmurType, propertyInfo, attribute);
+					break;
+				case ITokenCountProperty tokenCountType:
+					Visit(tokenCountType, propertyInfo, attribute);
+					break;
+				case IPercolatorProperty percolatorType:
+					Visit(percolatorType, propertyInfo, attribute);
+					break;
+				case IJoinProperty joinType:
+					Visit(joinType, propertyInfo, attribute);
+					break;
+				case IIntegerRangeProperty integerRangeType:
+					Visit(integerRangeType, propertyInfo, attribute);
+					break;
+				case ILongRangeProperty longRangeType:
+					Visit(longRangeType, propertyInfo, attribute);
+					break;
+				case IDoubleRangeProperty doubleRangeType:
+					Visit(doubleRangeType, propertyInfo, attribute);
+					break;
+				case IFloatRangeProperty floatRangeType:
+					Visit(floatRangeType, propertyInfo, attribute);
+					break;
+				case IDateRangeProperty dateRangeType:
+					Visit(dateRangeType, propertyInfo, attribute);
+					break;
+				case IIpRangeProperty ipRangeType:
+					Visit(ipRangeType, propertyInfo, attribute);
+					break;
+			}
 		}
 	}
 }

--- a/src/Nest/Mapping/Visitor/PropertyWalker.cs
+++ b/src/Nest/Mapping/Visitor/PropertyWalker.cs
@@ -158,6 +158,9 @@ namespace Nest
 			if (type == typeof(IpRange))
 				return new IpRangeProperty();
 
+			if (type == typeof(QueryContainer))
+				return new PercolatorProperty();
+
 			return new ObjectProperty();
 		}
 

--- a/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/src/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -99,6 +99,7 @@ namespace Tests.Indices.MappingManagement.GetMapping
 			visitor.CountsShouldContainKeyAndCountBe("float_range", 1);
 			visitor.CountsShouldContainKeyAndCountBe("integer_range", 1);
 			visitor.CountsShouldContainKeyAndCountBe("long_range", 1);
+			visitor.CountsShouldContainKeyAndCountBe("ip_range", 1);
 			visitor.CountsShouldContainKeyAndCountBe("nested", 1);
 		}
 	}
@@ -226,6 +227,11 @@ namespace Tests.Indices.MappingManagement.GetMapping
 		public void Visit(IDateRangeProperty property)
 		{
 			Increment("date_range");
+		}
+
+		public void Visit(IIpRangeProperty property)
+		{
+			Increment("ip_range");
 		}
 
 		public void Visit(IJoinProperty property)


### PR DESCRIPTION
This commit adds mapping and property visitor methods for
the range data types.

Map a QueryContainer property as a percolator data type by default.