### PR TITLE
6.x Performance Improvements

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -148,6 +148,9 @@ namespace Elasticsearch.Net
 		private IReadOnlyCollection<int> _skipDeserializationForStatusCodes = new ReadOnlyCollection<int>(new int[] {});
 		IReadOnlyCollection<int> IConnectionConfigurationValues.SkipDeserializationForStatusCodes => _skipDeserializationForStatusCodes;
 
+		private IMemoryStreamFactory _memoryStreamFactory = new RecyclableMemoryStreamFactory();
+		IMemoryStreamFactory IConnectionConfigurationValues.MemoryStreamFactory => _memoryStreamFactory;
+
 		private static void DefaultCompletedRequestHandler(IApiCallDetails response) { }
 		Action<IApiCallDetails> _completedRequestHandler = DefaultCompletedRequestHandler;
 		Action<IApiCallDetails> IConnectionConfigurationValues.OnRequestCompleted => _completedRequestHandler;

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -12,10 +12,13 @@ namespace Elasticsearch.Net
 		/// <summary> Provides a semaphoreslim to transport implementations that need to limit access to a resource</summary>
 		SemaphoreSlim BootstrapLock { get; }
 
-		/// <summary> The connection pool to use when talking with elasticsearch </summary>
+		/// <summary> Provides a memory stream factory</summary>
+		IMemoryStreamFactory MemoryStreamFactory { get; }
+
+		/// <summary> The connection pool to use when talking with Elasticsearch </summary>
 		IConnectionPool ConnectionPool { get; }
 
-		/// <summary> The connection implementation to use when talking with elasticsearch </summary>
+		/// <summary> The connection implementation to use when talking with Elasticsearch </summary>
 		IConnection Connection { get; }
 
 		/// <summary>The serializer to use to serialize requests and deserialize responses</summary>

