### PR TITLE
build cluster command

### DIFF
--- a/build/scripts/Building.fsx
+++ b/build/scripts/Building.fsx
@@ -37,7 +37,6 @@ module Build =
         if not (DotNetCli.isInstalled()) then failwith  "You need to install the dotnet command line SDK to build for .NET Core"
         let runningSdkVersion = DotNetCli.getVersion()
         if (runningSdkVersion <> pinnedSdkVersion) then failwithf "Attempting to run with dotnet.exe with %s but global.json mandates %s" runningSdkVersion pinnedSdkVersion
-        let incrementalFramework = DotNetFramework.NetStandard1_3
         let sourceLink = if not incremental && not isMono && runningRelease then "1" else ""
         let props = 
             [ 
@@ -58,7 +57,7 @@ module Build =
                     Configuration = "Release" 
                     Project = sln
                     TimeOut = TimeSpan.FromMinutes(3.)
-                    AdditionalArgs = if incremental then ["-f"; incrementalFramework.Identifier.Nuget; props] else [props]
+                    AdditionalArgs = [props]
                 }
             ) |> ignore
 

--- a/build/scripts/Commandline.fsx
+++ b/build/scripts/Commandline.fsx
@@ -29,6 +29,7 @@ Targets:
   - create a canary nuget package based on the current version if [feed] and [apikey] are provided
     also pushes to upstream (myget)
 * diff <github|nuget|dir|assembly> <version|path 1> <version|path 2> [format]
+* cluster <cluster-name> [version]
 
 NOTE: both the `test` and `integrate` targets can be suffixed with `-all` to force the tests against all suported TFM's
 
@@ -94,6 +95,7 @@ module Commandline =
         | (_, true) -> true
         //dotnet-xunit needs to a build of its own anyways
         | ("test", _)
+        | ("cluster", _)
         | ("integrate", _) -> false
         | _ -> true
         
@@ -102,6 +104,7 @@ module Commandline =
         | ("release", _) -> true
         //dotnet-xunit needs to a build of its own anyways
         | ("test", _)
+        | ("cluster", _)
         | ("integrate", _) 
         | ("build", _) -> false
         | _ -> true
@@ -213,6 +216,13 @@ module Commandline =
             setBuildParam "diffType" diffType
             setBuildParam "first" firstVersionOrPath
             setBuildParam "second" secondVersionOrPath         
+            
+        | ["cluster"; clusterName] ->
+            setBuildParam "clusterName" clusterName
+            setBuildParam "clusterVersion" ""
+        | ["cluster"; clusterName; clusterVersion] ->
+            setBuildParam "clusterName" clusterName
+            setBuildParam "clusterVersion" clusterVersion
 
         | ["touch"; ] -> ignore()
         | ["temp"; ] -> ignore()

--- a/src/Tests/BenchmarkProgram.cs
+++ b/src/Tests/BenchmarkProgram.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Tests.Framework;
+
+namespace Tests
+{
+	public static class BenchmarkProgram
+	{
+		public static int Main(string[] arguments)
+		{
+			Console.WriteLine("Running Benchmarking.");
+			if (arguments.Count() > 1 && arguments[0].Equals("non-interactive", StringComparison.OrdinalIgnoreCase))
+			{
+				Console.WriteLine("Running in Non-Interactive mode.");
+				foreach (var benchmarkType in GetBenchmarkTypes())
+				{
+					BenchmarkRunner.Run(benchmarkType);
+				}
+
+				return 0;
+			}
+
+			Console.WriteLine("Running in Interactive mode.");
+			var benchmarkSwitcher = new BenchmarkSwitcher(GetBenchmarkTypes());
+			benchmarkSwitcher.Run(arguments);
+			return 0;
+		}
+
+
+		private static Type[] GetBenchmarkTypes()
+		{
+			IEnumerable<Type> types;
+
+			try
+			{
+				types = typeof(Program).Assembly().GetTypes();
+			}
+			catch (ReflectionTypeLoadException e)
+			{
+				types = e.Types.Where(t => t != null);
+			}
+
+			return types
+				.Where(t => t.GetMethods(BindingFlags.Instance | BindingFlags.Public)
+					.Any(m => m.GetCustomAttributes(typeof(BenchmarkAttribute), false).Any()))
+				.OrderBy(t => t.Namespace)
+				.ThenBy(t => t.Name)
+				.ToArray();
+		}
+	}
+}

