### PR TITLE
Fix/old connection random

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ indent_size = 4
 indent_style = space
 indent_size = 4
 
-[*.{md,markdown,json,js,csproj,fsproj,targets}]
+[*.{md,markdown,json,js,csproj,fsproj,targets,targets,props}]
 indent_style = space
 indent_size = 2
 

--- a/build/Clients.Common.targets
+++ b/build/Clients.Common.targets
@@ -15,7 +15,6 @@
 
     <!-- we need to referenced assemblies during the command line build so that ILRepack can pick them up -->
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)'=='netstandard2.0'">true</CopyLocalLockFileAssemblies>
-    <DefineConstants Condition="'$(TargetFramework)'=='net461'">$(DefineConstants);FEATURE_HTTPWEBREQUEST</DefineConstants>
     
   </PropertyGroup>
 

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -61,6 +61,12 @@
     <None Include="Commandline.fsx" />
     <None Include="Targets.fsx" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\paket.bat"><Link>paket.bat</Link></Content>
+    <Content Include="..\..\paket.dependencies"><Link>paket.bat</Link></Content>
+    <Content Include="..\..\build.sh"><Link>paket.bat</Link></Content>
+    <Content Include="..\..\build.bat"><Link>paket.bat</Link></Content>
+  </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>

--- a/src/Artifacts.build.props
+++ b/src/Artifacts.build.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props" />
+  <!--
+   Sets up the properties for assemblies we want to publish to a separate output folder (outside of src) during our build process.
+   e.g ApiGenerator we'd like to keep private but we do want to publish it to build/_output during our FAKE build
+  -->
+  <PropertyGroup>
+    <OutputPath Condition="'$(OutputPathBaseDir)' != ''">$(OutputPathBaseDir)\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
+++ b/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -17,5 +18,4 @@
     <PackageReference Include="RazorLight.Unofficial" Version="2.0.0-beta1.1" />
     <!--<PackageReference Include="RazorLight" Version="2.0.0-beta1" />-->
   </ItemGroup>
-  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/CodeGeneration/DocGenerator/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/CodeGeneration/DocGenerator/Buildalyzer/ProjectAnalyzer.cs
@@ -119,6 +119,8 @@ namespace DocGenerator.Buildalyzer
 			}
 		}
 
+
+
 		// Tweaks the project file a bit to ensure a succesfull build
 		private static XDocument TweakProjectDocument(XDocument projectDocument, string projectFolder)
 		{
@@ -128,10 +130,12 @@ namespace DocGenerator.Buildalyzer
 				if (att == null) continue;
 
 				var project = att.Value;
-				if (project.EndsWith("Clients.Common.targets"))
-					att.Value = Path.GetFullPath(Path.Combine(projectFolder, att.Value));
-				else if (project.EndsWith("outputpath.props"))
-					att.Value = Path.GetFullPath(Path.Combine(projectFolder, att.Value));
+
+				if (!ResolveKnownPropsPath(projectFolder, project, att, "PublishArtifacts.build.props"))
+				{
+					ResolveKnownPropsPath(projectFolder, project, att, "Artifacts.build.props");
+				}
+				ResolveKnownPropsPath(projectFolder, project, att, "Library.build.props");
 			}
 			// Add SkipGetTargetFrameworkProperties to every ProjectReference
 			foreach (XElement projectReference in projectDocument.GetDescendants("ProjectReference").ToArray())
@@ -147,6 +151,17 @@ namespace DocGenerator.Buildalyzer
 			}
 
 			return projectDocument;
+		}
+
+		private static bool ResolveKnownPropsPath(string projectFolder, string project, XAttribute att, string buildPropFile)
+		{
+			if (!project.Contains(buildPropFile)) return false;
+			var dir = new DirectoryInfo(projectFolder).Parent;
+			while (dir != null && dir.Name != "src")
+				dir = dir.Parent;
+			if (dir == null) return true;
+			att.Value = Path.GetFullPath(Path.Combine(dir.FullName, buildPropFile));
+			return false;
 		}
 
 		private ProjectCollection CreateProjectCollection()

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -17,5 +18,4 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.2" />
     <PackageReference Include="NuDoq" Version="1.2.5" />
   </ItemGroup>
