### PR TITLE
Add CompositeAggregation

### DIFF
--- a/docs/aggregations.asciidoc
+++ b/docs/aggregations.asciidoc
@@ -108,6 +108,8 @@ In addition to the buckets themselves, the bucket aggregations also compute and 
 
 * <<children-aggregation-usage,Children Aggregation Usage>>
 
+* <<composite-aggregation-usage,Composite Aggregation Usage>>
+
 * <<date-histogram-aggregation-usage,Date Histogram Aggregation Usage>>
 
 * <<date-range-aggregation-usage,Date Range Aggregation Usage>>
@@ -158,6 +160,8 @@ See the Elasticsearch documentation on {ref_current}/search-aggregations-bucket.
 include::aggregations/bucket/adjacency-matrix/adjacency-matrix-usage.asciidoc[]
 
 include::aggregations/bucket/children/children-aggregation-usage.asciidoc[]
+
+include::aggregations/bucket/composite/composite-aggregation-usage.asciidoc[]
 
 include::aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc[]
 

--- a/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
@@ -1,0 +1,199 @@
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/6.1
+
+:github: https://github.com/elastic/elasticsearch-net
+
+:nuget: https://www.nuget.org/packages
+
+////
+IMPORTANT NOTE
+==============
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs. 
+If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
+please modify the original csharp file found at the link and submit the PR with that change. Thanks!
+////
+
+[[composite-aggregation-usage]]
+=== Composite Aggregation Usage
+
+A multi-bucket aggregation that creates composite buckets from different sources.
+
+Unlike the other multi-bucket aggregation the composite aggregation can be
+used to paginate all buckets from a multi-level aggregation efficiently.
+This aggregation provides a way to stream all buckets of a specific aggregation
+similarly to what scroll does for documents.
+
+The composite buckets are built from the combinations of the values extracted/created
+for each document and each combination is considered as a composite bucket.
+
+NOTE: Only available in Elasticsearch 6.1.0+
+
+Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-composite-aggregation.html[Composite Aggregation].
+
+==== Fluent DSL example
+
+[source,csharp]
+----
+a => a
+.Composite("my_buckets", date => date
+    .Sources(s => s
+        .Terms("branches", t => t
+            .Field(f => f.Branches.Suffix("keyword"))
+        )
+        .DateHistogram("started", d => d
+            .Field(f => f.StartedOn)
+            .Interval(DateInterval.Month)
+        )
+        .Histogram("branch_count", h => h
+            .Field(f => f.RequiredBranches)
+            .Interval(1)
+        )
+    )
+    .Aggregations(childAggs => childAggs
+        .Nested("project_tags", n => n
+            .Path(p => p.Tags)
+            .Aggregations(nestedAggs => nestedAggs
+                .Terms("tags", avg => avg.Field(p => p.Tags.First().Name))
+            )
+        )
+    )
+)
+----
+
+==== Object Initializer syntax example
+
+[source,csharp]
+----
+new CompositeAggregation("my_buckets")
+{
+    Sources = new List<ICompositeAggregationSource>
+    {
+        new TermsCompositeAggregationSource("branches")
+        {
+            Field = Infer.Field<Project>(f => f.Branches.Suffix("keyword"))
+        },
+        new DateHistogramCompositeAggregationSource("started")
+        {
+            Field = Infer.Field<Project>(f => f.StartedOn),
+            Interval = DateInterval.Month
+        },
+        new HistogramCompositeAggregationSource("branch_count")
+        {
+            Field = Infer.Field<Project>(f => f.RequiredBranches),
+            Interval = 1
+        }
+    },
+    Aggregations = new NestedAggregation("project_tags")
+    {
+        Path = Field<Project>(p => p.Tags),
+        Aggregations = new TermsAggregation("tags")
+        {
+            Field = Field<Project>(p => p.Tags.First().Name)
+        }
+    }
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "my_buckets": {
+    "composite": {
+      "sources": [
+        {
+          "branches": {
+            "terms": {
+              "field": "branches.keyword"
+            }
+          }
+        },
+        {
+          "started": {
+            "date_histogram": {
+              "field": "startedOn",
+              "interval": "month"
+            }
+          }
+        },
+        {
+          "branch_count": {
+            "histogram": {
+              "field": "requiredBranches",
+              "interval": 1.0
+            }
+          }
+        }
+      ]
+    },
+    "aggs": {
+      "project_tags": {
+        "nested": {
+          "path": "tags"
+        },
+        "aggs": {
+          "tags": {
+            "terms": {
+              "field": "tags.name"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+----
+
+==== Handling Responses
+
+Each Composite aggregation buckey key is an `ILazyDocument` that can be converted
+to a type of your choosing. Here, we demonstrate converting to
+an `IDictionary<string, object>` and a `CompositeKey` type we have
+defined.
+
+[source,csharp]
+----
+public class CompositeKey
+{
+    public string Branches { get; set; }
+    public long Started { get; set; }
+    [PropertyName("branch_count"), JsonProperty("branch_count")]
+    public double BranchCount { get; set; }
+}
+----
+
+[source,csharp]
+----
+response.ShouldBeValid();
+
+var composite = response.Aggregations.Composite("my_buckets");
+composite.Should().NotBeNull();
+composite.Buckets.Should().NotBeNullOrEmpty();
+var count = 0;
+foreach (var item in composite.Buckets)
+{
+    count++;
+    if (count % 2 == 0)
+    {
+        var key = item.Key.As<IDictionary<string, object>>();
+        key.Should().NotBeNull().And.ContainKeys("branches", "started", "branch_count");
+    }
+    else
+    {
+        var key = item.Key.As<CompositeKey>();
+        key.Should().NotBeNull();
+        key.Branches.Should().NotBeNullOrEmpty();
+        /** note that date values are returned as `long` */
+        key.Started.Should().BeGreaterThan(0);
+        key.BranchCount.Should().BeGreaterThan(0);
+    }
+
+    item.DocCount.Should().BeGreaterThan(0);
+
+    var nested = item.Nested("project_tags");
+    nested.Should().NotBeNull();
+
+    var nestedTerms = nested.Terms("tags");
+    nestedTerms.Buckets.Count.Should().BeGreaterThan(0);
+}
+----
+

--- a/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
@@ -145,21 +145,8 @@ new CompositeAggregation("my_buckets")
 
 ==== Handling Responses
 
-Each Composite aggregation buckey key is an `ILazyDocument` that can be converted
-to a type of your choosing. Here, we demonstrate converting to
-an `IDictionary<string, object>` and a `CompositeKey` type we have
-defined.
-
-[source,csharp]
-----
-public class CompositeKey
-{
-    public string Branches { get; set; }
-    public long Started { get; set; }
-    [PropertyName("branch_count"), JsonProperty("branch_count")]
-    public double BranchCount { get; set; }
-}
-----
+Each Composite aggregation bucket key is an `CompositeKey`, a specialized
+`IReadOnlyDictionary<string, object>` type with methods to convert values to supported types
 
 [source,csharp]
 ----
@@ -168,24 +155,19 @@ response.ShouldBeValid();
 var composite = response.Aggregations.Composite("my_buckets");
 composite.Should().NotBeNull();
 composite.Buckets.Should().NotBeNullOrEmpty();
-var count = 0;
 foreach (var item in composite.Buckets)
 {
-    count++;
-    if (count % 2 == 0)
-    {
-        var key = item.Key.As<IDictionary<string, object>>();
-        key.Should().NotBeNull().And.ContainKeys("branches", "started", "branch_count");
-    }
-    else
-    {
-        var key = item.Key.As<CompositeKey>();
-        key.Should().NotBeNull();
-        key.Branches.Should().NotBeNullOrEmpty();
-        /** note that date values are returned as `long` */
-        key.Started.Should().BeGreaterThan(0);
-        key.BranchCount.Should().BeGreaterThan(0);
-    }
+    var key = item.Key;
+    key.Should().NotBeNull();
+
+    key.TryGetValue("branches", out string branches).Should().BeTrue();
+    branches.Should().NotBeNullOrEmpty();
+
+    key.TryGetValue("started", out DateTime started).Should().BeTrue();
+    started.Should().BeAfter(default(DateTime));
+
+    key.TryGetValue("branch_count", out int branchCount).Should().BeTrue();
+    branchCount.Should().BeGreaterThan(0);
 
     item.DocCount.Should().BeGreaterThan(0);
 

--- a/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
@@ -130,8 +130,6 @@ var dateHistogram = response.Aggregations.DateHistogram("projects_started_per_mo
 dateHistogram.Should().NotBeNull();
 dateHistogram.Buckets.Should().NotBeNull();
 dateHistogram.Buckets.Count.Should().BeGreaterThan(10);
-dateHistogram.Buckets.Should().NotBeNull();
-dateHistogram.Buckets.Count.Should().BeGreaterThan(0);
 foreach (var item in dateHistogram.Buckets)
 {
     item.Date.Should().NotBe(default(DateTime));

--- a/src/Nest/Aggregations/AggregateDictionary.cs
+++ b/src/Nest/Aggregations/AggregateDictionary.cs
@@ -175,6 +175,8 @@ namespace Nest
 
 		public MultiBucketAggregate<DateHistogramBucket> DateHistogram(string key) => GetMultiBucketAggregate<DateHistogramBucket>(key);
 
+		public MultiBucketAggregate<CompositeBucket> Composite(string key) => GetMultiBucketAggregate<CompositeBucket>(key);
+
 		public MatrixStatsAggregate MatrixStats(string key) => this.TryGet<MatrixStatsAggregate>(key);
 
 		private TAggregate TryGet<TAggregate>(string key)

--- a/src/Nest/Aggregations/AggregateDictionaryConverter.cs
+++ b/src/Nest/Aggregations/AggregateDictionaryConverter.cs
@@ -55,8 +55,8 @@ namespace Nest
 			where TAggregate : IAggregate
 		{
 			reader.Read();
-			var geoCentroid = serializer.Deserialize<TAggregate>(reader);
-			dictionary.Add(name, geoCentroid);
+			var aggregate = serializer.Deserialize<TAggregate>(reader);
+			dictionary.Add(name, aggregate);
 		}
 
 		private static void ParseAggregate(JsonReader reader, JsonSerializer serializer, string name, Dictionary<string, IAggregate> dictionary)

--- a/src/Nest/Aggregations/AggregateJsonConverter.cs
+++ b/src/Nest/Aggregations/AggregateJsonConverter.cs
@@ -722,7 +722,7 @@ namespace Nest
 
 		private IBucket GetCompositeBucket(JsonReader reader, JsonSerializer serializer)
 		{
-			var key = new LazyDocument(JObject.Load(reader), serializer.GetConnectionSettings().SourceSerializer);
+			var key = new CompositeKey(serializer.Deserialize<IReadOnlyDictionary<string, object>>(reader));
 			reader.Read();
 			long? docCount = null;
 			if (reader.TokenType == JsonToken.PropertyName && (string)reader.Value == Parser.DocCount)

--- a/src/Nest/Aggregations/AggregationContainer.cs
+++ b/src/Nest/Aggregations/AggregationContainer.cs
@@ -6,8 +6,8 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	/// <summary>
-	/// Describes aggregations that we would like to execute on elasticsearch. In NEST `Aggregation` always refers to an aggregation
-	/// going to elasticsearch and an `Aggregate` describes an aggregation going out.
+	/// Describes aggregations that we would like to execute on Elasticsearch. In NEST `Aggregation` always refers to an aggregation
+	/// going to Elasticsearch and an `Aggregate` describes an aggregation going out.
 	/// </summary>
 	[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, IAggregationContainer>))]
 	public class AggregationDictionary : IsADictionaryBase<string, IAggregationContainer>
@@ -210,6 +210,9 @@ namespace Nest
 		[JsonProperty("adjacency_matrix")]
 		IAdjacencyMatrixAggregation AdjacencyMatrix { get; set; }
 
+		[JsonProperty("composite")]
+		ICompositeAggregation Composite { get; set; }
+
 		[JsonProperty("aggs")]
 		AggregationDictionary Aggregations { get; set; }
 
@@ -307,6 +310,8 @@ namespace Nest
 		public IMatrixStatsAggregation MatrixStats { get; set; }
 
 		public IAdjacencyMatrixAggregation AdjacencyMatrix { get; set; }
+
+		public ICompositeAggregation Composite { get; set; }
 
 		public AggregationDictionary Aggregations { get; set; }
 
@@ -440,6 +445,8 @@ namespace Nest
 		IMatrixStatsAggregation IAggregationContainer.MatrixStats { get; set; }
 
 		IAdjacencyMatrixAggregation IAggregationContainer.AdjacencyMatrix { get; set; }
+
+		ICompositeAggregation IAggregationContainer.Composite { get; set; }
 
 		public AggregationContainerDescriptor<T> Average(string name,
 			Func<AverageAggregationDescriptor<T>, IAverageAggregation> selector) =>
@@ -632,6 +639,10 @@ namespace Nest
 		public AggregationContainerDescriptor<T> AdjacencyMatrix(string name,
 			Func<AdjacencyMatrixAggregationDescriptor<T>, IAdjacencyMatrixAggregation> selector) =>
 			_SetInnerAggregation(name, selector, (a, d) => a.AdjacencyMatrix = d);
+
+		public AggregationContainerDescriptor<T> Composite(string name,
+			Func<CompositeAggregationDescriptor<T>, ICompositeAggregation> selector) =>
+			_SetInnerAggregation(name, selector, (a, d) => a.Composite = d);
 
 		/// <summary>
 		/// Fluent methods do not assign to properties on `this` directly but on IAggregationContainers inside `this.Aggregations[string, IContainer]

--- a/src/Nest/Aggregations/AggregationContainer.cs
+++ b/src/Nest/Aggregations/AggregationContainer.cs
@@ -6,8 +6,10 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	/// <summary>
-	/// Describes aggregations that we would like to execute on Elasticsearch. In NEST `Aggregation` always refers to an aggregation
-	/// going to Elasticsearch and an `Aggregate` describes an aggregation going out.
+	/// Describes aggregations that we would like to execute on Elasticsearch.
+	/// <para />
+	/// In NEST Aggregation always refers to an aggregation
+	/// sent to Elasticsearch and an Aggregate describes an aggregation returned from Elasticsearch.
 	/// </summary>
 	[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, IAggregationContainer>))]
 	public class AggregationDictionary : IsADictionaryBase<string, IAggregationContainer>

--- a/src/Nest/Aggregations/Bucket/Composite/CompositeAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/CompositeAggregation.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A multi-bucket aggregation that creates composite buckets from different sources.
+	/// </summary>
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	[ContractJsonConverter(typeof(AggregationJsonConverter<CompositeAggregation>))]
+	public interface ICompositeAggregation : IBucketAggregation
+	{
+		/// <summary>
+		/// Controls the sources that should be used to build the composite buckets
+		/// </summary>
+		[JsonProperty("sources")]
+		IEnumerable<ICompositeAggregationSource> Sources { get; set; }
+
+		/// <summary>
+		/// Defines how many composite buckets should be returned.
+		/// Each composite bucket is considered as a single bucket so
+		/// setting a size of 10 will return the first 10 composite buckets
+		/// created from the values source.
+		/// </summary>
+		[JsonProperty("size")]
+		int? Size { get; set; }
+
+		/// <summary>
+		/// Used to retrieve the composite buckets that are after the
+		/// last composite buckets returned in a previous round
+		/// </summary>
+		[JsonProperty("after")]
+		object After { get; set; }
+	}
+
+	/// <inheritdoc cref="ICompositeAggregation"/>
+	public class CompositeAggregation : BucketAggregationBase, ICompositeAggregation
+	{
+		internal CompositeAggregation() { }
+
+		public CompositeAggregation(string name) : base(name) { }
+
+		internal override void WrapInContainer(AggregationContainer c) => c.Composite = this;
+
+		/// <inheritdoc />
+		public IEnumerable<ICompositeAggregationSource> Sources { get; set; }
+
+		/// <inheritdoc />
+		public int? Size { get; set; }
+
+		/// <inheritdoc />
+		public object After { get; set; }
+	}
+
+	/// <inheritdoc cref="ICompositeAggregation"/>
+	public class CompositeAggregationDescriptor<T>
+		: BucketAggregationDescriptorBase<CompositeAggregationDescriptor<T>, ICompositeAggregation, T>
+			, ICompositeAggregation
+		where T : class
+	{
+		IEnumerable<ICompositeAggregationSource> ICompositeAggregation.Sources { get; set; }
+		int? ICompositeAggregation.Size { get; set; }
+		object ICompositeAggregation.After { get; set; }
+
+		/// <inheritdoc cref="ICompositeAggregation.Sources"/>
+		public CompositeAggregationDescriptor<T> Sources(Func<CompositeAggregationSourcesDescriptor<T>, IPromise<IList<ICompositeAggregationSource>>> selector) =>
+			Assign(a => a.Sources = selector?.Invoke(new CompositeAggregationSourcesDescriptor<T>())?.Value);
+
+		/// <inheritdoc cref="ICompositeAggregation.Size"/>
+		public CompositeAggregationDescriptor<T> Size(int? size) => Assign(a => a.Size = size);
+
+		/// <inheritdoc cref="ICompositeAggregation.After"/>
+		public CompositeAggregationDescriptor<T> After(object after) => Assign(a => a.After = after);
+	}
+}

--- a/src/Nest/Aggregations/Bucket/Composite/CompositeAggregationSource.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/CompositeAggregationSource.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Nest
+{
+	/// <summary>
+	/// A values source for <see cref="ICompositeAggregation"/>
+	/// </summary>
+	[ContractJsonConverter(typeof(CompositeAggregationSourceConverter))]
+	public interface ICompositeAggregationSource
+	{
+		/// <summary>
+		/// The name of the source
+		/// </summary>
+		[JsonIgnore]
+		string Name { get; set; }
+
+		/// <summary>
+		/// The type of the source
+		/// </summary>
+		[JsonIgnore]
+		string SourceType { get; }
+
+		/// <summary>
+		/// The field from which to extract value
+		/// </summary>
+		[JsonProperty("field")]
+		Field Field { get; set; }
+
+		/// <summary>
+		/// Defines the direction of sorting for each
+		/// value source. Defaults to <see cref="SortOrder.Ascending"/>
+		/// </summary>
+		[JsonProperty("order")]
+		SortOrder? Order { get; set; }
+	}
+
+	/// <inheritdoc />
+	public abstract class CompositeAggregationSourceBase : ICompositeAggregationSource
+	{
+		/// <inheritdoc />
+		string ICompositeAggregationSource.Name { get; set; }
+		string ICompositeAggregationSource.SourceType => SourceType;
+
+		/// <inheritdoc cref="ICompositeAggregationSource.SourceType"/>
+		protected abstract string SourceType { get;  }
+
+		internal CompositeAggregationSourceBase() { }
+
+		protected CompositeAggregationSourceBase(string name) =>
+			((ICompositeAggregationSource)this).Name = name;
+
+		/// <inheritdoc />
+		public Field Field { get; set; }
+
+		/// <inheritdoc />
+		public SortOrder? Order { get; set; }
+	}
+
+	/// <inheritdoc cref="ICompositeAggregationSource"/>
+	public class CompositeAggregationSourcesDescriptor<T> :
+		DescriptorPromiseBase<CompositeAggregationSourcesDescriptor<T>, IList<ICompositeAggregationSource>>
+		where T : class
+	{
+		public CompositeAggregationSourcesDescriptor() : base(new List<ICompositeAggregationSource>()) {}
+
+		/// <inheritdoc cref="ITermsCompositeAggregationSource"/>
+		public CompositeAggregationSourcesDescriptor<T> Terms(string name, Func<TermsCompositeAggregationSourceDescriptor<T>, ITermsCompositeAggregationSource> selector) =>
+			Assign(a => a.Add(selector?.Invoke(new TermsCompositeAggregationSourceDescriptor<T>(name))));
+
+		/// <inheritdoc cref="IHistogramCompositeAggregationSource"/>
+		public CompositeAggregationSourcesDescriptor<T> Histogram(string name, Func<HistogramCompositeAggregationSourceDescriptor<T>, IHistogramCompositeAggregationSource> selector) =>
+			Assign(a => a.Add(selector?.Invoke(new HistogramCompositeAggregationSourceDescriptor<T>(name))));
+
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource"/>
+		public CompositeAggregationSourcesDescriptor<T> DateHistogram(string name, Func<DateHistogramCompositeAggregationSourceDescriptor<T>, IDateHistogramCompositeAggregationSource> selector) =>
+			Assign(a => a.Add(selector?.Invoke(new DateHistogramCompositeAggregationSourceDescriptor<T>(name))));
+	}
+
+	/// <inheritdoc cref="ICompositeAggregationSource"/>
+	public abstract class CompositeAggregationSourceDescriptorBase<TDescriptor, TInterface, T>
+		: DescriptorBase<TDescriptor, TInterface>, ICompositeAggregationSource
+		where TDescriptor : CompositeAggregationSourceDescriptorBase<TDescriptor, TInterface, T>, TInterface
+		where TInterface : class, ICompositeAggregationSource
+	{
+		private readonly string _sourceType;
+
+		string ICompositeAggregationSource.Name { get; set; }
+		string ICompositeAggregationSource.SourceType => _sourceType;
+		Field ICompositeAggregationSource.Field { get; set; }
+		SortOrder? ICompositeAggregationSource.Order { get; set; }
+
+		protected CompositeAggregationSourceDescriptorBase(string name, string sourceType)
+		{
+			_sourceType = sourceType;
+			Self.Name = name;
+		}
+
+		/// <inheritdoc cref="ICompositeAggregationSource.Field"/>
+		public TDescriptor Field(Field field) => Assign(a => a.Field = field);
+
+		/// <inheritdoc cref="ICompositeAggregationSource.Field"/>
+		public TDescriptor Field(Expression<Func<T,object>> objectPath) => Assign(a => a.Field = objectPath);
+
+		/// <inheritdoc cref="ICompositeAggregationSource.Order"/>
+		public TDescriptor Order(SortOrder? order) => Assign(a => a.Order = order);
+	}
+
+	internal class CompositeAggregationSourceConverter : ReserializeJsonConverter<CompositeAggregationSourceBase, ICompositeAggregationSource>
+	{
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var jObject = JObject.Load(reader);
+			var property = jObject.Properties().Single();
+			var name = property.Name;
+			var source = (JObject)property.Value;
+			var sourceProperty = source.Properties().Single();
+			var sourceValue = sourceProperty.Value;
+			ICompositeAggregationSource compositeAggregationSource;
+
+			switch (sourceProperty.Name)
+			{
+				case "terms":
+					compositeAggregationSource = sourceValue.ToObject<TermsCompositeAggregationSource>(ElasticContractResolver.Empty);
+					break;
+				case "date_histogram":
+					compositeAggregationSource = sourceValue.ToObject<DateHistogramCompositeAggregationSource>(ElasticContractResolver.Empty);
+					break;
+				case "histogram":
+					compositeAggregationSource = sourceValue.ToObject<HistogramCompositeAggregationSource>(ElasticContractResolver.Empty);
+					break;
+				default:
+					throw new JsonSerializationException($"Unknown {nameof(ICompositeAggregationSource)}: {sourceProperty.Name}");
+			}
+
+			compositeAggregationSource.Name = name;
+			return compositeAggregationSource;
+		}
+
+		protected override void SerializeJson(JsonWriter writer, object value, ICompositeAggregationSource castValue, JsonSerializer serializer)
+		{
+			writer.WriteStartObject();
+				writer.WritePropertyName(castValue.Name);
+				writer.WriteStartObject();
+					writer.WritePropertyName(castValue.SourceType);
+					base.Reserialize(writer, value, serializer);
+				writer.WriteEndObject();
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/Nest/Aggregations/Bucket/Composite/CompositeBucket.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/CompositeBucket.cs
@@ -8,17 +8,106 @@ namespace Nest
 	/// </summary>
 	public class CompositeBucket : BucketBase
 	{
-		public CompositeBucket(IReadOnlyDictionary<string, IAggregate> dict, ILazyDocument key) : base(dict) =>
+		public CompositeBucket(IReadOnlyDictionary<string, IAggregate> dict, CompositeKey key) : base(dict) =>
 			Key = key;
 
 		/// <summary>
 		/// The bucket key
 		/// </summary>
-		public ILazyDocument Key { get; }
+		public CompositeKey Key { get; }
 
 		/// <summary>
 		/// The count of documents
 		/// </summary>
 		public long? DocCount { get; set; }
+	}
+
+	/// <summary>
+	/// A key for a <see cref="CompositeBucket"/>
+	/// </summary>
+	public class CompositeKey : IsAReadOnlyDictionaryBase<string, object>
+	{
+		private static readonly DateTimeOffset Epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+
+		public CompositeKey(IReadOnlyDictionary<string, object> backingDictionary) : base(backingDictionary)
+		{
+		}
+
+		/// <summary>
+		/// Tries to get a value with the given key as a string. Returns <c>false</c> if the key does
+		/// not exist or is not a string.
+		/// </summary>
+		public bool TryGetValue(string key, out string value) => TryGetValue<string>(key, out value);
+
+		/// <summary>
+		/// Tries to get a value with the given key as a double. Returns <c>false</c> if the key does
+		/// not exist or is not a double.
+		/// </summary>
+		public bool TryGetValue(string key, out double value) => TryGetValue<double>(key, out value);
+
+		/// <summary>
+		/// Tries to get a value with the given key as a int. Returns <c>false</c> if the key does
+		/// not exist or is not a int.
+		/// </summary>
+		public bool TryGetValue(string key, out int value) => TryGetValue<int>(key, out value);
+
+		/// <summary>
+		/// Tries to get a value with the given key as a long. Returns <c>false</c> if the key does
+		/// not exist or is not a long.
+		/// </summary>
+		public bool TryGetValue(string key, out long value) => TryGetValue<long>(key, out value);
+
+		/// <summary>
+		/// Tries to get a value with the given key as a DateTime. Returns <c>false</c> if the key does
+		/// not exist or cannot be converted to a DateTime.
+		/// </summary>
+		public bool TryGetValue(string key, out DateTime value)
+		{
+			if (TryGetValue(key, out DateTimeOffset dateTimeOffset))
+			{
+				value = dateTimeOffset.DateTime;
+				return true;
+			}
+
+			value = default(DateTime);
+			return false;
+		}
+
+		/// <summary>
+		/// Tries to get a value with the given key as a DateTimeOffset. Returns <c>false</c> if the key does
+		/// not exist or cannot be converted to a DateTimeOffset.
+		/// </summary>
+		public bool TryGetValue(string key, out DateTimeOffset value)
+		{
+			var exists = TryGetValue(key, out object o);
+			if (!exists || !long.TryParse(o.ToString(), out var l))
+			{
+				value = default(DateTimeOffset);
+				return false;
+			}
+
+			value = Epoch.AddMilliseconds(l);
+			return true;
+		}
+
+		private bool TryGetValue<TValue>(string key, out TValue value)
+		{
+			if (!this.BackingDictionary.TryGetValue(key, out var obj))
+			{
+				value = default(TValue);
+				return false;
+			}
+
+			try
+			{
+				value = (TValue) Convert.ChangeType(obj, typeof(TValue));
+				return true;
+			}
+			catch
+			{
+				value = default(TValue);
+				return false;
+			}
+		}
 	}
 }

--- a/src/Nest/Aggregations/Bucket/Composite/CompositeBucket.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/CompositeBucket.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace Nest
+{
+	/// <summary>
+	/// A bucket with a composite key
+	/// </summary>
+	public class CompositeBucket : BucketBase
+	{
+		public CompositeBucket(IReadOnlyDictionary<string, IAggregate> dict, ILazyDocument key) : base(dict) =>
+			Key = key;
+
+		/// <summary>
+		/// The bucket key
+		/// </summary>
+		public ILazyDocument Key { get; }
+
+		/// <summary>
+		/// The count of documents
+		/// </summary>
+		public long? DocCount { get; set; }
+	}
+}

--- a/src/Nest/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
@@ -1,0 +1,64 @@
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A values source that can be applied on date values to build fixed size interval over the values.
+	/// The interval parameter defines a date/time expression that determines how values should be transformed.
+	/// For instance an interval set to month will translate any values to its closest month interval..
+	/// </summary>
+	public interface IDateHistogramCompositeAggregationSource : ICompositeAggregationSource
+	{
+		/// <summary>
+		///	The interval to use when bucketing documents
+		/// </summary>
+		[JsonProperty("interval")]
+		Union<DateInterval?, Time> Interval { get; set; }
+
+		/// <summary>
+		/// Used to indicate that bucketing should use a different time zone.
+		/// Time zones may either be specified as an ISO 8601 UTC offset (e.g. +01:00 or -08:00)
+		/// or as a timezone id, an identifier used in the TZ database like America/Los_Angeles.
+		/// </summary>
+		[JsonProperty("time_zone")]
+		string Timezone { get; set; }
+	}
+
+	/// <inheritdoc cref="IDateHistogramCompositeAggregationSource"/>
+	public class DateHistogramCompositeAggregationSource : CompositeAggregationSourceBase, IDateHistogramCompositeAggregationSource
+	{
+		public DateHistogramCompositeAggregationSource(string name) : base(name) {}
+
+		/// <inheritdoc />
+		public Union<DateInterval?,Time> Interval { get; set; }
+
+		/// <inheritdoc />
+		public string Timezone { get; set; }
+
+		/// <inheritdoc />
+		protected override string SourceType => "date_histogram";
+	}
+
+	/// <inheritdoc cref="IDateHistogramCompositeAggregationSource"/>
+	public class DateHistogramCompositeAggregationSourceDescriptor<T>
+		: CompositeAggregationSourceDescriptorBase<DateHistogramCompositeAggregationSourceDescriptor<T>, IDateHistogramCompositeAggregationSource, T>,
+			IDateHistogramCompositeAggregationSource
+	{
+		Union<DateInterval?,Time> IDateHistogramCompositeAggregationSource.Interval { get; set; }
+		string IDateHistogramCompositeAggregationSource.Timezone { get; set; }
+
+		public DateHistogramCompositeAggregationSourceDescriptor(string name) : base(name, "date_histogram") {}
+
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.Interval"/>
+		public DateHistogramCompositeAggregationSourceDescriptor<T> Interval(DateInterval? interval) =>
+			Assign(a => a.Interval = interval);
+
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.Interval"/>
+		public DateHistogramCompositeAggregationSourceDescriptor<T> Interval(Time interval) =>
+			Assign(a => a.Interval = interval);
+
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.Timezone"/>
+		public DateHistogramCompositeAggregationSourceDescriptor<T> Timezone(string timezone) =>
+			Assign(a => a.Timezone = timezone);
+	}
+}

--- a/src/Nest/Aggregations/Bucket/Composite/HistogramCompositeAggregationSource.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/HistogramCompositeAggregationSource.cs
@@ -1,0 +1,59 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A value source that can be applied on numeric values to build fixed size interval over the values.
+	/// The interval parameter defines how the numeric values should be transformed.
+	/// For instance an interval set to 5 will translate any numeric values to its closest interval,
+	/// a value of 101 would be translated to 100 which is the key for the interval between 100 and 105.
+	/// </summary>
+	public interface IHistogramCompositeAggregationSource : ICompositeAggregationSource
+	{
+		/// <summary>
+		/// A script to create the values for the composite buckets
+		/// </summary>
+		[JsonProperty("script")]
+		IScript Script { get; set; }
+
+		/// <summary>
+		/// The interval to use when bucketing documents
+		/// </summary>
+		[JsonProperty("interval")]
+		double? Interval { get; set; }
+	}
+
+	/// <inheritdoc cref="IHistogramCompositeAggregationSource"/>
+	public class HistogramCompositeAggregationSource : CompositeAggregationSourceBase, IHistogramCompositeAggregationSource
+	{
+		public HistogramCompositeAggregationSource(string name) : base(name) {}
+
+		/// <inheritdoc />
+		public IScript Script { get; set; }
+
+		/// <inheritdoc />
+		public double? Interval { get; set; }
+
+		/// <inheritdoc />
+		protected override string SourceType => "histogram";
+	}
+
+	/// <inheritdoc cref="IHistogramCompositeAggregationSource"/>
+	public class HistogramCompositeAggregationSourceDescriptor<T>
+		: CompositeAggregationSourceDescriptorBase<HistogramCompositeAggregationSourceDescriptor<T>, IHistogramCompositeAggregationSource, T>, IHistogramCompositeAggregationSource
+	{
+		double? IHistogramCompositeAggregationSource.Interval { get; set; }
+		IScript IHistogramCompositeAggregationSource.Script { get; set; }
+
+		public HistogramCompositeAggregationSourceDescriptor(string name) : base(name, "histogram") {}
+
+		/// <inheritdoc cref="IHistogramCompositeAggregationSource.Interval"/>
+		public HistogramCompositeAggregationSourceDescriptor<T> Interval(double? interval) =>
+			Assign(a => a.Interval = interval);
+
+		/// <inheritdoc cref="IHistogramCompositeAggregationSource.Script"/>
+		public HistogramCompositeAggregationSourceDescriptor<T> Script(Func<ScriptDescriptor, IScript> selector) =>
+			Assign(a => a.Script = selector?.Invoke(new ScriptDescriptor()));
+	}
+}

--- a/src/Nest/Aggregations/Bucket/Composite/TermsCompositeAggregationSource.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/TermsCompositeAggregationSource.cs
@@ -1,0 +1,44 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+
+	/// <summary>
+	/// A values source that is equivalent to a simple terms aggregation.
+	/// The values are extracted from a field or a script exactly like the terms aggregation.
+	/// </summary>
+	public interface ITermsCompositeAggregationSource : ICompositeAggregationSource
+	{
+		/// <summary>
+		/// A script to create the values for the composite buckets
+		/// </summary>
+		[JsonProperty("script")]
+		IScript Script { get; set; }
+	}
+
+	/// <inheritdoc cref="ITermsCompositeAggregationSource"/>
+	public class TermsCompositeAggregationSource : CompositeAggregationSourceBase, ITermsCompositeAggregationSource
+	{
+		public TermsCompositeAggregationSource(string name) : base(name) {}
+
+		/// <inheritdoc />
+		public IScript Script { get; set; }
+
+		/// <inheritdoc />
+		protected override string SourceType => "terms";
+	}
+
+	/// <inheritdoc cref="ITermsCompositeAggregationSource"/>
+	public class TermsCompositeAggregationSourceDescriptor<T>
+		: CompositeAggregationSourceDescriptorBase<TermsCompositeAggregationSourceDescriptor<T>, ITermsCompositeAggregationSource, T>, ITermsCompositeAggregationSource
+	{
+		IScript ITermsCompositeAggregationSource.Script { get; set; }
+
+		public TermsCompositeAggregationSourceDescriptor(string name) : base(name, "terms") {}
+
+		/// <inheritdoc cref="ITermsCompositeAggregationSource.Script"/>
+		public TermsCompositeAggregationSourceDescriptor<T> Script(Func<ScriptDescriptor, IScript> selector) =>
+			Assign(a => a.Script = selector?.Invoke(new ScriptDescriptor()));
+	}
+}

--- a/src/Nest/Aggregations/Visitor/AggregationVisitor.cs
+++ b/src/Nest/Aggregations/Visitor/AggregationVisitor.cs
@@ -75,6 +75,7 @@ namespace Nest
 		void Visit(IBucketSortAggregation aggregation);
 		void Visit(ISamplerAggregation aggregation);
 		void Visit(IGeoCentroidAggregation aggregation);
+		void Visit(ICompositeAggregation aggregation);
 	}
 
 	public class AggregationVisitor : IAggregationVisitor
@@ -264,6 +265,10 @@ namespace Nest
 		}
 
 		public virtual void Visit(IGeoCentroidAggregation aggregation)
+		{
+		}
+
+		public virtual void Visit(ICompositeAggregation aggregation)
 		{
 		}
 

--- a/src/Nest/Aggregations/Visitor/AggregationWalker.cs
+++ b/src/Nest/Aggregations/Visitor/AggregationWalker.cs
@@ -82,6 +82,7 @@ namespace Nest
 			AcceptAggregation(aggregation.TopHits, visitor, (v, d) => v.Visit(d));
 			AcceptAggregation(aggregation.ValueCount, visitor, (v, d) => v.Visit(d));
 			AcceptAggregation(aggregation.GeoCentroid, visitor, (v, d) => v.Visit(d));
+			AcceptAggregation(aggregation.Composite, visitor, (v, d) => v.Visit(d));
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/LazyDocument/LazyDocument.cs
+++ b/src/Nest/CommonAbstractions/LazyDocument/LazyDocument.cs
@@ -6,6 +6,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Nest
 {
+	/// <summary>
+	/// A lazily deserialized document
+	/// </summary>
 	[ContractJsonConverter(typeof(LazyDocumentJsonConverter))]
 	public interface ILazyDocument
 	{
@@ -24,7 +27,7 @@ namespace Nest
 		object As(Type objectType);
 	}
 
-
+	/// <inheritdoc />
 	public class LazyDocument : ILazyDocument
 	{
 		internal JToken Token { get; }

--- a/src/Nest/CommonAbstractions/LazyDocument/LazyDocumentJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/LazyDocument/LazyDocumentJsonConverter.cs
@@ -9,7 +9,11 @@ namespace Nest
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
 			var d = (LazyDocument)value;
-			if (d?.Token == null) return;
+			if (d?.Token == null)
+			{
+				writer.WriteNull();
+				return;
+			}
 
 			writer.WriteToken(d.Token.CreateReader());
 		}

--- a/src/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Nest;
+using Newtonsoft.Json;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using Tests.Framework.MockData;
+using static Nest.Infer;
+
+namespace Tests.Aggregations.Bucket.Composite
+{
+	/**
+	 * A multi-bucket aggregation that creates composite buckets from different sources.
+     *
+     * Unlike the other multi-bucket aggregation the composite aggregation can be
+	 * used to paginate all buckets from a multi-level aggregation efficiently.
+	 * This aggregation provides a way to stream all buckets of a specific aggregation
+	 * similarly to what scroll does for documents.
+     *
+     * The composite buckets are built from the combinations of the values extracted/created
+	 * for each document and each combination is considered as a composite bucket.
+	 *
+	 * NOTE: Only available in Elasticsearch 6.1.0+
+	 *
+	 * Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-composite-aggregation.html[Composite Aggregation].
+	*/
+	[SkipVersion("<6.1.0", "Composite Aggregation is only available in Elasticsearch 6.1.0+")]
+	public class CompositeAggregationUsageTests : ProjectsOnlyAggregationUsageTestBase
+	{
+		public CompositeAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object AggregationJson => new
+		{
+			my_buckets = new
+			{
+				composite = new
+				{
+					sources = new object[]
+					{
+						new
+						{
+							branches = new
+							{
+								terms = new
+								{
+									field = "branches.keyword"
+								}
+							}
+						},
+						new
+						{
+							started = new
+							{
+								date_histogram = new
+								{
+									field = "startedOn",
+									interval = "month"
+								}
+							}
+						},
+						new
+						{
+							branch_count = new
+							{
+								histogram = new
+								{
+									field = "requiredBranches",
+									interval = 1d
+								}
+							}
+						},
+					}
+				},
+				aggs = new
+				{
+					project_tags = new
+					{
+						nested = new
+						{
+							path = "tags"
+						},
+						aggs = new
+						{
+							tags = new
+							{
+								terms = new {field = "tags.name"}
+							}
+						}
+					}
+				}
+			}
+		};
+
+		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
+			.Composite("my_buckets", date => date
+				.Sources(s => s
+					.Terms("branches", t => t
+						.Field(f => f.Branches.Suffix("keyword"))
+					)
+					.DateHistogram("started", d => d
+						.Field(f => f.StartedOn)
+						.Interval(DateInterval.Month)
+					)
+					.Histogram("branch_count", h => h
+						.Field(f => f.RequiredBranches)
+						.Interval(1)
+					)
+				)
+				.Aggregations(childAggs => childAggs
+					.Nested("project_tags", n => n
+						.Path(p => p.Tags)
+						.Aggregations(nestedAggs => nestedAggs
+							.Terms("tags", avg => avg.Field(p => p.Tags.First().Name))
+						)
+					)
+				)
+			);
+
+		protected override AggregationDictionary InitializerAggs =>
+			new CompositeAggregation("my_buckets")
+			{
+				Sources = new List<ICompositeAggregationSource>
+				{
+					new TermsCompositeAggregationSource("branches")
+					{
+						Field = Infer.Field<Project>(f => f.Branches.Suffix("keyword"))
+					},
+					new DateHistogramCompositeAggregationSource("started")
+					{
+						Field = Infer.Field<Project>(f => f.StartedOn),
+						Interval = DateInterval.Month
+					},
+					new HistogramCompositeAggregationSource("branch_count")
+					{
+						Field = Infer.Field<Project>(f => f.RequiredBranches),
+						Interval = 1
+					}
+				},
+				Aggregations = new NestedAggregation("project_tags")
+				{
+					Path = Field<Project>(p => p.Tags),
+					Aggregations = new TermsAggregation("tags")
+					{
+						Field = Field<Project>(p => p.Tags.First().Name)
+					}
+				}
+			};
+
+		/**==== Handling Responses
+		 * Each Composite aggregation buckey key is an `ILazyDocument` that can be converted
+		 * to a type of your choosing. Here, we demonstrate converting to
+		 * an `IDictionary<string, object>` and a `CompositeKey` type we have
+		 * defined.
+		 */
+		public class CompositeKey
+		{
+			public string Branches { get; set; }
+			public long Started { get; set; }
+			[PropertyName("branch_count"), JsonProperty("branch_count")]
+			public double BranchCount { get; set; }
+		}
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.ShouldBeValid();
+
+			var composite = response.Aggregations.Composite("my_buckets");
+			composite.Should().NotBeNull();
+			composite.Buckets.Should().NotBeNullOrEmpty();
+			var count = 0;
+			foreach (var item in composite.Buckets)
+			{
+				count++;
+				if (count % 2 == 0)
+				{
+					var key = item.Key.As<IDictionary<string, object>>();
+					key.Should().NotBeNull().And.ContainKeys("branches", "started", "branch_count");
+				}
+				else
+				{
+					var key = item.Key.As<CompositeKey>();
+					key.Should().NotBeNull();
+					key.Branches.Should().NotBeNullOrEmpty();
+					/** note that date values are returned as `long` */
+					key.Started.Should().BeGreaterThan(0);
+					key.BranchCount.Should().BeGreaterThan(0);
+				}
+
+				item.DocCount.Should().BeGreaterThan(0);
+
+				var nested = item.Nested("project_tags");
+				nested.Should().NotBeNull();
+
+				var nestedTerms = nested.Terms("tags");
+				nestedTerms.Buckets.Count.Should().BeGreaterThan(0);
+			}
+		}
+	}
+}

--- a/src/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
+++ b/src/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
@@ -120,8 +120,6 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 			dateHistogram.Should().NotBeNull();
 			dateHistogram.Buckets.Should().NotBeNull();
 			dateHistogram.Buckets.Count.Should().BeGreaterThan(10);
-			dateHistogram.Buckets.Should().NotBeNull();
-			dateHistogram.Buckets.Count.Should().BeGreaterThan(0);
 			foreach (var item in dateHistogram.Buckets)
 			{
 				item.Date.Should().NotBe(default(DateTime));


### PR DESCRIPTION
This commit adds Composite Aggregation support.

The bucket keys in the response to a Composite Aggregation are
`ILazyDocument`, allowing a user to convert to a type of their choosing.

Closes #2902