### PR TITLE
Bump to latest Elastic.Xunit and Proc

### DIFF
--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -16,6 +16,7 @@ elasticsearch_version: 6.3.0
 # do not spawn nodes as part of the test setup if we find a node is already running
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true
+# elasticsearch_out_after_started: true
 
 #random_source_serializer: true
 #random_old_connection: true

--- a/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/WatcherStateCluster.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/WatcherStateCluster.cs
@@ -1,7 +1,17 @@
-﻿namespace Tests.Core.ManagedElasticsearch.Clusters
+﻿using System;
+using System.Threading;
+using Elastic.Managed.Configuration;
+
+namespace Tests.Core.ManagedElasticsearch.Clusters
 {
 	/// <summary>
 	/// Cluster that modifies the state of the Watcher Service
 	/// </summary>
-	public class WatcherStateCluster : XPackCluster { }
+	public class WatcherStateCluster : XPackCluster
+	{
+		protected override void ModifyNodeConfiguration(NodeConfiguration n, int port)
+		{
+			n.WaitForShutdown = TimeSpan.FromSeconds(30);
+		}
+	}
 }

--- a/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/XPackCluster.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/XPackCluster.cs
@@ -24,8 +24,6 @@ namespace Tests.Core.ManagedElasticsearch.Clusters
 				var licenseContents = File.ReadAllText(licenseFilePath);
 				this.XPackLicenseJson = licenseContents;
 			}
-
-			this.ShowElasticsearchOutputAfterStarted = this.TestConfiguration.ShowElasticsearchOutputAfterStarted;
 			this.AdditionalBeforeNodeStartedTasks.Add(new EnsureWatcherActionConfigurationInElasticsearchYaml());
 		}
 	}

--- a/src/Tests/Tests.Core/Tests.Core.csproj
+++ b/src/Tests/Tests.Core/Tests.Core.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20180810T103700" />
+    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20180827T133305" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />

--- a/src/Tests/Tests.Domain/Tests.Domain.csproj
+++ b/src/Tests/Tests.Domain/Tests.Domain.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20180810T103700" />
+    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20180827T133305" />
     <ProjectReference Include="..\Tests.Configuration\Tests.Configuration.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Clusters can now quite easily provide an expected shutdown period.

[Proc](https://github.com/proc-net/proc) waits for the streamreaders to emit EOL after the process has exitted and if this does not happen before a timeout OnError on the observable is called.

In Elastic.Xunit we call `elasticsearch.bat` (host_ which spawns `elasticsearch.jar` (child) and so `ElasticsearchNode` tracks both process id's, however [Proc](https://github.com/proc-net/proc) tracks only the host. 

So while [Proc](https://github.com/proc-net/proc) was shutting down the host OK as that triggers the read wait for EOL on the console out streams these pipes (coming from `elasticsearch.jar`) can stay active quite a while. When we give up the jar is kept running (in shutdown mode).

This manifested itself later on when `EphemeralClusterComposer` wanted to run its clean up routines and the ephemeral directories were still in use.

NodeConfiguration can now provide `WaitForShutDown` which will set `Proc`'s `WaitForExit` and `WaitForStreamReaders`. `ClusterBase` also provided an overridable `ModifyNodeConfiguration` so that this can be set per cluster with relatively low ceremony.

This `WaitForShutdown` does not have to be accurate if its too short `ElasticsearchNode` now does a hard kill on both the host and and the java pid in a new hook provided by `ObservableProcessBase` `OnBeforeWaitForEndOfStreamsError`.