-  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Elasticsearch.Net/Connection/CertificateValidations.cs
+++ b/src/Elasticsearch.Net/Connection/CertificateValidations.cs
@@ -57,7 +57,7 @@ namespace Elasticsearch.Net
 
 		private static X509Certificate2 to2(X509Certificate certificate)
 		{
-			#if !FEATURE_HTTPWEBREQUEST
+			#if DOTNETCORE
 				return new X509Certificate2(certificate.Export(X509ContentType.Cert));
 			#else
 				return new X509Certificate2(certificate);

--- a/src/Elasticsearch.Net/Connection/ClientCertificate.cs
+++ b/src/Elasticsearch.Net/Connection/ClientCertificate.cs
@@ -36,8 +36,8 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Elasticsearch.Net
 {
-//.NET removed the setter for PrivateKey for X509Certificate, you'll have to manually convert to pfx/p12 or add the key to the machine store
-#if FEATURE_HTTPWEBREQUEST
+//.NET core removed the setter for PrivateKey for X509Certificate, you'll have to manually convert to pfx/p12 or add the key to the machine store
+#if !DOTNETCORE
 
 	public class ClientCertificate
 	{

--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -1,4 +1,4 @@
-﻿#if !FEATURE_HTTPWEBREQUEST
+﻿#if DOTNETCORE
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection-CoreFx.cs
@@ -29,6 +29,8 @@ namespace Elasticsearch.Net
 		public bool IsBypassed(Uri host) => host.IsLoopback;
 	}
 
+
+	/// <summary> The default IConnection implementation. Uses <see cref="HttpClient"/>.</summary>
 	public class HttpConnection : IConnection
 	{
 		private readonly object _lock = new object();

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 
 namespace Elasticsearch.Net
 {
+	/// <summary> The default IConnection implementation. Uses <see cref="HttpWebRequest"/> on the current .NET desktop framework.</summary>
 	public class HttpConnection : HttpWebRequestConnection
 	{
 	}

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -1,20 +1,9 @@
 #if !DOTNETCORE
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
 using System.Net;
-using System.Net.Security;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Elasticsearch.Net
 {
 	/// <summary> The default IConnection implementation. Uses <see cref="HttpWebRequest"/> on the current .NET desktop framework.</summary>
-	public class HttpConnection : HttpWebRequestConnection
-	{
-	}
+	public class HttpConnection : HttpWebRequestConnection { }
 }
 #endif

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -1,4 +1,4 @@
-#if FEATURE_HTTPWEBREQUEST
+#if !DOTNETCORE
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -57,7 +57,7 @@ namespace Elasticsearch.Net
 
 			request.Accept = requestData.Accept;
 			request.ContentType = requestData.RequestMimeType;
-#if FEATURE_HTTPWEBREQUEST
+#if !DOTNETCORE
 			// on netstandard/netcoreapp2.0 this throws argument exception
 			request.MaximumResponseHeadersLength = -1;
 #endif

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\build\Clients.Common.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\PublishArtifacts.build.props" />
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
@@ -8,5 +8,4 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
-  <Import Project="..\outputpath.props" />
 </Project>

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using System;
 using System.Linq;
-#if FEATURE_HTTPWEBREQUEST
+#if !DOTNETCORE
 using System.Net;
 #endif
 
@@ -203,7 +203,7 @@ namespace Elasticsearch.Net
 				//This causes it to behave differently to .NET FULL. We already wrapped the WebExeption
 				//under ElasticsearchServerException and it exposes way more information as part of it's
 				//exception message e.g the the root cause of the server error body.
-#if FEATURE_HTTPWEBREQUEST
+#if !DOTNETCORE
 				if (a.OriginalException is WebException)
 					a.OriginalException = clientException;
 #endif

--- a/src/Elasticsearch.sln
+++ b/src/Elasticsearch.sln
@@ -3,27 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2003
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Build", "_Build", "{432D5575-2347-4D3C-BF8C-3E38410C46CA}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RelatedFiles", "RelatedFiles", "{432D5575-2347-4D3C-BF8C-3E38410C46CA}"
 	ProjectSection(SolutionItems) = preProject
-		..\.editorconfig = ..\.editorconfig
-		..\.gitignore = ..\.gitignore
-		..\.travis.yml = ..\.travis.yml
-		..\appveyor.yml = ..\appveyor.yml
-		..\build.bat = ..\build.bat
-		..\build.sh = ..\build.sh
-		..\build\Clients.Common.targets = ..\build\Clients.Common.targets
-		..\contributing.md = ..\contributing.md
-		..\build\Elasticsearch.Net.nuspec = ..\build\Elasticsearch.Net.nuspec
-		..\global.json = ..\global.json
-		..\license.txt = ..\license.txt
-		..\build\NEST.JsonNetSerializer.nuspec = ..\build\NEST.JsonNetSerializer.nuspec
-		..\build\NEST.nuspec = ..\build\NEST.nuspec
-		..\NuGet.config = ..\NuGet.config
-		..\paket.bat = ..\paket.bat
-		..\paket.dependencies = ..\paket.dependencies
-		..\readme.md = ..\readme.md
-		outputpath.props = outputpath.props
-		Directory.build.props = Directory.build.props
+		..\src\PublishArtifacts.build.props = ..\src\PublishArtifacts.build.props
+		..\src\Artifacts.build.props = ..\src\Artifacts.build.props
+		..\src\Library.build.props = ..\src\Library.build.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeGeneration", "CodeGeneration", "{93331BEE-0AA0-47B7-B1D2-BD5BD31634D1}"
@@ -65,6 +49,30 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Reproduce", "Tests\Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.ScratchPad", "Tests\Tests.ScratchPad\Tests.ScratchPad.csproj", "{CE7AC1D4-15AF-47FB-83FA-F7137DFD9076}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Root", "Root", "{EAE89579-CCA9-45CE-AF83-3DCD98690EA8}"
+ProjectSection(SolutionItems) = preProject
+	..\.editorconfig = ..\.editorconfig
+	..\.gitignore = ..\.gitignore
+	..\.travis.yml = ..\.travis.yml
+	..\appveyor.yml = ..\appveyor.yml
+	..\global.json = ..\global.json
+EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{C7865979-1D1C-46AF-BDE8-1DA6F3ED81B3}"
+ProjectSection(SolutionItems) = preProject
+	..\build\NEST.JsonNetSerializer.nuspec = ..\build\NEST.JsonNetSerializer.nuspec
+	..\build\NEST.nuspec = ..\build\NEST.nuspec
+	..\NuGet.config = ..\NuGet.config
+	..\build\Elasticsearch.Net.nuspec = ..\build\Elasticsearch.Net.nuspec
+EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Markdown", "Markdown", "{2FABB663-F4DB-499A-89F8-3A08828D1D91}"
+ProjectSection(SolutionItems) = preProject
+	..\contributing.md = ..\contributing.md
+	..\license.txt = ..\license.txt
+	..\readme.md = ..\readme.md
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,7 +88,6 @@ Global
 		{56A87048-9065-459B-826D-3DF68B409845} = {93331BEE-0AA0-47B7-B1D2-BD5BD31634D1}
 		{98400F59-4BA8-4534-9A78-9C7FA0B42901} = {93331BEE-0AA0-47B7-B1D2-BD5BD31634D1}
 		{CDC8DEC8-3872-4337-9C40-9CDE5724BBDD} = {14241027-0A92-466D-B024-E0063F338915}
-		{D6997ADC-E933-418E-831C-DE1A78897493} = {432D5575-2347-4D3C-BF8C-3E38410C46CA}
 		{5B393962-7586-49BA-BD99-3B1E35F48E94} = {6C4A2627-AF22-4388-9DF7-7A9AEACFD635}
 		{BAA9802A-A664-4DB7-9A34-5FA84BEBDF81} = {6C4A2627-AF22-4388-9DF7-7A9AEACFD635}
 		{AC554BF8-8ED9-4C45-BB65-8833219CAC93} = {6C4A2627-AF22-4388-9DF7-7A9AEACFD635}
@@ -90,6 +97,9 @@ Global
 		{8C119416-DB47-4971-A9EC-566217241D95} = {6C4A2627-AF22-4388-9DF7-7A9AEACFD635}
 		{30FB80AE-3B37-4FBB-8450-9666969EEE1A} = {6C4A2627-AF22-4388-9DF7-7A9AEACFD635}
 		{CE7AC1D4-15AF-47FB-83FA-F7137DFD9076} = {6C4A2627-AF22-4388-9DF7-7A9AEACFD635}
+		{EAE89579-CCA9-45CE-AF83-3DCD98690EA8} = {432D5575-2347-4D3C-BF8C-3E38410C46CA}
+		{C7865979-1D1C-46AF-BDE8-1DA6F3ED81B3} = {432D5575-2347-4D3C-BF8C-3E38410C46CA}
+		{2FABB663-F4DB-499A-89F8-3A08828D1D91} = {432D5575-2347-4D3C-BF8C-3E38410C46CA}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5B393962-7586-49BA-BD99-3B1E35F48E94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/src/Elasticsearch.sln
+++ b/src/Elasticsearch.sln
@@ -27,9 +27,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nest.JsonNetSerializer", "Serializers\Nest.JsonNetSerializer\Nest.JsonNetSerializer.csproj", "{CDC8DEC8-3872-4337-9C40-9CDE5724BBDD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{6C4A2627-AF22-4388-9DF7-7A9AEACFD635}"
-ProjectSection(SolutionItems) = preProject
-	Tests\Directory.build.props = Tests\Directory.build.props
-EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests\Tests.csproj", "{5B393962-7586-49BA-BD99-3B1E35F48E94}"
 EndProject

--- a/src/Library.build.props
+++ b/src/Library.build.props
@@ -1,4 +1,7 @@
 <Project>
+  <!--
+  Sets up the common properties for all assemblies, Directory.build.props should work for this but Editor support seems flakey.
+  -->
 	<PropertyGroup>
 		<!-- Default Version numbers -->
 		<CurrentVersion>6.0.0</CurrentVersion>

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\build\Clients.Common.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\PublishArtifacts.build.props" />
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
@@ -11,5 +11,4 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
-  <Import Project="..\outputpath.props" />
 </Project>

--- a/src/PublishArtifacts.build.props
+++ b/src/PublishArtifacts.build.props
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+   Sets up the properties for assemblies we intent to push to a NuGet server 
+  -->
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
 
     <SignAssembly Condition="'$(OS)' == 'Windows_NT'">true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\keys\keypair.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\build\keys\keypair.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591,1572,1571,1573,1587,1570</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
@@ -12,20 +17,19 @@
 
     <DoSourceLink></DoSourceLink>
     <SourceLink Condition="'$(DoSourceLink)'!=''">$(BaseIntermediateOutputPath)\sl-$(MsBuildProjectName)-$(TargetFramework).json</SourceLink>
-
     <!-- we need to referenced assemblies during the command line build so that ILRepack can pick them up -->
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)'=='netstandard2.0'">true</CopyLocalLockFileAssemblies>
-    
+
   </PropertyGroup>
 
   <Target Name="GenerateSourceLink" BeforeTargets="CoreCompile" Condition="'$(DoSourceLink)'!=''">
-    <Delete Files="$(SourceLink)" Condition="Exists('$(SourceLink)')" />
+    <Delete Files="$(SourceLink)" Condition="Exists('$(SourceLink)')"/>
     <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="LatestCommit" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="LatestCommit"/>
     </Exec>
     <Exec Command="git rev-parse --show-toplevel" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitRootFolder" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitRootFolder"/>
     </Exec>
-    <WriteLinesToFile File="$(SourceLink)" Lines="{&quot;documents&quot;: { &quot;$([System.IO.Path]::GetFullPath('$(GitRootFolder)/').Replace('\','\\'))*&quot; : &quot;$(RepoUri)/$(LatestCommit)/*&quot; }}" />
+    <WriteLinesToFile File="$(SourceLink)" Lines="{&quot;documents&quot;: { &quot;$([System.IO.Path]::GetFullPath('$(GitRootFolder)/').Replace('\','\\'))*&quot; : &quot;$(RepoUri)/$(LatestCommit)/*&quot; }}"/>
   </Target>
 </Project>

--- a/src/Serializers/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
+++ b/src/Serializers/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
-  <Import Project="..\..\..\build\Clients.Common.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\PublishArtifacts.build.props" />
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
@@ -11,5 +11,4 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
-  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Tests/Directory.build.props
+++ b/src/Tests/Directory.build.props
@@ -1,7 +1,0 @@
-<Project>
-	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-	<PropertyGroup Condition="'$(TestPackageVersion)'!=''">
-		<RestoreSources>../../../build/output/_packages;https://api.nuget.org/v3/index.json</RestoreSources>
-		<DefineConstants>$(DefineConstants);TESTINGNUGETPACKAGE</DefineConstants>
-	</PropertyGroup>
-</Project>

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <OutputType>Exe</OutputType>
@@ -11,5 +12,4 @@
     <PackageReference Include="BenchMarkDotNet" Version="0.11.0" />
     <PackageReference Include="System.Buffers" Version="4.3.0" />
   </ItemGroup>
-  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Tests/Tests.ClusterLauncher/Tests.ClusterLauncher.csproj
+++ b/src/Tests/Tests.ClusterLauncher/Tests.ClusterLauncher.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -6,5 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
   </ItemGroup>
-  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
@@ -34,7 +34,6 @@ namespace Tests.Configuration
 			{
 				SourceSerializer = RandomBoolConfig("SOURCESERIALIZER", randomizer),
 				TypedKeys = RandomBoolConfig("TYPEDKEYS", randomizer),
-				OldConnection = RandomBoolConfig("OLDCONNECTION", randomizer),
 			};
 		}
 

--- a/src/Tests/Tests.Configuration/ITestConfiguration.cs
+++ b/src/Tests/Tests.Configuration/ITestConfiguration.cs
@@ -22,7 +22,5 @@
 	{
 		public bool SourceSerializer { get; set; }
 		public bool TypedKeys { get; set; }
-		public bool OldConnection { get; set; }
 	}
-
 }

--- a/src/Tests/Tests.Configuration/Tests.Configuration.csproj
+++ b/src/Tests/Tests.Configuration/Tests.Configuration.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>

--- a/src/Tests/Tests.Configuration/YamlConfiguration.cs
+++ b/src/Tests/Tests.Configuration/YamlConfiguration.cs
@@ -41,7 +41,6 @@ namespace Tests.Configuration
 			{
 				SourceSerializer = this.RandomBool("source_serializer", randomizer),
 				TypedKeys = this.RandomBool("typed_keys", randomizer),
-				OldConnection = this.RandomBool("old_connection", randomizer)
 			};
 		}
 

--- a/src/Tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
+++ b/src/Tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
@@ -38,7 +38,6 @@ namespace Tests.Core.Client.Settings
 				: ConnectionConfiguration.DefaultConnectionLimit;
 
 		internal ConnectionSettings ApplyTestSettings() => this
-			.ApplyFiddlerProxyWhenNeeded()
 			//TODO make this random
 			//.EnableHttpCompression()
 #if DEBUG
@@ -53,13 +52,6 @@ namespace Tests.Core.Client.Settings
 				if (!string.IsNullOrWhiteSpace(q) && q.Contains("routing=ignoredefaultcompletedhandler")) return;
 				foreach (var d in r.DeprecationWarnings) XunitRunState.SeenDeprecations.Add(d);
 			});