--- a/src/Tests/ClusterLaunchProgram.cs
+++ b/src/Tests/ClusterLaunchProgram.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Elastic.Managed;
+using Elastic.Managed.Ephemeral;
+using FluentAssertions.Common;
+using Tests.Framework;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+
+namespace Tests
+{
+	public static class ClusterLaunchProgram
+	{
+		public static int Main(string[] arguments)
+		{
+			if (arguments.Length < 1)
+			{
+				Console.Error.WriteLine("cluster command needs atleast one argument to indicate the cluster to start");
+				return 3;
+			}
+
+			var clusterName = arguments[0];
+			if 	(arguments.Length > 1)
+				Environment.SetEnvironmentVariable("NEST_INTEGRATION_VERSION", arguments[1], EnvironmentVariableTarget.Process);
+			Environment.SetEnvironmentVariable("NEST_INTEGRATION_SHOW_OUTPUT_AFTER_START", "1", EnvironmentVariableTarget.Process);
+
+			var cluster = GetClusters().FirstOrDefault(c => c.Name.StartsWith(clusterName, StringComparison.OrdinalIgnoreCase));
+			if (cluster == null)
+			{
+				Console.Error.WriteLine($"No cluster found that starts with '{clusterName}");
+				return 4;
+			}
+
+			if (!TryStartClientTestClusterBaseImplementation(cluster) && !TryStartXPackClusterImplementation(cluster))
+			{
+				Console.Error.WriteLine($"Could not create an instance of '{cluster.FullName}");
+				return 1;
+			}
+			return 0;
+		}
+		private static bool TryStartXPackClusterImplementation(Type cluster)
+		{
+			if (!(Activator.CreateInstance(cluster) is XPackCluster instance)) return false;
+			using (instance)
+			{
+				instance.Start();
+				Console.WriteLine("Press any key to shutdown the running cluster");
+				Console.ReadKey();
+				instance.Dispose();
+			}
+
+			return true;
+		}
+
+		private static bool TryStartClientTestClusterBaseImplementation(Type cluster)
+		{
+			if (!(Activator.CreateInstance(cluster) is ClientTestClusterBase instance)) return false;
+			using (instance)
+			{
+				instance.Start();
+				Console.WriteLine("Press any key to shutdown the running cluster");
+				Console.ReadKey();
+				instance.Dispose();
+			}
+			return true;
+		}
+
+
+		private static Type[] GetClusters()
+		{
+			IEnumerable<Type> types;
+
+			try
+			{
+				types = typeof(Program).Assembly().GetTypes();
+			}
+			catch (ReflectionTypeLoadException e)
+			{
+				types = e.Types.Where(t => t != null);
+			}
+
+			return types
+				.Where(t => t.Implements(typeof(IEphemeralCluster)))
+				.ToArray();
+		}
+	}
+}

--- a/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Framework/Configuration/EnvironmentConfiguration.cs
@@ -20,6 +20,7 @@ namespace Tests.Framework.Configuration
 		public sealed override string ClusterFilter { get; protected set; }
 		public sealed override string TestFilter { get; protected set; }
 		public sealed override int Seed { get; protected set; }