--- a/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
+++ b/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
@@ -47,7 +47,7 @@ namespace Elasticsearch.Net
 			var data = requestData.PostData;
 			if (data != null)
 			{
-				using (var stream = new MemoryStream())
+				using (var stream = requestData.MemoryStreamFactory.Create())
 				{
 					if (requestData.HttpCompression)
 						using (var zipStream = new GZipStream(stream, CompressionMode.Compress))
@@ -59,7 +59,7 @@ namespace Elasticsearch.Net
 			requestData.MadeItToResponse = true;
 
 			var sc = statusCode ?? this._statusCode;
-			Stream s = (body != null) ? new MemoryStream(body) : new MemoryStream(EmptyBody);
+			Stream s = (body != null) ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
 			return ResponseBuilder.ToResponse<TResponse>(requestData, _exception, sc, null, s, contentType ?? _contentType ?? RequestData.MimeType);
 		}
 
@@ -70,7 +70,7 @@ namespace Elasticsearch.Net
 			var data = requestData.PostData;
 			if (data != null)
 			{
-				using (var stream = new MemoryStream())
+				using (var stream = requestData.MemoryStreamFactory.Create())
 				{
 					if (requestData.HttpCompression)
 						using (var zipStream = new GZipStream(stream, CompressionMode.Compress))
@@ -82,7 +82,7 @@ namespace Elasticsearch.Net
 			requestData.MadeItToResponse = true;
 
 			var sc = statusCode ?? this._statusCode;
-			Stream s = (body != null) ? new MemoryStream(body) : new MemoryStream(EmptyBody);
+			Stream s = (body != null) ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
 			return await ResponseBuilder.ToResponseAsync<TResponse>(requestData, _exception, sc, null, s, contentType ?? _contentType, cancellationToken)
 				.ConfigureAwait(false);
 		}

--- a/src/Elasticsearch.Net/ConnectionPool/IConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/IConnectionPool.cs
@@ -6,8 +6,9 @@ namespace Elasticsearch.Net
 	public interface IConnectionPool : IDisposable
 	{
 		/// <summary>
-		/// Returns a readonly constant view of all the nodes in the cluster, this might involve creating copies of the nodes e.g
-		/// if you are using the sniffing connectionpool. If you do not need an isolated copy of the nodes please read <see cref="CreateView"/> to completion
+		/// Returns a read only view of all the nodes in the cluster, which might involve creating copies of nodes e.g
+		/// if you are using <see cref="SniffingConnectionPool"/>.
+		/// If you do not need an isolated copy of the nodes, please read <see cref="CreateView"/> to completion
 		/// </summary>
 		IReadOnlyCollection<Node> Nodes { get; }
 
@@ -19,33 +20,40 @@ namespace Elasticsearch.Net
 		int MaxRetries { get; }
 
 		/// <summary>
-		/// Signals that this implemenation can accept new nodes
+		/// Whether reseeding with new nodes is supported
 		/// </summary>
 		bool SupportsReseeding { get; }
 
+		/// <summary>
+		/// Whether pinging is supported
+		/// </summary>
 		bool SupportsPinging { get; }
 
+		/// <summary>
+		/// The last time that this instance was updated
+		/// </summary>
 		DateTime LastUpdate { get; }
 
 		/// <summary>
-		/// Whether or not SSL is being using
+		/// Whether SSL/TLS is being used
 		/// </summary>
 		bool UsingSsl { get; }
 
 		/// <summary>
-		/// Bookkeeps wheter this connectionpool has seen a sniff on startup. its up to to the callee to set this in a threadsafe fashion
+		/// Whether a sniff is seen on startup. The implementation is
+		/// responsible for setting this in a thread safe fashion.
 		/// </summary>
 		bool SniffedOnStartup { get; set; }
 
 		/// <summary>
-		/// Creates a view with changing starting positions that wraps over on each call
+		/// Creates a view over the nodes, with changing starting positions, that wraps over on each call
 		/// e.g Thread A might get 1,2,3,4,5 and thread B will get 2,3,4,5,1.
 		/// if there are no live nodes yields a different dead node to try once
 		/// </summary>
 		IEnumerable<Node> CreateView(Action<AuditEvent, Node> audit = null);
 
 		/// <summary>
-		/// Update the node list, it's the IConnectionPool's responsibility to do so in a threadsafe fashion
+		/// Reseeds the nodes. The implementation is responsible for thread safety
 		/// </summary>
 		void Reseed(IEnumerable<Node> nodes);
 

--- a/src/Elasticsearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace Elasticsearch.Net
 {
+	/// <summary>
+	/// A connection pool to a single node or endpoint
+	/// </summary>
 	public class SingleNodeConnectionPool : IConnectionPool
 	{
 		/// <inheritdoc/>
@@ -21,7 +24,7 @@ namespace Elasticsearch.Net
 		public bool UsingSsl { get; }
 
 		/// <inheritdoc/>
-		public bool SniffedOnStartup { get { return true; } set {  } }
+		public bool SniffedOnStartup { get => true; set {  } }
 
 		/// <inheritdoc/>
 		public IReadOnlyCollection<Node> Nodes { get; }

--- a/src/Elasticsearch.Net/Extensions/TypeExtensions.cs
+++ b/src/Elasticsearch.Net/Extensions/TypeExtensions.cs
@@ -20,10 +20,9 @@ namespace Elasticsearch.Net
 
 		internal static object CreateInstance(this Type t, params object[] args)
 		{
-			ObjectActivator<object> activator;
 			var argKey = args.Length;
 			var key = argKey + "--" + t.FullName;
-			if (CachedActivators.TryGetValue(key, out activator))
+			if (CachedActivators.TryGetValue(key, out var activator))
 				return activator(args);
 
 			var generic = GetActivatorMethodInfo.MakeGenericMethod(t);

--- a/src/Elasticsearch.Net/Providers/IMemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/IMemoryStreamFactory.cs
@@ -2,13 +2,19 @@
 
 namespace Elasticsearch.Net
 {
+	/// <summary>
+	/// A factory for creating memory streams
+	/// </summary>
 	public interface IMemoryStreamFactory
 	{
+		/// <summary>
+		/// Creates a memory stream
+		/// </summary>
 		MemoryStream Create();
-	}
 
-	public class MemoryStreamFactory : IMemoryStreamFactory
-	{
-		public MemoryStream Create() => new MemoryStream();
+		/// <summary>
+		/// Creates a memory stream with the bytes written to the stream
+		/// </summary>
+		MemoryStream Create(byte[] bytes);
 	}
 }

--- a/src/Elasticsearch.Net/Providers/MemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/MemoryStreamFactory.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// A factory for creating memory streams using instances of <see cref="MemoryStream"/>
+	/// </summary>
+	public class MemoryStreamFactory : IMemoryStreamFactory
+	{
+		/// <summary>
+		/// Creates a memory stream using <see cref="MemoryStream"/>
+		/// </summary>
+		public MemoryStream Create() => new MemoryStream();
+
+		/// <summary>
+		/// Creates a memory stream using <see cref="MemoryStream"/> with the bytes written to the stream
+		/// </summary>
+		public MemoryStream Create(byte[] bytes) => new MemoryStream(bytes);
+	}
+}

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStream.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStream.cs
@@ -1,0 +1,853 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015-2016 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream/blob/master/src/RecyclableMemoryStream.cs
+// MIT license: https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream/blob/master/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// MemoryStream implementation that deals with pooling and managing memory streams which use potentially large
+	/// buffers.
+	/// </summary>
+	/// <remarks>
+	/// This class works in tandem with the RecylableMemoryStreamManager to supply MemoryStream
+	/// objects to callers, while avoiding these specific problems:
+	/// 1. LOH allocations - since all large buffers are pooled, they will never incur a Gen2 GC
+	/// 2. Memory waste - A standard memory stream doubles its size when it runs out of room. This
+	/// leads to continual memory growth as each stream approaches the maximum allowed size.
+	/// 3. Memory copying - Each time a MemoryStream grows, all the bytes are copied into new buffers.
+	/// This implementation only copies the bytes when GetBuffer is called.
+	/// 4. Memory fragmentation - By using homogeneous buffer sizes, it ensures that blocks of memory
+	/// can be easily reused.
+	///
+	/// The stream is implemented on top of a series of uniformly-sized blocks. As the stream's length grows,
+	/// additional blocks are retrieved from the memory manager. It is these blocks that are pooled, not the stream
+	/// object itself.
+	///
+	/// The biggest wrinkle in this implementation is when GetBuffer() is called. This requires a single
+	/// contiguous buffer. If only a single block is in use, then that block is returned. If multiple blocks
+	/// are in use, we retrieve a larger buffer from the memory manager. These large buffers are also pooled,
+	/// split by size--they are multiples of a chunk size (1 MB by default).
+	///
+	/// Once a large buffer is assigned to the stream the blocks are NEVER again used for this stream. All operations take place on the
+	/// large buffer. The large buffer can be replaced by a larger buffer from the pool as needed. All blocks and large buffers
+	/// are maintained in the stream until the stream is disposed (unless AggressiveBufferReturn is enabled in the stream manager).
+	///
+	/// </remarks>
+	internal class RecyclableMemoryStream : MemoryStream
+	{
+		private const long MaxStreamLength = Int32.MaxValue;
+
+		private static readonly byte[] EmptyArray = new byte[0];
+
+		/// <summary>
+		/// All of these blocks must be the same size
+		/// </summary>
+		private readonly List<byte[]> _blocks = new List<byte[]>(1);
+
+		private readonly Guid _id;
+
+		private readonly RecyclableMemoryStreamManager _memoryManager;
+
+		private readonly string _tag;
+
+		/// <summary>
+		/// This list is used to store buffers once they're replaced by something larger.
+		/// This is for the cases where you have users of this class that may hold onto the buffers longer
+		/// than they should and you want to prevent race conditions which could corrupt the data.
+		/// </summary>
+		private List<byte[]> _dirtyBuffers;
+
+		// long to allow Interlocked.Read (for .NET Standard 1.4 compat)
+		private long _disposedState;
+
+		/// <summary>
+		/// This is only set by GetBuffer() if the necessary buffer is larger than a single block size, or on
+		/// construction if the caller immediately requests a single large buffer.
+		/// </summary>
+		/// <remarks>If this field is non-null, it contains the concatenation of the bytes found in the individual
+		/// blocks. Once it is created, this (or a larger) largeBuffer will be used for the life of the stream.
+		/// </remarks>
+		private byte[] _largeBuffer;
+
+		/// <summary>
+		/// Unique identifier for this stream across it's entire lifetime
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		internal Guid Id
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this._id;
+			}
+		}
+
+		/// <summary>
+		/// A temporary identifier for the current usage of this stream.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		internal string Tag
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this._tag;
+			}
+		}
+
+		/// <summary>
+		/// Gets the memory manager being used by this stream.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		internal RecyclableMemoryStreamManager MemoryManager
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this._memoryManager;
+			}
+		}
+
+		#region Constructors
+		/// <summary>
+		/// Allocate a new RecyclableMemoryStream object.
+		/// </summary>
+		/// <param name="memoryManager">The memory manager</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager)
+			: this(memoryManager, null, 0, null) { }
+
+		/// <summary>
+		/// Allocate a new RecyclableMemoryStream object
+		/// </summary>
+		/// <param name="memoryManager">The memory manager</param>
+		/// <param name="tag">A string identifying this stream for logging and debugging purposes</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, string tag)
+			: this(memoryManager, tag, 0, null) { }
+
+		/// <summary>
+		/// Allocate a new RecyclableMemoryStream object
+		/// </summary>
+		/// <param name="memoryManager">The memory manager</param>
+		/// <param name="tag">A string identifying this stream for logging and debugging purposes</param>
+		/// <param name="requestedSize">The initial requested size to prevent future allocations</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, string tag, int requestedSize)
+			: this(memoryManager, tag, requestedSize, null) { }
+
+		/// <summary>
+		/// Allocate a new RecyclableMemoryStream object
+		/// </summary>
+		/// <param name="memoryManager">The memory manager</param>
+		/// <param name="tag">A string identifying this stream for logging and debugging purposes</param>
+		/// <param name="requestedSize">The initial requested size to prevent future allocations</param>
+		/// <param name="initialLargeBuffer">An initial buffer to use. This buffer will be owned by the stream and returned to the memory manager upon Dispose.</param>
+		internal RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, string tag, int requestedSize,
+			byte[] initialLargeBuffer)
+			: base(EmptyArray)
+		{
+			this._memoryManager = memoryManager;
+			this._id = Guid.NewGuid();
+			this._tag = tag;
+
+			if (requestedSize < memoryManager.BlockSize)
+			{
+				requestedSize = memoryManager.BlockSize;
+			}
+
+			if (initialLargeBuffer == null)
+			{
+				this.EnsureCapacity(requestedSize);
+			}
+			else
+			{
+				this._largeBuffer = initialLargeBuffer;
+			}
+		}
+		#endregion
+
+		#region Dispose and Finalize
+		~RecyclableMemoryStream()
+		{
+			this.Dispose(false);
+		}
+
+		/// <summary>
+		/// Returns the memory used by this stream back to the pool.
+		/// </summary>
+		/// <param name="disposing">Whether we're disposing (true), or being called by the finalizer (false)</param>
+		[SuppressMessage("Microsoft.Usage", "CA1816:CallGCSuppressFinalizeCorrectly",
+			Justification = "We have different disposal semantics, so SuppressFinalize is in a different spot.")]
+		protected override void Dispose(bool disposing)
+		{
+			if (Interlocked.CompareExchange(ref this._disposedState, 1, 0) != 0)
+			{
+				return;
+			}
+
+			if (disposing)
+			{
+				GC.SuppressFinalize(this);
+			}
+			else
+			{
+#if !DOTNETCORE
+				if (AppDomain.CurrentDomain.IsFinalizingForUnload())
+				{
+					// If we're being finalized because of a shutdown, don't go any further.
+					// We have no idea what's already been cleaned up. Triggering events may cause
+					// a crash.
+					base.Dispose(disposing);
+					return;
+				}
+#endif
+			}
+
+			if (this._largeBuffer != null)
+			{
+				this._memoryManager.ReturnLargeBuffer(this._largeBuffer, this._tag);
+			}
+
+			if (this._dirtyBuffers != null)
+			{
+				foreach (var buffer in this._dirtyBuffers)
+				{
+					this._memoryManager.ReturnLargeBuffer(buffer, this._tag);
+				}
+			}
+
+			this._memoryManager.ReturnBlocks(this._blocks, this._tag);
+			this._blocks.Clear();
+
+			base.Dispose(disposing);
+		}
+
+		/// <summary>
+		/// Equivalent to Dispose
+		/// </summary>
+#if DOTNETCORE
+        public void Close()
+#else
+		public override void Close()
+#endif
+		{
+			this.Dispose(true);
+		}
+		#endregion
+
+		#region MemoryStream overrides
+		/// <summary>
+		/// Gets or sets the capacity
+		/// </summary>
+		/// <remarks>Capacity is always in multiples of the memory manager's block size, unless
+		/// the large buffer is in use.  Capacity never decreases during a stream's lifetime.
+		/// Explicitly setting the capacity to a lower value than the current value will have no effect.
+		/// This is because the buffers are all pooled by chunks and there's little reason to
+		/// allow stream truncation.
+		/// </remarks>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public override int Capacity
+		{
+			get
+			{
+				this.CheckDisposed();
+				if (this._largeBuffer != null)
+				{
+					return this._largeBuffer.Length;
+				}
+
+				long size = (long)this._blocks.Count * this._memoryManager.BlockSize;
+				return (int)Math.Min(int.MaxValue, size);
+			}
+			set
+			{
+				this.CheckDisposed();
+				this.EnsureCapacity(value);
+			}
+		}
+
+		private int length;
+
+		/// <summary>
+		/// Gets the number of bytes written to this stream.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public override long Length
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this.length;
+			}
+		}
+
+		private int position;
+
+		/// <summary>
+		/// Gets the current position in the stream
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public override long Position
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this.position;
+			}
+			set
+			{
+				this.CheckDisposed();
+				if (value < 0)
+				{
+					throw new ArgumentOutOfRangeException("value", "value must be non-negative");
+				}
+
+				if (value > MaxStreamLength)
+				{
+					throw new ArgumentOutOfRangeException("value", "value cannot be more than " + MaxStreamLength);
+				}
+
+				this.position = (int)value;
+			}
+		}
+
+		/// <summary>
+		/// Whether the stream can currently read
+		/// </summary>
+		public override bool CanRead => !this.Disposed;
+
+		/// <summary>
+		/// Whether the stream can currently seek
+		/// </summary>
+		public override bool CanSeek => !this.Disposed;
+
+		/// <summary>
+		/// Always false
+		/// </summary>
+		public override bool CanTimeout => false;
+
+		/// <summary>
+		/// Whether the stream can currently write
+		/// </summary>
+		public override bool CanWrite => !this.Disposed;
+
+		/// <summary>
+		/// Returns a single buffer containing the contents of the stream.
+		/// The buffer may be longer than the stream length.
+		/// </summary>
+		/// <returns>A byte[] buffer</returns>
+		/// <remarks>IMPORTANT: Doing a Write() after calling GetBuffer() invalidates the buffer. The old buffer is held onto
+		/// until Dispose is called, but the next time GetBuffer() is called, a new buffer from the pool will be required.</remarks>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+#if DOTNETCORE
+        public byte[] GetBuffer()
+#else
+		public override byte[] GetBuffer()
+#endif
+		{
+			this.CheckDisposed();
+
+			if (this._largeBuffer != null)
+			{
+				return this._largeBuffer;
+			}
+
+			if (this._blocks.Count == 1)
+			{
+				return this._blocks[0];
+			}
+
+			// Buffer needs to reflect the capacity, not the length, because
+			// it's possible that people will manipulate the buffer directly
+			// and set the length afterward. Capacity sets the expectation
+			// for the size of the buffer.
+			var newBuffer = this._memoryManager.GetLargeBuffer(this.Capacity, this._tag);
+
+			// InternalRead will check for existence of largeBuffer, so make sure we
+			// don't set it until after we've copied the data.
+			this.InternalRead(newBuffer, 0, this.length, 0);
+			this._largeBuffer = newBuffer;
+
+			if (this._blocks.Count > 0 && this._memoryManager.AggressiveBufferReturn)
+			{
+				this._memoryManager.ReturnBlocks(this._blocks, this._tag);
+				this._blocks.Clear();
+			}
+
+			return this._largeBuffer;
+		}
+
+		/// <summary>
+		/// Returns a new array with a copy of the buffer's contents. You should almost certainly be using GetBuffer combined with the Length to
+		/// access the bytes in this stream. Calling ToArray will destroy the benefits of pooled buffers, but it is included
+		/// for the sake of completeness.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+#pragma warning disable CS0809
+		[Obsolete("This method has degraded performance vs. GetBuffer and should be avoided.")]
+		public override byte[] ToArray()
+		{
+			this.CheckDisposed();
+			var newBuffer = new byte[this.Length];
+
+			this.InternalRead(newBuffer, 0, this.length, 0);
+			return newBuffer;
+		}
+#pragma warning restore CS0809
+
+		/// <summary>
+		/// Reads from the current position into the provided buffer
+		/// </summary>
+		/// <param name="buffer">Destination buffer</param>
+		/// <param name="offset">Offset into buffer at which to start placing the read bytes.</param>
+		/// <param name="count">Number of bytes to read.</param>
+		/// <returns>The number of bytes read</returns>
+		/// <exception cref="ArgumentNullException">buffer is null</exception>
+		/// <exception cref="ArgumentOutOfRangeException">offset or count is less than 0</exception>
+		/// <exception cref="ArgumentException">offset subtracted from the buffer length is less than count</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			return this.SafeRead(buffer, offset, count, ref this.position);
+		}
+
+		/// <summary>
+		/// Reads from the specified position into the provided buffer
+		/// </summary>
+		/// <param name="buffer">Destination buffer</param>
+		/// <param name="offset">Offset into buffer at which to start placing the read bytes.</param>
+		/// <param name="count">Number of bytes to read.</param>
+		/// <param name="streamPosition">Position in the stream to start reading from</param>
+		/// <returns>The number of bytes read</returns>
+		/// <exception cref="ArgumentNullException">buffer is null</exception>
+		/// <exception cref="ArgumentOutOfRangeException">offset or count is less than 0</exception>
+		/// <exception cref="ArgumentException">offset subtracted from the buffer length is less than count</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public int SafeRead(byte[] buffer, int offset, int count, ref int streamPosition)
+		{
+			this.CheckDisposed();
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
+			if (offset < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(offset), "offset cannot be negative");
+			}
+
+			if (count < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(count), "count cannot be negative");
+			}
+
+			if (offset + count > buffer.Length)
+			{
+				throw new ArgumentException("buffer length must be at least offset + count");
+			}
+
+			int amountRead = this.InternalRead(buffer, offset, count, streamPosition);
+			streamPosition += amountRead;
+			return amountRead;
+		}
+
+		/// <summary>
+		/// Writes the buffer to the stream
+		/// </summary>
+		/// <param name="buffer">Source buffer</param>
+		/// <param name="offset">Start position</param>
+		/// <param name="count">Number of bytes to write</param>
+		/// <exception cref="ArgumentNullException">buffer is null</exception>
+		/// <exception cref="ArgumentOutOfRangeException">offset or count is negative</exception>
+		/// <exception cref="ArgumentException">buffer.Length - offset is not less than count</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public override void Write(byte[] buffer, int offset, int count)
+		{
+			this.CheckDisposed();
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
+			if (offset < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(offset), offset,
+					"Offset must be in the range of 0 - buffer.Length-1");
+			}
+
+			if (count < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(count), count, "count must be non-negative");
+			}
+
+			if (count + offset > buffer.Length)
+			{
+				throw new ArgumentException("count must be greater than buffer.Length - offset");
+			}
+
+			int blockSize = this._memoryManager.BlockSize;
+			long end = (long)this.position + count;
+			// Check for overflow
+			if (end > MaxStreamLength)
+			{
+				throw new IOException("Maximum capacity exceeded");
+			}
+
+			long requiredBuffers = (end + blockSize - 1) / blockSize;
+
+			if (requiredBuffers * blockSize > MaxStreamLength)
+			{
+				throw new IOException("Maximum capacity exceeded");
+			}
+
+			this.EnsureCapacity((int)end);
+
+			if (this._largeBuffer == null)
+			{
+				int bytesRemaining = count;
+				int bytesWritten = 0;
+				var blockAndOffset = this.GetBlockAndRelativeOffset(this.position);
+
+				while (bytesRemaining > 0)
+				{
+					byte[] currentBlock = this._blocks[blockAndOffset.Block];
+					int remainingInBlock = blockSize - blockAndOffset.Offset;
+					int amountToWriteInBlock = Math.Min(remainingInBlock, bytesRemaining);
+
+					Buffer.BlockCopy(buffer, offset + bytesWritten, currentBlock, blockAndOffset.Offset,
+						amountToWriteInBlock);
+
+					bytesRemaining -= amountToWriteInBlock;
+					bytesWritten += amountToWriteInBlock;
+
+					++blockAndOffset.Block;
+					blockAndOffset.Offset = 0;
+				}
+			}
+			else
+			{
+				Buffer.BlockCopy(buffer, offset, this._largeBuffer, this.position, count);
+			}
+			this.position = (int)end;
+			this.length = Math.Max(this.position, this.length);
+		}
+
+		/// <summary>
+		/// Returns a useful string for debugging. This should not normally be called in actual production code.
+		/// </summary>
+		public override string ToString()
+		{
+			return $"Id = {this.Id}, Tag = {this.Tag}, Length = {this.Length:N0} bytes";
+		}
+
+		/// <summary>
+		/// Writes a single byte to the current position in the stream.
+		/// </summary>
+		/// <param name="value">byte value to write</param>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public override void WriteByte(byte value)
+		{
+			this.CheckDisposed();
+			int end = this.position + 1;
+
+			// Check for overflow
+			if (end > MaxStreamLength)
+			{
+				throw new IOException("Maximum capacity exceeded");
+			}
+
+			this.EnsureCapacity(end);
+			if (this._largeBuffer == null)
+			{
+				var blockSize = this._memoryManager.BlockSize;
+				var block = this.position / blockSize;
+				var offset = this.position - block * blockSize;
+				var currentBlock = this._blocks[block];
+				currentBlock[offset] = value;
+			}
+			else
+			{
+				this._largeBuffer[this.position] = value;
+			}
+
+			this.position = end;
+			this.length = Math.Max(this.position, this.length);
+		}
+
+		/// <summary>
+		/// Reads a single byte from the current position in the stream.
+		/// </summary>
+		/// <returns>The byte at the current position, or -1 if the position is at the end of the stream.</returns>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public override int ReadByte()
+		{
+			return this.SafeReadByte(ref this.position);
+		}
+
+		/// <summary>
+		/// Reads a single byte from the specified position in the stream.
+		/// </summary>
+		/// <param name="streamPosition">The position in the stream to read from</param>
+		/// <returns>The byte at the current position, or -1 if the position is at the end of the stream.</returns>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public int SafeReadByte(ref int streamPosition)
+		{
+			this.CheckDisposed();
+			if (streamPosition == this.length)
+			{
+				return -1;
+			}
+			byte value;
+			if (this._largeBuffer == null)
+			{
+				var blockAndOffset = this.GetBlockAndRelativeOffset(streamPosition);
+				value = this._blocks[blockAndOffset.Block][blockAndOffset.Offset];
+			}
+			else
+			{
+				value = this._largeBuffer[streamPosition];
+			}
+			streamPosition++;
+			return value;
+		}
+
+		/// <summary>
+		/// Sets the length of the stream
+		/// </summary>
+		/// <exception cref="ArgumentOutOfRangeException">value is negative or larger than MaxStreamLength</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		public override void SetLength(long value)
+		{
+			this.CheckDisposed();
+			if (value < 0 || value > MaxStreamLength)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value),
+					"value must be non-negative and at most " + MaxStreamLength);
+			}
+
+			this.EnsureCapacity((int)value);
+
+			this.length = (int)value;
+			if (this.position > value)
+			{
+				this.position = (int)value;
+			}
+		}
+
+		/// <summary>
+		/// Sets the position to the offset from the seek location
+		/// </summary>
+		/// <param name="offset">How many bytes to move</param>
+		/// <param name="loc">From where</param>
+		/// <returns>The new position</returns>
+		/// <exception cref="ObjectDisposedException">Object has been disposed</exception>
+		/// <exception cref="ArgumentOutOfRangeException">offset is larger than MaxStreamLength</exception>
+		/// <exception cref="ArgumentException">Invalid seek origin</exception>
+		/// <exception cref="IOException">Attempt to set negative position</exception>
+		public override long Seek(long offset, SeekOrigin loc)
+		{
+			this.CheckDisposed();
+			if (offset > MaxStreamLength)
+			{
+				throw new ArgumentOutOfRangeException(nameof(offset), "offset cannot be larger than " + MaxStreamLength);
+			}
+
+			int newPosition;
+			switch (loc)
+			{
+				case SeekOrigin.Begin:
+					newPosition = (int)offset;
+					break;
+				case SeekOrigin.Current:
+					newPosition = (int)offset + this.position;
+					break;
+				case SeekOrigin.End:
+					newPosition = (int)offset + this.length;
+					break;
+				default:
+					throw new ArgumentException("Invalid seek origin", nameof(loc));
+			}
+			if (newPosition < 0)
+			{
+				throw new IOException("Seek before beginning");
+			}
+			this.position = newPosition;
+			return this.position;
+		}
+
+		/// <summary>
+		/// Synchronously writes this stream's bytes to the parameter stream.
+		/// </summary>
+		/// <param name="stream">Destination stream</param>
+		/// <remarks>Important: This does a synchronous write, which may not be desired in some situations</remarks>
+		public override void WriteTo(Stream stream)
+		{
+			this.CheckDisposed();
+			if (stream == null)
+			{
+				throw new ArgumentNullException(nameof(stream));
+			}
+
+			if (this._largeBuffer == null)
+			{
+				int currentBlock = 0;
+				int bytesRemaining = this.length;
+
+				while (bytesRemaining > 0)
+				{
+					int amountToCopy = Math.Min(this._blocks[currentBlock].Length, bytesRemaining);
+					stream.Write(this._blocks[currentBlock], 0, amountToCopy);
+
+					bytesRemaining -= amountToCopy;
+
+					++currentBlock;
+				}
+			}
+			else
+			{
+				stream.Write(this._largeBuffer, 0, this.length);
+			}
+		}
+		#endregion
+
+		#region Helper Methods
+		private bool Disposed => Interlocked.Read(ref this._disposedState) != 0;
+
+		private void CheckDisposed()
+		{
+			if (this.Disposed)
+			{
+				throw new ObjectDisposedException($"The stream with Id {this._id} and Tag {this._tag} is disposed.");
+			}
+		}
+
+		private int InternalRead(byte[] buffer, int offset, int count, int fromPosition)
+		{
+			if (this.length - fromPosition <= 0)
+			{
+				return 0;
+			}
+
+			int amountToCopy;
+
+			if (this._largeBuffer == null)
+			{
+				var blockAndOffset = this.GetBlockAndRelativeOffset(fromPosition);
+				int bytesWritten = 0;
+				int bytesRemaining = Math.Min(count, this.length - fromPosition);
+
+				while (bytesRemaining > 0)
+				{
+					amountToCopy = Math.Min(this._blocks[blockAndOffset.Block].Length - blockAndOffset.Offset,
+						bytesRemaining);
+
+					Buffer.BlockCopy(this._blocks[blockAndOffset.Block], blockAndOffset.Offset, buffer,
+						bytesWritten + offset, amountToCopy);
+
+					bytesWritten += amountToCopy;
+					bytesRemaining -= amountToCopy;
+
+					++blockAndOffset.Block;
+					blockAndOffset.Offset = 0;
+				}
+				return bytesWritten;
+			}
+			amountToCopy = Math.Min(count, this.length - fromPosition);
+			Buffer.BlockCopy(this._largeBuffer, fromPosition, buffer, offset, amountToCopy);
+			return amountToCopy;
+		}
+
+		private struct BlockAndOffset
+		{
+			public int Block;
+			public int Offset;
+
+			public BlockAndOffset(int block, int offset)
+			{
+				this.Block = block;
+				this.Offset = offset;
+			}
+		}
+
+		private BlockAndOffset GetBlockAndRelativeOffset(int offset)
+		{
+			var blockSize = this._memoryManager.BlockSize;
+			return new BlockAndOffset(offset / blockSize, offset % blockSize);
+		}
+
+		private void EnsureCapacity(int newCapacity)
+		{
+			if (newCapacity > this._memoryManager.MaximumStreamCapacity && this._memoryManager.MaximumStreamCapacity > 0)
+			{
+				throw new InvalidOperationException("Requested capacity is too large: " + newCapacity + ". Limit is " +
+				                                    this._memoryManager.MaximumStreamCapacity);
+			}
+
+			if (this._largeBuffer != null)
+			{
+				if (newCapacity > this._largeBuffer.Length)
+				{
+					var newBuffer = this._memoryManager.GetLargeBuffer(newCapacity, this._tag);
+					this.InternalRead(newBuffer, 0, this.length, 0);
+					this.ReleaseLargeBuffer();
+					this._largeBuffer = newBuffer;
+				}
+			}
+			else
+			{
+				while (this.Capacity < newCapacity)
+				{
+					_blocks.Add((this._memoryManager.GetBlock()));
+				}
+			}
+		}
+
+		/// <summary>
+		/// Release the large buffer (either stores it for eventual release or returns it immediately).
+		/// </summary>
+		private void ReleaseLargeBuffer()
+		{
+			if (this._memoryManager.AggressiveBufferReturn)
+			{
+				this._memoryManager.ReturnLargeBuffer(this._largeBuffer, this._tag);
+			}
+			else
+			{
+				if (this._dirtyBuffers == null)
+				{
+					// We most likely will only ever need space for one
+					this._dirtyBuffers = new List<byte[]>(1);
+				}
+				this._dirtyBuffers.Add(this._largeBuffer);
+			}
+
+			this._largeBuffer = null;
+		}
+		#endregion
+	}
+}

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamFactory.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// A factory for creating memory streams using a recyclable pool of <see cref="MemoryStream"/> instances
+	/// </summary>
+	public class RecyclableMemoryStreamFactory : IMemoryStreamFactory
+	{
+		private readonly RecyclableMemoryStreamManager _manager;
+
+		public RecyclableMemoryStreamFactory() =>
+			_manager = new RecyclableMemoryStreamManager { AggressiveBufferReturn = true };
+
+		public MemoryStream Create() => _manager.GetStream();
+
+		public MemoryStream Create(byte[] bytes) => _manager.GetStream(string.Empty, bytes, 0, bytes.Length);
+	}
+}

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
@@ -1,0 +1,456 @@
+﻿// ---------------------------------------------------------------------
+// Copyright (c) 2015-2016 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ---------------------------------------------------------------------
+//
+// https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream/blob/master/src/RecyclableMemoryStreamManager.cs
+// MIT license: https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream/blob/master/LICENSE
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+
+namespace Elasticsearch.Net
+{
+	internal class RecyclableMemoryStreamManager
+	{
+		public const int DefaultBlockSize = 128 * 1024;
+		public const int DefaultLargeBufferMultiple = 1024 * 1024;
+		public const int DefaultMaximumBufferSize = 128 * 1024 * 1024;
+
+		private readonly int _blockSize;
+		private readonly long[] _largeBufferFreeSize;
+		private readonly long[] _largeBufferInUseSize;
+		private readonly int _largeBufferMultiple;
+
+		/// <summary>
+		/// pools[0] = 1x largeBufferMultiple buffers
+		/// pools[1] = 2x largeBufferMultiple buffers
+		/// etc., up to maximumBufferSize
+		/// </summary>
+		private readonly ConcurrentStack<byte[]>[] largePools;
+
+		private readonly int _maximumBufferSize;
+		private readonly ConcurrentStack<byte[]> smallPool;
+
+		private long _smallPoolFreeSize;
+		private long _smallPoolInUseSize;
+
+		/// <summary>
+		/// Initializes the memory manager with the default block/buffer specifications.
+		/// </summary>
+		public RecyclableMemoryStreamManager()
+			: this(DefaultBlockSize, DefaultLargeBufferMultiple, DefaultMaximumBufferSize) { }
+
+		/// <summary>
+		/// Initializes the memory manager with the given block requiredSize.
+		/// </summary>
+		/// <param name="blockSize">Size of each block that is pooled. Must be > 0.</param>
+		/// <param name="largeBufferMultiple">Each large buffer will be a multiple of this value.</param>
+		/// <param name="maximumBufferSize">Buffers larger than this are not pooled</param>
+		/// <exception cref="ArgumentOutOfRangeException">blockSize is not a positive number, or largeBufferMultiple is not a positive number, or maximumBufferSize is less than blockSize.</exception>
+		/// <exception cref="ArgumentException">maximumBufferSize is not a multiple of largeBufferMultiple</exception>
+		public RecyclableMemoryStreamManager(int blockSize, int largeBufferMultiple, int maximumBufferSize)
+		{
+			if (blockSize <= 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(blockSize), blockSize, "blockSize must be a positive number");
+			}
+
+			if (largeBufferMultiple <= 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(largeBufferMultiple),
+					"largeBufferMultiple must be a positive number");
+			}
+
+			if (maximumBufferSize < blockSize)
+			{
+				throw new ArgumentOutOfRangeException(nameof(maximumBufferSize),
+					"maximumBufferSize must be at least blockSize");
+			}
+
+			this._blockSize = blockSize;
+			this._largeBufferMultiple = largeBufferMultiple;
+			this._maximumBufferSize = maximumBufferSize;
+
+			if (!this.IsLargeBufferMultiple(maximumBufferSize))
+			{
+				throw new ArgumentException("maximumBufferSize is not a multiple of largeBufferMultiple",
+					nameof(maximumBufferSize));
+			}
+
+			this.smallPool = new ConcurrentStack<byte[]>();
+			var numLargePools = maximumBufferSize / largeBufferMultiple;
+
+			// +1 to store size of bytes in use that are too large to be pooled
+			this._largeBufferInUseSize = new long[numLargePools + 1];
+			this._largeBufferFreeSize = new long[numLargePools];
+
+			this.largePools = new ConcurrentStack<byte[]>[numLargePools];
+
+			for (var i = 0; i < this.largePools.Length; ++i)
+			{
+				this.largePools[i] = new ConcurrentStack<byte[]>();
+			}
+		}
+
+		/// <summary>
+		/// The size of each block. It must be set at creation and cannot be changed.
+		/// </summary>
+		public int BlockSize => this._blockSize;
+
+		/// <summary>
+		/// All buffers are multiples of this number. It must be set at creation and cannot be changed.
+		/// </summary>
+		public int LargeBufferMultiple => this._largeBufferMultiple;
+
+		/// <summary>
+		/// Gets or sets the maximum buffer size.
+		/// </summary>
+		/// <remarks>Any buffer that is returned to the pool that is larger than this will be
+		/// discarded and garbage collected.</remarks>
+		public int MaximumBufferSize => this._maximumBufferSize;
+
+		/// <summary>
+		/// Number of bytes in small pool not currently in use
+		/// </summary>
+		public long SmallPoolFreeSize => this._smallPoolFreeSize;
+
+		/// <summary>
+		/// Number of bytes currently in use by stream from the small pool
+		/// </summary>
+		public long SmallPoolInUseSize => this._smallPoolInUseSize;
+
+		/// <summary>
+		/// Number of bytes in large pool not currently in use
+		/// </summary>
+		public long LargePoolFreeSize
+		{
+			get
+			{
+				long sum = 0;
+				for (var index = 0; index < this._largeBufferFreeSize.Length; index++)
+				{
+					var freeSize = this._largeBufferFreeSize[index];
+					sum += freeSize;
+				}
+
+				return sum;
+			}
+		}
+
+		/// <summary>
+		/// Number of bytes currently in use by streams from the large pool
+		/// </summary>
+		public long LargePoolInUseSize
+		{
+			get
+			{
+				long sum = 0;
+				for (var index = 0; index < this._largeBufferInUseSize.Length; index++)
+				{
+					var inUseSize = this._largeBufferInUseSize[index];
+					sum += inUseSize;
+				}
+
+				return sum;
+			}
+		}
+
+		/// <summary>
+		/// How many blocks are in the small pool
+		/// </summary>
+		public long SmallBlocksFree => this.smallPool.Count;
+
+		/// <summary>
+		/// How many buffers are in the large pool
+		/// </summary>
+		public long LargeBuffersFree
+		{
+			get
+			{
+				long free = 0;
+				foreach (var pool in this.largePools)
+				{
+					free += pool.Count;
+				}
+				return free;
+			}
+		}
+
+		/// <summary>
+		/// How many bytes of small free blocks to allow before we start dropping
+		/// those returned to us.
+		/// </summary>
+		public long MaximumFreeSmallPoolBytes { get; set; }
+
+		/// <summary>
+		/// How many bytes of large free buffers to allow before we start dropping
+		/// those returned to us.
+		/// </summary>
+		public long MaximumFreeLargePoolBytes { get; set; }
+
+		/// <summary>
+		/// Maximum stream capacity in bytes. Attempts to set a larger capacity will
+		/// result in an exception.
+		/// </summary>
+		/// <remarks>A value of 0 indicates no limit.</remarks>
+		public long MaximumStreamCapacity { get; set; }
+
+		/// <summary>
+		/// Whether dirty buffers can be immediately returned to the buffer pool. E.g. when GetBuffer() is called on
+		/// a stream and creates a single large buffer, if this setting is enabled, the other blocks will be returned
+		/// to the buffer pool immediately.
+		/// Note when enabling this setting that the user is responsible for ensuring that any buffer previously
+		/// retrieved from a stream which is subsequently modified is not used after modification (as it may no longer
+		/// be valid).
+		/// </summary>
+		public bool AggressiveBufferReturn { get; set; }
+
+		/// <summary>
+		/// Removes and returns a single block from the pool.
+		/// </summary>
+		/// <returns>A byte[] array</returns>
+		internal byte[] GetBlock()
+		{
+			if (!this.smallPool.TryPop(out var block))
+			{
+				// We'll add this back to the pool when the stream is disposed
+				// (unless our free pool is too large)
+				block = new byte[this.BlockSize];
+			}
+			else
+			{
+				Interlocked.Add(ref this._smallPoolFreeSize, -this.BlockSize);
+			}
+
+			Interlocked.Add(ref this._smallPoolInUseSize, this.BlockSize);
+			return block;
+		}
+
+		/// <summary>
+		/// Returns a buffer of arbitrary size from the large buffer pool. This buffer
+		/// will be at least the requiredSize and always be a multiple of largeBufferMultiple.
+		/// </summary>
+		/// <param name="requiredSize">The minimum length of the buffer</param>
+		/// <param name="tag">The tag of the stream returning this buffer, for logging if necessary.</param>
+		/// <returns>A buffer of at least the required size.</returns>
+		internal byte[] GetLargeBuffer(int requiredSize, string tag)
+		{
+			requiredSize = this.RoundToLargeBufferMultiple(requiredSize);
+
+			var poolIndex = requiredSize / this._largeBufferMultiple - 1;
+
+			byte[] buffer;
+			if (poolIndex < this.largePools.Length)
+			{
+				if (!this.largePools[poolIndex].TryPop(out buffer))
+				{
+					buffer = new byte[requiredSize];
+				}
+				else
+				{
+					Interlocked.Add(ref this._largeBufferFreeSize[poolIndex], -buffer.Length);
+				}
+			}
+			else
+			{
+				// Buffer is too large to pool. They get a new buffer.
+
+				// We still want to track the size, though, and we've reserved a slot
+				// in the end of the inuse array for nonpooled bytes in use.
+				poolIndex = this._largeBufferInUseSize.Length - 1;
+
+				// We still want to round up to reduce heap fragmentation.
+				buffer = new byte[requiredSize];
+			}
+
+			Interlocked.Add(ref this._largeBufferInUseSize[poolIndex], buffer.Length);
+
+			return buffer;
+		}
+
+		private int RoundToLargeBufferMultiple(int requiredSize)
+		{
+			return ((requiredSize + this.LargeBufferMultiple - 1) / this.LargeBufferMultiple) * this.LargeBufferMultiple;
+		}
+
+		private bool IsLargeBufferMultiple(int value)
+		{
+			return (value != 0) && (value % this.LargeBufferMultiple) == 0;
+		}
+
+		/// <summary>
+		/// Returns the buffer to the large pool
+		/// </summary>
+		/// <param name="buffer">The buffer to return.</param>
+		/// <param name="tag">The tag of the stream returning this buffer, for logging if necessary.</param>
+		/// <exception cref="ArgumentNullException">buffer is null</exception>
+		/// <exception cref="ArgumentException">buffer.Length is not a multiple of LargeBufferMultiple (it did not originate from this pool)</exception>
+		internal void ReturnLargeBuffer(byte[] buffer, string tag)
+		{
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
+			if (!this.IsLargeBufferMultiple(buffer.Length))
+			{
+				throw new ArgumentException(
+					"buffer did not originate from this memory manager. The size is not a multiple of " +
+					this.LargeBufferMultiple);
+			}
+
+			var poolIndex = buffer.Length / this._largeBufferMultiple - 1;
+
+			if (poolIndex < this.largePools.Length)
+			{
+				if ((this.largePools[poolIndex].Count + 1) * buffer.Length <= this.MaximumFreeLargePoolBytes ||
+				    this.MaximumFreeLargePoolBytes == 0)
+				{
+					this.largePools[poolIndex].Push(buffer);
+					Interlocked.Add(ref this._largeBufferFreeSize[poolIndex], buffer.Length);
+				}
+			}
+			else
+			{
+				// This is a non-poolable buffer, but we still want to track its size for inuse
+				// analysis. We have space in the inuse array for this.
+				poolIndex = this._largeBufferInUseSize.Length - 1;
+			}
+
+			Interlocked.Add(ref this._largeBufferInUseSize[poolIndex], -buffer.Length);
+		}
+
+		/// <summary>
+		/// Returns the blocks to the pool
+		/// </summary>
+		/// <param name="blocks">Collection of blocks to return to the pool</param>
+		/// <param name="tag">The tag of the stream returning these blocks, for logging if necessary.</param>
+		/// <exception cref="ArgumentNullException">blocks is null</exception>
+		/// <exception cref="ArgumentException">blocks contains buffers that are the wrong size (or null) for this memory manager</exception>
+		internal void ReturnBlocks(ICollection<byte[]> blocks, string tag)
+		{
+			if (blocks == null)
+			{
+				throw new ArgumentNullException(nameof(blocks));
+			}
+
+			var bytesToReturn = blocks.Count * this.BlockSize;
+			Interlocked.Add(ref this._smallPoolInUseSize, -bytesToReturn);
+
+			foreach (var block in blocks)
+			{
+				if (block == null || block.Length != this.BlockSize)
+				{
+					throw new ArgumentException("blocks contains buffers that are not BlockSize in length");
+				}
+			}
+
+			foreach (var block in blocks)
+			{
+				if (this.MaximumFreeSmallPoolBytes == 0 || this.SmallPoolFreeSize < this.MaximumFreeSmallPoolBytes)
+				{
+					Interlocked.Add(ref this._smallPoolFreeSize, this.BlockSize);
+					this.smallPool.Push(block);
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieve a new MemoryStream object with no tag and a default initial capacity.
+		/// </summary>
+		/// <returns>A MemoryStream.</returns>
+		public MemoryStream GetStream()
+		{
+			return new RecyclableMemoryStream(this);
+		}
+
+		/// <summary>
+		/// Retrieve a new MemoryStream object with the given tag and a default initial capacity.
+		/// </summary>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <returns>A MemoryStream.</returns>
+		public MemoryStream GetStream(string tag)
+		{
+			return new RecyclableMemoryStream(this, tag);
+		}
+
+		/// <summary>
+		/// Retrieve a new MemoryStream object with the given tag and at least the given capacity.
+		/// </summary>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="requiredSize">The minimum desired capacity for the stream.</param>
+		/// <returns>A MemoryStream.</returns>
+		public MemoryStream GetStream(string tag, int requiredSize)
+		{
+			return new RecyclableMemoryStream(this, tag, requiredSize);
+		}
+
+		/// <summary>
+		/// Retrieve a new MemoryStream object with the given tag and at least the given capacity, possibly using
+		/// a single continugous underlying buffer.
+		/// </summary>
+		/// <remarks>Retrieving a MemoryStream which provides a single contiguous buffer can be useful in situations
+		/// where the initial size is known and it is desirable to avoid copying data between the smaller underlying
+		/// buffers to a single large one. This is most helpful when you know that you will always call GetBuffer
+		/// on the underlying stream.</remarks>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="requiredSize">The minimum desired capacity for the stream.</param>
+		/// <param name="asContiguousBuffer">Whether to attempt to use a single contiguous buffer.</param>
+		/// <returns>A MemoryStream.</returns>
+		public MemoryStream GetStream(string tag, int requiredSize, bool asContiguousBuffer)
+		{
+			if (!asContiguousBuffer || requiredSize <= this.BlockSize)
+			{
+				return this.GetStream(tag, requiredSize);
+			}
+
+			return new RecyclableMemoryStream(this, tag, requiredSize, this.GetLargeBuffer(requiredSize, tag));
+		}
+
+		/// <summary>
+		/// Retrieve a new MemoryStream object with the given tag and with contents copied from the provided
+		/// buffer. The provided buffer is not wrapped or used after construction.
+		/// </summary>
+		/// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="buffer">The byte buffer to copy data from.</param>
+		/// <param name="offset">The offset from the start of the buffer to copy from.</param>
+		/// <param name="count">The number of bytes to copy from the buffer.</param>
+		/// <returns>A MemoryStream.</returns>
+		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+		public MemoryStream GetStream(string tag, byte[] buffer, int offset, int count)
+		{
+			var stream = new RecyclableMemoryStream(this, tag, count);
+			stream.Write(buffer, offset, count);
+			stream.Position = 0;
+			return stream;
+		}
+	}
+}

--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace Elasticsearch.Net
 {
 	/// <summary>
-	/// A response from elasticsearch including details about the request/response life cycle
+	/// A response from Elasticsearch including details about the request/response life cycle
 	/// </summary>
 	public abstract class ElasticsearchResponseBase : IApiCallDetails, IElasticsearchResponse
 	{
@@ -47,7 +47,7 @@ namespace Elasticsearch.Net
 	}
 
 	/// <summary>
-	/// A response from elasticsearch including details about the request/response life cycle. Base class for the built in low level response
+	/// A response from Elasticsearch including details about the request/response life cycle. Base class for the built in low level response
 	/// types: <see cref="StringResponse"/> <see cref="BytesResponse"/> and <see cref="DynamicResponse"/>
 	/// </summary>
 	public abstract class ElasticsearchResponse<T> : ElasticsearchResponseBase

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -107,6 +107,7 @@ namespace Elasticsearch.Net
 
 		public bool Refresh { get; private set; }
 
+		// TODO: rename to DepeletedRetries in 7.x
 		public bool DepleededRetries => this.Retried >= this.MaxRetries + 1 || this.IsTakingTooLong;
 
 		private Auditable Audit(AuditEvent type) => new Auditable(type, this.AuditTrail, this._dateTimeProvider);
@@ -258,7 +259,7 @@ namespace Elasticsearch.Net
 				EnableHttpPipelining = this.RequestConfiguration?.EnableHttpPipelining ?? this._settings.HttpPipeliningEnabled,
 				ForceNode = this.RequestConfiguration?.ForceNode
 			};
-			IRequestParameters requestParameters = new RootNodeInfoRequestParameters { };
+			IRequestParameters requestParameters = new RootNodeInfoRequestParameters();
 			requestParameters.RequestConfiguration = requestOverrides;
 
 			var data = new RequestData(HttpMethod.HEAD, "/", null, this._settings, requestParameters, this._memoryStreamFactory) { Node = node };

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -42,8 +42,7 @@ namespace Elasticsearch.Net
 		{
 			responseStream.ThrowIfNull(nameof(responseStream));
 			var details = Initialize(requestData, ex, statusCode, warnings, mimeType);
-			var response = (await SetBodyAsync<TResponse>(details, requestData, responseStream, mimeType, cancellationToken)
-				               .ConfigureAwait(false))
+			var response = await SetBodyAsync<TResponse>(details, requestData, responseStream, mimeType, cancellationToken).ConfigureAwait(false)
 				?? new TResponse();
 			response.ApiCall = details;
 			return response;

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -43,7 +43,7 @@ namespace Elasticsearch.Net
 			this.Settings = configurationValues;
 			this.PipelineProvider = pipelineProvider ?? new RequestPipelineFactory();
 			this.DateTimeProvider = dateTimeProvider ?? Elasticsearch.Net.DateTimeProvider.Default;
-			this.MemoryStreamFactory = memoryStreamFactory ?? new MemoryStreamFactory();
+			this.MemoryStreamFactory = memoryStreamFactory ?? configurationValues.MemoryStreamFactory;
 		}
 
 		public TResponse Request<TResponse>(HttpMethod method, string path, PostData data = null, IRequestParameters requestParameters = null)

--- a/src/Nest/Aggregations/AggregateJsonConverter.cs
+++ b/src/Nest/Aggregations/AggregateJsonConverter.cs
@@ -583,10 +583,7 @@ namespace Nest
 				return valueMetric;
 			}
 
