### PR TITLE
Fix IndexName Parse

### DIFF
--- a/src/Tests/Tests.Reproduce/GithubIssue3411.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue3411.cs
@@ -1,0 +1,21 @@
+﻿using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3411
+	{
+		[U]
+		public void IndexNameParsesClusterAndIndexWithMultipleColons()
+		{
+			var name = "write::some-name";
+			IndexName indexName = name;
+			indexName.Cluster.Should().Be("write");
+			indexName.Name.Should().Be(":some-name");
+
+			var inferrer = new Inferrer(new ConnectionSettings());
+			inferrer.IndexName(indexName).Should().Be(name);
+		}
+	}
+}


### PR DESCRIPTION
This commit changes the implementation of the parsing
function on IndexName to be able to handle consecutive
colons in the index name, when determining cluster name
and index name.

Closes  #3411