### PR TITLE
Move files from machine learning zip

### DIFF
--- a/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/XPackCluster.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/XPackCluster.cs
@@ -24,6 +24,7 @@ namespace Tests.Core.ManagedElasticsearch.Clusters
 				var licenseContents = File.ReadAllText(licenseFilePath);
 				XPackLicenseJson = licenseContents;
 			}
+			TrialMode = XPackTrialMode.Trial;
 			AdditionalBeforeNodeStartedTasks.Add(new EnsureWatcherActionConfigurationInElasticsearchYaml());
 			ShowElasticsearchOutputAfterStarted = true; //this.TestConfiguration.ShowElasticsearchOutputAfterStarted;
 		}


### PR DESCRIPTION
This commit updates the DownloadMachineLearningSampleDataDistribution
compose task to move all files from files directory in the unzip
target directory into the top level target directory.