### PR TITLE
Include Format property on Field for Doc Values fields

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
@@ -6,10 +6,11 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Elasticsearch.Net;
+using Newtonsoft.Json;
 
 namespace Nest
 {
-	[ContractJsonConverter(typeof(FieldsJsonConverter))]
+	[JsonConverter(typeof(FieldsJsonConverter))]
 	[DebuggerDisplay("{DebugDisplay,nq}")]
 	public class Fields : IUrlParameter, IEnumerable<Field>, IEquatable<Fields>
 	{
@@ -37,33 +38,33 @@ namespace Nest
 			return string.Join(",", ListOfFields.Where(f => f != null).Select(f => ((IUrlParameter)f).GetString(nestSettings)));
 		}
 
-		public static implicit operator Fields(string[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f => (Field)f));
+		public static implicit operator Fields(string[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f => new Field(f)));
 
 		public static implicit operator Fields(string field) => field.IsNullOrEmptyCommaSeparatedList(out var split)
 			? null
-			: new Fields(split.Select(f => (Field)f));
+			: new Fields(split.Select(f => new Field(f)));
 
-		public static implicit operator Fields(Expression[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f => (Field)f));
+		public static implicit operator Fields(Expression[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f => new Field(f)));
 
-		public static implicit operator Fields(Expression field) => field == null ? null : new Fields(new[] { (Field)field });
+		public static implicit operator Fields(Expression field) => field == null ? null : new Fields(new[] { new Field(field) });
 
 		public static implicit operator Fields(Field field) => field == null ? null : new Fields(new[] { field });
 
 		public static implicit operator Fields(PropertyInfo field) => field == null ? null : new Fields(new Field[] { field });
 
-		public static implicit operator Fields(PropertyInfo[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f => (Field)f));
+		public static implicit operator Fields(PropertyInfo[] fields) => fields.IsEmpty() ? null : new Fields(fields.Select(f => new Field(f)));
 
 		public static implicit operator Fields(Field[] fields) => fields.IsEmpty() ? null : new Fields(fields);
 
-		public Fields And<T>(Expression<Func<T, object>> field, double? boost = null) where T : class
+		public Fields And<T>(Expression<Func<T, object>> field, double? boost = null, string format = null) where T : class
 		{
-			ListOfFields.Add(new Field(field, boost));
+			ListOfFields.Add(new Field(field, boost, format));
 			return this;
 		}
 
-		public Fields And(string field, double? boost = null)
+		public Fields And(string field, double? boost = null, string format = null)
 		{
-			ListOfFields.Add(new Field(field, boost));
+			ListOfFields.Add(new Field(field, boost, format));
 			return this;
 		}
 
@@ -75,19 +76,19 @@ namespace Nest
 
 		public Fields And<T>(params Expression<Func<T, object>>[] fields) where T : class
 		{
-			ListOfFields.AddRange(fields.Select(f => (Field)f));
+			ListOfFields.AddRange(fields.Select(f => new Field(f)));
 			return this;
 		}
 
 		public Fields And(params string[] fields)
 		{
-			ListOfFields.AddRange(fields.Select(f => (Field)f));
+			ListOfFields.AddRange(fields.Select(f => new Field(f)));
 			return this;
 		}
 
 		public Fields And(params PropertyInfo[] properties)
 		{
-			ListOfFields.AddRange(properties.Select(f => (Field)f));
+			ListOfFields.AddRange(properties.Select(f => new Field(f)));
 			return this;
 		}
 

--- a/src/Nest/CommonAbstractions/Infer/Fields/FieldsDescriptor.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/FieldsDescriptor.cs
@@ -15,9 +15,11 @@ namespace Nest
 
 		public FieldsDescriptor<T> Fields(IEnumerable<Field> fields) => Assign(f => f.ListOfFields.AddRange(fields));
 
-		public FieldsDescriptor<T> Field(Expression<Func<T, object>> field, double? boost = null) => Assign(f => f.And(field, boost));
+		public FieldsDescriptor<T> Field(Expression<Func<T, object>> field, double? boost = null, string format = null) =>
+			Assign(f => f.And(field, boost, format));
 
-		public FieldsDescriptor<T> Field(string field, double? boost = null) => Assign(f => f.And(field, boost));
+		public FieldsDescriptor<T> Field(string field, double? boost = null, string format = null) =>
+			Assign(f => f.And(field, boost, format));
 
 		public FieldsDescriptor<T> Field(Field field) => Assign(f => f.And(field));
 	}

