### PR TITLE
add split_queries_on_whitespace to keyword property mappings

### DIFF
--- a/src/Nest/Mapping/Types/Core/Keyword/KeywordAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/Keyword/KeywordAttribute.cs
@@ -18,17 +18,25 @@ namespace Nest
 		bool? IKeywordProperty.Index { get; set; }
 		IndexOptions? IKeywordProperty.IndexOptions { get; set; }
 		bool? IKeywordProperty.Norms { get; set; }
+		bool? IKeywordProperty.SplitQueriesOnWhitespace { get; set; }
 		string IKeywordProperty.NullValue { get; set; }
 		string IKeywordProperty.Normalizer { get; set; }
 
-		public double Boost { get { return Self.Boost.GetValueOrDefault(); } set { Self.Boost = value; } }
-		public bool EagerGlobalOrdinals { get { return Self.EagerGlobalOrdinals.GetValueOrDefault(); } set { Self.EagerGlobalOrdinals = value; } }
-		public int IgnoreAbove { get { return Self.IgnoreAbove.GetValueOrDefault(); } set { Self.IgnoreAbove = value; } }
-		public bool Index { get { return Self.Index.GetValueOrDefault(); } set { Self.Index = value; } }
-		public IndexOptions IndexOptions { get { return Self.IndexOptions.GetValueOrDefault(); } set { Self.IndexOptions = value; } }
-		public string NullValue { get { return Self.NullValue; } set { Self.NullValue = value; } }
-		public bool Norms { get { return Self.Norms.GetValueOrDefault(true); } set { Self.Norms = value; } }
-		public string Normalizer { get { return Self.Normalizer; } set { Self.Normalizer = value; } }
+		// ReSharper disable ArrangeThisQualifier
+		public double Boost { get => Self.Boost.GetValueOrDefault(); set => Self.Boost = value; }
+		public bool EagerGlobalOrdinals { get => Self.EagerGlobalOrdinals.GetValueOrDefault(); set => Self.EagerGlobalOrdinals = value; }
+		public int IgnoreAbove { get => Self.IgnoreAbove.GetValueOrDefault(); set => Self.IgnoreAbove = value; }
+		public bool Index { get => Self.Index.GetValueOrDefault(); set => Self.Index = value; }
+		public IndexOptions IndexOptions { get => Self.IndexOptions.GetValueOrDefault(); set => Self.IndexOptions = value; }
+		public string NullValue { get => Self.NullValue; set => Self.NullValue = value; }
+		public bool Norms { get => Self.Norms.GetValueOrDefault(true); set => Self.Norms = value; }
+		public bool SplitQueriesOnWhitespace
+		{
+			get => Self.SplitQueriesOnWhitespace.GetValueOrDefault(false);
+			set => Self.SplitQueriesOnWhitespace = value;
+		}
+		public string Normalizer { get => Self.Normalizer; set => Self.Normalizer = value; }
+		// ReSharper restore ArrangeThisQualifier
 
 	}
 }

--- a/src/Nest/Mapping/Types/Core/Keyword/KeywordProperty.cs
+++ b/src/Nest/Mapping/Types/Core/Keyword/KeywordProperty.cs
@@ -29,6 +29,10 @@ namespace Nest
 		[JsonProperty("norms")]
 		bool? Norms { get; set; }
 
+		/// <summary> Whether full text queries should split the input on whitespace when building a query for this field. </summary>
+		[JsonProperty("split_queries_on_whitespace")]
+		bool? SplitQueriesOnWhitespace { get; set; }
+
 		[JsonProperty("null_value")]
 		string NullValue { get; set; }
 
@@ -47,6 +51,8 @@ namespace Nest
 		public bool? Index { get; set; }
 		public IndexOptions? IndexOptions { get; set; }
 		public bool? Norms { get; set; }
+		/// <inheritdoc cref="IKeywordProperty.SplitQueriesOnWhitespace"/>
+		public bool? SplitQueriesOnWhitespace { get; set; }
 		public string NullValue { get; set; }
 		public string Normalizer { get; set; }
 	}
@@ -62,6 +68,7 @@ namespace Nest
 		bool? IKeywordProperty.Index{ get; set; }
 		IndexOptions? IKeywordProperty.IndexOptions{ get; set; }
 		bool? IKeywordProperty.Norms{ get; set; }
