### PR TITLE
Long range query support

### DIFF
--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -138,6 +138,9 @@ namespace Nest
 		public QueryContainer Range(Func<NumericRangeQueryDescriptor<T>, INumericRangeQuery> selector) =>
 			WrapInContainer(selector, (query, container) => container.Range = query);
 
+		public QueryContainer LongRange(Func<LongRangeQueryDescriptor<T>, ILongRangeQuery> selector) =>
+			WrapInContainer(selector, (query, container) => container.Range = query);
+
 		/// <summary>
 		/// Matches documents with fields that have terms within a certain date range.
 		/// </summary>

--- a/src/Nest/QueryDsl/Query.cs
+++ b/src/Nest/QueryDsl/Query.cs
@@ -125,6 +125,9 @@ namespace Nest
 		public static QueryContainer Range(Func<NumericRangeQueryDescriptor<T>, INumericRangeQuery> selector) =>
 			new QueryContainerDescriptor<T>().Range(selector);
 
+		public static QueryContainer LongRange(Func<LongRangeQueryDescriptor<T>, ILongRangeQuery> selector) =>
+			new QueryContainerDescriptor<T>().LongRange(selector);
+
 		public static QueryContainer Regexp(Func<RegexpQueryDescriptor<T>, IRegexpQuery> selector) =>
 			new QueryContainerDescriptor<T>().Regexp(selector);
 
@@ -175,9 +178,6 @@ namespace Nest
 
 		public static QueryContainer Terms(Func<TermsQueryDescriptor<T>, ITermsQuery> selector) =>
 			new QueryContainerDescriptor<T>().Terms(selector);
-
-		public static QueryContainer TermsSet(Func<TermsSetQueryDescriptor<T>, ITermsSetQuery> selector) =>
-			new QueryContainerDescriptor<T>().TermsSet(selector);
 
 		public static QueryContainer Type(Func<TypeQueryDescriptor, ITypeQuery> selector) =>
 			new QueryContainerDescriptor<T>().Type(selector);

--- a/src/Nest/QueryDsl/Query.cs
+++ b/src/Nest/QueryDsl/Query.cs
@@ -179,6 +179,9 @@ namespace Nest
 		public static QueryContainer Terms(Func<TermsQueryDescriptor<T>, ITermsQuery> selector) =>
 			new QueryContainerDescriptor<T>().Terms(selector);
 
+		public static QueryContainer TermsSet(Func<TermsSetQueryDescriptor<T>, ITermsSetQuery> selector) =>
+			new QueryContainerDescriptor<T>().TermsSet(selector);
+
 		public static QueryContainer Type(Func<TypeQueryDescriptor, ITypeQuery> selector) =>
 			new QueryContainerDescriptor<T>().Type(selector);
 

--- a/src/Nest/QueryDsl/TermLevel/Range/LongRangeQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Range/LongRangeQuery.cs
@@ -42,6 +42,7 @@ namespace Nest
 		}
 	}
 
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public class LongRangeQueryDescriptor<T>
 		: FieldNameQueryDescriptorBase<LongRangeQueryDescriptor<T>, ILongRangeQuery, T>
 			, ILongRangeQuery where T : class

