### PR TITLE
Patch elasticsearch.bat for 6.2 versions

### DIFF
--- a/src/Tests/Framework/Configuration/Versions/ElasticsearchVersion.cs
+++ b/src/Tests/Framework/Configuration/Versions/ElasticsearchVersion.cs
@@ -40,6 +40,10 @@ namespace Tests.Framework.Versions
 				: new ElasticsearchVersion(version, resolver);
 		}
 
+		public static implicit operator ElasticsearchVersion(string version) => string.IsNullOrWhiteSpace(version)
+			? null
+			: Create(version);
+
 		internal ElasticsearchVersion(string version, ElasticsearchVersionResolver resolver)
 			: base(TranslateConfigVersion(version, resolver))
 		{

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/EnsureElasticsearchBatWorksAcrossDrives.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/InstallationTasks/EnsureElasticsearchBatWorksAcrossDrives.cs
@@ -1,0 +1,34 @@
+﻿using System.IO;
+using Tests.Framework.ManagedElasticsearch.Nodes;
+using Tests.Framework.Versions;
+
+namespace Tests.Framework.ManagedElasticsearch.Tasks.InstallationTasks
+{
+	/// <summary>
+	/// Fixes https://github.com/elastic/elasticsearch/issues/29057
+	/// </summary>
+	public class EnsureElasticsearchBatWorksAcrossDrives : InstallationTaskBase
+	{
+		private readonly ElasticsearchVersion _sixTwoZero = "6.2.0";
+		private readonly ElasticsearchVersion _sixThreeZero = "6.3.0";
+
+		public override void Run(NodeConfiguration config, NodeFileSystem fileSystem)
+		{
+			if (config.ElasticsearchVersion < _sixTwoZero || config.ElasticsearchVersion >= _sixThreeZero)
+				return;
+
+			var batFile = Path.Combine(fileSystem.ElasticsearchHome, "bin", "elasticsearch.bat");
+			var contents = File.ReadAllLines(batFile);
+			for (var i = 0; i < contents.Length; i++)
+			{
+				if (contents[i] == "cd \"%ES_HOME%\"")
+				{
+					contents[i] = "cd /d \"%ES_HOME%\"";
+					break;
+				}
+			}
+
+			File.WriteAllLines(batFile, contents);
+		}
+	}
+}

--- a/src/Tests/Framework/ManagedElasticsearch/Tasks/NodeTaskRunner.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Tasks/NodeTaskRunner.cs
@@ -29,6 +29,7 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks
 			new EnsureJavaHomeEnvironmentVariableIsSet(),
 			new DownloadCurrentElasticsearchDistribution(),
 			new UnzipCurrentElasticsearchDistribution(),
+			new EnsureElasticsearchBatWorksAcrossDrives(),
 			new CreateEasyRunBatFile(),
 			new InstallPlugins(),
 			new WriteAnalysisFiles(),
@@ -41,6 +42,7 @@ namespace Tests.Framework.ManagedElasticsearch.Tasks
 		{
 			new CreateEasyRunClusterBatFile()
 		};
+
 		private static IEnumerable<AfterNodeStoppedTaskBase> NodeStoppedTasks { get; } = new List<AfterNodeStoppedTaskBase>
 		{
 			new CleanUpDirectoriesAfterNodeStopped()


### PR DESCRIPTION
This commit patches the elasticsearch.bat file for 6.2 versions to include the
fix in PR https://github.com/elastic/elasticsearch/pull/29086