+		public sealed override bool ShowElasticsearchOutputAfterStarted { get; protected set; }
 
 		public EnvironmentConfiguration()
 		{
@@ -30,6 +31,7 @@ namespace Tests.Framework.Configuration
 
 			this.ElasticsearchVersion = ElasticsearchVersion.From(string.IsNullOrWhiteSpace(version) ? DefaultVersion : version);
 			this.ClusterFilter = Environment.GetEnvironmentVariable("NEST_INTEGRATION_CLUSTER");
+			this.ShowElasticsearchOutputAfterStarted = Environment.GetEnvironmentVariable("NEST_INTEGRATION_SHOW_OUTPUT_AFTER_START") == "1";
 			this.TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
 
 			var newRandom = new Random().Next(1, 100000);

--- a/src/Tests/Framework/Configuration/ITestConfiguration.cs
+++ b/src/Tests/Framework/Configuration/ITestConfiguration.cs
@@ -17,6 +17,7 @@ namespace Tests.Framework.Configuration
 		bool RunUnitTests { get; }
 
 		RandomConfiguration Random { get; }
+		bool ShowElasticsearchOutputAfterStarted { get; }
 	}
 
 	public class RandomConfiguration

--- a/src/Tests/Framework/Configuration/TestConfigurationBase.cs
+++ b/src/Tests/Framework/Configuration/TestConfigurationBase.cs
@@ -10,6 +10,7 @@ namespace Tests.Framework.Configuration
 		public abstract TestMode Mode { get; protected set; }
 		public abstract string ClusterFilter { get; protected set; }
 		public abstract string TestFilter { get; protected set; }
+		public abstract bool ShowElasticsearchOutputAfterStarted { get; protected set; }
 
 
 		public virtual bool RunIntegrationTests => Mode == TestMode.Mixed || Mode == TestMode.Integration;

--- a/src/Tests/Framework/Configuration/YamlConfiguration.cs
+++ b/src/Tests/Framework/Configuration/YamlConfiguration.cs
@@ -18,6 +18,7 @@ namespace Tests.Framework.Configuration
 		public sealed override string ClusterFilter { get; protected set; }
 		public sealed override string TestFilter { get; protected set; }
 		public sealed override int Seed { get; protected set; }
+		public sealed override bool ShowElasticsearchOutputAfterStarted { get; protected set; }
 
 		public YamlConfiguration(string configurationFile)
 		{
@@ -31,6 +32,7 @@ namespace Tests.Framework.Configuration
 			this.ElasticsearchVersion = _config["elasticsearch_version"];
 			this.ForceReseed = BoolConfig("force_reseed", false);
 			this.TestAgainstAlreadyRunningElasticsearch = BoolConfig("test_against_already_running_elasticsearch", false);
+			this.ShowElasticsearchOutputAfterStarted = BoolConfig("elasticsearch_out_after_started", false);
 			this.ClusterFilter = _config.ContainsKey("cluster_filter") ? _config["cluster_filter"] : null;
 			this.TestFilter = _config.ContainsKey("test_filter") ? _config["test_filter"] : null;
 

--- a/src/Tests/Framework/ManagedElasticsearch/Clusters/ClientTestClusterBase.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Clusters/ClientTestClusterBase.cs
@@ -41,7 +41,7 @@ namespace Tests.Framework.ManagedElasticsearch.Clusters
 			: base(TestClient.Configuration.ElasticsearchVersion, features, new ElasticsearchPlugins(plugins), numberOfNodes)
 		{
 			this.TestConfiguration = TestClient.Configuration;
-			this.ShowElasticsearchOutputAfterStarted = false;
+			this.ShowElasticsearchOutputAfterStarted = this.TestConfiguration.ShowElasticsearchOutputAfterStarted;
 
 			this.CacheEsHomeInstallation = true;
 			this.TrialMode = XPackTrialMode.Trial;

--- a/src/Tests/Framework/ManagedElasticsearch/Clusters/INestTestCluster.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Clusters/INestTestCluster.cs
@@ -1,4 +1,5 @@
-﻿using Nest;
+﻿using System;
+using Nest;
 
 namespace Tests.Framework.ManagedElasticsearch.Clusters
 {

--- a/src/Tests/Framework/ManagedElasticsearch/Clusters/XPackCluster.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/Clusters/XPackCluster.cs
@@ -24,7 +24,7 @@ namespace Tests.Framework.ManagedElasticsearch.Clusters
 				this.XPackLicenseJson = licenseContents;
 			}
 
-			this.ShowElasticsearchOutputAfterStarted = true;
+			this.ShowElasticsearchOutputAfterStarted = this.TestConfiguration.ShowElasticsearchOutputAfterStarted;
 			this.AdditionalBeforeNodeStartedTasks.Add(new EnsureWatcherActionConfigurationInElasticsearchYaml());
 		}
 	}

