### PR TITLE
Bump Newtonsoft.Json to 12 on 6.x

### DIFF
--- a/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
+++ b/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
@@ -10,7 +10,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ShellProgressBar" Version="4.0.0" />
     <PackageReference Include="CsQuery.Core" Version="2.0.1" />
 

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha6" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.7.179" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.2" />

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="..\Elasticsearch.Net\Elasticsearch.Net.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Serializers/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
+++ b/src/Serializers/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
@@ -9,6 +9,6 @@
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Domain/Tests.Domain.csproj
+++ b/src/Tests/Tests.Domain/Tests.Domain.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TestPackageVersion)'!=''">
     <PackageReference Include="NEST" Version="$(TestPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TestPackageVersion)'==''">
     <ProjectReference Include="..\..\Nest\Nest.csproj" />


### PR DESCRIPTION
On `6.x` `Nest.JsonNetSerializer.csproj` is the only one that publishes `Json.Net` as dependency on nuget but we still use it as an internalized dependency in `Nest`. 

We are working on moving away from that internalized `Json.Net` on `6.x` but in the interim lets stay up to date and upgrade.