### PR TITLE
Assign instance to Aggregations property

### DIFF
--- a/src/Nest/Aggregations/Bucket/BucketAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/BucketAggregate.cs
@@ -12,8 +12,15 @@ namespace Nest
 
 	public class SingleBucketAggregate : BucketAggregateBase
 	{
-		public SingleBucketAggregate(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations) { }
+		public SingleBucketAggregate(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations)
+		{
+#pragma warning disable 618
+			// TODO: Remove in NEST 7.x.
+			Aggregations = this;
+#pragma warning restore 618
+		}
 
+		[Obsolete("Use methods on instance itself. Will be removed in NEST 7.x")]
 		public AggregateDictionary Aggregations { get; protected internal set; }
 
 		public long DocCount { get; internal set; }

--- a/src/Nest/Aggregations/Bucket/BucketAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/BucketAggregate.cs
@@ -20,7 +20,7 @@ namespace Nest
 #pragma warning restore 618
 		}
 
-		[Obsolete("Use methods on instance itself. Will be removed in NEST 7.x")]
+		[Obsolete("Use methods on this instance to access sub aggregations. Will be removed in NEST 7.x")]
 		public AggregateDictionary Aggregations { get; protected internal set; }
 
 		public long DocCount { get; internal set; }

--- a/src/Tests/Reproduce/GithubIssue3286.cs
+++ b/src/Tests/Reproduce/GithubIssue3286.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3286 : IClusterFixture<WritableCluster>
+	{
+		private readonly WritableCluster _cluster;
+
+		public GithubIssue3286(WritableCluster cluster)
+		{
+			_cluster = cluster;
+		}
+
+		[I]
+		public void AggregationsShouldNotBeNullOnNestedAggregation()
+		{
+			var client = _cluster.Client;
+			var index = Guid.NewGuid().ToString("N").Substring(0, 8);
+
+			if (client.IndexExists(index).Exists)
+				client.DeleteIndex(index);
+
+			client.CreateIndex(index, c => c
+				.Mappings(m => m
+					.Map<MyDocument>(mm => mm
+						.AutoMap()
+						.Properties(p => p
+							.Nested<Rate>(n => n
+								.AutoMap()
+								.Name(nn => nn.Rates)
+							)
+						)
+					)
+				)
+			);
+
+			client.Bulk(b => b
+				.Index(index)
+				.IndexMany(new[]
+				{
+					new MyDocument
+					{
+						Name = "doc 1",
+						Rates = new[]
+						{
+							new Rate
+							{
+								Start = new DateTime(2018, 6, 9),
+								End = new DateTime(2018, 6, 16),
+								WeeklyRate = 100
+							},
+							new Rate
+							{
+								Start = new DateTime(2018, 6, 16),
+								End = new DateTime(2018, 6, 23),
+								WeeklyRate = 200
+							}
+						}
+					},
+					new MyDocument
+					{
+						Name = "doc 2",
+						Rates = new[]
+						{
+							new Rate
+							{
+								Start = new DateTime(2018, 6, 9),
+								End = new DateTime(2018, 6, 16),
+								WeeklyRate = 120
+							},
+							new Rate
+							{
+								Start = new DateTime(2018, 6, 16),
+								End = new DateTime(2018, 6, 23),
+								WeeklyRate = 250
+							}
+						}
+					}
+				})
+				.Refresh(Refresh.WaitFor)
+			);
+
+			var searchResponse = client.Search<MyDocument>(s => s
+				.Index(index)
+				.Size(0)
+				.Aggregations(a => a
+					.Nested("nested_start_dates", n => n
+						.Path(f => f.Rates)
+						.Aggregations(aa => aa
+							.DateHistogram("start_dates", dh => dh
+								.Field(f => f.Rates.First().Start)
+								.Interval(DateInterval.Day)
+								.MinimumDocumentCount(1)
+								.Aggregations(aaa => aaa
+									.Min("min_rate", m => m
+										.Field(f => f.Rates.First().WeeklyRate)
+									)
+									.Max("max_rate", m => m
+										.Field(f => f.Rates.First().WeeklyRate)
+									)
+								)
+							)
+						)
+					)
+				)
+			);
+
+			searchResponse.IsValid.Should().BeTrue();
+
+			var nested = searchResponse.Aggregations.Nested("nested_start_dates");
+
+#pragma warning disable 618
+			nested.Aggregations.Should().NotBeNull();
+			nested.Should().BeSameAs(nested.Aggregations);
+#pragma warning restore 618
+		}
+	}
+
+	public class MyDocument
+	{
+		public string Name { get; set; }
+		public IEnumerable<Rate> Rates { get; set; }
+	}
+
+	public class Rate
+	{
+		public DateTime Start { get; set; }
+		public DateTime End { get; set; }
+		public double WeeklyRate { get; set; }
+	}
+}

--- a/src/Tests/tests.default.yaml
+++ b/src/Tests/tests.default.yaml
@@ -8,7 +8,7 @@
 mode: u
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
-elasticsearch_version: 6.2.3
+elasticsearch_version: 6.2.4
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
 # cluster_filter:
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running


### PR DESCRIPTION
This commit fixes a bug with SingleBucketAggregate having an Aggregations
property; the property should not be there. Mark as obsolete and assign the
instance itself to the property, to at least mitigate null reference exception.

Remove `Aggregations` when porting to master

Closes #3286