--- a/src/Nest/QueryDsl/TermLevel/Range/LongRangeQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Range/LongRangeQuery.cs
@@ -1,0 +1,66 @@
+﻿using Newtonsoft.Json;
+
+namespace Nest
+{
+	public interface ILongRangeQuery : IRangeQuery
+	{
+		[JsonProperty("gte")]
+		long? GreaterThanOrEqualTo { get; set; }
+
+		[JsonProperty("lte")]
+		long? LessThanOrEqualTo { get; set; }
+
+		[JsonProperty("gt")]
+		long? GreaterThan { get; set; }
+
+		[JsonProperty("lt")]
+		long? LessThan { get; set; }
+
+		[JsonProperty("relation")]
+		RangeRelation? Relation { get; set; }
+	}
+
+	public class LongRangeQuery : FieldNameQueryBase, ILongRangeQuery
+	{
+		protected override bool Conditionless => IsConditionless(this);
+		public long? GreaterThanOrEqualTo { get; set; }
+		public long? LessThanOrEqualTo { get; set; }
+		public long? GreaterThan { get; set; }
+		public long? LessThan { get; set; }
+
+		public RangeRelation? Relation { get; set; }
+
+		internal override void InternalWrapInContainer(IQueryContainer c) => c.Range = this;
+
+		internal static bool IsConditionless(ILongRangeQuery q)
+		{
+			return q.Field.IsConditionless()
+			       || (q.GreaterThanOrEqualTo == null
+			           && q.LessThanOrEqualTo == null
+			           && q.GreaterThan == null
+			           && q.LessThan == null);
+		}
+	}
+
+	public class LongRangeQueryDescriptor<T>
+		: FieldNameQueryDescriptorBase<LongRangeQueryDescriptor<T>, ILongRangeQuery, T>
+			, ILongRangeQuery where T : class
+	{
+		protected override bool Conditionless => LongRangeQuery.IsConditionless(this);
+		long? ILongRangeQuery.GreaterThanOrEqualTo { get; set; }
+		long? ILongRangeQuery.LessThanOrEqualTo { get; set; }
+		long? ILongRangeQuery.GreaterThan { get; set; }
+		long? ILongRangeQuery.LessThan { get; set; }
+		RangeRelation? ILongRangeQuery.Relation { get; set; }
+
+		public LongRangeQueryDescriptor<T> Relation(RangeRelation? relation) => Assign(a => a.Relation = relation);
+
+		public LongRangeQueryDescriptor<T> GreaterThan(long? from) => Assign(a => a.GreaterThan = from);
+
+		public LongRangeQueryDescriptor<T> GreaterThanOrEquals(long? from) => Assign(a => a.GreaterThanOrEqualTo = from);
+
+		public LongRangeQueryDescriptor<T> LessThan(long? to) => Assign(a => a.LessThan = to);
+
+		public LongRangeQueryDescriptor<T> LessThanOrEquals(long? to) => Assign(a => a.LessThanOrEqualTo = to);
+	}
+}

--- a/src/Nest/QueryDsl/TermLevel/Range/NumericRangeQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Range/NumericRangeQuery.cs
@@ -20,24 +20,6 @@ namespace Nest
 		RangeRelation? Relation { get; set; }
 	}
 
-	public interface ILongRangeQuery : IRangeQuery
-	{
-		[JsonProperty("gte")]
-		long? GreaterThanOrEqualTo { get; set; }
-
-		[JsonProperty("lte")]
-		long? LessThanOrEqualTo { get; set; }
-
-		[JsonProperty("gt")]
-		long? GreaterThan { get; set; }
-
-		[JsonProperty("lt")]
-		long? LessThan { get; set; }
-
-		[JsonProperty("relation")]
-		RangeRelation? Relation { get; set; }
-	}
-
 	public class NumericRangeQuery : FieldNameQueryBase, INumericRangeQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
@@ -59,29 +41,6 @@ namespace Nest
 				&& q.LessThan == null);
 		}
 	}
-
-	public class LongRangeQuery : FieldNameQueryBase, ILongRangeQuery
-	{
-		protected override bool Conditionless => IsConditionless(this);
-		public long? GreaterThanOrEqualTo { get; set; }
-		public long? LessThanOrEqualTo { get; set; }
-		public long? GreaterThan { get; set; }
-		public long? LessThan { get; set; }
-
-		public RangeRelation? Relation { get; set; }
-
-		internal override void InternalWrapInContainer(IQueryContainer c) => c.Range = this;
-
-		internal static bool IsConditionless(ILongRangeQuery q)
-		{
-			return q.Field.IsConditionless()
-			       || (q.GreaterThanOrEqualTo == null
-			           && q.LessThanOrEqualTo == null
-			           && q.GreaterThan == null
-			           && q.LessThan == null);
-		}
-	}
-
 
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public class NumericRangeQueryDescriptor<T>
@@ -105,27 +64,5 @@ namespace Nest
 		public NumericRangeQueryDescriptor<T> LessThanOrEquals(double? to) => Assign(a => a.LessThanOrEqualTo = to);
 
 		public NumericRangeQueryDescriptor<T> Relation(RangeRelation? relation) => Assign(a => a.Relation = relation);