-
-		private ConnectionSettings ApplyFiddlerProxyWhenNeeded()
-		{
-			if (!TestConfiguration.Instance.Random.OldConnection) return this;
-			if (!RunningFiddler) return this;
-			return this.Proxy(new Uri("http://localhost:8888"), null, null);
-		}
 
 		private static SourceSerializerFactory CreateSerializerFactory(SourceSerializerFactory provided)
 		{

--- a/src/Tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
+++ b/src/Tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
@@ -8,7 +8,7 @@ namespace Tests.Core.Extensions
 	{
 		//on this branch HttpConnection is either webrequest or httpclient based depending on the TFM
 		private static IConnection CreateLiveConnection(this ITestConfiguration configuration) =>
-			configuration.Random.OldConnection ? (IConnection) new HttpWebRequestConnection() : new HttpConnection();
+			new HttpConnection();
 
 		public static IConnection CreateConnection(this ITestConfiguration configuration, bool forceInMemory = false) =>
 			configuration.RunIntegrationTests && !forceInMemory ? configuration.CreateLiveConnection() : new InMemoryConnection();

--- a/src/Tests/Tests.Core/Tests.Core.csproj
+++ b/src/Tests/Tests.Core/Tests.Core.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>

--- a/src/Tests/Tests.Core/Xunit/NestXunitRunOptions.cs
+++ b/src/Tests/Tests.Core/Xunit/NestXunitRunOptions.cs
@@ -48,7 +48,6 @@ namespace Tests.Core.Xunit
 			Console.WriteLine($" - Random:");
 			Console.WriteLine($" \t- {nameof(config.Random.SourceSerializer)}: {config.Random.SourceSerializer}");
 			Console.WriteLine($" \t- {nameof(config.Random.TypedKeys)}: {config.Random.TypedKeys}");
-			Console.WriteLine($" \t- {nameof(config.Random.OldConnection)}: {config.Random.OldConnection}");
 			Console.WriteLine(new string('-', 20));
 
 		}
@@ -115,7 +114,6 @@ namespace Tests.Core.Xunit
 
 			AppendExplictConfig(nameof(RandomConfiguration.SourceSerializer), sb);
 			AppendExplictConfig(nameof(RandomConfiguration.TypedKeys), sb);
-			AppendExplictConfig(nameof(RandomConfiguration.OldConnection), sb);
 
 			if (runningIntegrations)
 				sb.Append("integrate ")

--- a/src/Tests/Tests.Core/Xunit/NestXunitRunOptions.cs
+++ b/src/Tests/Tests.Core/Xunit/NestXunitRunOptions.cs
@@ -115,9 +115,7 @@ namespace Tests.Core.Xunit
 
 			AppendExplictConfig(nameof(RandomConfiguration.SourceSerializer), sb);
 			AppendExplictConfig(nameof(RandomConfiguration.TypedKeys), sb);
-#if FEATURE_HTTPWEBREQUEST
 			AppendExplictConfig(nameof(RandomConfiguration.OldConnection), sb);
-#endif
 
 			if (runningIntegrations)
 				sb.Append("integrate ")

--- a/src/Tests/Tests.Domain/Tests.Domain.csproj
+++ b/src/Tests/Tests.Domain/Tests.Domain.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>

--- a/src/Tests/Tests.Profiling/Tests.Profiling.csproj
+++ b/src/Tests/Tests.Profiling/Tests.Profiling.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -19,5 +20,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
   </ItemGroup>
-  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Tests/Tests.Reproduce/Tests.Reproduce.csproj
+++ b/src/Tests/Tests.Reproduce/Tests.Reproduce.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>

--- a/src/Tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/src/Tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -10,5 +11,4 @@
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="BenchMarkDotNet" Version="0.11.0" />
   </ItemGroup>
-  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/Tests/Tests/ClientConcepts/Certificates/WorkingWithCertificates.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Certificates/WorkingWithCertificates.doc.cs
@@ -34,11 +34,8 @@ namespace Tests.ClientConcepts.Certificates
 		* by setting
 		*/
 #if !DOTNETCORE
-		public void ServerValidationCallback()
-		{
-			ServicePointManager.ServerCertificateValidationCallback +=
-				(sender, cert, chain, errors) => true;
-		}
+		public void ServerValidationCallback() => ServicePointManager.ServerCertificateValidationCallback +=
+			(sender, cert, chain, errors) => true;
 #endif
 		/**
 		 * validation will not be performed for HTTPS connections to *both* Elasticsearch *and* that external web service.
@@ -175,7 +172,7 @@ namespace Tests.ClientConcepts.Certificates
 		* the local CA certificate is part of the chain that was used to generate the servers key.
 		*/
 
-#if FEATURE_HTTPWEBREQUEST
+#if !DOTNETCORE
 		/**
 		 * ==== Client Certificates
 		 *
@@ -207,7 +204,7 @@ namespace Tests.ClientConcepts.Certificates
 
 			protected override ConnectionSettings Authenticate(ConnectionSettings s) => s // <1> Set the client certificate on `ConnectionSettings`
 				.ClientCertificate(
-					ClientCertificate.LoadWithPrivateKey(
+					Elasticsearch.Net.ClientCertificate.LoadWithPrivateKey(
 						this.ClusterConfiguration.FileSystem.ClientCertificate, // <2> The path to the `.cer` file
 						this.ClusterConfiguration.FileSystem.ClientPrivateKey, // <3> The path to the `.key` file
 						"") // <4> The password for the private key
@@ -229,7 +226,7 @@ namespace Tests.ClientConcepts.Certificates
 #endif
 	}
 
-#if FEATURE_HTTPWEBREQUEST
+#if !DOTNETCORE
 	/**
 	 * Or per request on `RequestConfiguration` which will take precedence over the ones defined on `ConnectionConfiguration`
 	 */

--- a/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -56,25 +56,17 @@ namespace Tests.ClientConcepts.Connection
 			connection.ClientCount.Should().Be(1);
 		}
 
