### PR TITLE
Add .net 45 file source for 6.2.0

### DIFF
--- a/build/NEST.nuspec
+++ b/build/NEST.nuspec
@@ -38,6 +38,9 @@
 		</dependencies>
 	</metadata>
 	<files>
+		<file src="output\Nest\net45\Nest.dll" target="lib\net45"/>
+		<file src="output\Nest\net45\Nest.XML" target="lib\net45"/>
+		
 		<file src="output\Nest\net46\Nest.dll" target="lib\net46"/>
 		<file src="output\Nest\net46\Nest.XML" target="lib\net46"/>
 


### PR DESCRIPTION
Sorry for the incorrect base here but what I am proposing is make a branch off of the 6.2.0 tag so that this bug can be corrected. That same should be done for ElasticSearch.net.

@Mpdreamz I thought this might be a better way of explaining what I am saying. Thanks!
https://github.com/elastic/elasticsearch-net/issues/3423