### PR TITLE
[DOCS] Fixes certutil command name

### DIFF
--- a/src/Tests/ClientConcepts/Certificates/WorkingWithCertificates.doc.cs
+++ b/src/Tests/ClientConcepts/Certificates/WorkingWithCertificates.doc.cs
@@ -108,7 +108,7 @@ namespace Tests.ClientConcepts.Certificates
 		 * If your client application has access to the public CA certificate locally, Elasticsearch.NET and NEST ship with some handy helpers
 		 * that can assert that a certificate the server presents is one that came from the local CA.
 		 *
-		 * If you use X-Pack's {ref_current}/certutil.html[+certutil+ tool] to generate SSL certificates, the generated node certificate
+		 * If you use X-Pack's {ref_current}/certutil.html[+elasticsearch-certutil+ tool] to generate SSL certificates, the generated node certificate
 		 * does not include the CA in the certificate chain, in order to cut down on SSL handshake size. In those case you can use
 		 * `CertificateValidations.AuthorityIsRoot` and pass it your local copy of the CA public key to assert that
 		 * the certificate the server presented was generated using it
@@ -173,11 +173,11 @@ namespace Tests.ClientConcepts.Certificates
 		 * ==== Client Certificates
 		 *
 		 * X-Pack also allows you to configure a {xpack_current}/pki-realm.html[PKI realm] to enable user authentication
-		 * through client certificates. The {ref_current}/certutil.html[+certutil+ tool] included with X-Pack allows you to
+		 * through client certificates. The {ref_current}/certutil.html[+elasticsearch-certutil+ tool] included with X-Pack allows you to
 		 * generate client certificates as well and assign the distinguished name (DN) of the
 		 * certificate to a user with a certain role.
 		 *
-		 * By default, the `certutil` tool only generates a public certificate (`.cer`) and a private key `.key`. To authenticate with client certificates, you need to present both
+		 * By default, the `elasticsearch-certutil` tool only generates a public certificate (`.cer`) and a private key `.key`. To authenticate with client certificates, you need to present both
 		 * as one certificate. The easiest way to do this is to generate a `pfx` or `p12` file from the `.cer` and `.key`
 		 * and attach these to requests using `new X509Certificate(pathToPfx)`.
 		 *


### PR DESCRIPTION
This PR fixes https://www.elastic.co/guide/en/elasticsearch/client/net-api/master/working-with-certificates.html such that it uses the command name "elasticsearch-certutil" instead of just "certutil". 