### PR TITLE
Add ability to specify fields from _source to reindex

### DIFF
--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexSource.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexSource.cs
@@ -57,6 +57,12 @@ namespace Nest
 		/// </remarks>
 		[JsonProperty("slice")]
 		ISlicedScroll Slice { get; set; }
+
+		/// <summary>
+		/// Individual fields from _source to reindex
+		/// </summary>
+		[JsonProperty("_source")]
+		Fields Source { get; set; }
     }
 
 	/// <inheritdoc />
@@ -82,6 +88,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public ISlicedScroll Slice { get; set; }
+
+		/// <inheritdoc />
+		public Fields Source { get; set; }
 	}
 
 	/// <inheritdoc cref="IReindexSource"/>
@@ -94,6 +103,7 @@ namespace Nest
         int? IReindexSource.Size { get; set; }
         IRemoteSource IReindexSource.Remote { get; set; }
 		ISlicedScroll IReindexSource.Slice { get; set; }
+		Fields IReindexSource.Source { get; set; }
 
 		/// <inheritdoc cref="IReindexSource.Query"/>
         public ReindexSourceDescriptor Query<T>(Func<QueryContainerDescriptor<T>, QueryContainer> querySelector) where T : class =>
@@ -119,5 +129,9 @@ namespace Nest
 		/// <inheritdoc cref="IReindexSource.Slice"/>
 		public ReindexSourceDescriptor Slice<T>(Func<SlicedScrollDescriptor<T>, ISlicedScroll> selector) where T : class =>
 			Assign(a => a.Slice = selector?.Invoke(new SlicedScrollDescriptor<T>()));
+
+		/// <inheritdoc cref="IReindexSource.Source"/>
+		public ReindexSourceDescriptor Source<T>(Func<FieldsDescriptor<T>, IPromise<Fields>> fields) where T : class =>
+			Assign(a => a.Source = fields?.Invoke(new FieldsDescriptor<T>())?.Value);
     }
 }

--- a/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSourceApiTests.cs
+++ b/src/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSourceApiTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using Elasticsearch.Net;
+using Nest;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using static Nest.Infer;
+
+namespace Tests.Document.Multiple.ReindexOnServer
+{
+	public class ReindexOnServerSourceApiTests : ApiIntegrationTestBase<IntrusiveOperationCluster, IReindexOnServerResponse, IReindexOnServerRequest, ReindexOnServerDescriptor, ReindexOnServerRequest>
+	{
+		public class Test
+		{
+			public long Id { get; set; }
+			public string Flag { get; set; }
+		}
+
+		public ReindexOnServerSourceApiTests(IntrusiveOperationCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var index in values.Values)
+			{
+				this.Client.Bulk(b => b
+					.Index(index)
+					.IndexMany(new []
+					{
+						new Test { Id = 1, Flag = "bar" },
+						new Test { Id = 2, Flag = "bar" }
+					})
+					.Refresh(Refresh.WaitFor)
+				);
+			}
+		}
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.ReindexOnServer(f),
+			fluentAsync: (client, f) => client.ReindexOnServerAsync(f),
+			request: (client, r) => client.ReindexOnServer(r),
+			requestAsync: (client, r) => client.ReindexOnServerAsync(r)
+		);
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+
+		protected override string UrlPath => $"/_reindex?refresh=true";
+
+		protected override bool SupportsDeserialization => false;
+
+		protected override Func<ReindexOnServerDescriptor, IReindexOnServerRequest> Fluent => d => d
+			.Source(s => s
+				.Index(CallIsolatedValue)
+				.Type("test")
+				.Source<Test>(f => f
+					.Field(ff => ff.Id)
+					.Field(ff => ff.Flag)
+				)
+			)
+			.Destination(s => s
+				.Index(CallIsolatedValue + "-clone")
+				.Type("test")
+			)
+			.Conflicts(Conflicts.Proceed)
+			.Refresh();
+
+		protected override ReindexOnServerRequest Initializer => new ReindexOnServerRequest
+		{
+			Source = new ReindexSource
+			{
+				Index = CallIsolatedValue,
+				Type = "test",
+				Source = Infer.Fields<Test>(
+					ff => ff.Id,
+					ff => ff.Flag
+				)
+			},
+			Destination = new ReindexDestination
+			{
+				Index = CallIsolatedValue + "-clone",
+				Type = Type<Test>(),
+			},
+			Conflicts = Conflicts.Proceed,
+			Refresh = true,
+		};
+
+		protected override void ExpectResponse(IReindexOnServerResponse response)
+		{
+			response.ShouldBeValid();
+		}
+
+		protected override object ExpectJson =>
+			new
+			{
+				dest = new
+				{
+					index = $"{CallIsolatedValue}-clone",
+					type = "test",
+				},
+				source = new
+				{
+					index = CallIsolatedValue,
+					_source = new [] { "id", "flag" },
+					type = new[] { "test" },
+				},
+				conflicts = "proceed"
+			};
+	}
+}


### PR DESCRIPTION
This commit adds the ability to specify the fields from source to reindex
when using the Reindex API (ReindexOnServer in NEST).

Closes #3288