-	}
-
-	public class LongRangeQueryDescriptor<T>
-		: FieldNameQueryDescriptorBase<LongRangeQueryDescriptor<T>, ILongRangeQuery, T>
-			, ILongRangeQuery where T : class
-	{
-		protected override bool Conditionless => LongRangeQuery.IsConditionless(this);
-		long? ILongRangeQuery.GreaterThanOrEqualTo { get; set; }
-		long? ILongRangeQuery.LessThanOrEqualTo { get; set; }
-		long? ILongRangeQuery.GreaterThan { get; set; }
-		long? ILongRangeQuery.LessThan { get; set; }
-		RangeRelation? ILongRangeQuery.Relation { get; set; }
-
-		public LongRangeQueryDescriptor<T> Relation(RangeRelation? relation) => Assign(a => a.Relation = relation);
-
-		public LongRangeQueryDescriptor<T> GreaterThan(long? from) => Assign(a => a.GreaterThan = from);
-
-		public LongRangeQueryDescriptor<T> GreaterThanOrEquals(long? from) => Assign(a => a.GreaterThanOrEqualTo = from);
-
-		public LongRangeQueryDescriptor<T> LessThan(long? to) => Assign(a => a.LessThan = to);
-
-		public LongRangeQueryDescriptor<T> LessThanOrEquals(long? to) => Assign(a => a.LessThanOrEqualTo = to);
 	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Range/NumericRangeQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Range/NumericRangeQuery.cs
@@ -20,6 +20,24 @@ namespace Nest
 		RangeRelation? Relation { get; set; }
 	}
 
+	public interface ILongRangeQuery : IRangeQuery
+	{
+		[JsonProperty("gte")]
+		long? GreaterThanOrEqualTo { get; set; }
+
+		[JsonProperty("lte")]
+		long? LessThanOrEqualTo { get; set; }
+
+		[JsonProperty("gt")]
+		long? GreaterThan { get; set; }
+
+		[JsonProperty("lt")]
+		long? LessThan { get; set; }
+
+		[JsonProperty("relation")]
+		RangeRelation? Relation { get; set; }
+	}
+
 	public class NumericRangeQuery : FieldNameQueryBase, INumericRangeQuery
 	{
 		protected override bool Conditionless => IsConditionless(this);
@@ -42,6 +60,29 @@ namespace Nest
 		}
 	}
 
+	public class LongRangeQuery : FieldNameQueryBase, ILongRangeQuery
+	{
+		protected override bool Conditionless => IsConditionless(this);
+		public long? GreaterThanOrEqualTo { get; set; }
+		public long? LessThanOrEqualTo { get; set; }
+		public long? GreaterThan { get; set; }
+		public long? LessThan { get; set; }
+
+		public RangeRelation? Relation { get; set; }
+
+		internal override void InternalWrapInContainer(IQueryContainer c) => c.Range = this;
+
+		internal static bool IsConditionless(ILongRangeQuery q)
+		{
+			return q.Field.IsConditionless()
+			       || (q.GreaterThanOrEqualTo == null
+			           && q.LessThanOrEqualTo == null
+			           && q.GreaterThan == null
+			           && q.LessThan == null);
+		}
+	}
+
+
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public class NumericRangeQueryDescriptor<T>
 		: FieldNameQueryDescriptorBase<NumericRangeQueryDescriptor<T>, INumericRangeQuery, T>
