### PR TITLE
Workaround RIDER-19912 

### DIFF
--- a/src/Tests/Tests/Aggregations/AggregationUsageTestBase.cs
+++ b/src/Tests/Tests/Aggregations/AggregationUsageTestBase.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using Nest;
 using Tests.Core.Client;
@@ -7,19 +9,29 @@ using Tests.Core.ManagedElasticsearch.NodeSeeders;
 using Tests.Domain;
 using Tests.Framework;
 using Tests.Framework.Integration;
-using Tests.Framework.ManagedElasticsearch.Clusters;
-using Tests.Framework.ManagedElasticsearch.NodeSeeders;
 using static Nest.Infer;
-using Xunit;
 
 namespace Tests.Aggregations
 {
 	public abstract class AggregationUsageTestBase
 		: ApiIntegrationTestBase<ReadOnlyCluster, ISearchResponse<Project>, ISearchRequest, SearchDescriptor<Project>, SearchRequest<Project>>
 	{
-		protected AggregationUsageTestBase(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage)
-		{
-		}
+		protected AggregationUsageTestBase(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		// https://youtrack.jetbrains.com/issue/RIDER-19912
+		[U] protected override Task HitsTheCorrectUrl() => base.HitsTheCorrectUrl();
+
+		[U] protected override Task UsesCorrectHttpMethod() => base.UsesCorrectHttpMethod();
+
+		[U] protected override void SerializesInitializer() => base.SerializesInitializer();
+
+		[U] protected override void SerializesFluent() => base.SerializesFluent();
+
+		[I] public override Task ReturnsExpectedStatusCode() => base.ReturnsExpectedResponse();
+
+		[I] public override Task ReturnsExpectedIsValid() => base.ReturnsExpectedIsValid();
+
+		[I] public override Task ReturnsExpectedResponse() => base.ReturnsExpectedResponse();
 
 		protected override LazyResponses ClientUsage() => Calls(
 			fluent: (client, f) => client.Search<Project>(f),
@@ -74,5 +86,20 @@ namespace Tests.Aggregations
 		protected ProjectsOnlyAggregationUsageTestBase(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override Nest.Indices AgainstIndex => DefaultSeeder.ProjectsAliasFilter;
+
+		// https://youtrack.jetbrains.com/issue/RIDER-19912
+		[U] protected override Task HitsTheCorrectUrl() => base.HitsTheCorrectUrl();
+
+		[U] protected override Task UsesCorrectHttpMethod() => base.UsesCorrectHttpMethod();
+
+		[U] protected override void SerializesInitializer() => base.SerializesInitializer();
+
+		[U] protected override void SerializesFluent() => base.SerializesFluent();
+
+		[I] public override Task ReturnsExpectedStatusCode() => base.ReturnsExpectedResponse();
+
+		[I] public override Task ReturnsExpectedIsValid() => base.ReturnsExpectedIsValid();
+
+		[I] public override Task ReturnsExpectedResponse() => base.ReturnsExpectedResponse();
 	}
 }

--- a/src/Tests/Tests/Framework/EndpointTests/ApiIntegrationAgainstNewIndexTestBase.cs
+++ b/src/Tests/Tests/Framework/EndpointTests/ApiIntegrationAgainstNewIndexTestBase.cs
@@ -1,5 +1,7 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Elastic.Managed.Ephemeral;
+using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using Nest;
 using Tests.Core.Extensions;
@@ -28,5 +30,20 @@ namespace Tests.Framework
 		}
 
 		protected virtual ICreateIndexRequest CreateIndexSettings(CreateIndexDescriptor create) => create;
+
+		// https://youtrack.jetbrains.com/issue/RIDER-19912
+		[U] protected override Task HitsTheCorrectUrl() => base.HitsTheCorrectUrl();
+
+		[U] protected override Task UsesCorrectHttpMethod() => base.UsesCorrectHttpMethod();
+
+		[U] protected override void SerializesInitializer() => base.SerializesInitializer();
+
+		[U] protected override void SerializesFluent() => base.SerializesFluent();
+
+		[I] public override Task ReturnsExpectedStatusCode() => base.ReturnsExpectedResponse();
+
+		[I] public override Task ReturnsExpectedIsValid() => base.ReturnsExpectedIsValid();
+
+		[I] public override Task ReturnsExpectedResponse() => base.ReturnsExpectedResponse();
 	}
 }

