### PR TITLE
Include include_global_state in Snapshot status API. Closes #3258.

### DIFF
--- a/src/Nest/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusResponse.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusResponse.cs
@@ -25,11 +25,11 @@ namespace Nest
 		[JsonProperty("repository")]
 		public string Repository { get; internal set; }
 		[JsonProperty("uuid")]
-		public string UID { get; internal set; }
+		public string UUID { get; internal set; }
 		[JsonProperty("state")]
 		public string State { get; internal set; }
 		[JsonProperty("include_global_state")]
-		public bool IncludeGlobalState { get; internal set; }
+		public bool? IncludeGlobalState { get; internal set; }
 		[JsonProperty("shards_stats")]
 		public SnapshotShardsStats ShardsStats { get; internal set; }
 		[JsonProperty("stats")]

--- a/src/Nest/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusResponse.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusResponse.cs
@@ -24,8 +24,12 @@ namespace Nest
 		public string Snapshot { get; internal set; }
 		[JsonProperty("repository")]
 		public string Repository { get; internal set; }
+		[JsonProperty("uuid")]
+		public string UID { get; internal set; }
 		[JsonProperty("state")]
 		public string State { get; internal set; }
+		[JsonProperty("include_global_state")]
+		public bool IncludeGlobalState { get; internal set; }
 		[JsonProperty("shards_stats")]
 		public SnapshotShardsStats ShardsStats { get; internal set; }
 		[JsonProperty("stats")]


### PR DESCRIPTION
Needs porting to `6.x` and part of `6.2` release.

Relates to: https://github.com/elastic/elasticsearch/pull/26853

Example reference: https://github.com/liketic/elasticsearch/blob/ab0b127efd47b06aefea0eda27b99fd9d92abbe5/core/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatusTests.java