-
-			//var scriptedMetric = serializer.Deserialize(reader);
-			var scriptedMetric = JToken.ReadFrom(reader);
-
+			var scriptedMetric = reader.ReadTokenWithDateParseHandlingNone();
 			reader.Read();
 			if (scriptedMetric != null)
 			{

--- a/src/Nest/Aggregations/AggregateJsonConverter.cs
+++ b/src/Nest/Aggregations/AggregateJsonConverter.cs
@@ -248,16 +248,14 @@ namespace Nest
 			if (o == null)
 				return null;
 			var geoBoundsMetric = new GeoBoundsAggregate();
-			JToken topLeftToken;
-			if (o.TryGetValue(Parser.TopLeft, out topLeftToken) && topLeftToken != null)
+			if (o.TryGetValue(Parser.TopLeft, out var topLeftToken) && topLeftToken != null)
 			{
 				var topLeft = topLeftToken.ToObject<LatLon>();
 				if (topLeft != null)
 					geoBoundsMetric.Bounds.TopLeft = topLeft;
 			}
 
-			JToken bottomRightToken;
-			if (o.TryGetValue(Parser.BottomRight, out bottomRightToken) && bottomRightToken != null)
+			if (o.TryGetValue(Parser.BottomRight, out var bottomRightToken) && bottomRightToken != null)
 			{
 				var bottomRight = bottomRightToken.ToObject<LatLon>();
 				if (bottomRight != null)

--- a/src/Nest/CommonAbstractions/LazyDocument/LazyDocument.cs
+++ b/src/Nest/CommonAbstractions/LazyDocument/LazyDocument.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using Elasticsearch.Net;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Nest
@@ -44,7 +45,7 @@ namespace Nest
 		public T As<T>()
 		{
 			if (Token == null) return default(T);
-			using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(Token.ToString())))
+			using (var ms = Token.ToStream())
 				return _serializer.Deserialize<T>(ms);
 		}
 