--- a/src/Tests/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
+++ b/src/Tests/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
@@ -33,13 +33,22 @@ namespace Tests.Framework
 		public override IElasticClient Client => this.Cluster.Client;
 		protected override TInitializer Initializer => Activator.CreateInstance<TInitializer>();
 
-		[I] public async Task ReturnsExpectedStatusCode() =>
+		// https://youtrack.jetbrains.com/issue/RIDER-19912
+		[U] protected override Task HitsTheCorrectUrl() => base.HitsTheCorrectUrl();
+
+		[U] protected override Task UsesCorrectHttpMethod() => base.UsesCorrectHttpMethod();
+
+		[U] protected override void SerializesInitializer() => base.SerializesInitializer();
+
+		[U] protected override void SerializesFluent() => base.SerializesFluent();
+
+		[I] public virtual async Task ReturnsExpectedStatusCode() =>
 			await this.AssertOnAllResponses(r => r.ApiCall.HttpStatusCode.Should().Be(this.ExpectStatusCode));
 
-		[I] public async Task ReturnsExpectedIsValid() =>
+		[I] public virtual async Task ReturnsExpectedIsValid() =>
 			await this.AssertOnAllResponses(r => r.ShouldHaveExpectedIsValid(this.ExpectIsValid));
 
-		[I] public async Task ReturnsExpectedResponse() => await this.AssertOnAllResponses(ExpectResponse);
+		[I] public virtual async Task ReturnsExpectedResponse() => await this.AssertOnAllResponses(ExpectResponse);
 
 		protected override Task AssertOnAllResponses(Action<TResponse> assert)
 		{

--- a/src/Tests/Tests/Framework/EndpointTests/ApiTestBase.cs
+++ b/src/Tests/Tests/Framework/EndpointTests/ApiTestBase.cs
@@ -26,17 +26,14 @@ namespace Tests.Framework
 
 		protected ApiTestBase(TCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
-		[U] protected async Task HitsTheCorrectUrl() =>
-			await this.AssertOnAllResponses(r => this.AssertUrl(r.ApiCall.Uri));
+		[U] protected virtual async Task HitsTheCorrectUrl() => await this.AssertOnAllResponses(r => this.AssertUrl(r.ApiCall.Uri));
 
-		[U] protected async Task UsesCorrectHttpMethod() =>
-			await this.AssertOnAllResponses(
-				r => r.ApiCall.HttpMethod.Should().Be(this.HttpMethod,
-					this.UniqueValues.CurrentView.GetStringValue()));
+		[U] protected virtual async Task UsesCorrectHttpMethod() =>
+			await this.AssertOnAllResponses(r => r.ApiCall.HttpMethod.Should().Be(this.HttpMethod, this.UniqueValues.CurrentView.GetStringValue()));
 
-		[U] protected void SerializesInitializer() => this.RoundTripsOrSerializes<TInterface>(this.Initializer);
+		[U] protected virtual void SerializesInitializer() => this.RoundTripsOrSerializes<TInterface>(this.Initializer);
 
-		[U] protected void SerializesFluent() => this.RoundTripsOrSerializes(this.Fluent?.Invoke(NewDescriptor()));
+		[U] protected virtual void SerializesFluent() => this.RoundTripsOrSerializes(this.Fluent?.Invoke(NewDescriptor()));
 
 		private void AssertUrl(Uri u) => u.PathEquals(this.UrlPath, this.UniqueValues.CurrentView.GetStringValue());
 	}

--- a/src/Tests/Tests/Framework/EndpointTests/CanConnectTestBase.cs
+++ b/src/Tests/Tests/Framework/EndpointTests/CanConnectTestBase.cs
@@ -1,4 +1,6 @@
+using System.Threading.Tasks;
 using Elastic.Managed.Ephemeral;
+using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
@@ -32,5 +34,20 @@ namespace Tests.Framework
 			response.Tagline.Should().NotBeNullOrWhiteSpace();
 			response.Name.Should().NotBeNullOrWhiteSpace();
 		}