+		bool? IKeywordProperty.SplitQueriesOnWhitespace { get; set; }
 		string IKeywordProperty.NullValue{ get; set; }
 		string IKeywordProperty.Normalizer{ get; set; }
 
@@ -73,6 +80,8 @@ namespace Nest
 		public KeywordPropertyDescriptor<T> Index(bool? index = true) => Assign(a => a.Index = index);
 		public KeywordPropertyDescriptor<T> IndexOptions(IndexOptions? indexOptions) => Assign(a => a.IndexOptions = indexOptions);
 		public KeywordPropertyDescriptor<T> Norms(bool? enabled = true) => Assign(a => a.Norms = enabled);
+		/// <inheritdoc cref="IKeywordProperty.SplitQueriesOnWhitespace"/>
+		public KeywordPropertyDescriptor<T> SplitQueriesOnWhitespace(bool? split = true) => Assign(a => a.SplitQueriesOnWhitespace = split);
 		public KeywordPropertyDescriptor<T> NullValue(string nullValue) => Assign(a => a.NullValue = nullValue);
 		public KeywordPropertyDescriptor<T> Normalizer(string normalizer) => Assign(a => a.Normalizer = normalizer);
 	}

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: m
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 6.4.1

--- a/src/Tests/Tests/Mapping/Types/Core/Keyword/KeywordPropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/Keyword/KeywordPropertyTests.cs
@@ -1,20 +1,18 @@
 ﻿using System;
 using Elastic.Xunit.XunitPlumbing;
-using Elasticsearch.Net;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
-using Tests.Framework;
 using Tests.Framework.Integration;
-using Tests.Framework.ManagedElasticsearch.Clusters;
 using static Tests.Framework.Promisify;
 
 namespace Tests.Mapping.Types.Core.Keyword
 {
-	[SkipVersion("<5.2.0", "This uses the normalizer feature introduced in 5.2.0")]
 	public class KeywordPropertyTests : PropertyTestsBase
 	{
-		public KeywordPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public KeywordPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage)
+		{
+		}
 
 		protected override ICreateIndexRequest CreateIndexSettings(CreateIndexDescriptor create) => create
 			.Settings(s => s
@@ -80,7 +78,8 @@ namespace Tests.Mapping.Types.Core.Keyword
 
 		protected override IProperties InitializerProperties => new Properties
 		{
-			{ "state", new KeywordProperty
+			{
+				"state", new KeywordProperty
 				{
 					DocValues = false,
 					Boost = 1.2,
@@ -95,10 +94,50 @@ namespace Tests.Mapping.Types.Core.Keyword
 					Store = true,
 					Fields = new Properties
 					{
-						{ "foo", new KeywordProperty { IgnoreAbove = 10 } }
+						{"foo", new KeywordProperty {IgnoreAbove = 10}}
 					}
 				}
 			}
 		};
+
+		[SkipVersion("<6.4.0", "split_queries_on_whitespace is a new option https://github.com/elastic/elasticsearch/pull/30691")]
+		public class KeywordPropertySplitQueriesOnWhitespaceTests : PropertyTestsBase
+		{
+			public KeywordPropertySplitQueriesOnWhitespaceTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+			protected override ICreateIndexRequest CreateIndexSettings(CreateIndexDescriptor create) => create
+				.Settings(s => s
+					.Analysis(a => a
+						.CharFilters(t => Promise(Analysis.CharFilters.CharFilterUsageTests.FluentExample(s).Value.Analysis.CharFilters))
+						.TokenFilters(
+							t => Promise(Analysis.TokenFilters.TokenFilterUsageTests.FluentExample(s).Value.Analysis.TokenFilters))
+						.Normalizers(t => Promise(Analysis.Normalizers.NormalizerUsageTests.FluentExample(s).Value.Analysis.Normalizers))
+					)
+				);
+
+			protected override object ExpectJson => new
+			{
+				properties = new
+				{
+					state = new
+					{
+						type = "keyword",
+						split_queries_on_whitespace = true
+					}
+				}
+			};
+
+			protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+				.Keyword(b => b
+					.Name(p => p.State)
+					.SplitQueriesOnWhitespace()
+				);
+
+
+			protected override IProperties InitializerProperties => new Properties
+			{
+				{ "state", new KeywordProperty { SplitQueriesOnWhitespace = true } }
+			};
+		}
 	}
 }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/30691