### PR TITLE
Allow null refresh_interval to be passed

### DIFF
--- a/src/Nest/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
@@ -5,6 +5,9 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// Dynamic index settings
+	/// </summary>
 	[ContractJsonConverter(typeof(IndexSettingsConverter))]
 	public interface IDynamicIndexSettings : IIsADictionary<string, object>
 	{
@@ -98,8 +101,10 @@ namespace Nest
 		ISimilarities Similarity { get; set; }
 	}
 
+	/// <inheritdoc />
 	public class DynamicIndexSettings : IsADictionaryBase<string, object>, IDynamicIndexSettings
 	{
+		private Time _refreshInterval;
 		public DynamicIndexSettings() { }
 
 		public DynamicIndexSettings(IDictionary<string, object> container) : base(container) { }
@@ -135,7 +140,15 @@ namespace Nest
 		public Union<int, RecoveryInitialShards> RecoveryInitialShards { get; set; }
 
 		/// <inheritdoc/>
-		public Time RefreshInterval { get; set; }
+		public Time RefreshInterval
+		{
+			get => _refreshInterval;
+			set
+			{
+				this.BackingDictionary[UpdatableIndexSettings.RefreshInterval] = value;
+				_refreshInterval = value;
+			}
+		}
 
 		/// <inheritdoc/>
 		public int? RoutingAllocationTotalShardsPerNode { get; set; }
@@ -158,88 +171,89 @@ namespace Nest
 		/// <summary>
 		/// Add any setting to the index
 		/// </summary>
-		public void Add(string setting, object value) => this.BackingDictionary.Add(setting, value);
+		public void Add(string setting, object value) => this.BackingDictionary[setting] = value;
 
 	}
 
+	/// <inheritdoc cref="DynamicIndexSettings"/>
 	public class DynamicIndexSettingsDescriptor :
 		DynamicIndexSettingsDescriptorBase<DynamicIndexSettingsDescriptor, DynamicIndexSettings>
 	{
 		public DynamicIndexSettingsDescriptor() : base(new DynamicIndexSettings()) { }
 	}
 
+	/// <summary>Base descriptor implementation for dynamic index settings</summary>
 	public abstract class DynamicIndexSettingsDescriptorBase<TDescriptor, TIndexSettings> : IsADictionaryDescriptorBase<TDescriptor, TIndexSettings, string, object>
 		where TDescriptor : DynamicIndexSettingsDescriptorBase<TDescriptor, TIndexSettings>
 		where TIndexSettings : class, IDynamicIndexSettings
 	{
 		protected DynamicIndexSettingsDescriptorBase(TIndexSettings instance) : base(instance) { }
 
-		/// <summary>
-		/// Add any setting to the index
-		/// </summary>
+		/// <inheritdoc cref="DynamicIndexSettings.Add"/>
 		public TDescriptor Setting(string setting, object value)
 		{
-			this.PromisedValue.Add(setting, value);
+			this.PromisedValue[setting] = value;
 			return (TDescriptor)this;
 		}
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.NumberOfReplicas"/>
 		public TDescriptor NumberOfReplicas(int? numberOfReplicas) => Assign(a => a.NumberOfReplicas = numberOfReplicas);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.AutoExpandReplicas"/>
 		public TDescriptor AutoExpandReplicas(AutoExpandReplicas autoExpandReplicas) => Assign(a => a.AutoExpandReplicas = autoExpandReplicas);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.BlocksMetadata"/>
 		public TDescriptor BlocksMetadata(bool? blocksMetadata = true) => Assign(a => a.BlocksMetadata = blocksMetadata);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.BlocksRead"/>
 		public TDescriptor BlocksRead(bool? blocksRead = true) => Assign(a => a.BlocksRead = blocksRead);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.BlocksReadOnly"/>
 		public TDescriptor BlocksReadOnly(bool? blocksReadOnly = true) => Assign(a => a.BlocksReadOnly = blocksReadOnly);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.BlocksWrite"/>
 		public TDescriptor BlocksWrite(bool? blocksWrite = true) => Assign(a => a.BlocksWrite = blocksWrite);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.Priority"/>
 		public TDescriptor Priority(int? priority) => Assign(a => a.Priority = priority);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.Merge"/>
 		public TDescriptor Merge(Func<MergeSettingsDescriptor, IMergeSettings> merge) =>
 			Assign(a => a.Merge = merge?.Invoke(new MergeSettingsDescriptor()));
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.RecoveryInitialShards"/>
 		public TDescriptor RecoveryInitialShards(Union<int, RecoveryInitialShards> initialShards) =>
 			Assign(a => a.RecoveryInitialShards = initialShards);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.RequestsCacheEnabled"/>
 		public TDescriptor RequestsCacheEnabled(bool? enable = true) =>
 			Assign(a => a.RequestsCacheEnabled = enable);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.RefreshInterval"/>
 		public TDescriptor RefreshInterval(Time time) => Assign(a => a.RefreshInterval = time);
 
-		/// <inheritdoc/>
+		// TODO: align name for 7.x
+		/// <inheritdoc cref="DynamicIndexSettings.RoutingAllocationTotalShardsPerNode"/>
 		public TDescriptor TotalShardsPerNode(int? totalShardsPerNode) =>
 			Assign(a => a.RoutingAllocationTotalShardsPerNode = totalShardsPerNode);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.SlowLog"/>
 		public TDescriptor SlowLog(Func<SlowLogDescriptor, ISlowLog> slowLogSelector) =>
 			Assign(a => a.SlowLog = slowLogSelector?.Invoke(new SlowLogDescriptor()));
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.Translog"/>
 		public TDescriptor Translog(Func<TranslogSettingsDescriptor, ITranslogSettings> translogSelector) =>
 			Assign(a => a.Translog = translogSelector?.Invoke(new TranslogSettingsDescriptor()));
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.UnassignedNodeLeftDelayedTimeout"/>
 		public TDescriptor UnassignedNodeLeftDelayedTimeout(Time time) =>
 			Assign(a => a.UnassignedNodeLeftDelayedTimeout = time);
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.Analysis"/>
 		public TDescriptor Analysis(Func<AnalysisDescriptor, IAnalysis> selector) =>
 			Assign(a => a.Analysis = selector?.Invoke(new AnalysisDescriptor()));
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="DynamicIndexSettings.Similarity"/>
 		public TDescriptor Similarity(Func<SimilaritiesDescriptor, IPromise<ISimilarities>> selector) =>
 			Assign(a => a.Similarity = selector?.Invoke(new SimilaritiesDescriptor())?.Value);
 	}

