### PR TITLE
Use AssertionScope to always include response.DebugInformation

### DIFF
--- a/src/Tests/Tests/Search/Request/FieldsUsageTests.cs
+++ b/src/Tests/Tests/Search/Request/FieldsUsageTests.cs
@@ -60,7 +60,6 @@ namespace Tests.Search.Request
 				var name = fieldValues.Value<string>(Field<Project>(p => p.Name));
 				name.Should().NotBeNullOrWhiteSpace();
 
-
 				var commits = fieldValues.ValueOf<Project, float?>(p => p.NumberOfCommits);
 				commits.Should().BeGreaterThan(0);
 


### PR DESCRIPTION
When we do our response testing in the API integration tests only.

This changes the way assertions are executed though, reporting on all ALL the failures. 
Since we do quite a few assertions in a single method this would become noisy so we hack the message to only include the first failure as before