### PR TITLE
Correctly deserialize JoinField

### DIFF
--- a/src/Serializers/Nest.JsonNetSerializer/Converters/HandleNestTypesOnSourceJsonConverter.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/Converters/HandleNestTypesOnSourceJsonConverter.cs
@@ -45,7 +45,7 @@ namespace Nest.JsonNetSerializer.Converters
 			//even though we pass type JSON.NET won't try the registered converter for that type
 			//even if it can handle string tokens :(
 			if (objectType == typeof(JoinField) && token.Type == JTokenType.String)
-				return JoinField.Root(token.ToString(Formatting.None));
+				return JoinField.Root(token.Value<string>());
 
 			using (var ms = token.ToStream())
 				return _builtInSerializer.Deserialize(objectType, ms);

--- a/src/Tests/Tests.Core/Client/TestClient.cs
+++ b/src/Tests/Tests.Core/Client/TestClient.cs
@@ -1,4 +1,5 @@
 ﻿using Nest;
+using Nest.JsonNetSerializer;
 using Tests.Configuration;
 using Tests.Core.Client.Settings;
 using Tests.Domain.Extensions;
@@ -9,6 +10,8 @@ namespace Tests.Core.Client
 	{
 		public static readonly IElasticClient Default = new ElasticClient(new TestConnectionSettings().ApplyDomainSettings());
 		public static readonly IElasticClient DefaultInMemoryClient = new ElasticClient(new AlwaysInMemoryConnectionSettings().ApplyDomainSettings());
+		public static readonly IElasticClient InMemoryWithJsonNetSerializer = new ElasticClient(
+			new AlwaysInMemoryConnectionSettings(sourceSerializerFactory: JsonNetSerializer.Default).ApplyDomainSettings());
 		public static readonly IElasticClient DisabledStreaming = new ElasticClient(new TestConnectionSettings().ApplyDomainSettings().DisableDirectStreaming());
 
 		public static readonly ITestConfiguration Configuration = TestConfiguration.Instance;

--- a/src/Tests/Tests.Core/Serialization/SerializationTester.cs
+++ b/src/Tests/Tests.Core/Serialization/SerializationTester.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using Elasticsearch.Net;
 using FluentAssertions;
@@ -63,6 +64,8 @@ namespace Tests.Core.Serialization
 	public class SerializationTester
 	{
 		public static SerializationTester Default { get; } = new SerializationTester(TestClient.DefaultInMemoryClient);
+
+		public static SerializationTester DefaultWithJsonNetSerializer { get; } = new SerializationTester(TestClient.InMemoryWithJsonNetSerializer);
 
 		public SerializationTester(IElasticClient client) => this.Client = client;
 

--- a/src/Tests/Tests.Reproduce/GithubIssue3356.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue3356.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Nest.JsonNetSerializer;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3356
+	{
+		[U]
+		public void JoinFieldDeserializedCorrectly()
+		{
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(pool, new InMemoryConnection(), JsonNetSerializer.Default)
+				.DisableDirectStreaming()
+				.DefaultIndex("docs");
+			var client = new ElasticClient(connectionSettings);
+
+			var doc = new MyDocument
+			{
+				Join = JoinField.Root("parent")
+			};
+
+			var response = client.IndexDocument(doc);
+
+			Encoding.UTF8.GetString(response.ApiCall.RequestBodyInBytes).Should().Be("{\"join\":\"parent\"}");
+			using (var stream = new MemoryStream(response.ApiCall.RequestBodyInBytes))
+			{
+				doc = client.SourceSerializer.Deserialize<MyDocument>(stream);
+				doc.Join.Match(p =>
+				{
+					p.Name.Should().Be("parent");
+				}, c => { });
+			}
+		}
+
+		private class MyDocument
+		{
+			public JoinField Join { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
When the join field is a string and using JsonNetSerializer, the string
conversion should not emit the surrounding double quotes

Closes #3356