### PR TITLE
Fix HTTP method choice for index requests

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/Id/Id.cs
+++ b/src/Nest/CommonAbstractions/Infer/Id/Id.cs
@@ -30,12 +30,9 @@ namespace Nest
 
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings)
 		{
-			var nestSettings = settings as IConnectionSettingsValues;
-			return GetString(nestSettings);
+			var nestSettings = (IConnectionSettingsValues)settings;
+			return nestSettings.Inferrer.Id(this.Document) ?? this.StringOrLongValue;
 		}
-
-		private string GetString(IConnectionSettingsValues nestSettings) =>
-			this.Document != null ? nestSettings.Inferrer.Id(this.Document) : this.StringOrLongValue;
 
 		public bool Equals(Id other)
 		{

--- a/src/Nest/Document/Single/Index/IndexRequest.cs
+++ b/src/Nest/Document/Single/Index/IndexRequest.cs
@@ -19,7 +19,8 @@ namespace Nest
 
 		protected override HttpMethod HttpMethod => GetHttpMethod(this);
 
-		internal static HttpMethod GetHttpMethod(IIndexRequest<TDocument> request) => request.Id.IsConditionless() ? HttpMethod.POST : HttpMethod.PUT;
+		internal static HttpMethod GetHttpMethod(IIndexRequest<TDocument> request) =>
+			request.Id?.StringOrLongValue != null || request.RouteValues.Id != null ? HttpMethod.PUT: HttpMethod.POST;
 
 		partial void DocumentFromPath(TDocument document) => this.Document = document;
 
@@ -27,7 +28,6 @@ namespace Nest
 
 		void IProxyRequest.WriteJson(IElasticsearchSerializer sourceSerializer, Stream stream, SerializationFormatting formatting) =>
 			sourceSerializer.Serialize(this.Document, stream, formatting);
-
 	}
 
 	public partial class IndexDescriptor<TDocument>  where TDocument : class
@@ -41,7 +41,5 @@ namespace Nest
 
 		void IProxyRequest.WriteJson(IElasticsearchSerializer sourceSerializer, Stream stream, SerializationFormatting formatting) =>
 			sourceSerializer.Serialize(Self.Document, stream, formatting);
-
 	}
-
 }

--- a/src/Tests/Document/Single/Index/IndexUrlTests.cs
+++ b/src/Tests/Document/Single/Index/IndexUrlTests.cs
@@ -23,14 +23,11 @@ namespace Tests.Document.Single.Index
 					Document = project
 				}));
 
-			//no explit ID is provided and none can be inferred on the anonymous object so this falls back to a PUT to /index/type
-			await PUT("/project/doc")
-				.Fluent(c => c.Index(new { }, i => i.Index(typeof(Project)).Type(typeof(Project))))
-				.FluentAsync(c => c.IndexAsync(new { }, i => i.Index(typeof(Project)).Type(typeof(Project))));
-
-			//no explit ID is provided and document is not fed into DocumentPath using explicit OIS.
+			//no explicit ID is provided and none can be inferred on the anonymous object so this falls back to a POST to /index/type
 			await POST("/project/doc")
+				.Fluent(c => c.Index(new { }, i => i.Index(typeof(Project)).Type(typeof(Project))))
 				.Request(c => c.Index(new IndexRequest<object>("project", "doc") {Document = new { }}))
+				.FluentAsync(c => c.IndexAsync(new { }, i => i.Index(typeof(Project)).Type(typeof(Project))))
 				.RequestAsync(c => c.IndexAsync(new IndexRequest<object>(typeof(Project), TypeName.From<Project>())
 				{
 					Document = new { }


### PR DESCRIPTION
This commit fixes the selection of HTTP method for an index request based
on the presence of an explicilty set Id, or an Id value that can be inferred from
the document.

In the previous implementation, the IUrlParameter.GetString() method on the Id type
evaluated the Document to infer an Id from it, setting the internal Value of the Id to this
inferred value. As part of refactoring, this assignment was removed, which changes the
behaviour of the client when determining the HTTP method for an index request; in this
scenario, it is not enough to look to see if the Id type has a value, or that the Document is
not null, we need to know at this point that an Id can be inferred from the Document, and can
thereby send a PUT request.

An Id is inferred from the Document before the HTTP method is determined as part of resolving
RouteValues, so this commit changes the implementation to check if Id has a value, or
RouteValues.Id has a value.