### PR TITLE
Add GenericProperty.Indexed to support bool? values

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -48,8 +48,8 @@
 
     <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
     <PropertyGroup>
-      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
-      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketRestoreCacheFile)" | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketLockFilePath)" | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
     </PropertyGroup>
 
     <!-- If shasum and awk exist get the hashes -->

--- a/src/Nest/Mapping/Types/Specialized/Generic/GenericProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/Generic/GenericProperty.cs
@@ -11,8 +11,12 @@ namespace Nest
 	[JsonObject(MemberSerialization.OptIn)]
 	public interface IGenericProperty : IDocValuesProperty
 	{
-		[JsonProperty("index")]
+		[JsonIgnore]
+		[Obsolete("Please use Indexed. Will be fixed in NEST 7.x")]
 		FieldIndexOption? Index { get; set; }
+
+		[JsonProperty("index")]
+		bool? Indexed { get; set; }
 
 		[JsonProperty("term_vector")]
 		TermVectorOption? TermVector { get; set; }
@@ -52,6 +56,8 @@ namespace Nest
 	[DebuggerDisplay("{DebugDisplay}")]
 	public class GenericProperty : DocValuesPropertyBase, IGenericProperty
 	{
+		private FieldIndexOption? _index;
+
 		public GenericProperty() : base(FieldType.Object) => this.TypeOverride = null;
 
 		public TermVectorOption? TermVector { get; set; }
@@ -60,7 +66,31 @@ namespace Nest
 		public int? IgnoreAbove { get; set; }
 		public int? PositionIncrementGap { get; set; }
 		public IStringFielddata Fielddata { get; set; }
-		public FieldIndexOption? Index { get; set; }
+
+		[Obsolete("Please use Indexed. Will be fixed in NEST 7.x")]
+		public FieldIndexOption? Index
+		{
+			get => _index;
+			set
+			{
+				_index = value;
+				switch (_index)
+				{
+					case FieldIndexOption.Analyzed:
+					case FieldIndexOption.NotAnalyzed:
+						Indexed = true;
+						break;
+					case FieldIndexOption.No:
+						Indexed = false;
+						break;
+					default:
+						Indexed = null;
+						break;
+				}
+			}
+		}
+
+		public bool? Indexed { get; set; }
 		public string NullValue { get; set; }
 		public bool? Norms { get; set; }
 		public IndexOptions? IndexOptions { get; set; }
@@ -82,7 +112,31 @@ namespace Nest
 		: DocValuesPropertyDescriptorBase<GenericPropertyDescriptor<T>, IGenericProperty, T>, IGenericProperty
 		where T : class
 	{
-		FieldIndexOption? IGenericProperty.Index { get; set; }
+		private FieldIndexOption? _index;
+
+		FieldIndexOption? IGenericProperty.Index
+		{
+			get => _index;
+			set
+			{
+				_index = value;
+				switch (_index)
+				{
+					case FieldIndexOption.Analyzed:
+					case FieldIndexOption.NotAnalyzed:
+						Self.Indexed = true;
+						break;
+					case FieldIndexOption.No:
+						Self.Indexed = false;
+						break;
+					default:
+						Self.Indexed = null;
+						break;
+				}
+			}
+		}
+
+		bool? IGenericProperty.Indexed { get; set; }
 		TermVectorOption? IGenericProperty.TermVector { get; set; }
 		double? IGenericProperty.Boost { get; set; }
 		string IGenericProperty.NullValue { get; set; }
@@ -98,12 +152,16 @@ namespace Nest
 
 		public GenericPropertyDescriptor<T> Type(string type) => Assign(a => this.TypeOverride = type);
 
+		[Obsolete("Please use the overload that accepts bool?. Will be fixed in NEST 7.x")]
 		public GenericPropertyDescriptor<T> Index(FieldIndexOption? index = FieldIndexOption.NotAnalyzed) => Assign(a => a.Index = index);
+
+		public GenericPropertyDescriptor<T> Index(bool? index = true) => Assign(a => a.Indexed = index);
 
 		public GenericPropertyDescriptor<T> Boost(double? boost) => Assign(a => a.Boost = boost);
 
 		public GenericPropertyDescriptor<T> NullValue(string nullValue) => Assign(a => a.NullValue = nullValue);
 
+		[Obsolete("Deprecated. Will be removed in NEST 7.x")]
 		public GenericPropertyDescriptor<T> NotAnalyzed() => Index(FieldIndexOption.NotAnalyzed);
 
 		public GenericPropertyDescriptor<T> TermVector(TermVectorOption? termVector) => Assign(a => a.TermVector = termVector);

--- a/src/Tests/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateApiTests.cs
+++ b/src/Tests/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateApiTests.cs
@@ -49,7 +49,7 @@ namespace Tests.Indices.IndexSettings.IndexTemplates.PutIndexTemplate
 								match_mapping_type = "*",
 								mapping = new
 								{
-									index = "no"
+									index = false
 								}
 							}
 						}
@@ -74,7 +74,7 @@ namespace Tests.Indices.IndexSettings.IndexTemplates.PutIndexTemplate
 							.MatchMappingType("*")
 							.Mapping(mm => mm
 								.Generic(g => g
-									.Index(FieldIndexOption.No)
+									.Index(false)
 								)
 							)
 						)
@@ -106,7 +106,7 @@ namespace Tests.Indices.IndexSettings.IndexTemplates.PutIndexTemplate
 									MatchMappingType = "*",
 									Mapping = new GenericProperty
 									{
-										Index = FieldIndexOption.No
+										Indexed = false
 									}
 								}
 							}

--- a/src/Tests/Mapping/Types/Specialized/Generic/GenericPropertyTests.cs
+++ b/src/Tests/Mapping/Types/Specialized/Generic/GenericPropertyTests.cs
@@ -10,18 +10,18 @@ namespace Tests.Mapping.Types.Specialized.Generic
 		private const string GenericType = "{dynamic_type}";
 		public GenericPropertyTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
-		protected override object SingleMappingJson { get; } = new {index = "no", type= GenericType};
+		protected override object SingleMappingJson { get; } = new {index = false, type= GenericType};
 
 		protected override Func<SingleMappingSelector<object>, IProperty> FluentSingleMapping => m => m
 			.Generic(g => g
 				.Type(GenericType)
-				.Index(FieldIndexOption.No)
+				.Index(false)
 			);
 
 		protected override IProperty InitializerSingleMapping { get; } = new GenericProperty
 		{
 			Type = GenericType,
-			Index = FieldIndexOption.No
+			Indexed = false
 		};
 	}
 }


### PR DESCRIPTION
This commit adds `GenericProperty.Indexed` to allow a
`bool?` value to be specified for the field's "index" value,
in line with other properties.

Deprecate the usage of `GenericProperty.Index` and point users to users
`GenericProperty.Indexed`. If a user does continue to use `GenericProperty.Index`
however, set a value of `true` for `FieldIndexOption.Analyzed` and
`FieldIndexOption.NotAnalyzed`, `false` for `FieldIndexOption.No`, and `null` for `null`.

`GenericProperty.Index` will be updated to type `bool?` in 7.x in #3224 

Fixes #3103