### PR TITLE
SeedNode() on DefaultSeeder parallelizes where possible

### DIFF
--- a/src/Tests/Tests.Profiling/Framework/ProfilingCluster.cs
+++ b/src/Tests/Tests.Profiling/Framework/ProfilingCluster.cs
@@ -5,11 +5,6 @@ namespace Tests.Profiling.Framework
 {
 	public class ProfilingCluster : ClientTestClusterBase
 	{
-		protected override void SeedCluster()
-		{
-			var seeder = new DefaultSeeder(this.Client);
-			seeder.DeleteIndicesAndTemplates();
-			seeder.CreateIndices();
-		}
+		protected override void SeedCluster() => new DefaultSeeder(this.Client).SeedNodeNoData();
 	}
 }

--- a/src/Tests/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/Reindex/ReindexApiTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive.Linq;
 using System.Threading;
-using Elastic.Xunit.Sdk;
 using Elastic.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Nest;
@@ -11,33 +9,17 @@ using Tests.Core.Extensions;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Core.ManagedElasticsearch.NodeSeeders;
 using Tests.Domain;
-using Tests.Framework;
-using Tests.Framework.Integration;
-using Tests.Framework.ManagedElasticsearch;
-using Tests.Framework.ManagedElasticsearch.Clusters;
-using Tests.Framework.ManagedElasticsearch.NodeSeeders;
-using Xunit;
 
 namespace Tests.Document.Multiple.Reindex
 {
 	public class ReindexCluster : ClientTestClusterBase
 	{
-		protected override void SeedCluster()
-		{
-			var seeder = new DefaultSeeder(this.Client);
-			seeder.DeleteIndicesAndTemplates();
-			seeder.CreateIndices();
-		}
+		protected override void SeedCluster() => new DefaultSeeder(this.Client).SeedNodeNoData();
 	}
 
 	public class ManualReindexCluster : ClientTestClusterBase
 	{
-		protected override void SeedCluster()
-		{
-			var seeder = new DefaultSeeder(this.Client);
-			seeder.DeleteIndicesAndTemplates();
-			seeder.CreateIndices();
-		}
+		protected override void SeedCluster() => new DefaultSeeder(this.Client).SeedNodeNoData();
 	}
 
 	public class ReindexApiTests : IClusterFixture<ManualReindexCluster>


### PR DESCRIPTION
Before:
![prior](https://user-images.githubusercontent.com/245275/44989302-b8c57d00-af8d-11e8-9202-8e2166617e06.PNG)

After:

![after](https://user-images.githubusercontent.com/245275/44989314-bc590400-af8d-11e8-8815-302bbd936bdc.PNG)

Speeds up launching an integration cluster (`ReadOnlyCluster` and others who use `DefaultSeeder`).