+
+		// https://youtrack.jetbrains.com/issue/RIDER-19912
+		[U] protected override Task HitsTheCorrectUrl() => base.HitsTheCorrectUrl();
+
+		[U] protected override Task UsesCorrectHttpMethod() => base.UsesCorrectHttpMethod();
+
+		[U] protected override void SerializesInitializer() => base.SerializesInitializer();
+
+		[U] protected override void SerializesFluent() => base.SerializesFluent();
+
+		[I] public override Task ReturnsExpectedStatusCode() => base.ReturnsExpectedResponse();
+
+		[I] public override Task ReturnsExpectedIsValid() => base.ReturnsExpectedIsValid();
+
+		[I] public override Task ReturnsExpectedResponse() => base.ReturnsExpectedResponse();
 	}
 }

--- a/src/Tests/Tests/Framework/EndpointTests/ConnectionErrorTestBase.cs
+++ b/src/Tests/Tests/Framework/EndpointTests/ConnectionErrorTestBase.cs
@@ -25,7 +25,7 @@ namespace Tests.Framework
 			request: (client, r) => client.RootNodeInfo(r),
 			requestAsync: (client, r) => client.RootNodeInfoAsync(r)
 		);
-		
+
 		protected override object ExpectJson { get; } = null;
 
 		public override IElasticClient Client => this.Cluster.Client;

--- a/src/Tests/Tests/Search/SearchUsageTestBase.cs
+++ b/src/Tests/Tests/Search/SearchUsageTestBase.cs
@@ -1,4 +1,6 @@
-﻿using Elasticsearch.Net;
+﻿using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
@@ -31,6 +33,22 @@ namespace Tests.Search
 		};
 
 		protected object ProjectFilterExpectedJson = new {term = new {type = new {value = Project.TypeName}}};
+
+		// https://youtrack.jetbrains.com/issue/RIDER-19912
+		[U] protected override Task HitsTheCorrectUrl() => base.HitsTheCorrectUrl();
+
+		[U] protected override Task UsesCorrectHttpMethod() => base.UsesCorrectHttpMethod();
+
+		[U] protected override void SerializesInitializer() => base.SerializesInitializer();
+
+		[U] protected override void SerializesFluent() => base.SerializesFluent();
+
+		[I] public override Task ReturnsExpectedStatusCode() => base.ReturnsExpectedResponse();
+
+		[I] public override Task ReturnsExpectedIsValid() => base.ReturnsExpectedIsValid();
+
+		[I] public override Task ReturnsExpectedResponse() => base.ReturnsExpectedResponse();
+
 
 	}
 }

--- a/src/Tests/Tests/XPack/MachineLearning/MachineLearningIntegrationTestBase.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/MachineLearningIntegrationTestBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using Nest;
@@ -18,6 +19,21 @@ namespace Tests.XPack.MachineLearning
 		where TInterface : class
 	{
 		protected MachineLearningIntegrationTestBase(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		// https://youtrack.jetbrains.com/issue/RIDER-19912
+		[U] protected override Task HitsTheCorrectUrl() => base.HitsTheCorrectUrl();
+
+		[U] protected override Task UsesCorrectHttpMethod() => base.UsesCorrectHttpMethod();
+
+		[U] protected override void SerializesInitializer() => base.SerializesInitializer();
+
+		[U] protected override void SerializesFluent() => base.SerializesFluent();
+
+		[I] public override Task ReturnsExpectedStatusCode() => base.ReturnsExpectedResponse();
+
+		[I] public override Task ReturnsExpectedIsValid() => base.ReturnsExpectedIsValid();
+
+		[I] public override Task ReturnsExpectedResponse() => base.ReturnsExpectedResponse();
 
 		protected IPutJobResponse PutJob(IElasticClient client, string jobId)
 		{


### PR DESCRIPTION
This PR duplicates inherited tests in the tests base class hierarchy, this fixes a bug in the jetBrains Rider/Resharper test runner that removes tests inherited from a (great++) grandparent when you open the test file https://youtrack.jetbrains.com/issue/RIDER-19912