### PR TITLE
Closes #3251. Rename levenstein to levenshtein.

### DIFF
--- a/src/Nest/Search/Suggesters/TermSuggester/StringDistance.cs
+++ b/src/Nest/Search/Suggesters/TermSuggester/StringDistance.cs
@@ -16,7 +16,7 @@ namespace Nest
 		Internal,
 		[EnumMember(Value = "damerau_levenshtein")]
 		DamerauLevenshtein,
-		[EnumMember(Value = "levenstein")]
+		[EnumMember(Value = "levenshtein")]
 		Levenstein,
 		[EnumMember(Value = "jarowinkler")]
 		Jarowinkler,


### PR DESCRIPTION
Unsure if we should rename the enumeration value at this stage as it would break binary compatibility.

Potentially consider implementing another enumeration value with the correct spelling? @russcam - thoughts?