@@ -52,7 +53,7 @@ namespace Nest
 		public object As(Type objectType)
 		{
 			if (Token == null) return null;
-			using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(Token.ToString())))
+			using (var ms = Token.ToStream())
 				return _serializer.Deserialize(objectType, ms);
 		}
 	}

--- a/src/Nest/CommonAbstractions/LazyDocument/LazyDocumentJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/LazyDocument/LazyDocumentJsonConverter.cs
@@ -21,7 +21,7 @@ namespace Nest
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var sourceSerializer = serializer.GetConnectionSettings().SourceSerializer;
-			var token = JToken.ReadFrom(reader);
+			var token = reader.ReadTokenWithDateParseHandlingNone();
 			return new LazyDocument(token, sourceSerializer);
 		}
 

--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/ErrorCauseJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/ErrorCauseJsonConverter.cs
@@ -134,13 +134,11 @@ namespace Nest
 			}
 			return true;
 		}
-		private static readonly IReadOnlyCollection<ShardFailure> DefaultFailedShards =
-			new ReadOnlyCollection<ShardFailure>(new ShardFailure[0] { });
 
 		protected static IReadOnlyCollection<ShardFailure> ExtractFailedShards(JsonReader reader, JsonSerializer serializer)
 		{
 			reader.Read();
-			if (reader.TokenType != JsonToken.StartArray) return DefaultFailedShards;
+			if (reader.TokenType != JsonToken.StartArray) return EmptyReadOnly<ShardFailure>.Collection;
 			var shardFailures = serializer.Deserialize<List<ShardFailure>>(reader);
 			return new ReadOnlyCollection<ShardFailure>(shardFailures);
 		}

