### PR TITLE
Associate an external id with a task, so that it can be cancelled later.

### DIFF
--- a/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
@@ -25,6 +25,7 @@ namespace Elasticsearch.Net
 
 		/// <summary>
 		/// Associate an Id with this user-initiated task, such that it can be located in the cluster task list.
+		/// Valid only for Elasticsearch 6.2.0+
 		/// <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks</pre>
 		/// </summary>
 		string OpaqueId { get; set; }
@@ -181,6 +182,7 @@ namespace Elasticsearch.Net
 
 		/// <summary>
 		/// Associate an Id with this user-initiated task, such that it can be located in the cluster task list.
+		/// Valid only for Elasticsearch 6.2.0+
 		/// <pre>https://www.elastic.co/guide/en/elasticsearch/reference/6.2/tasks.html#_identifying_running_tasks</pre>
 		/// </summary>
 		public RequestConfigurationDescriptor OpaqueId(string opaqueId)

--- a/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
@@ -26,7 +26,6 @@ namespace Elasticsearch.Net
 		/// <summary>
 		/// Associate an Id with this user-initiated task, such that it can be located in the cluster task list.
 		/// Valid only for Elasticsearch 6.2.0+
-		/// <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks</pre>
 		/// </summary>
 		string OpaqueId { get; set; }
 
@@ -183,7 +182,6 @@ namespace Elasticsearch.Net
 		/// <summary>
 		/// Associate an Id with this user-initiated task, such that it can be located in the cluster task list.
 		/// Valid only for Elasticsearch 6.2.0+
-		/// <pre>https://www.elastic.co/guide/en/elasticsearch/reference/6.2/tasks.html#_identifying_running_tasks</pre>
 		/// </summary>
 		public RequestConfigurationDescriptor OpaqueId(string opaqueId)
 		{

--- a/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
@@ -24,6 +24,12 @@ namespace Elasticsearch.Net
 		string ContentType { get; set; }
 
 		/// <summary>
+		/// Associate an Id with this user-initiated task, such that it can be located in the cluster task list.
+		/// <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks</pre>
+		/// </summary>
+		string OpaqueId { get; set; }
+
+		/// <summary>
 		/// Force a different Accept header on the request
 		/// </summary>
 		string Accept { get; set; }
@@ -95,6 +101,7 @@ namespace Elasticsearch.Net
 		public TimeSpan? RequestTimeout { get; set; }
 		public TimeSpan? PingTimeout { get; set; }
 		public string ContentType { get; set; }
+		public string OpaqueId { get; set; }
 		public string Accept { get; set; }
 		public int? MaxRetries { get; set; }
 		public Uri ForceNode { get; set; }
@@ -121,6 +128,7 @@ namespace Elasticsearch.Net
 		TimeSpan? IRequestConfiguration.RequestTimeout { get; set; }
 		TimeSpan? IRequestConfiguration.PingTimeout { get; set; }
 		string IRequestConfiguration.ContentType { get; set; }
+		string IRequestConfiguration.OpaqueId { get; set; }
 		string IRequestConfiguration.Accept { get; set; }
 
 		int? IRequestConfiguration.MaxRetries { get; set; }
@@ -152,6 +160,7 @@ namespace Elasticsearch.Net
 			Self.RunAs = config?.RunAs;
 			Self.ClientCertificates = config?.ClientCertificates;
 			Self.ThrowExceptions = config?.ThrowExceptions;
+			Self.OpaqueId = config?.OpaqueId;
 		}
 
 		/// <summary>
@@ -167,6 +176,16 @@ namespace Elasticsearch.Net
 		public RequestConfigurationDescriptor RequestTimeout(TimeSpan requestTimeout)
 		{
 			Self.RequestTimeout = requestTimeout;
+			return this;
+		}
+
+		/// <summary>
+		/// Associate an Id with this user-initiated task, such that it can be located in the cluster task list.
+		/// <pre>https://www.elastic.co/guide/en/elasticsearch/reference/6.2/tasks.html#_identifying_running_tasks</pre>
+		/// </summary>
+		public RequestConfigurationDescriptor OpaqueId(string opaqueId)
+		{
+			Self.OpaqueId = opaqueId;
 			return this;
 		}
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -12,6 +12,7 @@ namespace Elasticsearch.Net
 	{
 		public const string MimeType = "application/json";
 		public const string RunAsSecurityHeader = "es-security-runas-user";
+		public const string OpaqueIdHeader = "X-Opaque-Id";
 
 		public Uri Uri => this.Node != null ? new Uri(this.Node.Uri, this.PathAndQuery) : null;
 
@@ -77,6 +78,10 @@ namespace Elasticsearch.Net
 			this.RequestMimeType = local?.ContentType ?? MimeType;
 			this.Accept = local?.Accept ?? MimeType;
 			this.Headers = global.Headers != null ? new NameValueCollection(global.Headers) : new NameValueCollection();
+
+			if (!string.IsNullOrEmpty(local?.OpaqueId))
+				this.Headers.Add(OpaqueIdHeader, local.OpaqueId);
+
 			this.RunAs = local?.RunAs;
 			this.SkipDeserializationForStatusCodes = global?.SkipDeserializationForStatusCodes;
 			this.ThrowExceptions = local?.ThrowExceptions ?? global.ThrowExceptions;

--- a/src/Nest/Cluster/TaskManagement/GetTask/TaskInfo.cs
+++ b/src/Nest/Cluster/TaskManagement/GetTask/TaskInfo.cs
@@ -39,5 +39,8 @@ namespace Nest
 
 		[JsonProperty("headers")]
 		public IReadOnlyDictionary<string, string> Headers { get; internal set; } = EmptyReadOnly<string, string>.Dictionary;
+
+		[JsonProperty("children")]
+		public IReadOnlyCollection<TaskInfo> Children { get; internal set; } = EmptyReadOnly<TaskInfo>.Collection;
 	}
 }

--- a/src/Nest/Cluster/TaskManagement/GetTask/TaskInfo.cs
+++ b/src/Nest/Cluster/TaskManagement/GetTask/TaskInfo.cs
@@ -36,5 +36,8 @@ namespace Nest
 
 		[JsonProperty("cancellable")]
 		public bool Cancellable { get; internal set; }
+
+		[JsonProperty("headers")]
+		public IReadOnlyDictionary<string, string> Headers { get; internal set; } = EmptyReadOnly<string, string>.Dictionary;
 	}
 }

--- a/src/Nest/Cluster/TaskManagement/ListTasks/ListTasksResponse.cs
+++ b/src/Nest/Cluster/TaskManagement/ListTasks/ListTasksResponse.cs
@@ -73,6 +73,12 @@ namespace Nest
 
 		[JsonProperty("parent_task_id")]
 		public TaskId ParentTaskId { get; internal set; }
+
+		[JsonProperty("cancellable")]
+		public bool Cancellable { get; internal set; }
+
+		[JsonProperty("headers")]
+		public IReadOnlyDictionary<string, string> Headers { get; internal set; } = EmptyReadOnly<string, string>.Dictionary;
 	}
 
 	public class TaskStatus


### PR DESCRIPTION
Closes #3259