@@ -52,6 +93,7 @@ namespace Nest
 		double? INumericRangeQuery.LessThanOrEqualTo { get; set; }
 		double? INumericRangeQuery.GreaterThan { get; set; }
 		double? INumericRangeQuery.LessThan { get; set; }
+
 		RangeRelation? INumericRangeQuery.Relation{ get; set; }
 
 		public NumericRangeQueryDescriptor<T> GreaterThan(double? from) => Assign(a => a.GreaterThan = from);
@@ -63,5 +105,27 @@ namespace Nest
 		public NumericRangeQueryDescriptor<T> LessThanOrEquals(double? to) => Assign(a => a.LessThanOrEqualTo = to);
 
 		public NumericRangeQueryDescriptor<T> Relation(RangeRelation? relation) => Assign(a => a.Relation = relation);
+	}
+
+	public class LongRangeQueryDescriptor<T>
+		: FieldNameQueryDescriptorBase<LongRangeQueryDescriptor<T>, ILongRangeQuery, T>
+			, ILongRangeQuery where T : class
+	{
+		protected override bool Conditionless => LongRangeQuery.IsConditionless(this);
+		long? ILongRangeQuery.GreaterThanOrEqualTo { get; set; }
+		long? ILongRangeQuery.LessThanOrEqualTo { get; set; }
+		long? ILongRangeQuery.GreaterThan { get; set; }
+		long? ILongRangeQuery.LessThan { get; set; }
+		RangeRelation? ILongRangeQuery.Relation { get; set; }
+
+		public LongRangeQueryDescriptor<T> Relation(RangeRelation? relation) => Assign(a => a.Relation = relation);
+
+		public LongRangeQueryDescriptor<T> GreaterThan(long? from) => Assign(a => a.GreaterThan = from);
+
+		public LongRangeQueryDescriptor<T> GreaterThanOrEquals(long? from) => Assign(a => a.GreaterThanOrEqualTo = from);
+
+		public LongRangeQueryDescriptor<T> LessThan(long? to) => Assign(a => a.LessThan = to);
+
+		public LongRangeQueryDescriptor<T> LessThanOrEquals(long? to) => Assign(a => a.LessThanOrEqualTo = to);
 	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Range/RangeQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/TermLevel/Range/RangeQueryJsonConverter.cs
@@ -37,14 +37,13 @@ namespace Nest
 
 		private static IRangeQuery GetRangeQuery(JsonSerializer serializer, JObject jo)
 		{
-			IRangeQuery fq = FromJson.ReadAs<DateRangeQuery>(jo.CreateReader(), serializer);
 			var isNumeric = false;
 			var isLong = false;
 
 			foreach (var property in jo.Properties())
 			{
 				if (property.Name == "format" || property.Name == "time_zone")
-					return fq;
+					return FromJson.ReadAs<DateRangeQuery>(jo.CreateReader(), serializer);
 				if (_rangeKeys.Contains(property.Name))
 				{
 					if (property.Value.Type == JTokenType.Float)
@@ -58,7 +57,7 @@ namespace Nest
 			if (isLong)
 				return FromJson.ReadAs<LongRangeQuery>(jo.CreateReader(), serializer);
 
-			return fq;
+			return null;
 		}
 
 		private static TReturn GetPropValue<TReturn>(JObject jObject, string field)

--- a/src/Nest/QueryDsl/TermLevel/Range/RangeQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/TermLevel/Range/RangeQueryJsonConverter.cs
@@ -37,13 +37,10 @@ namespace Nest
 
 		private static IRangeQuery GetRangeQuery(JsonSerializer serializer, JObject jo)
 		{
-			var isLong = !jo.Properties().Any(p => p.Name == "format" || p.Name == "time_zone")
-			             && jo.Properties().Any(p => _rangeKeys.Contains(p.Name) && p.Value.Type == JTokenType.Integer);
+			var nameIsValid = !jo.Properties().Any(p => p.Name == "format" || p.Name == "time_zone");
 
-			var isNumeric = !jo.Properties().Any(p => p.Name == "format" || p.Name == "time_zone")
-			                && jo.Properties().Any(p =>
-				                _rangeKeys.Contains(p.Name) &&
-				                p.Value.Type == JTokenType.Float);
+			var isLong = nameIsValid && CheckType(jo, JTokenType.Integer);
+			var isNumeric = nameIsValid && CheckType(jo, JTokenType.Float);
 
 			IRangeQuery fq;
 
@@ -61,6 +58,13 @@ namespace Nest
 			}
 
 			return fq;
+		}
+
+		private static bool CheckType(JObject jo, JTokenType jTokenType)
+		{
+			return jo.Properties().Any(p =>
+				       _rangeKeys.Contains(p.Name) &&
+				       p.Value.Type == jTokenType);
 		}
 
 		private static TReturn GetPropValue<TReturn>(JObject jObject, string field)

--- a/src/Nest/QueryDsl/TermLevel/Range/RangeQueryJsonConverter.cs
+++ b/src/Nest/QueryDsl/TermLevel/Range/RangeQueryJsonConverter.cs
@@ -57,7 +57,7 @@ namespace Nest
 			if (isLong)
 				return FromJson.ReadAs<LongRangeQuery>(jo.CreateReader(), serializer);
 
-			return null;
+			return FromJson.ReadAs<DateRangeQuery>(jo.CreateReader(), serializer);
 		}
 
 		private static TReturn GetPropValue<TReturn>(JObject jObject, string field)

--- a/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
@@ -79,7 +79,7 @@ namespace Nest
 
 		public virtual void Visit(INumericRangeQuery query) => Write("numeric_range");
 
-		public virtual void Visit(ILongRangeQuery query) => Write("numeric_range");
+		public virtual void Visit(ILongRangeQuery query) => Write("long_range");
 
 		public virtual void Visit(ITermRangeQuery query) => Write("term_range");
 

--- a/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
@@ -79,7 +79,9 @@ namespace Nest
 
 		public virtual void Visit(INumericRangeQuery query) => Write("numeric_range");
 
-        public virtual void Visit(ITermRangeQuery query) => Write("term_range");
+		public virtual void Visit(ILongRangeQuery query) => Write("numeric_range");
+
+		public virtual void Visit(ITermRangeQuery query) => Write("term_range");
 
 		public virtual void Visit(IFunctionScoreQuery query) => Write("function_core");
 

--- a/src/Nest/QueryDsl/Visitor/QueryVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/QueryVisitor.cs
@@ -61,6 +61,7 @@
 		void Visit(IExistsQuery query);
 		void Visit(IDateRangeQuery query);
 		void Visit(INumericRangeQuery query);
+		void Visit(ILongRangeQuery query);
 		void Visit(ITermRangeQuery query);
 		void Visit(ISpanFirstQuery query);
 		void Visit(ISpanNearQuery query);
@@ -123,7 +124,9 @@
 
 		public virtual void Visit(INumericRangeQuery query) { }
 
-        public virtual void Visit(ITermRangeQuery query) { }
+		public virtual void Visit(ILongRangeQuery query) { }
+
+		public virtual void Visit(ITermRangeQuery query) { }
 
 		public virtual void Visit(IFunctionScoreQuery query) { }
 

--- a/src/Nest/QueryDsl/Visitor/QueryWalker.cs
+++ b/src/Nest/QueryDsl/Visitor/QueryWalker.cs
@@ -26,6 +26,7 @@ namespace Nest
 				v.Visit(d);
 				VisitQuery(d as IDateRangeQuery, visitor, (vv, dd) => v.Visit(dd));
 				VisitQuery(d as INumericRangeQuery, visitor, (vv, dd) => v.Visit(dd));
+				VisitQuery(d as ILongRangeQuery, visitor, (vv, dd) => v.Visit(dd));
 				VisitQuery(d as ITermRangeQuery, visitor, (vv, dd) => v.Visit(dd));
 			});
 			VisitQuery(qd.GeoShape, visitor, (v, d) =>

--- a/src/Tests/QueryDsl/TermLevel/Range/LongRangeQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Range/LongRangeQueryUsageTests.cs
@@ -1,0 +1,65 @@
+using Nest;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using Tests.Framework.MockData;
+
+namespace Tests.QueryDsl.TermLevel.Range
+{
+	public class LongRangeQueryUsageTests : QueryDslUsageTestsBase
+	{
+		public LongRangeQueryUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) {}
+
+		protected override object QueryJson => new
+		{
+			range = new
+			{
+				description = new
+				{
+					_name = "named_query",
+					boost = 1.1,
+					gt = 636634079999999999,
+					gte = 636634080000000000,
+					lt = 636634080000000000,
+					lte = 636634079999999999,
+					relation = "within"
+				}
+			}
+		};
+
+		protected override QueryContainer QueryInitializer => new LongRangeQuery
+		{
+			Name = "named_query",
+			Boost = 1.1,
+			Field = "description",
+			GreaterThan = 636634079999999999,
+			GreaterThanOrEqualTo = 636634080000000000,
+			LessThan = 636634080000000000,
+			LessThanOrEqualTo = 636634079999999999,
+			Relation = RangeRelation.Within
+		};
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.Range(c => c
+				.Name("named_query")
+				.Boost(1.1)
+				.Field(p => p.Description)
+				.GreaterThan(636634079999999999)
+				.GreaterThanOrEquals(636634080000000000)
+				.LessThan(636634079999999999)
+				.LessThanOrEquals(636634079999999999)
+				.Relation(RangeRelation.Within)
+			);
+
+		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<ILongRangeQuery>(q => q.Range as ILongRangeQuery)
+		{
+			q=> q.Field = null,
+			q=>
+			{
+				q.GreaterThan = null;
+				q.GreaterThanOrEqualTo = null;
+				q.LessThan = null;
+				q.LessThanOrEqualTo = null;
+			}
+		};
+	}
+}