--- a/src/Tests/Framework/ManagedElasticsearch/XunitSetup.cs
+++ b/src/Tests/Framework/ManagedElasticsearch/XunitSetup.cs
@@ -26,6 +26,7 @@ namespace Tests.Framework.ManagedElasticsearch
 			this.ClusterFilter = TestClient.Configuration.ClusterFilter;
 			this.TestFilter = TestClient.Configuration.TestFilter;
 			this.Version = TestClient.Configuration.ElasticsearchVersion;
+			this.IntegrationTestsMayUseAlreadyRunningNode = TestClient.Configuration.TestAgainstAlreadyRunningElasticsearch;
 
 			Generators.Initialize();
 		}

--- a/src/Tests/ProfileProgram.cs
+++ b/src/Tests/ProfileProgram.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Tests.Framework.Profiling;
+using Tests.Framework.Profiling.Memory;
+using Tests.Framework.Profiling.Performance;
+using Tests.Framework.Profiling.Timeline;
+
+namespace Tests
+{
+	public static class ProfileProgram
+	{
+		private const string SelfProfileSdkDirectory = "dottrace-selfprofile";
+
+		public static string InputDirPath { get; }
+		public static string OutputDirPath { get; }
+		private static string SdkPath { get; }
+		private static string OutputPath { get; }
+
+		static ProfileProgram()
+		{
+			var currentDirectory = new DirectoryInfo(Directory.GetCurrentDirectory());
+			if ((currentDirectory.Name == "Debug" || currentDirectory.Name == "Release") && currentDirectory.Parent.Name == "bin")
+			{
+				SdkPath = new DirectoryInfo(
+					Path.Combine(
+						Directory.GetCurrentDirectory(),
+						$@".\..\..\..\..\build\tools\{SelfProfileSdkDirectory}")).FullName;
+
+				OutputPath = new DirectoryInfo(
+					Path.Combine(
+						Directory.GetCurrentDirectory(),
+						$@".\..\..\..\..\build\output\profiling")).FullName;
+			}
+			else
+			{
+				SdkPath = new DirectoryInfo(
+					Path.Combine(
+						Directory.GetCurrentDirectory(),
+						$@".\build\tools\{SelfProfileSdkDirectory}")).FullName;
+
+				OutputPath = new DirectoryInfo(
+					Path.Combine(
+						Directory.GetCurrentDirectory(),
+						$@".\build\output\profiling")).FullName;
+			}
+		}
+
+		public static int Main(string[] arguments)
+		{
+#if FEATURE_PROFILING
+			var configuration = ProfileConfiguration.Parse(arguments);
+			Console.WriteLine("Running Profiling with the following:");
+			Console.WriteLine($"- SdkPath: {SdkPath}");
+			Console.WriteLine($"- OutputPath: {OutputPath}");
+			Console.WriteLine($"- Classes: [{(configuration.ClassNames.Any() ? string.Join(",", configuration.ClassNames) : "*All*")}]");
+
+			using (var cluster = new ProfilingCluster())
+			{
+				foreach (var profilingFactory in CreateProfilingFactory(cluster))
+				{
+					profilingFactory.Run(configuration);
+					profilingFactory.RunAsync(configuration).Wait();
+				}
+			}
+
+			return 0;
+#else
+			Console.ForegroundColor = ConsoleColor.Red;
+			Console.WriteLine("Tests.exe is not built with Profiling support");
+			Console.ResetColor();
+			return 2;
+#endif
+		}
+#if FEATURE_PROFILING
+		private static IEnumerable<IProfileFactory> CreateProfilingFactory(ProfilingCluster cluster)
+		{
+			yield return new PerformanceProfileFactory(SdkPath, OutputPath, cluster, Assembly.GetEntryAssembly(), new ColoredConsoleWriter());
+			yield return new TimelineProfileFactory(SdkPath, OutputPath, cluster, Assembly.GetEntryAssembly(), new ColoredConsoleWriter());
+			yield return new MemoryProfileFactory(SdkPath, OutputPath, cluster, Assembly.GetEntryAssembly(), new ColoredConsoleWriter());
+		}
+#endif
+	}
+}

