### PR TITLE
Honour DataMember and DataContract attributes

### DIFF
--- a/docs/client-concepts/high-level/inference/field-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/field-inference.asciidoc
@@ -114,7 +114,8 @@ Expect("name")
 To ease creating a `Field` instance from expressions, there is a static `Infer` class you can use
 
 [TIP]
-This example uses the https://msdn.microsoft.com/en-us/library/sf0df423.aspx#Anchor_0[static import] `using static Nest.Infer;` in the using directives to shorthand `Nest.Infer.Field<T>()`
+This example uses the https://msdn.microsoft.com/en-us/library/sf0df423.aspx#Anchor_0[static import] `using static Nest.Infer;`
+in the using directives to shorthand `Nest.Infer.Field<T>()`
 to simply `Field<T>()`. Be sure to include this static import if copying any of these examples.
 
 [source,csharp]
@@ -322,6 +323,7 @@ Expect("leadDeveloper.firstName.raw.evendeeper").WhenSerializing(multiSuffixFiel
 Expect("metadata.hardcoded.raw.evendeeper").WhenSerializing(multiSuffixFieldExpressions[4]);
 ----
 
+[[field-name-attribute]]
 ==== Attribute based naming
 
 Using NEST's property attributes you can specify a new name for the properties
@@ -337,9 +339,29 @@ public class BuiltIn
 Expect("naam").WhenSerializing(Field<BuiltIn>(p => p.Name));
 ----
 
-Starting with NEST 2.x, we also ask the serializer if it can resolve a property to a name.
-Here we ask the default `JsonNetSerializer` to resolve a property name and it takes
-the `JsonPropertyAttribute` into account
+[[data-member-field-attribute]]
+==== DataMember attributes
+
+If a property has a `System.Runtime.Serialization.DataMemberAttribute` applied, this can be used to resolve
+a field value for a property
+
+[source,csharp]
+----
+public class DataMember
+{
+    [DataMember(Name = "nameFromDataMember")]
+    public string Name { get; set; }
+}
+
+Expect("nameFromDataMember").WhenSerializing(Field<DataMember>(p => p.Name));
+----
+
+[[serializer-specific-field-attribute]]
+==== Serializer specific attributes
+
+NEST can also use a serializer specific attribute to resolve a field value for a property.
+In this example, the {nuget}/NEST.JsonNetSerializer[`JsonNetSerializer`] is hooked up as the
+<<custom-serialization, custom serializer>> for the client and we use the `JsonPropertyAttribute` to resolve a field
 
 [source,csharp]
 ----
@@ -439,10 +461,11 @@ fieldNameOnB.Should().Be("c.name");
 
 To wrap up, the precedence in which field names are inferred is:
 
-1) A hard rename of the property on connection settings using `.PropertyName()`
-2) A NEST PropertyNameAttribute
-3) Ask the serializer if the property has a verbatim value, e.g it has a JsonPropertyAttribute.
-4) Pass the MemberInfo's Name to the DefaultFieldNameInferrer, which by default will camelCase
+1) A naming of the property on `ConnectionSettings` using `.PropertyName()`
+2) A NEST `PropertyNameAttribute`
+3) Ask the serializer if the property has a verbatim value, e.g. it has a `JsonPropertyAttribute` if using {nuget}/NEST.JsonNetSerializer[`JsonNetSerializer`]
+4) See if the `MemberInfo` has a `DataMemberAttribute` applied
+5) Pass the `MemberInfo` to the `DefaultFieldNameInferrer`, which by default will camel case the `Name` property
 
 The following example class will demonstrate this precedence
 
@@ -466,6 +489,9 @@ class Precedence
 
     [PropertyName("dontaskme"),JsonProperty("dontaskme")]
     public string AskSerializer { get; set; } <5>
+
+    [DataMember(Name = "data")]
+    public string DataMember { get; set; }
 
     public string DefaultFieldNameInferrer { get; set; } <6>
 }