--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/GenericProxyRequestConverterBase.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/GenericProxyRequestConverterBase.cs
@@ -12,10 +12,8 @@ namespace Nest
 	{
 		private readonly Type _genericRequestType;
 
-		protected GenericProxyRequestConverterBase(Type genericRequestType)
-		{
+		protected GenericProxyRequestConverterBase(Type genericRequestType) =>
 			_genericRequestType = genericRequestType;
-		}
 
 		public override bool CanRead => true;
 		public override bool CanWrite => true;
@@ -24,7 +22,7 @@ namespace Nest
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var token = reader.ReadTokenWithDateParseHandlingNone();
-			using (var ms = token.ToStream())
+			using (var ms = token.ToStream(serializer.GetConnectionSettings().MemoryStreamFactory))
 			{
                 //not optimized but deserializing create requests is far from common practice
                 var genericType = objectType.GetTypeInfo().GenericTypeArguments[0];

--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/GenericProxyRequestConverterBase.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/GenericProxyRequestConverterBase.cs
@@ -23,8 +23,8 @@ namespace Nest
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
-			var token = JToken.ReadFrom(reader);
-			using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(token.ToString())))
+			var token = reader.ReadTokenWithDateParseHandlingNone();
+			using (var ms = token.ToStream())
 			{
                 //not optimized but deserializing create requests is far from common practice
                 var genericType = objectType.GetTypeInfo().GenericTypeArguments[0];

--- a/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/ReserializeJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/GenericJsonConverters/ReserializeJsonConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Newtonsoft.Json;
 
 namespace Nest

--- a/src/Nest/CommonAbstractions/SerializationBehavior/InternalSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/InternalSerializer.cs
@@ -11,7 +11,7 @@ namespace Nest
 	/// <summary>The built in internal serializer that the high level client NEST uses.</summary>
 	internal class InternalSerializer : IElasticsearchSerializer
 	{
-		private static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
+		internal static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
 
 		private static readonly Task CompletedTask = Task.CompletedTask;
 

--- a/src/Nest/CommonAbstractions/SerializationBehavior/InternalSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/InternalSerializer.cs
@@ -1,17 +1,13 @@
 using System;
-using System.Collections.Concurrent;
 using System.IO;
-using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Nest
 {
-
 	/// <summary>The built in internal serializer that the high level client NEST uses.</summary>
 	internal class InternalSerializer : IElasticsearchSerializer
 	{
@@ -71,7 +67,6 @@ namespace Nest
 			}
 		}
 
-
 		public Task SerializeAsync<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented,
 			CancellationToken cancellationToken = default(CancellationToken))
 		{
@@ -81,46 +76,45 @@ namespace Nest
 			return CompletedTask;
 		}
 
-		public T Deserialize<T>(Stream stream) => (T) this.Deserialize(typeof(T), stream);
+		public T Deserialize<T>(Stream stream)
+		{
+			if (stream == null || stream.Length == 0) return default(T);
+			using (var streamReader = new StreamReader(stream))
+			using (var jsonTextReader = new JsonTextReader(streamReader))
+				return this.Serializer.Deserialize<T>(jsonTextReader);
+		}
 
 		public object Deserialize(Type type, Stream stream)
 		{
-			if (stream == null) return type.DefaultValue();
+			if (stream == null || stream.Length == 0) return type.DefaultValue();
 			using (var streamReader = new StreamReader(stream))
 			using (var jsonTextReader = new JsonTextReader(streamReader))
-			{
-				var t = this.Serializer.Deserialize(jsonTextReader, type);
-				return t;
-			}
+				return this.Serializer.Deserialize(jsonTextReader, type);
 		}
 
+#pragma warning disable 1998 // we know this is not an async operation
 		public async Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore 1998
 		{
-			if (stream == null) return default(T);
-			var bytes = await ReadToBytesAsync(stream, cancellationToken);
-
-			if (bytes == null || bytes.Length == 0) return default(T);
-            using (var ms  = new MemoryStream(bytes))
-            using (var sr = new StreamReader(ms))
+			if (stream == null || stream.Length == 0) return default(T);
+            using (var sr = new StreamReader(stream))
             using (var jtr = new JsonTextReader(sr))
 				return this.Serializer.Deserialize<T>(jtr);
 		}
 
+#pragma warning disable 1998 // we know this is not an async operation
 		public async Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore 1998
 		{
-			if (stream == null) return type.DefaultValue();
-			var bytes = await ReadToBytesAsync(stream, cancellationToken);
-
-			if (bytes == null || bytes.Length == 0) return type.DefaultValue();
-            using (var ms  = new MemoryStream(bytes))
-            using (var sr = new StreamReader(ms))
+			if (stream == null || stream.Length == 0) return type.DefaultValue();
+            using (var sr = new StreamReader(stream))
             using (var jtr = new JsonTextReader(sr))
 				return this.Serializer.Deserialize(jtr, type);
 		}
 
 		private JsonSerializerSettings CreateSettings(SerializationFormatting formatting)
 		{
-			var settings = new JsonSerializerSettings()
+			var settings = new JsonSerializerSettings
 			{
 				Formatting = formatting == SerializationFormatting.Indented ? Formatting.Indented : Formatting.None,
 				ContractResolver = this.ContractResolver,
@@ -128,20 +122,10 @@ namespace Nest
 				NullValueHandling = NullValueHandling.Ignore
 			};
 
-			if (!(settings.ContractResolver is ElasticContractResolver contract))
+			if (!(settings.ContractResolver is ElasticContractResolver))
 				throw new Exception($"NEST needs an instance of {nameof(ElasticContractResolver)} registered on Json.NET's JsonSerializerSettings");
 
 			return settings;
-		}
-
-		private static async Task<byte[]> ReadToBytesAsync(Stream stream, CancellationToken cancellationToken)
-		{
-			if (stream is MemoryStream o) return o.ToArray();
-			using (var ms = new MemoryStream())
-			{
-				await stream.CopyToAsync(ms, ResponseBuilder.BufferSize, cancellationToken);
-				return ms.ToArray();
-			}
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/InternalSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/InternalSerializer.cs
@@ -79,6 +79,10 @@ namespace Nest
 			return CompletedTask;
 		}
 
+		public T Deserialize<T>(JsonReader reader) => this.Serializer.Deserialize<T>(reader);
+
+		public object Deserialize(JsonReader reader, Type objectType) => this.Serializer.Deserialize(reader, objectType);
+
 		public T Deserialize<T>(Stream stream)
 		{
 			if (stream == null || stream.Length == 0) return default(T);

--- a/src/Nest/CommonAbstractions/SerializationBehavior/InternalSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/InternalSerializer.cs
@@ -11,6 +11,9 @@ namespace Nest
 	/// <summary>The built in internal serializer that the high level client NEST uses.</summary>
 	internal class InternalSerializer : IElasticsearchSerializer
 	{
+		// Default buffer size of StreamWriter, which is private :(
+		internal const int DefaultBufferSize = 1024;
+
 		internal static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
 
 		private static readonly Task CompletedTask = Task.CompletedTask;
@@ -29,7 +32,7 @@ namespace Nest
 		/// </summary>
 		// Performance tests as part of https://github.com/elastic/elasticsearch-net/issues/1899 indicate this
 		// to be a good compromise buffer size for performance throughput and bytes allocated.
-		protected virtual int BufferSize => 1024;
+		protected virtual int BufferSize => DefaultBufferSize;
 
 		public InternalSerializer(IConnectionSettingsValues settings) : this(settings, null) { }
 

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JTokenExtensions.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JTokenExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Elasticsearch.Net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -13,9 +15,12 @@ namespace Nest
 		/// <summary>
 		/// Writes a <see cref="JToken"/> to a <see cref="MemoryStream"/> using <see cref="InternalSerializer.ExpectedEncoding"/>
 		/// </summary>
-		public static MemoryStream ToStream(this JToken token)
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static MemoryStream ToStream(
+			this JToken token,
+			IMemoryStreamFactory memoryStreamFactory = null)
 		{
-			var ms = new MemoryStream();
+			var ms = memoryStreamFactory?.Create() ?? new MemoryStream();
 			using (var streamWriter = new StreamWriter(ms, InternalSerializer.ExpectedEncoding, InternalSerializer.DefaultBufferSize, leaveOpen: true))
 			using (var writer = new JsonTextWriter(streamWriter))
 			{
@@ -29,9 +34,13 @@ namespace Nest
 		/// <summary>
 		/// Writes a <see cref="JToken"/> asynchronously to a <see cref="MemoryStream"/> using <see cref="InternalSerializer.ExpectedEncoding"/>
 		/// </summary>
-		public static async Task<MemoryStream> ToStreamAsync(this JToken token, CancellationToken cancellationToken = default(CancellationToken))
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static async Task<MemoryStream> ToStreamAsync(
+			this JToken token,
+			IMemoryStreamFactory memoryStreamFactory = null,
+			CancellationToken cancellationToken = default(CancellationToken))
 		{
-			var ms = new MemoryStream();
+			var ms = memoryStreamFactory?.Create() ?? new MemoryStream();
 			using (var streamWriter = new StreamWriter(ms, InternalSerializer.ExpectedEncoding, InternalSerializer.DefaultBufferSize, leaveOpen: true))
 			using (var writer = new JsonTextWriter(streamWriter))
 			{

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JTokenExtensions.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JTokenExtensions.cs
@@ -16,7 +16,7 @@ namespace Nest
 		public static MemoryStream ToStream(this JToken token)
 		{
 			var ms = new MemoryStream();
-			using (var streamWriter = new StreamWriter(ms, InternalSerializer.ExpectedEncoding, 1024, leaveOpen: true))
+			using (var streamWriter = new StreamWriter(ms, InternalSerializer.ExpectedEncoding, InternalSerializer.DefaultBufferSize, leaveOpen: true))
 			using (var writer = new JsonTextWriter(streamWriter))
 			{
 				token.WriteTo(writer);
@@ -32,7 +32,7 @@ namespace Nest
 		public static async Task<MemoryStream> ToStreamAsync(this JToken token, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var ms = new MemoryStream();
-			using (var streamWriter = new StreamWriter(ms, InternalSerializer.ExpectedEncoding, 1024, leaveOpen: true))
+			using (var streamWriter = new StreamWriter(ms, InternalSerializer.ExpectedEncoding, InternalSerializer.DefaultBufferSize, leaveOpen: true))
 			using (var writer = new JsonTextWriter(streamWriter))
 			{
 				await token.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JTokenExtensions.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JTokenExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Nest
+{
+	internal static class JTokenExtensions
+	{
+		/// <summary>
+		/// Writes a <see cref="JToken"/> to a <see cref="MemoryStream"/> using <see cref="InternalSerializer.ExpectedEncoding"/>
+		/// </summary>
+		public static MemoryStream ToStream(this JToken token)
+		{
+			var ms = new MemoryStream();
+			using (var streamWriter = new StreamWriter(ms, InternalSerializer.ExpectedEncoding, 1024, leaveOpen: true))
+			using (var writer = new JsonTextWriter(streamWriter))
+			{
+				token.WriteTo(writer);
+				writer.Flush();
+				ms.Position = 0;
+				return ms;
+			}
+		}
+
+		/// <summary>
+		/// Writes a <see cref="JToken"/> asynchronously to a <see cref="MemoryStream"/> using <see cref="InternalSerializer.ExpectedEncoding"/>
+		/// </summary>
+		public static async Task<MemoryStream> ToStreamAsync(this JToken token, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			var ms = new MemoryStream();
+			using (var streamWriter = new StreamWriter(ms, InternalSerializer.ExpectedEncoding, 1024, leaveOpen: true))
+			using (var writer = new JsonTextWriter(streamWriter))
+			{
+				await token.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
+				await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+				ms.Position = 0;
+				return ms;
+			}
+		}
+	}
+}

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonReaderExtensions.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonReaderExtensions.cs
@@ -1,9 +1,19 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Nest
 {
 	internal static class JsonReaderExtensions
 	{
+		public static JToken ReadTokenWithDateParseHandlingNone(this JsonReader reader)
+		{
+			var dateParseHandling = reader.DateParseHandling;
+			reader.DateParseHandling = DateParseHandling.None;
+			var token = JToken.ReadFrom(reader);
+			reader.DateParseHandling = dateParseHandling;
+			return token;
+		}
+
 		public static T ReadToEnd<T>(this JsonReader reader, int depth, T r = null)
 			where T : class
 		{
@@ -14,6 +24,7 @@ namespace Nest
 			} while (reader.Depth >= depth && reader.TokenType != JsonToken.EndObject);
 			return r;
 		}
+
 		public static T ExhaustTo<T>(this JsonReader reader, int depth, T r = null, JsonToken endType = JsonToken.EndObject)
 			where T : class
 		{

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonReaderExtensions.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonReaderExtensions.cs
@@ -5,6 +5,7 @@ namespace Nest
 {
 	internal static class JsonReaderExtensions
 	{
+		// https://github.com/JamesNK/Newtonsoft.Json/issues/862
 		public static JToken ReadTokenWithDateParseHandlingNone(this JsonReader reader)
 		{
 			var dateParseHandling = reader.DateParseHandling;

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonReaderExtensions.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonReaderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Nest
@@ -6,6 +7,7 @@ namespace Nest
 	internal static class JsonReaderExtensions
 	{
 		// https://github.com/JamesNK/Newtonsoft.Json/issues/862
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static JToken ReadTokenWithDateParseHandlingNone(this JsonReader reader)
 		{
 			var dateParseHandling = reader.DateParseHandling;

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
@@ -26,12 +26,8 @@ namespace Nest
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
-			// https://github.com/JamesNK/Newtonsoft.Json/issues/862
-			var dateParseHandling = reader.DateParseHandling;
-			reader.DateParseHandling = DateParseHandling.None;
-			var token = JToken.ReadFrom(reader);
-			reader.DateParseHandling = dateParseHandling;
-			using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(token.ToString(Formatting.None))))
+			var token = reader.ReadTokenWithDateParseHandlingNone();
+			using (var ms = token.ToStream())
 				return serializer.GetConnectionSettings().SourceSerializer.Deserialize(objectType, ms);
 		}
 	}

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
@@ -27,7 +27,7 @@ namespace Nest
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var token = reader.ReadTokenWithDateParseHandlingNone();
-			using (var ms = token.ToStream())
+			using (var ms = token.ToStream(serializer.GetConnectionSettings().MemoryStreamFactory))
 				return serializer.GetConnectionSettings().SourceSerializer.Deserialize(objectType, ms);
 		}
 	}

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
@@ -26,11 +26,6 @@ namespace Nest
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
-			var sourceSerializer = serializer.GetConnectionSettings().SourceSerializer;
-
-			if (sourceSerializer is InternalSerializer internalSerializer)
-				return internalSerializer.Deserialize(reader, objectType);
-
 			var token = reader.ReadTokenWithDateParseHandlingNone();
 			using (var ms = token.ToStream())
 				return serializer.GetConnectionSettings().SourceSerializer.Deserialize(objectType, ms);

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SourceConverter.cs
@@ -26,6 +26,11 @@ namespace Nest
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
+			var sourceSerializer = serializer.GetConnectionSettings().SourceSerializer;
+
+			if (sourceSerializer is InternalSerializer internalSerializer)
+				return internalSerializer.Deserialize(reader, objectType);
+
 			var token = reader.ReadTokenWithDateParseHandlingNone();
 			using (var ms = token.ToStream())
 				return serializer.GetConnectionSettings().SourceSerializer.Deserialize(objectType, ms);

--- a/src/Nest/CommonAbstractions/SerializationBehavior/StatefulDeserialization/JsonConverterPiggyBackState.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/StatefulDeserialization/JsonConverterPiggyBackState.cs
@@ -3,11 +3,11 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	/// <summary>
-	/// Registerering global jsonconverters is very costly,
+	/// Registering global JsonConverter is very costly,
 	/// The best thing is to specify them as a contract (see ElasticContractResolver)
-	/// This however prevents a way to give a jsonconverter state which for some calls is needed i.e:
+	/// This however prevents a way to give a JsonConverter state which for some calls is needed i.e:
 	/// A multiget and multisearch need access to the descriptor that describes what types are used.
-	/// When NEST knows it has to piggyback this it has to pass serialization state it will create a new 
+	/// When NEST knows it has to piggyback this it has to pass serialization state it will create a new
 	/// serializersettings object with a new contract resolver which holds this state. Its ugly but it does boost
 	/// massive performance gains.
 	/// </summary>

--- a/src/Nest/CommonAbstractions/Union/UnionJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Union/UnionJsonConverter.cs
@@ -84,7 +84,7 @@ namespace Nest
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			Union<TFirst, TSecond> u = null;
-			using (var r = JToken.Load(reader).CreateReader())
+			using (var r = reader.ReadTokenWithDateParseHandlingNone().CreateReader())
 			{
 				if (this.TryRead(r, serializer, out TFirst first)) u = first;
 				else if (this.TryRead(r, serializer, out TSecond second)) u = second;

--- a/src/Nest/CommonOptions/Attributes/AlternativeEnumMemberAttribute.cs
+++ b/src/Nest/CommonOptions/Attributes/AlternativeEnumMemberAttribute.cs
@@ -2,14 +2,15 @@
 
 namespace Nest
 {
+	/// <summary>
+	/// Similar to <see cref="System.Runtime.Serialization.EnumMemberAttribute"/>, but allows an alternative string
+	/// value to be specified for an enum field value.
+	/// </summary>
 	[AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
 	public class AlternativeEnumMemberAttribute : Attribute
 	{
-		public AlternativeEnumMemberAttribute(string value)
-		{
-			Value = value;
-		}
+		public AlternativeEnumMemberAttribute(string value) => Value = value;
 
-		public string Value { get; private set; }
+		public string Value { get; }
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
@@ -63,7 +63,7 @@ namespace Nest
 		long PrimaryTerm { get; }
 
 		/// <summary>
-		/// Specifies wheter this particular bulk operation succeeded or not
+		/// Specifies whether this particular bulk operation succeeded or not
 		/// </summary>
 		bool IsValid { get; }
 	}

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Dsl.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Dsl.cs
@@ -5,12 +5,12 @@ namespace Nest
 {
 	internal static class QueryContainerExtensions
 	{
-		public static bool IsConditionless(this QueryContainer q) => q == null || (q.IsConditionless);
+		public static bool IsConditionless(this QueryContainer q) => q == null || q.IsConditionless;
 	}
 
 	public partial class QueryContainer : IQueryContainer, IDescriptor
 	{
-		bool IQueryContainer.IsConditionless => (ContainedQuery?.Conditionless).GetValueOrDefault(true);
+		bool IQueryContainer.IsConditionless => ContainedQuery?.Conditionless ?? true;
 		internal bool IsConditionless => Self.IsConditionless;
 
 		bool IQueryContainer.IsStrict { get; set; }
@@ -56,8 +56,8 @@ namespace Nest
 		{
 			queryContainer = null;
 			if (leftContainer == null && rightContainer == null) return true;
-			var leftWritable = (leftContainer?.IsWritable).GetValueOrDefault(false);
-			var rightWritable = (rightContainer?.IsWritable).GetValueOrDefault(false);
+			var leftWritable = leftContainer?.IsWritable ?? false;
+			var rightWritable = rightContainer?.IsWritable ?? false;
 			if (leftWritable && rightWritable) return false;
 			if (!leftWritable && !rightWritable) return true;
 

--- a/src/Nest/QueryDsl/Abstractions/Query/BoolQueryOrExtensions.cs
+++ b/src/Nest/QueryDsl/Abstractions/Query/BoolQueryOrExtensions.cs
@@ -56,8 +56,7 @@ namespace Nest
 			boolQuery != null && boolQuery.IsWritable && !boolQuery.Locked && boolQuery.HasOnlyShouldClauses();
 
 		private static QueryContainer CreateShouldContainer(List<QueryContainer> shouldClauses) =>
-			//new BoolQuery(createdByBoolDsl: true)
-			new BoolQuery()
+			new BoolQuery
 			{
 				Should = shouldClauses.ToListOrNullIfEmpty()
 			};

--- a/src/Nest/QueryDsl/Abstractions/Query/QueryBase.cs
+++ b/src/Nest/QueryDsl/Abstractions/Query/QueryBase.cs
@@ -7,29 +7,50 @@ namespace Nest
 	public interface IQuery
 	{
 		/// <summary>
-		/// The _name of the query. this allows you to retrieve for each document what part of the query it matched on
+		/// The name of the query. Allows you to retrieve for each document what part of the query it matched on.
 		/// </summary>
 		[JsonProperty("_name")]
 		string Name { get; set; }
 
+		/// <summary>
+		/// Provides a boost to this query to influence its relevance score.
+		/// For example, a query with a boost of 2 is twice as important as a query with a boost of 1,
+		/// although the actual boost value that is applied undergoes normalization and internal optimization.
+		/// </summary>
 		[JsonProperty("boost")]
 		double? Boost { get; set; }
 
+		/// <summary>
+		/// Whether the query is conditionless. A conditionless query is not serialized as part of the request
+		/// sent to Elasticsearch.
+		/// </summary>
 		[JsonIgnore]
 		bool Conditionless { get; }
 
+		/// <summary>
+		/// Whether the query should be treated as verbatim. A verbatim query will be serialized as part of the request, irrespective
+		/// of whether it is <see cref="Conditionless"/> or not.
+		/// </summary>
 		[JsonIgnore]
 		bool IsVerbatim { get; set; }
 
+		/// <summary>
+		/// Whether the query should be treated as strict. A strict query will throw an exception when serialized
+		/// if it is <see cref="Conditionless"/>.
+		/// </summary>
 		[JsonIgnore]
 		bool IsStrict { get; set; }
 
+		/// <summary>
+		/// Whether the query should be treated as writable. Used when determining how to combine queries.
+		/// </summary>
 		[JsonIgnore]
 		bool IsWritable { get; }
 	}
 
 	public abstract class QueryBase : IQuery
 	{
+		/// <inheritdoc />
 		public string Name { get; set; }
 		public double? Boost { get; set; }
 		public bool IsVerbatim { get; set; }
@@ -59,8 +80,7 @@ namespace Nest
 
 		private static QueryBase Combine(QueryBase leftQuery, QueryBase rightQuery, Func<QueryContainer, QueryContainer, QueryContainer> combine)
 		{
-			QueryBase q;
-			if (IfEitherIsEmptyReturnTheOtherOrEmpty(leftQuery, rightQuery, out q))
+			if (IfEitherIsEmptyReturnTheOtherOrEmpty(leftQuery, rightQuery, out var q))
 				return q;
 
 			IQueryContainer container = combine(leftQuery, rightQuery);
@@ -76,10 +96,15 @@ namespace Nest
 
 		private static bool IfEitherIsEmptyReturnTheOtherOrEmpty(QueryBase leftQuery, QueryBase rightQuery, out QueryBase query)
 		{
-			var combined = new [] {leftQuery, rightQuery};
-			var anyEmpty = combined.Any(q => q == null || !q.IsWritable);
-			query = anyEmpty ? combined.FirstOrDefault(q => q != null && q.IsWritable) : null;
-			return anyEmpty;
+			query = null;
+			if (leftQuery == null && rightQuery == null) return true;
+			var leftWritable = leftQuery?.IsWritable ?? false;
+			var rightWritable = rightQuery?.IsWritable ?? false;
+			if (leftWritable && rightWritable) return false;
+			if (!leftWritable && !rightWritable) return true;
+
+			query = leftWritable ? leftQuery : rightQuery;
+			return true;
 		}
 
 		public static implicit operator QueryContainer(QueryBase query) =>

--- a/src/Nest/QueryDsl/VariableFields.cs
+++ b/src/Nest/QueryDsl/VariableFields.cs
@@ -49,8 +49,8 @@ namespace Nest
 			if (locationField == null) return query;
 
 			var propertyValue = jo.Property(fieldProperty).Value;
-			var o = JToken.ReadFrom(propertyValue.CreateReader()).Value<JObject>();
-			var r = (deeperPropertyName.IsNullOrEmpty() ? (JToken)o : o.Property(deeperPropertyName).Value).CreateReader();
+			var o = propertyValue.CreateReader().ReadTokenWithDateParseHandlingNone().Value<JObject>();
+			var r = (deeperPropertyName.IsNullOrEmpty() ? o : o.Property(deeperPropertyName).Value).CreateReader();
 
 			var locationValue = serializer.Deserialize(r, locationField.PropertyType);
 			locationField.ValueProvider.SetValue(query, locationValue);
@@ -96,8 +96,7 @@ namespace Nest
 
 		private static Tuple<JsonProperty, VariableFieldAttribute> GetOrCreateTypeInfo(Type t)
 		{
-			Tuple<JsonProperty, VariableFieldAttribute> info;
-			if (!VariableFields.CachedTypeInformation.TryGetValue(t, out info))
+			if (!VariableFields.CachedTypeInformation.TryGetValue(t, out var info))
 			{
 				var properties = from prop in t.GetCachedObjectProperties(MemberSerialization.OptOut)
 					let attributes = prop.AttributeProvider.GetAttributes(typeof (VariableFieldAttribute), true)

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -154,7 +154,7 @@ namespace Nest
 	}
 
 	/// <summary>
-	/// A descriptor wich describes a search operation for _search and _msearch
+	/// A descriptor which describes a search operation for _search and _msearch
 	/// </summary>
 	public partial class SearchDescriptor<T> where T : class
 	{

--- a/src/Nest/Search/SearchShards/SearchShardsRequest.cs
+++ b/src/Nest/Search/SearchShards/SearchShardsRequest.cs
@@ -7,7 +7,7 @@
 	public partial class SearchShardsRequest<T> where T : class { }
 
 	/// <summary>
-	/// A descriptor wich describes a search operation for _search_shards
+	/// A descriptor which describes a search operation for _search_shards
 	/// </summary>
 	public partial class SearchShardsDescriptor<T> where T : class { }
 }

--- a/src/Nest/Search/Suggesters/SuggestDictionary.cs
+++ b/src/Nest/Search/Suggesters/SuggestDictionary.cs
@@ -24,13 +24,11 @@ namespace Nest
 
 		public SuggestDictionary(IReadOnlyDictionary<string, Suggest<T>[]> backingDictionary) : base(backingDictionary) { }
 
-		private static readonly char[] TypedKeysSeparator = {'#'};
 		protected override string Sanitize(string key)
 		{
 			//typed_keys = true results in suggest keys being returned as "<type>#<name>"
-			var tokens = key.Split(TypedKeysSeparator, 2, StringSplitOptions.RemoveEmptyEntries);
-			return tokens.Length > 1 ? tokens[1] : tokens[0];
+			var hashIndex = key.IndexOf('#');
+			return hashIndex > -1 ? key.Substring(hashIndex + 1) : key;
 		}
-
 	}
 }

--- a/src/Serializers/Nest.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.Customization.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/ConnectionSettingsAwareSerializerBase.Customization.cs
@@ -12,8 +12,11 @@ namespace Nest.JsonNetSerializer
 {
 	public abstract partial class ConnectionSettingsAwareSerializerBase : IElasticsearchSerializer
 	{
+		// Default buffer size of StreamWriter, which is private :(
+		internal const int DefaultBufferSize = 1024;
+
 		internal static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
-		protected virtual int BufferSize => 1024;
+		protected virtual int BufferSize => DefaultBufferSize;
 
 		private readonly JsonSerializer _serializer;
 		private readonly JsonSerializer _collapsedSerializer;

--- a/src/Serializers/Nest.JsonNetSerializer/JTokenExtensions.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/JTokenExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Nest.JsonNetSerializer
+{
+	internal static class JTokenExtensions
+	{
+		/// <summary>
+		/// Writes a <see cref="JToken"/> to a <see cref="MemoryStream"/> using <see cref="ConnectionSettingsAwareSerializerBase.ExpectedEncoding"/>
+		/// </summary>
+		public static MemoryStream ToStream(this JToken token)
+		{
+			var ms = new MemoryStream();
+			using (var streamWriter = new StreamWriter(ms, ConnectionSettingsAwareSerializerBase.ExpectedEncoding, 1024, leaveOpen: true))
+			using (var writer = new JsonTextWriter(streamWriter))
+			{
+				token.WriteTo(writer);
+				writer.Flush();
+				ms.Position = 0;
+				return ms;
+			}
+		}
+
+		/// <summary>
+		/// Writes a <see cref="JToken"/> asynchronously to a <see cref="MemoryStream"/> using <see cref="ConnectionSettingsAwareSerializerBase.ExpectedEncoding"/>
+		/// </summary>
+		public static async Task<MemoryStream> ToStreamAsync(this JToken token, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			var ms = new MemoryStream();
+			using (var streamWriter = new StreamWriter(ms, ConnectionSettingsAwareSerializerBase.ExpectedEncoding, 1024, leaveOpen: true))
+			using (var writer = new JsonTextWriter(streamWriter))
+			{
+				await token.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
+				await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+				ms.Position = 0;
+				return ms;
+			}
+		}
+	}
+}

--- a/src/Serializers/Nest.JsonNetSerializer/JTokenExtensions.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/JTokenExtensions.cs
@@ -15,7 +15,7 @@ namespace Nest.JsonNetSerializer
 		public static MemoryStream ToStream(this JToken token)
 		{
 			var ms = new MemoryStream();
-			using (var streamWriter = new StreamWriter(ms, ConnectionSettingsAwareSerializerBase.ExpectedEncoding, 1024, leaveOpen: true))
+			using (var streamWriter = new StreamWriter(ms, ConnectionSettingsAwareSerializerBase.ExpectedEncoding, ConnectionSettingsAwareSerializerBase.DefaultBufferSize, leaveOpen: true))
 			using (var writer = new JsonTextWriter(streamWriter))
 			{
 				token.WriteTo(writer);
@@ -31,7 +31,7 @@ namespace Nest.JsonNetSerializer
 		public static async Task<MemoryStream> ToStreamAsync(this JToken token, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var ms = new MemoryStream();
-			using (var streamWriter = new StreamWriter(ms, ConnectionSettingsAwareSerializerBase.ExpectedEncoding, 1024, leaveOpen: true))
+			using (var streamWriter = new StreamWriter(ms, ConnectionSettingsAwareSerializerBase.ExpectedEncoding, ConnectionSettingsAwareSerializerBase.DefaultBufferSize, leaveOpen: true))
 			using (var writer = new JsonTextWriter(streamWriter))
 			{
 				await token.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);

--- a/src/Serializers/Nest.JsonNetSerializer/JsonNetSerializer.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/JsonNetSerializer.cs
@@ -19,6 +19,5 @@ namespace Nest.JsonNetSerializer
 			: base(builtinSerializer, connectionSettings, jsonSerializerSettingsFactory, modifyContractResolver, contractJsonConverters)
 		{
 		}
-
 	}
 }

--- a/src/Serializers/Nest.JsonNetSerializer/JsonReaderExtensions.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/JsonReaderExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Nest.JsonNetSerializer
+{
+	internal static class JsonReaderExtensions
+	{
+		public static JToken ReadTokenWithDateParseHandlingNone(this JsonReader reader)
+		{
+			var dateParseHandling = reader.DateParseHandling;
+			reader.DateParseHandling = DateParseHandling.None;
+			var token = JToken.ReadFrom(reader);
+			reader.DateParseHandling = dateParseHandling;
+			return token;
+		}
+
+		public static async Task<JToken> ReadTokenWithDateParseHandlingNoneAsync(this JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			var dateParseHandling = reader.DateParseHandling;
+			reader.DateParseHandling = DateParseHandling.None;
+			var token = await JToken.ReadFromAsync(reader, cancellationToken).ConfigureAwait(false);
+			reader.DateParseHandling = dateParseHandling;
+			return token;
+		}
+	}
+}

--- a/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
+++ b/src/Tests/ClientConcepts/ConnectionPooling/Dispose/ResponseBuilderDisposeTests.cs
@@ -21,6 +21,14 @@ namespace Tests.ClientConcepts.ConnectionPooling.Dispose
 
 		private class TrackDisposeStream : MemoryStream
 		{
+			public TrackDisposeStream()
+			{
+			}
+
+			public TrackDisposeStream(byte[] bytes) : base(bytes)
+			{
+			}
+
 			public bool IsDisposed { get; private set; }
 			protected override void Dispose(bool disposing)
 			{
@@ -36,6 +44,13 @@ namespace Tests.ClientConcepts.ConnectionPooling.Dispose
 			public MemoryStream Create()
 			{
 				var stream = new TrackDisposeStream();
+				this.Created.Add(stream);
+				return stream;
+			}
+
+			public MemoryStream Create(byte[] bytes)
+			{
+				var stream = new TrackDisposeStream(bytes);
 				this.Created.Add(stream);
 				return stream;
 			}

--- a/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
@@ -442,7 +442,8 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			}
 		}
 
-		[U(Skip = "The Tests use Newtonsoft.Json.JsonPropertyAttribute, the CI builds use the Nest.Json.JsonPropertyAttribute, so the behaviour changes.")]
+		[U]
+		[SkipOnTeamCity("The Tests use Newtonsoft.Json.JsonPropertyAttribute, the CI builds use the Nest.Json.JsonPropertyAttribute, so the behaviour changes.")]
 		public void PrecedenceIsAsExpected()
 		{
 			/** Here we provide an explicit rename of a property on `ConnectionSettings` using `.PropertyName()`

--- a/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
+++ b/src/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
@@ -443,7 +443,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 		}
 
 		[U]
-		[SkipOnTeamCity("The Tests use Newtonsoft.Json.JsonPropertyAttribute, the CI builds use the Nest.Json.JsonPropertyAttribute, so the behaviour changes.")]
+		[SkipOnTeamCity]
 		public void PrecedenceIsAsExpected()
 		{
 			/** Here we provide an explicit rename of a property on `ConnectionSettings` using `.PropertyName()`

--- a/src/Tests/Framework/MockData/Generators.cs
+++ b/src/Tests/Framework/MockData/Generators.cs
@@ -9,6 +9,8 @@ namespace Tests.Framework.MockData
 	{
 		static Generators()
 		{
+			var r = Gimme.Random.Number(1, 3);
+			var tags = Tag.Generator;
 			var people = Person.People;
 			var developers = Developer.Developers;
 			var projects = Project.Projects;

--- a/src/Tests/Framework/MockData/SimpleGeoPoint.cs
+++ b/src/Tests/Framework/MockData/SimpleGeoPoint.cs
@@ -11,6 +11,6 @@ namespace Tests.Framework.MockData
 			new Faker<SimpleGeoPoint>()
 				.RuleFor(p => p.Lat, f => f.Address.Latitude())
 				.RuleFor(p => p.Lon, f => f.Address.Longitude())
-			;
+			.Clone();
 	}
 }

--- a/src/Tests/Framework/MockData/Tag.cs
+++ b/src/Tests/Framework/MockData/Tag.cs
@@ -14,6 +14,6 @@ namespace Tests.Framework.MockData
 				.UseSeed(TestClient.Configuration.Seed)
 				.RuleFor(p => p.Name, p => p.Lorem.Words(1).First())
 				.RuleFor(p => p.Added, p => p.Date.Recent())
-			;
+			.Clone();
 	}
 }

--- a/src/Tests/Framework/SerializationTests/Roundtrip.cs
+++ b/src/Tests/Framework/SerializationTests/Roundtrip.cs
@@ -32,8 +32,8 @@ namespace Tests.Framework
 
 		public virtual void DeserializesTo<T>(Action<string, T> assert)
 		{
-			var json = (this.ExpectJson is string)
-				? (string) ExpectJson
+			var json = (this.ExpectJson is string s)
+				? s
 				: JsonConvert.SerializeObject(this.ExpectJson, NullValueSettings);
 
 			T sut;

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -198,7 +198,7 @@ namespace Tests.Framework
 			modifySettings = modifySettings ?? ((m) =>
 			{
 
-				//only enable debug mode when running in DEBUG mode (always) or optionally wheter we are executing unit tests
+				//only enable debug mode when running in DEBUG mode (always) or optionally whether we are executing unit tests
 				//during RELEASE builds tests
 #if !DEBUG
 			if (TestClient.Configuration.RunUnitTests)

--- a/src/Tests/XPack/Watcher/DeleteWatch/DeleteWatchApiTests.cs
+++ b/src/Tests/XPack/Watcher/DeleteWatch/DeleteWatchApiTests.cs
@@ -104,7 +104,7 @@ namespace Tests.XPack.Watcher.DeleteWatch
 
 		protected override void ExpectResponse(IDeleteWatchResponse response)
 		{
-			//This API returns different results depending on wheter `.watches` exists or not
+			//This API returns different results depending on whether `.watches` exists or not
 			if (response.ServerError?.Status == 404)
 			{
 				response.ServerError.Error.Reason.Should().Be("no such index");


### PR DESCRIPTION
This PR introduces some performance improvements to 6.x

- remove string allocations when creating a `Stream` from a `JToken` by writing token to stream directly
- remove the need to read the response into bytes to check the length, by checking the length of the stream directly
- lazily evaluate whether the internal serializer is being used as the source (document) serializer, to avoid the performance costs associated with `SourceConverter`
- Add `RecyclableMemoryStreamFactory` to pool byte buffers for streams

## BenchmarkDotNet results 

Comparing 5.6.2, 6.1.0 and 6.x (this branch).

Note that these use `InMemoryConnection` to return a fixed set of bytes.

### Search returning 100 documents

``` ini

BenchmarkDotNet=v0.10.14.585-nightly, OS=Windows 10.0.16299.371 (1709/FallCreatorsUpdate/Redstone3)
Intel Core i7-2920XM CPU 2.50GHz (Sandy Bridge), 1 CPU, 8 logical and 4 physical cores
Frequency=2433504 Hz, Resolution=410.9301 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2633.0
  Job-KBLBLJ : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit LegacyJIT/clrjit-v4.7.2633.0;compatjit-v4.7.2633.0
  Job-PFMEQG : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0

MinIterationTime=500.0000 ms  Platform=AnyCpu  MinTargetIterationCount=30  

```
|                          Method |     Jit |     Mean |     Error |    StdDev | Scaled | ScaledSD |  Allocated |
|-------------------------------- |-------- |---------:|----------:|----------:|-------:|---------:|-----------:|
|                       Search562 | Default | 3.638 ms | 0.0400 ms | 0.0573 ms |   0.43 |     0.01 |   563.2 KB |
|                  Search562Async | Default | 3.743 ms | 0.0478 ms | 0.0715 ms |   0.44 |     0.01 |   563.2 KB |
|                       Search610 | Default | 8.523 ms | 0.0786 ms | 0.1152 ms |   1.00 |     0.00 | 3919.24 KB |
|                  Search610Async | Default | 8.667 ms | 0.1369 ms | 0.2049 ms |   1.02 |     0.03 | 4280.32 KB |
|      Search610JsonNetSerializer | Default | 9.221 ms | 0.0742 ms | 0.1088 ms |   1.08 |     0.02 | 3919.24 KB |
| Search610JsonNetSerializerAsync | Default | 9.494 ms | 0.0566 ms | 0.0756 ms |   1.11 |     0.02 | 4280.32 KB |
|                        Search6x | Default | 3.460 ms | 0.0445 ms | 0.0666 ms |   0.41 |     0.01 |   531.2 KB |
|                   Search6xAsync | Default | 3.357 ms | 0.0493 ms | 0.0738 ms |   0.39 |     0.01 |   531.2 KB |
|       Search6xJsonNetSerializer | Default | 8.842 ms | 0.1011 ms | 0.1513 ms |   1.04 |     0.02 | 3532.49 KB |
|  Search6xJsonNetSerializerAsync | Default | 8.869 ms | 0.0748 ms | 0.1120 ms |   1.04 |     0.02 | 3532.49 KB |
|                                 |         |          |           |           |        |          |            |
|                       Search562 |  RyuJit | 3.506 ms | 0.0398 ms | 0.0596 ms |   0.40 |     0.01 |   563.2 KB |
|                  Search562Async |  RyuJit | 3.529 ms | 0.0661 ms | 0.0989 ms |   0.41 |     0.01 |   563.2 KB |
|                       Search610 |  RyuJit | 8.664 ms | 0.1381 ms | 0.2066 ms |   1.00 |     0.00 | 3919.24 KB |
|                  Search610Async |  RyuJit | 8.356 ms | 0.0925 ms | 0.1384 ms |   0.97 |     0.03 | 4280.32 KB |
|      Search610JsonNetSerializer |  RyuJit | 9.188 ms | 0.1353 ms | 0.1983 ms |   1.06 |     0.03 | 3919.24 KB |
| Search610JsonNetSerializerAsync |  RyuJit | 9.296 ms | 0.1189 ms | 0.1779 ms |   1.07 |     0.03 | 4280.32 KB |
|                        Search6x |  RyuJit | 3.382 ms | 0.0627 ms | 0.0900 ms |   0.39 |     0.01 |   531.2 KB |
|                   Search6xAsync |  RyuJit | 3.414 ms | 0.0679 ms | 0.1076 ms |   0.39 |     0.02 |   531.2 KB |
|       Search6xJsonNetSerializer |  RyuJit | 9.032 ms | 0.1200 ms | 0.1796 ms |   1.04 |     0.03 | 3532.49 KB |
|  Search6xJsonNetSerializerAsync |  RyuJit | 9.137 ms | 0.1433 ms | 0.2100 ms |   1.06 |     0.03 | 3532.49 KB |


### Search returning 1000 documents

``` ini

BenchmarkDotNet=v0.10.14.585-nightly, OS=Windows 10.0.16299.371 (1709/FallCreatorsUpdate/Redstone3)
Intel Core i7-2920XM CPU 2.50GHz (Sandy Bridge), 1 CPU, 8 logical and 4 physical cores
Frequency=2433504 Hz, Resolution=410.9301 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2633.0
  Job-KBLBLJ : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit LegacyJIT/clrjit-v4.7.2633.0;compatjit-v4.7.2633.0
  Job-PFMEQG : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0

MinIterationTime=500.0000 ms  Platform=AnyCpu  MinTargetIterationCount=30  

```
|                          Method |     Jit |      Mean |     Error |    StdDev | Scaled | ScaledSD |     Gen 0 |     Gen 1 | Allocated |
|-------------------------------- |-------- |----------:|----------:|----------:|-------:|---------:|----------:|----------:|----------:|
|                       Search562 | Default |  35.77 ms | 0.4422 ms | 0.6619 ms |   0.42 |     0.01 |         - |         - |   3.84 MB |
|                  Search562Async | Default |  35.76 ms | 0.6612 ms | 0.9897 ms |   0.42 |     0.01 |         - |         - |   3.84 MB |
|                       Search610 | Default |  85.05 ms | 0.9365 ms | 1.4017 ms |   1.00 |     0.00 | 5000.0000 | 1000.0000 |  33.16 MB |
|                  Search610Async | Default |  91.19 ms | 0.7971 ms | 1.1930 ms |   1.07 |     0.02 | 5000.0000 | 1000.0000 |  36.35 MB |
|      Search610JsonNetSerializer | Default |  95.54 ms | 0.7945 ms | 1.1395 ms |   1.12 |     0.02 | 5000.0000 | 1000.0000 |  33.16 MB |
| Search610JsonNetSerializerAsync | Default | 100.69 ms | 0.6511 ms | 0.9337 ms |   1.18 |     0.02 | 5000.0000 | 1000.0000 |  36.35 MB |
|                        Search6x | Default |  35.34 ms | 0.4391 ms | 0.6572 ms |   0.42 |     0.01 |         - |         - |   3.59 MB |
|                   Search6xAsync | Default |  33.00 ms | 0.2429 ms | 0.3561 ms |   0.39 |     0.01 |         - |         - |   3.59 MB |
|       Search6xJsonNetSerializer | Default |  87.50 ms | 0.8645 ms | 1.2940 ms |   1.03 |     0.02 | 5000.0000 | 1000.0000 |  30.36 MB |
|  Search6xJsonNetSerializerAsync | Default |  91.36 ms | 1.8024 ms | 3.4725 ms |   1.07 |     0.04 | 5000.0000 | 1000.0000 |  30.36 MB |
|                                 |         |           |           |           |        |          |           |           |           |
|                       Search562 |  RyuJit |  35.02 ms | 0.5554 ms | 0.7785 ms |   0.43 |     0.01 |         - |         - |   3.84 MB |
|                  Search562Async |  RyuJit |  34.44 ms | 0.6850 ms | 1.2176 ms |   0.42 |     0.02 |         - |         - |   3.84 MB |
|                       Search610 |  RyuJit |  81.45 ms | 0.3979 ms | 0.5956 ms |   1.00 |     0.00 | 5000.0000 | 1000.0000 |  33.16 MB |
|                  Search610Async |  RyuJit |  85.03 ms | 0.6983 ms | 0.9323 ms |   1.04 |     0.01 | 5000.0000 | 1000.0000 |  36.35 MB |
|      Search610JsonNetSerializer |  RyuJit |  91.25 ms | 0.5301 ms | 0.7770 ms |   1.12 |     0.01 | 5000.0000 | 1000.0000 |  33.16 MB |
| Search610JsonNetSerializerAsync |  RyuJit |  95.72 ms | 0.4528 ms | 0.6637 ms |   1.18 |     0.01 | 5000.0000 | 1000.0000 |  36.35 MB |
|                        Search6x |  RyuJit |  33.21 ms | 0.4803 ms | 0.7189 ms |   0.41 |     0.01 |         - |         - |   3.59 MB |
|                   Search6xAsync |  RyuJit |  33.19 ms | 0.3661 ms | 0.5366 ms |   0.41 |     0.01 |         - |         - |   3.59 MB |
|       Search6xJsonNetSerializer |  RyuJit |  92.38 ms | 0.7229 ms | 1.0368 ms |   1.13 |     0.01 | 5000.0000 | 1000.0000 |  30.36 MB |
|  Search6xJsonNetSerializerAsync |  RyuJit |  89.78 ms | 1.2280 ms | 1.8000 ms |   1.10 |     0.02 | 5000.0000 | 1000.0000 |  30.36 MB |

### Search returning 10000 documents

``` ini

BenchmarkDotNet=v0.10.14.585-nightly, OS=Windows 10.0.16299.371 (1709/FallCreatorsUpdate/Redstone3)
Intel Core i7-2920XM CPU 2.50GHz (Sandy Bridge), 1 CPU, 8 logical and 4 physical cores
Frequency=2433504 Hz, Resolution=410.9301 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2633.0
  Job-KBLBLJ : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit LegacyJIT/clrjit-v4.7.2633.0;compatjit-v4.7.2633.0
  Job-PFMEQG : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0

MinIterationTime=500.0000 ms  Platform=AnyCpu  MinTargetIterationCount=30  

```
|                          Method |     Jit |       Mean |     Error |    StdDev |     Median | Scaled | ScaledSD |      Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|-------------------------------- |-------- |-----------:|----------:|----------:|-----------:|-------:|---------:|-----------:|-----------:|----------:|----------:|
|                       Search562 | Default |   380.8 ms |  3.624 ms |  5.425 ms |   379.5 ms |   0.44 |     0.01 |  6000.0000 |  2000.0000 |         - |  37.61 MB |
|                  Search562Async | Default |   391.9 ms |  3.979 ms |  5.833 ms |   392.5 ms |   0.45 |     0.01 |  6000.0000 |  2000.0000 |         - |  37.61 MB |
|                       Search610 | Default |   869.8 ms | 14.065 ms | 21.052 ms |   864.0 ms |   1.00 |     0.00 | 59000.0000 | 12000.0000 | 1000.0000 | 336.99 MB |
|                  Search610Async | Default |   886.3 ms | 12.057 ms | 17.673 ms |   881.5 ms |   1.02 |     0.03 | 57000.0000 | 13000.0000 |         - | 369.79 MB |
|      Search610JsonNetSerializer | Default |   948.7 ms | 18.684 ms | 29.089 ms |   954.4 ms |   1.09 |     0.04 | 59000.0000 | 12000.0000 | 1000.0000 | 337.01 MB |
| Search610JsonNetSerializerAsync | Default | 1,006.9 ms | 20.129 ms | 43.759 ms | 1,004.5 ms |   1.16 |     0.06 | 57000.0000 | 13000.0000 |         - |  369.8 MB |
|                        Search6x | Default |   379.3 ms |  7.471 ms | 11.632 ms |   376.4 ms |   0.44 |     0.02 |  6000.0000 |  2000.0000 |         - |   35.1 MB |
|                   Search6xAsync | Default |   358.2 ms |  7.160 ms | 12.351 ms |   360.3 ms |   0.41 |     0.02 |  6000.0000 |  2000.0000 |         - |   35.1 MB |
|       Search6xJsonNetSerializer | Default |   896.9 ms | 17.620 ms | 27.433 ms |   906.7 ms |   1.03 |     0.04 | 51000.0000 | 10000.0000 |         - | 306.37 MB |
|  Search6xJsonNetSerializerAsync | Default |   898.0 ms | 17.938 ms | 32.801 ms |   916.7 ms |   1.03 |     0.04 | 51000.0000 | 10000.0000 |         - | 306.36 MB |
|                                 |         |            |           |           |            |        |          |            |            |           |           |
|                       Search562 |  RyuJit |   387.9 ms |  6.964 ms | 10.424 ms |   390.5 ms |   0.46 |     0.01 |  6000.0000 |  2000.0000 |         - |   37.6 MB |
|                  Search562Async |  RyuJit |   360.6 ms |  1.359 ms |  1.814 ms |   360.4 ms |   0.43 |     0.01 |  6000.0000 |  2000.0000 |         - |  37.61 MB |
|                       Search610 |  RyuJit |   844.5 ms | 10.982 ms | 15.750 ms |   842.1 ms |   1.00 |     0.00 | 57000.0000 | 13000.0000 |         - | 336.94 MB |
|                  Search610Async |  RyuJit |   854.8 ms | 16.752 ms | 29.340 ms |   860.2 ms |   1.01 |     0.04 | 57000.0000 | 13000.0000 |         - |  369.8 MB |
|      Search610JsonNetSerializer |  RyuJit |   926.3 ms | 16.568 ms | 24.798 ms |   919.7 ms |   1.10 |     0.04 | 57000.0000 | 13000.0000 |         - | 336.95 MB |
| Search610JsonNetSerializerAsync |  RyuJit |   939.1 ms |  6.488 ms |  9.510 ms |   941.5 ms |   1.11 |     0.02 | 58000.0000 | 12000.0000 | 1000.0000 | 369.86 MB |
|                        Search6x |  RyuJit |   356.9 ms |  2.711 ms |  3.888 ms |   356.5 ms |   0.42 |     0.01 |  6000.0000 |  2000.0000 |         - |   35.1 MB |
|                   Search6xAsync |  RyuJit |   364.7 ms |  6.757 ms | 10.113 ms |   363.6 ms |   0.43 |     0.01 |  6000.0000 |  2000.0000 |         - |   35.1 MB |
|       Search6xJsonNetSerializer |  RyuJit |   884.8 ms | 11.681 ms | 16.375 ms |   880.8 ms |   1.05 |     0.03 | 51000.0000 | 10000.0000 |         - | 306.37 MB |
|  Search6xJsonNetSerializerAsync |  RyuJit |   918.3 ms |  6.877 ms |  9.863 ms |   920.3 ms |   1.09 |     0.02 | 51000.0000 | 10000.0000 |         - | 306.36 MB |