### PR TITLE
Fix #3485

### DIFF
--- a/src/Elasticsearch.Net/Responses/ResponseStatics.cs
+++ b/src/Elasticsearch.Net/Responses/ResponseStatics.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -49,10 +50,26 @@ namespace Elasticsearch.Net
 			{
 				var audit = a.a;
 				sb.Append($" - [{a.i + 1}] {audit.Event.GetStringValue()}:");
-				if (audit.Node?.Uri != null) sb.Append($" Node: {audit.Node.Uri}");
+
+				AuditNodeUrl(sb, audit);
+
 				if (audit.Exception != null) sb.Append($" Exception: {audit.Exception.GetType().Name}");
 				sb.AppendLine($" Took: {(audit.Ended - audit.Started).ToString()}");
 			}
+		}
+
+		private static void AuditNodeUrl(StringBuilder sb, Audit audit)
+		{
+			var uri = audit.Node?.Uri;
+			if (uri == null) return;
+
+			if (!string.IsNullOrEmpty(uri.UserInfo))
+			{
+				var builder = new UriBuilder(uri);
+				builder.Password = "redacted";
+				uri = builder.Uri;
+			}
+			sb.Append($" Node: {uri}");
 		}
 	}
 }

--- a/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
@@ -29,10 +29,10 @@ namespace Tests.ClientConcepts.Troubleshooting
 	{
 		public DebugInformation(ReadOnlyCluster cluster) : base(cluster) {}
 
-        [I] public void DefaultDebug()
-        {
-            // hide
-            var client = this.Client;
+		[I] public void DefaultDebug()
+		{
+			// hide
+			var client = this.Client;
 
 			var response = client.Search<Project>(s => s
 				.Query(q => q
@@ -77,6 +77,7 @@ namespace Tests.ClientConcepts.Troubleshooting
 
 			response.DebugInformation.Should().NotContain("pass2");
 		}
+<<<<<<< HEAD
 
 		/**
 		 * This can be useful in tracking down numerous problems and can also be useful when filing an
@@ -96,6 +97,26 @@ namespace Tests.ClientConcepts.Troubleshooting
 			var client = new ElasticClient(settings);
 		}
 
+=======
+		/**
+		 * This can be useful in tracking down numerous problems and can also be useful when filing an
+		 * {github}/issues[issue] on our github repository.
+		 *
+		 * By default, the request and response bytes are not available within the debug information, but
+		 * can be enabled globally on Connection Settings
+		 *
+		 */
+		public void DisableDirectStreaming()
+		{
+			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+			var settings = new ConnectionSettings(connectionPool)
+				.DisableDirectStreaming(); // <1> disable direct streaming for *all* requests
+
+			var client = new ElasticClient(settings);
+		}
+
+>>>>>>> fix tabs in DebugInformation.doc.cs
 		/**
 		 * or on a _per request_ basis
 		 */

--- a/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
@@ -9,6 +9,7 @@ using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Core.Client;
+using Tests.Core.Client.Settings;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
 using Tests.Framework;
@@ -28,11 +29,10 @@ namespace Tests.ClientConcepts.Troubleshooting
 	{
 		public DebugInformation(ReadOnlyCluster cluster) : base(cluster) {}
 
-		[I]
-		public void DefaultDebug()
-		{
-			// hide
-			var client = this.Client;
+        [I] public void DefaultDebug()
+        {
+            // hide
+            var client = this.Client;
 
 			var response = client.Search<Project>(s => s
 				.Query(q => q
@@ -42,6 +42,42 @@ namespace Tests.ClientConcepts.Troubleshooting
 
 			response.DebugInformation.Should().Contain("Valid NEST response");
 		}
+		//hide
+		[U] public void PasswordIsNotExposedInDebugInformation()
+		{
+			// hide
+			var client = new ElasticClient(new AlwaysInMemoryConnectionSettings()
+				.DefaultIndex("index")
+				.BasicAuthentication("user1", "pass2")
+			);
+
+			var response = client.Search<Project>(s => s
+				.Query(q => q
+					.MatchAll()
+				)
+			);
+
+			response.DebugInformation.Should().NotContain("pass2");
+		}
+
+		//hide
+		[U] public void PasswordIsNotExposedInDebugInformationWhenPartOfUrl()
+		{
+			// hide
+			var pool = new SingleNodeConnectionPool(new Uri("http://user1:pass2@localhost:9200"));
+			var client = new ElasticClient(new ConnectionSettings(pool, new InMemoryConnection())
+				.DefaultIndex("index")
+			);
+
+			var response = client.Search<Project>(s => s
+				.Query(q => q
+					.MatchAll()
+				)
+			);
+
+			response.DebugInformation.Should().NotContain("pass2");
+		}
+
 		/**
 		 * This can be useful in tracking down numerous problems and can also be useful when filing an
 		 * {github}/issues[issue] on our github repository.

--- a/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
@@ -77,8 +77,6 @@ namespace Tests.ClientConcepts.Troubleshooting
 
 			response.DebugInformation.Should().NotContain("pass2");
 		}
-<<<<<<< HEAD
-
 		/**
 		 * This can be useful in tracking down numerous problems and can also be useful when filing an
 		 * {github}/issues[issue] on our github repository.
@@ -97,26 +95,6 @@ namespace Tests.ClientConcepts.Troubleshooting
 			var client = new ElasticClient(settings);
 		}
 
-=======
-		/**
-		 * This can be useful in tracking down numerous problems and can also be useful when filing an
-		 * {github}/issues[issue] on our github repository.
-		 *
-		 * By default, the request and response bytes are not available within the debug information, but
-		 * can be enabled globally on Connection Settings
-		 *
-		 */
-		public void DisableDirectStreaming()
-		{
-			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
-
-			var settings = new ConnectionSettings(connectionPool)
-				.DisableDirectStreaming(); // <1> disable direct streaming for *all* requests
-
-			var client = new ElasticClient(settings);
-		}
-
->>>>>>> fix tabs in DebugInformation.doc.cs
 		/**
 		 * or on a _per request_ basis
 		 */


### PR DESCRIPTION
Passing username/pass in the `Node` Uri directly bleeds into `DebugInformation`.

If you use `BasicAuthentication(username, password)` on `ConnectionSettings` which is the recommended route this does not happen.