### PR TITLE
Fix #3303 Cat Response error should bubble out

### DIFF
--- a/src/Nest/Cat/ElasticClient-Cat.cs
+++ b/src/Nest/Cat/ElasticClient-Cat.cs
@@ -13,8 +13,14 @@ namespace Nest
 		private CatResponse<TCatRecord> DeserializeCatResponse<TCatRecord>(IApiCallDetails response, Stream stream)
 			where TCatRecord : ICatRecord
 		{
+			var catResponse = new CatResponse<TCatRecord>();
+
+			if (!response.Success) return catResponse;
+
 			var records = this.RequestResponseSerializer.Deserialize<IReadOnlyCollection<TCatRecord>>(stream);
-			return new CatResponse<TCatRecord> { Records = records };
+			catResponse.Records = records;
+
+			return catResponse;
 		}
 
 		private ICatResponse<TCatRecord> DoCat<TRequest, TParams, TCatRecord>(

--- a/src/Tests/Cat/CatIndices/CatIndicesApiTests.cs
+++ b/src/Tests/Cat/CatIndices/CatIndicesApiTests.cs
@@ -1,4 +1,6 @@
-﻿using Elasticsearch.Net;
+﻿using System;
+using Elastic.Managed.Ephemeral;
+using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Framework;
@@ -26,6 +28,44 @@ namespace Tests.Cat.CatIndices
 		protected override void ExpectResponse(ICatResponse<CatIndicesRecord> response)
 		{
 			response.Records.Should().NotBeEmpty().And.Contain(a => !string.IsNullOrEmpty(a.Status));
+		}
+	}
+
+	public class CatIndicesApiNotFoundWithSecurityTests : ApiIntegrationTestBase<XPackCluster,ICatResponse<CatIndicesRecord>, ICatIndicesRequest, CatIndicesDescriptor, CatIndicesRequest>
+	{
+		public CatIndicesApiNotFoundWithSecurityTests(XPackCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.CatIndices(f),
+			fluentAsync: (client, f) => client.CatIndicesAsync(f),
+			request: (client, r) => client.CatIndices(r),
+			requestAsync: (client, r) => client.CatIndicesAsync(r)
+		);
+
+		protected override bool ExpectIsValid => false;
+		protected override int ExpectStatusCode => 403;
+		protected override HttpMethod HttpMethod => HttpMethod.GET;
+		protected override string UrlPath => "/_cat/indices/doesnot-exist-%2A";
+
+		protected override Func<CatIndicesDescriptor, ICatIndicesRequest> Fluent => f => f
+			.Index("doesnot-exist-*")
+			.RequestConfiguration(r=>r.BasicAuthentication(ClusterAuthentication.User.Username, ClusterAuthentication.User.Password));
+
+		protected override CatIndicesRequest Initializer => new CatIndicesRequest("doesnot-exist-*")
+		{
+			RequestConfiguration = new RequestConfiguration
+			{
+				BasicAuthenticationCredentials = new BasicAuthenticationCredentials
+				{
+					Username = ClusterAuthentication.User.Username,
+					Password = ClusterAuthentication.User.Password,
+				}
+			}
+		};
+
+		protected override void ExpectResponse(ICatResponse<CatIndicesRecord> response)
+		{
+			response.Records.Should().BeEmpty();
+			response.ApiCall.Should().NotBeNull();
 		}
 	}
 }

--- a/src/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
+++ b/src/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
@@ -4,6 +4,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Elastic.Managed.Ephemeral;
 using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Framework.Integration;
@@ -42,7 +43,8 @@ namespace Tests.Framework
 
 			return base.AssertOnAllResponses((r) =>
 			{
-				if (TestClient.Configuration.RunIntegrationTests && !r.IsValid && r.ApiCall.OriginalException != null)
+				if (TestClient.Configuration.RunIntegrationTests && !r.IsValid && r.ApiCall.OriginalException != null
+				    && !(r.ApiCall.OriginalException is ElasticsearchClientException))
 				{
 					ExceptionDispatchInfo.Capture(r.ApiCall.OriginalException.Demystify()).Throw();
 					return;


### PR DESCRIPTION
Right now we always attempt to deserialize to list of records but when a
server side error is returned we have can't deserialize the array as as
an object so we need to special case this in the converter callback