-	    [I] public async Task MultipleInstancesOfHttpClientWhenRequestTimeoutChanges()
-		{
-			await MultipleInstancesOfHttpClientWhen(() => CreateRequestData(TimeSpan.FromSeconds(30)));
-		}
+	    [I] public async Task MultipleInstancesOfHttpClientWhenRequestTimeoutChanges() =>
+		    await MultipleInstancesOfHttpClientWhen(() => CreateRequestData(TimeSpan.FromSeconds(30)));
 
-		[I] public async Task MultipleInstancesOfHttpClientWhenProxyChanges()
-		{
+	    [I] public async Task MultipleInstancesOfHttpClientWhenProxyChanges() =>
 			await MultipleInstancesOfHttpClientWhen(() => CreateRequestData(proxyAddress: new Uri("http://localhost:9400")));
-		}
 
-		[I] public async Task MultipleInstancesOfHttpClientWhenAutomaticProxyDetectionChanges()
-		{
+	    [I] public async Task MultipleInstancesOfHttpClientWhenAutomaticProxyDetectionChanges() =>
 			await MultipleInstancesOfHttpClientWhen(() => CreateRequestData(disableAutomaticProxyDetection: true));
-		}
 
-		[I] public async Task MultipleInstancesOfHttpClientWhenHttpCompressionChanges()
-		{
+	    [I] public async Task MultipleInstancesOfHttpClientWhenHttpCompressionChanges() =>
 			await MultipleInstancesOfHttpClientWhen(() => CreateRequestData(httpCompression: true));
-		}
 
 	    private static async Task MultipleInstancesOfHttpClientWhen(Func<RequestData> differentRequestData)
 	    {

--- a/src/Tests/Tests/ClientConcepts/Connection/ModifyingDefaultConnection.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/ModifyingDefaultConnection.doc.cs
@@ -123,7 +123,7 @@ namespace Tests.ClientConcepts.Connection
         * If you are running on the Desktop CLR you can override specific properties for the current `ServicePoint` easily
         * by overriding `AlterServicePoint` on an `IConnection` implementation deriving from `HttpConnection`
         */
-#if FEATURE_HTTPWEBREQUEST
+#if !DOTNETCORE
         public class MyCustomHttpConnection : HttpConnection
         {
             protected override void AlterServicePoint(ServicePoint requestServicePoint, RequestData requestData)

--- a/src/Tests/Tests/Tests.csproj
+++ b/src/Tests/Tests/Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <VersionPrefix>6.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>

--- a/src/Tests/Tests/Tests.csproj
+++ b/src/Tests/Tests/Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <VersionPrefix>6.0.0</VersionPrefix>
@@ -25,5 +26,4 @@
   <ItemGroup>
     <EmbeddedResource Include="Document\Single\Index\Attachment_Test_Document.pdf" />
   </ItemGroup>
-  <Import Project="..\..\outputpath.props" />
 </Project>

--- a/src/outputpath.props
+++ b/src/outputpath.props
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <OutputPath Condition="'$(OutputPathBaseDir)' != ''">$(OutputPathBaseDir)\$(MSBuildProjectName)\</OutputPath>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
The default `HttpConnection` on .NET core is one that uses `HttpClient`.
The default `HttpConnection` full .NET (4.x) is one that uses `HttpWebRequest`.  ``HttpConnection` here is an alias for `HttpWebRequestConnection`. 

We switched to testing only `netcoreapp2.1` and randomly selecting either `HttpConnection` or `HttpWebRequestConnection`.  However [HttpWebRequest implementation on CoreFx](https://github.com/dotnet/corefx/blob/master/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs#L1096-L1106) is pretty naive in its `HttpClient` usage and we see it leak sockets on our CI environment a lot (TCP connections in `TIME_WAIT` building up). 

This reverts the changes to our testing setup and explicitly tests `netcoreapp2.1` and `net`461` again. 