--- a/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsConverter.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsConverter.cs
@@ -16,6 +16,9 @@ namespace Nest
 		public override bool CanWrite => true;
 		public override bool CanConvert(Type objectType) => true;
 
+		protected override bool SkipValue(JsonSerializer serializer, KeyValuePair<string, object> entry) =>
+			entry.Key != RefreshInterval && base.SkipValue(serializer, entry);
+
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
 			var ds = value as IDynamicIndexSettings ?? (value as IUpdateIndexSettingsRequest)?.IndexSettings;

--- a/src/Tests/Tests/Document/Multiple/Bulk/BulkApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/Bulk/BulkApiTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Document.Multiple.Bulk
 			);
 
 			if (!pipelineResponse.IsValid)
-				throw new Exception("Failed to set up pipeline required for bulk");
+				throw new Exception("Failed to set up pipeline named 'default-pipeline' required for bulk");
 
 			pipelineResponse = client.PutPipeline("pipeline", p => p
 				.Processors(pr => pr
@@ -47,7 +47,7 @@ namespace Tests.Document.Multiple.Bulk
 			);
 
 			if (!pipelineResponse.IsValid)
-				throw new Exception("Failed to set up pipeline required for bulk");
+				throw new Exception($"Failed to set up pipeline named 'pipeline' required for bulk");
 
 			base.IntegrationSetup(client, values);
 		}

--- a/src/Tests/Tests/Indices/IndexSettings/UpdateIndicesSettings/UpdateIndexSettingsApiTests.cs
+++ b/src/Tests/Tests/Indices/IndexSettings/UpdateIndicesSettings/UpdateIndexSettingsApiTests.cs
@@ -65,4 +65,52 @@ namespace Tests.Indices.IndexSettings.UpdateIndicesSettings
 			}
 		};
 	}
+
+	public class UpdateIndexSettingsRefreshIntervalNullApiTests : ApiIntegrationTestBase<WritableCluster, IUpdateIndexSettingsResponse, IUpdateIndexSettingsRequest, UpdateIndexSettingsDescriptor, UpdateIndexSettingsRequest>
+	{
+		public UpdateIndexSettingsRefreshIntervalNullApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var value in values)
+			{
+				var index = value.Value;
+				var createIndexResponse = client.CreateIndex(index);
+
+				if (!createIndexResponse.IsValid)
+					throw new Exception($"Invalid response when setting up index for integration test {this.GetType().Name}");
+			}
+		}
+
+		protected override LazyResponses ClientUsage() => Calls(
+			fluent: (client, f) => client.UpdateIndexSettings(CallIsolatedValue, f),
+			fluentAsync: (client, f) => client.UpdateIndexSettingsAsync(CallIsolatedValue, f),
+			request: (client, r) => client.UpdateIndexSettings(r),
+			requestAsync: (client, r) => client.UpdateIndexSettingsAsync(r)
+		);
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+		protected override HttpMethod HttpMethod => HttpMethod.PUT;
+		protected override string UrlPath => $"{CallIsolatedValue}/_settings";
+
+		protected override object ExpectJson { get; } = new Dictionary<string, object>
+		{
+			{ "index.refresh_interval", null },
+		};
+
+		protected override Func<UpdateIndexSettingsDescriptor, IUpdateIndexSettingsRequest> Fluent => d => d
+			.Index(CallIsolatedValue)
+			.IndexSettings(i => i
+				.RefreshInterval(null)
+			);
+
+		protected override UpdateIndexSettingsRequest Initializer => new UpdateIndexSettingsRequest(CallIsolatedValue)
+		{
+			IndexSettings = new Nest.IndexSettings
+			{
+				RefreshInterval = null
+			}
+		};
+	}
 }


### PR DESCRIPTION
This commit allows a null value to be passed for refresh_interval, which
allows a user to remove a transient value to fallback to the configured
persistent value.

A couple of different approaches were considered

1. Introducing an internal field on concrete implementations of IDynamicIndexSettings
that could be checked in IndexSettingsConverter to determine whether to serialize
the refresh_interval value, allowing a user to pass null. This has the downside of
needing to cast to concrete implementations in IndexSettingsConverter, rendering the
interface less useful.
2. Introducing a Time 'null' value with a Null Object pattern implementation, and
setting a Time.Null value in the event that null is passed to the property setter.
This would mean that IndexSettingsConverter would not need to change, but now introduces
much more complexity within the Time type to handle a new special value for equality and
comparisons.

In the end, the least intrusive approach of setting the key and value in the underlying
dictionary, and handling whether the key/value should be skipped in IndexSettingsConverter
was considered the cleanest.

Closes #3402