--- a/src/Nest/CommonAbstractions/Infer/Fields/FieldsJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/FieldsJsonConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -17,37 +18,22 @@ namespace Nest
 			writer.WriteStartArray();
 			if (fields != null)
 			{
-				var infer = serializer.GetConnectionSettings().Inferrer;
-				foreach (var f in fields.ListOfFields) writer.WriteValue(infer.Field(f));
+				// overridden Equals() method means a Fields with only one Field
+				// results in Equality, which triggers Json.NET's Reference loop detection
+				var referenceLoopHandling = serializer.ReferenceLoopHandling;
+				serializer.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+
+				foreach (var field in fields.ListOfFields)
+					serializer.Serialize(writer, field);
+
+				serializer.ReferenceLoopHandling = referenceLoopHandling;
 			}
 			writer.WriteEndArray();
 		}
 
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-		{
-			if (reader.TokenType != JsonToken.StartArray) return null;
-
-			var fields = new Fields();
-			while (reader.TokenType != JsonToken.EndArray)
-			{
-				// as per https://github.com/elastic/elasticsearch/pull/29639 this can now be an array of objects
-				reader.Read();
-				switch (reader.TokenType)
-				{
-					case JsonToken.String:
-						fields.And((string)reader.Value);
-						break;
-					case JsonToken.StartObject:
-						/// TODO 6.4 this is temporary until we add proper support for doc_values format
-						reader.Read(); // "field";
-						var field = reader.ReadAsString();
-						fields.And(field);
-						while (reader.TokenType != JsonToken.EndObject) reader.Read();
-						reader.Read(); // "}";
-						break;
-				}
-			}
-			return fields;
-		}
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) =>
+			reader.TokenType != JsonToken.StartArray
+				? null
+				: new Fields(serializer.Deserialize<IEnumerable<Field>>(reader));
 	}
 }

--- a/src/Nest/CommonAbstractions/Static/Infer.cs
+++ b/src/Nest/CommonAbstractions/Static/Infer.cs
@@ -46,25 +46,24 @@ namespace Nest
 		public static Id Id<T>(T document) where T : class => Nest.Id.From(document);
 
 		public static Fields Fields<T>(params Expression<Func<T, object>>[] fields) where T : class =>
-			new Fields(fields.Select(f => (Field)f));
+			new Fields(fields.Select(f => new Field(f)));
 
-		public static Fields Fields(params string[] fields) => new Fields(fields.Select(f => (Field)f));
+		public static Fields Fields(params string[] fields) => new Fields(fields.Select(f => new Field(f)));
 
-		public static Fields Fields(params PropertyInfo[] properties) => new Fields(properties.Select(f => (Field)f));
+		public static Fields Fields(params PropertyInfo[] properties) => new Fields(properties.Select(f => new Field(f)));
 
 		/// <summary>
 		/// Create a strongly typed string field name representation of the path to a property
 		/// <para>e.g. p => p.Array.First().SubProperty.Field will return 'array.subProperty.field'</para>
 		/// </summary>
-		/// <typeparam name="T">The type of the object</typeparam>
-		/// <param name="path">The path we want to specify</param>
-		/// <param name="boost">An optional ^boost postfix, only make sense with certain queries</param>
-		public static Field Field<T>(Expression<Func<T, object>> path, double? boost = null)
-			where T : class => new Field(path, boost);
+		public static Field Field<T>(Expression<Func<T, object>> path, double? boost = null, string format = null)
+			where T : class => new Field(path, boost, format);
 
-		public static Field Field(string field, double? boost = null) => new Field(field, boost);
+		public static Field Field(string field, double? boost = null, string format = null) =>
+			new Field(field, boost, format);
 