--- a/src/Tests/Program.cs
+++ b/src/Tests/Program.cs
@@ -1,20 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
-using Elastic.Managed;
-using FluentAssertions;
-using Tests.Framework;
-using Tests.Framework.Integration;
-using Tests.Framework.ManagedElasticsearch;
-using Tests.Framework.ManagedElasticsearch.Clusters;
-using Tests.Framework.Profiling;
-using Tests.Framework.Profiling.Memory;
-using Tests.Framework.Profiling.Performance;
-using Tests.Framework.Profiling.Timeline;
 
 namespace Tests
 {
@@ -25,122 +10,24 @@ namespace Tests
 	// That will run the benchmarking/profiling.
 	public class Program { }
 
-	public class BenchmarkProgram
+	public static class ProgramDispatcher
 	{
-		static BenchmarkProgram()
-		{
-			var currentDirectory = new DirectoryInfo(Directory.GetCurrentDirectory());
-			if ((currentDirectory.Name == "Debug" || currentDirectory.Name == "Release") && currentDirectory.Parent.Name == "bin")
-			{
-				SdkPath = new DirectoryInfo(
-					Path.Combine(
-						Directory.GetCurrentDirectory(),
-						$@".\..\..\..\..\build\tools\{SelfProfileSdkDirectory}")).FullName;
-
-				OutputPath = new DirectoryInfo(
-					Path.Combine(
-						Directory.GetCurrentDirectory(),
-						$@".\..\..\..\..\build\output\profiling")).FullName;
-			}
-			else
-			{
-				SdkPath = new DirectoryInfo(
-					Path.Combine(
-						Directory.GetCurrentDirectory(),
-						$@".\build\tools\{SelfProfileSdkDirectory}")).FullName;
-
-				OutputPath = new DirectoryInfo(
-					Path.Combine(
-						Directory.GetCurrentDirectory(),
-						$@".\build\output\profiling")).FullName;
-			}
-		}
-
-		public static string InputDirPath { get; }
-
-		public static string OutputDirPath { get; }
-
-		private const string SelfProfileSdkDirectory = "dottrace-selfprofile";
-
-		private static string SdkPath { get; }
-		private static string OutputPath { get; }
-
-		public static void Main(string[] args)
+		public static int Main(string[] args)
 		{
 			if (args.Length == 0)
-				Console.WriteLine("Must specify at least one argument: Profile/Benchmark");
+				Console.WriteLine("Must atleast specify one argument to indicate what command to run");
 
-			var arguments = args.Skip(1).ToArray();
-			if (args[0].Equals("Profile", StringComparison.OrdinalIgnoreCase))
+			var command = args[0].ToLowerInvariant();
+			var programArguments = args.Skip(1).ToArray();
+			switch (command)
 			{
-#if FEATURE_PROFILING
-				var configuration = ProfileConfiguration.Parse(arguments);
-				Console.WriteLine("Running Profiling with the following:");
-				Console.WriteLine($"- SdkPath: {SdkPath}");
-				Console.WriteLine($"- OutputPath: {OutputPath}");
-				Console.WriteLine($"- Classes: [{(configuration.ClassNames.Any() ? string.Join(",", configuration.ClassNames) : "*All*")}]");
-
-				using (var cluster = new ProfilingCluster())
-				{
-					foreach (var profilingFactory in CreateProfilingFactory(cluster))
-					{
-						profilingFactory.Run(configuration);
-						profilingFactory.RunAsync(configuration).Wait();
-					}
-				}
-#else
-				Console.ForegroundColor = ConsoleColor.Red;
-				Console.WriteLine("Tests.exe is not built with Profiling support");
-				Console.ResetColor();
-				Environment.Exit(9);
-#endif
+				case "profile": return ProfileProgram.Main(programArguments);
+				case "benchmark": return BenchmarkProgram.Main(programArguments);
+				case "cluster": return ClusterLaunchProgram.Main(programArguments);
+				default:
+					Console.Error.WriteLine($"Unknown command '{command}");
+					return 1;
 			}
-			else if (args[0].Equals("Benchmark", StringComparison.OrdinalIgnoreCase))
-			{
-				Console.WriteLine("Running Benchmarking.");
-				if (args.Count() > 1 && args[1].Equals("non-interactive", StringComparison.OrdinalIgnoreCase))
-				{
-					Console.WriteLine("Running in Non-Interactive mode.");
-					foreach (var benchmarkType in GetBenchmarkTypes())
-					{
-						BenchmarkRunner.Run(benchmarkType);
-					}
-					return;
-				}
-
-				Console.WriteLine("Running in Interactive mode.");
-				var benchmarkSwitcher = new BenchmarkSwitcher(GetBenchmarkTypes());
-				benchmarkSwitcher.Run(arguments);
-			}
-		}
-
-#if FEATURE_PROFILING
-		private static IEnumerable<IProfileFactory> CreateProfilingFactory(ProfilingCluster cluster)
-		{
-			yield return new PerformanceProfileFactory(SdkPath, OutputPath, cluster, Assembly.GetEntryAssembly(), new ColoredConsoleWriter());
-			yield return new TimelineProfileFactory(SdkPath, OutputPath, cluster, Assembly.GetEntryAssembly(), new ColoredConsoleWriter());
-			yield return new MemoryProfileFactory(SdkPath, OutputPath, cluster, Assembly.GetEntryAssembly(), new ColoredConsoleWriter());
-		}
-#endif
-		private static Type[] GetBenchmarkTypes()
-		{
-			IEnumerable<Type> types;
-
-			try
-			{
-				types = typeof(Program).Assembly().GetTypes();
-			}
-			catch (ReflectionTypeLoadException e)
-			{
-				types = e.Types.Where(t => t != null);
-			}
-
-			return types
-				.Where(t => t.GetMethods(BindingFlags.Instance | BindingFlags.Public)
-							 .Any(m => m.GetCustomAttributes(typeof(BenchmarkAttribute), false).Any()))
-				.OrderBy(t => t.Namespace)
-				.ThenBy(t => t.Name)
-				.ToArray();
 		}
 	}
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -7,7 +7,7 @@
     <!--<TargetFramework>net46</TargetFramework>-->
     <VersionPrefix>6.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
-    <StartupObject>Tests.BenchmarkProgram</StartupObject>
+    <StartupObject>Tests.ProgramDispatcher</StartupObject>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>
     <DefineConstants Condition="'$(TargetFramework)'=='netcoreapp2.1'">$(DefineConstants);DOTNETCORE</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)'=='net46'">$(DefineConstants);FEATURE_HTTPWEBREQUEST</DefineConstants>
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20180712T132618" />
+    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20180716T123929" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="DiffPlex" Version="1.4.1" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />


### PR DESCRIPTION
Can now start a test cluster from the root of the project by calling
`build cluster <clustername> <version>`

This will build and run the specified cluster from a temporary location.
Allowing us to develop and build under src/Test while it's running.

When running tests `Elastic.Xunit` now supports allowing it to assume a
cluster is already started. With a cluster already running, running the
integration tests from the IDE will be more responsive as we do not have
to wait for the whole cluster setup and teardown.

This brings back the final missing piece of functionality we had before
breaking `Elastic.Xunit` into its own project