--- a/src/Tests/QueryDsl/TermLevel/Range/LongRangeQueryUsageTests.cs
+++ b/src/Tests/QueryDsl/TermLevel/Range/LongRangeQueryUsageTests.cs
@@ -39,13 +39,13 @@ namespace Tests.QueryDsl.TermLevel.Range
 		};
 
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
-			.Range(c => c
+			.LongRange(c => c
 				.Name("named_query")
 				.Boost(1.1)
 				.Field(p => p.Description)
 				.GreaterThan(636634079999999999)
 				.GreaterThanOrEquals(636634080000000000)
-				.LessThan(636634079999999999)
+				.LessThan(636634080000000000)
 				.LessThanOrEquals(636634079999999999)
 				.Relation(RangeRelation.Within)
 			);


### PR DESCRIPTION
Hello, everybody,

I want to make range queries that correctly work with long type. So, I have added support of long range query. 

Small test to demonstrate trouble that I want to solve .
We want to work with timestamps that are long type:
```
q.Range(c => c
	.Name("named_query")
	.Boost(1.1)
	.Field(p => p.Description)
	.GreaterThan(636634079999999999)
	.GreaterThanOrEquals(636634080000000000)
	.LessThan(636634080000000000)
	.LessThanOrEquals(636634079999999999)
	.Relation(RangeRelation.Within))
```
converts numbers to double type:
```
   query = new {
          range = new {
            description = new {
              _name = "named_query",
              boost = 1.1,
              gt = 6.3663408E+17,
              gte = 6.3663408E+17,
              lt = 6.3663408E+17,
              lte = 6.3663408E+17,
              relation = "within"
            }
          }
        }
```
and loses precision.
Elasticsearch himself is able to make such requests, but in NEST this functionality is missed.

I will be grateful if you merge my pull request and I'm ready to discuss my decision.