-		public static Field Field(PropertyInfo property, double? boost = null) => new Field(property, boost);
+		public static Field Field(PropertyInfo property, double? boost = null, string format = null) =>
+			new Field(property, boost, format);
 
 		public static PropertyName Property(string property) => property;
 

--- a/src/Tests/Tests/Search/Search/SearchApiTests.cs
+++ b/src/Tests/Tests/Search/Search/SearchApiTests.cs
@@ -108,9 +108,9 @@ namespace Tests.Search.Search
 		}
 	}
 
-	public class SearchApiFieldsTests : SearchApiTests
+	public class SearchApiStoredFieldsTests : SearchApiTests
 	{
-		public SearchApiFieldsTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public SearchApiStoredFieldsTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override object ExpectJson => new
 		{
@@ -185,6 +185,103 @@ namespace Tests.Search.Search
 			response.Hits.First().Should().NotBeNull();
 			response.Hits.First().Fields.ValueOf<Project, string>(p => p.Name).Should().NotBeNullOrEmpty();
 			response.Hits.First().Fields.ValueOf<Project, int?>(p => p.NumberOfCommits).Should().BeGreaterThan(0);
+			response.Aggregations.Count.Should().BeGreaterThan(0);
+			var startDates = response.Aggregations.Terms("startDates");
+			startDates.Should().NotBeNull();
+		}
+	}
+
+	[SkipVersion("<6.4.0", "Doc Value Fields format only in Elasticsearch 6.4.0+")]
+	public class SearchApiDocValueFieldsTests : SearchApiTests
+	{
+		public SearchApiDocValueFieldsTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			from = 10,
+			size = 20,
+			query = new
+			{
+				match_all = new { }
+			},
+			aggs = new
+			{
+				startDates = new
+				{
+					terms = new
+					{
+						field = "startedOn"
+					}
+				}
+			},
+			post_filter = new
+			{
+				term = new
+				{
+					state = new
+					{
+						value = "Stable"
+					}
+				}
+			},
+			docvalue_fields = new object[]
+			{
+				new
+				{
+					field = "name",
+					format = "use_field_mapping"
+				},
+				new
+				{
+					field = "lastActivity",
+					format = "weekyear"
+				},
+			}
+		};
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.From(10)
+			.Size(20)
+			.Query(q => q
+				.MatchAll()
+			)
+			.Aggregations(a => a
+				.Terms("startDates", t => t
+					.Field(p => p.StartedOn)
+				)
+			)
+			.PostFilter(f => f
+				.Term(p => p.State, StateOfBeing.Stable)
+			)
+			.DocValueFields(fs => fs
+				.Field(p => p.Name, format: "use_field_mapping")
+				.Field(p => p.LastActivity, format: "weekyear")
+			);
+
+		protected override SearchRequest<Project> Initializer => new SearchRequest<Project>()
+		{
+			From = 10,
+			Size = 20,
+			Query = new QueryContainer(new MatchAllQuery()),
+			Aggregations = new TermsAggregation("startDates")
+			{
+				Field = "startedOn"
+			},
+			PostFilter = new QueryContainer(new TermQuery
+			{
+				Field = "state",
+				Value = "Stable"
+			}),
+			DocValueFields = Infer.Field<Project>(p => p.Name, format: "use_field_mapping")
+				.And<Project>(p => p.LastActivity, format: "weekyear")
+		};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.Hits.Count().Should().BeGreaterThan(0);
+			response.Hits.First().Should().NotBeNull();
+			response.Hits.First().Fields.ValueOf<Project, string>(p => p.Name).Should().NotBeNullOrEmpty();
+			response.Hits.First().Fields.Value<int>("lastActivity").Should().BeGreaterThan(0);
 			response.Aggregations.Count.Should().BeGreaterThan(0);
 			var startDates = response.Aggregations.Terms("startDates");
 			startDates.Should().NotBeNull();


### PR DESCRIPTION
This commit adds a format property on the Field type
to use with Doc Values fields, and updates serialization
components to handle the presence of a Format property value.

Closes #3490 