@@ -515,6 +541,7 @@ usingSettings.Expect("nestAtt").ForField(Field<Precedence>(p => p.NestAttribute)
 usingSettings.Expect("nestProp").ForField(Field<Precedence>(p => p.NestProperty));
 usingSettings.Expect("jsonProp").ForField(Field<Precedence>(p => p.JsonProperty));
 usingSettings.Expect("ask").ForField(Field<Precedence>(p => p.AskSerializer));
+usingSettings.Expect("data").ForField(Field<Precedence>(p => p.DataMember));
 usingSettings.Expect("DEFAULTFIELDNAMEINFERRER").ForField(Field<Precedence>(p => p.DefaultFieldNameInferrer));
 ----
 
@@ -529,7 +556,8 @@ usingSettings.Expect(new []
     "jsonProp",
     "nestProp",
     "nestAtt",
-    "renamed"
+    "renamed",
+    "data"
 }).AsPropertiesOf(new Precedence
 {
     RenamedOnConnectionSettings = "renamed on connection settings",
@@ -537,7 +565,8 @@ usingSettings.Expect(new []
     NestProperty = "using a nest property",
     JsonProperty = "the default serializer resolves json property attributes",
     AskSerializer = "serializer fiddled with this one",
-    DefaultFieldNameInferrer = "shouting much?"
+    DefaultFieldNameInferrer = "shouting much?",
+    DataMember = "using a DataMember attribute"
 });
 
 public class Parent

--- a/docs/client-concepts/high-level/inference/types-and-relations-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/types-and-relations-inference.asciidoc
@@ -15,7 +15,7 @@ please modify the original csharp file found at the link and submit the PR with 
 [[types-and-relations-inference]]
 === Type and Relation names inference
 
-Type names are resolved in NEST by lowercasing the CLR type name
+Type names are resolved in NEST by default, by lowercasing the CLR type name
 
 [source,csharp]
 ----
@@ -23,6 +23,39 @@ var settings = new ConnectionSettings();
 var resolver = new TypeNameResolver(settings);
 var type = resolver.Resolve<Project>();
 type.Should().Be("project");
+----
+
+[[elasticsearchtype-attribute]]
+==== Applying a type name with `ElasticsearchTypeAttribute`
+
+A type name can be applied for a CLR type, using the Name property on `ElasticsearchTypeAttribute`
+
+[source,csharp]
+----
+[ElasticsearchType(Name = "attributed_project")]
+public class AttributedProject { }
+
+var settings = new ConnectionSettings();
+var resolver = new TypeNameResolver(settings);
+var type = resolver.Resolve<AttributedProject>();
+type.Should().Be("attributed_project");
+----
+
+[[datacontract-attribute]]
+==== Applying a type name with `DataContractAttribute`
+
+Similarly to <<elasticsearchtype-attribute, `ElasticsearchTypeAttribute`>>, a type name can be applied for a
+CLR type, using the Name property on `System.Runtime.Serialization.DataContractAttribute`
+
+[source,csharp]
+----
+[DataContract(Name = "data_contract_project")]
+public class DataContractProject { }
+
+var settings = new ConnectionSettings();
+var resolver = new TypeNameResolver(settings);
+var type = resolver.Resolve<DataContractProject>();
+type.Should().Be("data_contract_project");
 ----
 
 [[default-type-name]]
@@ -58,7 +91,8 @@ type.Should().Be("project-suffix");
 ----
 
 [[relation-names]]
-==== Relation names
+[float]
+=== Relation names
 
 Prior to Elasticsearch 6.x you could have multiple types per index. They acted as a discrimatory column but were often
 confused with tables. The fact that the mapping API's treated them as seperate entities did not help.

--- a/docs/high-level.asciidoc
+++ b/docs/high-level.asciidoc
@@ -209,37 +209,37 @@ include::aggregations/reserved-aggregation-names.asciidoc[]
 
 There are a number of conventions that NEST uses for inference of
 
-* <<document-paths, Document paths>>
-
-* <<field-inference, Fields>>
-
-* <<ids-inference, Ids>>
-
 * <<index-name-inference, Index names>>
+
+* <<types-and-relations-inference, Type and Relation names>>
+
+* <<ids-inference, Document Ids>>
+
+* <<field-inference, Document field names>>
+
+* <<property-inference, Document properties>>
+
+* <<document-paths, Document paths>>
 
 * <<indices-paths, Index paths>>
 
-* <<property-inference, Properties>>
-
 * <<routing-inference, Routing>>
 
-:includes-from-dirs: client-concepts/high-level/inference
+include::{output-dir}/inference/index-name-inference.asciidoc[]
 
-include::client-concepts/high-level/inference/document-paths.asciidoc[]
+include::{output-dir}/inference/types-and-relations-inference.asciidoc[]
 
-include::client-concepts/high-level/inference/field-inference.asciidoc[]
+include::{output-dir}/inference/ids-inference.asciidoc[]
 
-include::client-concepts/high-level/inference/ids-inference.asciidoc[]
+include::{output-dir}/inference/field-inference.asciidoc[]
 
-include::client-concepts/high-level/inference/index-name-inference.asciidoc[]
+include::{output-dir}/inference/property-inference.asciidoc[]
 
-include::client-concepts/high-level/inference/indices-paths.asciidoc[]
+include::{output-dir}/inference/document-paths.asciidoc[]
 
-include::client-concepts/high-level/inference/property-inference.asciidoc[]
+include::{output-dir}/inference/indices-paths.asciidoc[]
 
-include::client-concepts/high-level/inference/routing-inference.asciidoc[]
-
-include::client-concepts/high-level/inference/types-and-relations-inference.asciidoc[]
+include::{output-dir}/inference/routing-inference.asciidoc[]
 
 [[common-types]]
 == Common Types

--- a/src/Nest/CommonAbstractions/Infer/Field/FieldExpressionVisitor.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/FieldExpressionVisitor.cs
@@ -17,7 +17,7 @@ namespace Nest
 		private bool _found;
 		public bool Found
 		{
-			get { return _found; }
+			get => _found;
 			// This is only set to true once to prevent clobbering from subsequent node visits
 			private set { if (!_found) _found = value; }
 		}
@@ -36,11 +36,10 @@ namespace Nest
 
 		protected override Expression VisitMethodCall(MethodCallExpression node)
 		{
-			if (node.Method.Name == "Suffix" && node.Arguments.Any())
+			if (node.Method.Name == nameof(SuffixExtensions.Suffix) && node.Arguments.Any())
 			{
 				var lastArg = node.Arguments.Last();
-				var constantExpression = lastArg as ConstantExpression;
-				this.Found = constantExpression == null;
+				this.Found = !(lastArg is ConstantExpression);
 			}
 			else if (node.Method.Name == "get_Item" && node.Arguments.Any())
 			{
@@ -53,8 +52,7 @@ namespace Nest
 				if (!isDict)
 					return base.VisitMethodCall(node);
 				var lastArg = node.Arguments.Last();
-				var constantExpression = lastArg as ConstantExpression;
-				this.Found = constantExpression == null;
+				this.Found = !(lastArg is ConstantExpression);
 			}
 			return base.VisitMethodCall(node);
 		}
@@ -90,8 +88,7 @@ namespace Nest
 
 			var name = info.Name;
 
-			IPropertyMapping propertyMapping = null;
-			if (this._settings.PropertyMappings.TryGetValue(info, out propertyMapping))
+			if (this._settings.PropertyMappings.TryGetValue(info, out var propertyMapping))
 				return propertyMapping.Name;
 
 			var att = ElasticsearchPropertyAttributeBase.From(info);
@@ -111,7 +108,7 @@ namespace Nest
 
 		protected override Expression VisitMethodCall(MethodCallExpression methodCall)
 		{
-			if (methodCall.Method.Name == "Suffix" && methodCall.Arguments.Any())
+			if (methodCall.Method.Name == nameof(SuffixExtensions.Suffix) && methodCall.Arguments.Any())
 			{
 				VisitConstantOrVariable(methodCall, _stack);
 				var callingMember = new ReadOnlyCollection<Expression>(

--- a/src/Nest/CommonAbstractions/Infer/TypeName/TypeNameResolver.cs
+++ b/src/Nest/CommonAbstractions/Infer/TypeName/TypeNameResolver.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Nest
 {
@@ -35,8 +37,13 @@ namespace Nest
 				typeName = att.Name;
 			else
 			{
-				var inferredType =_connectionSettings.DefaultTypeNameInferrer(type);
-				typeName = !inferredType.IsNullOrEmpty() ? inferredType : _connectionSettings.DefaultTypeName;
+				var dataContract = type.GetAttributes<DataContractAttribute>().FirstOrDefault();
+				if (dataContract != null) typeName = dataContract.Name;
+				else
+				{
+					var inferredType =_connectionSettings.DefaultTypeNameInferrer(type);
+					typeName = !inferredType.IsNullOrEmpty() ? inferredType : _connectionSettings.DefaultTypeName;
+				}
 			}
 			if (typeName.IsNullOrEmpty()) throw new ArgumentNullException($"{type.FullName} resolved to an empty string or null");
 

--- a/src/Nest/CommonAbstractions/SerializationBehavior/PropertyMapping.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/PropertyMapping.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -59,10 +60,11 @@ namespace Nest
 		private static IPropertyMapping PropertyMappingFromAttributes(MemberInfo memberInfo)
 		{
 			var jsonProperty = memberInfo.GetCustomAttribute<JsonPropertyAttribute>(true);
-			var rename = memberInfo.GetCustomAttribute<PropertyNameAttribute>(true);
+			var dataMemberProperty = memberInfo.GetCustomAttribute<DataMemberAttribute>(true);
+			var propertyName = memberInfo.GetCustomAttribute<PropertyNameAttribute>(true);
 			var ignore = memberInfo.GetCustomAttribute<IgnoreAttribute>(true);
-			if (jsonProperty == null && ignore == null && rename == null) return null;
-			return new PropertyMapping {Name = rename?.Name ?? jsonProperty?.PropertyName, Ignore = ignore != null};
+			if (jsonProperty == null && ignore == null && propertyName == null && dataMemberProperty == null) return null;
+			return new PropertyMapping {Name = propertyName?.Name ?? jsonProperty?.PropertyName ?? dataMemberProperty?.Name, Ignore = ignore != null};
 		}
 	}
 

--- a/src/Tests/Framework/TestClient.cs
+++ b/src/Tests/Framework/TestClient.cs
@@ -181,7 +181,7 @@ namespace Tests.Framework
 			return settings;
 		}
 
-		public static IElasticClient GetInMemoryClient() => new ElasticClient(GlobalDefaultSettings);
+		public static IElasticClient GetInMemoryClient() => GetInMemoryClient(null);
 
 		public static IElasticClient GetInMemoryClient(Func<ConnectionSettings, ConnectionSettings> modifySettings, int port = 9200) =>
 			new ElasticClient(CreateSettings(modifySettings, port, forceInMemory: true).EnableDebugMode());

--- a/src/Tests/Reproduce/GithubIssue3107.cs
+++ b/src/Tests/Reproduce/GithubIssue3107.cs
@@ -1,0 +1,49 @@
+﻿using System.Runtime.Serialization;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Tests.Framework;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3107
+	{
+		[U] public void FieldResolverRespectsDataMemberAttributes()
+		{
+			var client = TestClient.DefaultInMemoryClient;
+
+			var document = new SourceEntity
+			{
+				Name = "name",
+				DisplayName = "display name"
+			};
+
+			var indexResponse = client.IndexDocument(document);
+			var requestJson = Encoding.UTF8.GetString(indexResponse.ApiCall.RequestBodyInBytes);
+			requestJson.Should().Contain("display_name");
+			indexResponse.ApiCall.Uri.AbsoluteUri.Should().Contain("source_entity");
+
+			var searchResponse = client.Search<SourceEntity>(s => s
+				.Query(q => q
+					.Terms(t => t
+						.Field(f => f.DisplayName)
+						.Terms("term")
+					)
+				)
+			);
+
+			requestJson = Encoding.UTF8.GetString(searchResponse.ApiCall.RequestBodyInBytes);
+			requestJson.Should().Contain("display_name");
+		}
+
+		[DataContract(Name = "source_entity")]
+		public class SourceEntity
+		{
+			[DataMember(Name = "name")]
+			public string Name { get; set; }
+
+			[DataMember(Name = "display_name")]
+			public string DisplayName { get; set; }
+		}
+	}
+}

--- a/src/Tests/high-level.asciidoc
+++ b/src/Tests/high-level.asciidoc
@@ -158,15 +158,23 @@ include::aggregations/reserved-aggregation-names.asciidoc[]
 
 There are a number of conventions that NEST uses for inference of
 
-- <<document-paths, Document paths>>
-- <<field-inference, Fields>>
-- <<ids-inference, Ids>>
 - <<index-name-inference, Index names>>
+- <<types-and-relations-inference, Type and Relation names>>
+- <<ids-inference, Document Ids>>
+- <<field-inference, Document field names>>
+- <<property-inference, Document properties>>
+- <<document-paths, Document paths>>
 - <<indices-paths, Index paths>>
-- <<property-inference, Properties>>
 - <<routing-inference, Routing>>
 
-:includes-from-dirs: client-concepts/high-level/inference
+include::{output-dir}/inference/index-name-inference.asciidoc[]
+include::{output-dir}/inference/types-and-relations-inference.asciidoc[]
+include::{output-dir}/inference/ids-inference.asciidoc[]
+include::{output-dir}/inference/field-inference.asciidoc[]
+include::{output-dir}/inference/property-inference.asciidoc[]
+include::{output-dir}/inference/document-paths.asciidoc[]
+include::{output-dir}/inference/indices-paths.asciidoc[]
+include::{output-dir}/inference/routing-inference.asciidoc[]
 
 [[common-types]]
 == Common Types


### PR DESCRIPTION
This commit updates the behaviour of TypeNameResolver and
PropertyMapping to respect the usage of DataMember and
DataContract attributes for all requests.

Prior behaviour to this commit was that indexing would honour
DataMember attributes on a document due to the internal implementation of
JSON.Net honouring them. With other requests such as Search however,
where a Field type is used, the the resolution of the Field string name did
not honour the attributes.

Closes #3107