### PR TITLE
Add support for alias property mapping

### DIFF
--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -86,6 +86,8 @@ namespace Nest
 		DateRange,
 		[EnumMember(Value = "ip_range")]
 		IpRange,
+		[EnumMember(Value = "alias")]
+		Alias,
 		[EnumMember(Value = "join")]
 		Join,
 	}

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -132,6 +132,8 @@ namespace Nest
 
 		public PropertiesDescriptor<T> Join(Func<JoinPropertyDescriptor<T>, IJoinProperty> selector) => SetProperty(selector);
 
+		public PropertiesDescriptor<T> FieldAlias(Func<FieldAliasPropertyDescriptor<T>, IFieldAliasProperty> selector) => SetProperty(selector);
+
 		public PropertiesDescriptor<T> Custom(IProperty customType) => SetProperty(customType);
 
 		private PropertiesDescriptor<T> SetProperty<TDescriptor, TInterface>(Func<TDescriptor, TInterface> selector)
@@ -152,6 +154,7 @@ namespace Nest
 
 			return this.Assign(a => a[type.Name] = type);
 		}
+
 	}
 
 	internal static class PropertiesExtensions

--- a/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
+++ b/src/Nest/Mapping/Types/PropertyDescriptorBase.cs
@@ -20,7 +20,7 @@ namespace Nest
 
 		protected string DebugDisplay => $"Type: {Self.Type ?? "<empty>"}, Name: {Self.Name.DebugDisplay} ";
 
-		protected PropertyDescriptorBase(FieldType type) { Self.Type = type.GetStringValue(); }
+		protected PropertyDescriptorBase(FieldType type) => Self.Type = type.GetStringValue();
 
 		/// <inheritdoc cref="IProperty.Name"/>
 		public TDescriptor Name(PropertyName name) => Assign(a => a.Name = name);

--- a/src/Nest/Mapping/Types/PropertyJsonConverter.cs
+++ b/src/Nest/Mapping/Types/PropertyJsonConverter.cs
@@ -61,6 +61,7 @@ namespace Nest
 				case FieldType.LongRange: return ReadProperty<LongRangeProperty>(jObject, serializer);
 				case FieldType.IpRange: return ReadProperty<IpRangeProperty>(jObject, serializer);
 				case FieldType.Join: return ReadProperty<JoinProperty>(jObject, serializer);
+				case FieldType.Alias: return ReadProperty<FieldAliasProperty>(jObject, serializer);
 				case FieldType.None:
 					break;
 				default:

--- a/src/Nest/Mapping/Types/Specialized/FieldAlias/FieldAliasProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/FieldAlias/FieldAliasProperty.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// An alias mapping defines an alternate name for a field in the index. The alias can be used in place
+	/// of the target field in search requests, and selected other APIs like field capabilities.
+	/// </summary>
+	[JsonObject(MemberSerialization.OptIn)]
+	public interface IFieldAliasProperty : IProperty
+	{
+		/// <summary> The full path to alias </summary>
+		[JsonProperty("path")]
+		Field Path { get; set; }
+	}
+
+	/// <inheritdoc cref="IFieldAliasProperty.Path" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class FieldAliasProperty : PropertyBase, IFieldAliasProperty
+	{
+		public FieldAliasProperty() : base(FieldType.Alias) { }
+
+		/// <inheritdoc cref="IFieldAliasProperty.Path" />
+		public Field Path { get; set; }
+	}
+
+	/// <inheritdoc cref="IFieldAliasProperty.Path" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class FieldAliasPropertyDescriptor<T>
+		: PropertyDescriptorBase<FieldAliasPropertyDescriptor<T>, IFieldAliasProperty, T>, IFieldAliasProperty
+		where T : class
+	{
+		Field IFieldAliasProperty.Path { get; set; }
+
+		public FieldAliasPropertyDescriptor() : base(FieldType.Alias) { }
+
+		/// <inheritdoc cref="IFieldAliasProperty.Path" />
+		public FieldAliasPropertyDescriptor<T> Path(Expression<Func<T, object>> field) => Assign(a => a.Path = field);
+
+		/// <inheritdoc cref="IFieldAliasProperty.Path" />
+		public FieldAliasPropertyDescriptor<T> Path(Field field) => Assign(a => a.Path = field);
+
+	}
+}

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: m
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
 elasticsearch_version: 6.4.1

--- a/src/Tests/Tests/Mapping/Types/Specialized/FieldAlias/AliasPropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Specialized/FieldAlias/AliasPropertyTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.Integration;
+
+namespace Tests.Mapping.Types.Specialized.FieldAlias
+{
+	public class FieldAliasPropertyTests : PropertyTestsBase
+	{
+		public FieldAliasPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				leadDevFirstName = new
+				{
+					type = "alias",
+					path = "leadDeveloper.firstName",
+				}
+			}
+		};
+
+		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+				.FieldAlias(s => s
+					.Name("leadDevFirstName")
+					.Path(p=>p.LeadDeveloper.FirstName)
+				);
+
+		protected override IProperties InitializerProperties => new Properties
+		{
+			{ "leadDevFirstName", new FieldAliasProperty
+				{
+					Path = Infer.Field<Project>(p=>p.LeadDeveloper.FirstName)
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/32172

This property mapping is not exposed as an attribute since this feature is about creating `"virtual"` fields I think it makes very little sense to map concrete POCO properties as aliases.