### PR TITLE
Add support for source only snapshot repository

### DIFF
--- a/src/Nest/Ingest/Processors/Plugins/GeoIpProcessor.cs
+++ b/src/Nest/Ingest/Processors/Plugins/GeoIpProcessor.cs
@@ -82,7 +82,6 @@ namespace Nest
 		IEnumerable<string> IGeoIpProcessor.Properties { get; set; }
 		Field IGeoIpProcessor.TargetField { get; set; }
 
-
 		public GeoIpProcessorDescriptor<T> Field(Field field) => Assign(a => a.Field = field);
 
 		public GeoIpProcessorDescriptor<T> Field(Expression<Func<T, object>> objectPath) =>

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/AzureRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/AzureRepository.cs
@@ -12,6 +12,7 @@ namespace Nest
 		public AzureRepository(IAzureRepositorySettings settings) => Settings = settings;
 
 		public IAzureRepositorySettings Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Settings;
 		public string Type { get; } = "azure";
 	}
 
@@ -87,6 +88,7 @@ namespace Nest
 	{
 		IAzureRepositorySettings IRepository<IAzureRepositorySettings>.Settings { get; set; }
 		string ISnapshotRepository.Type { get; } = "azure";
+		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 
 		public AzureRepositoryDescriptor Settings(Func<AzureRepositorySettingsDescriptor, IAzureRepositorySettings> settingsSelector) =>
 			Assign(a => a.Settings = settingsSelector?.Invoke(new AzureRepositorySettingsDescriptor()));

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryRequest.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryRequest.cs
@@ -40,17 +40,17 @@ namespace Nest
 		public CreateRepositoryDescriptor Azure(Func<AzureRepositoryDescriptor, IAzureRepository> selector = null) =>
 			Assign(a => a.Repository = selector.InvokeOrDefault(new AzureRepositoryDescriptor()));
 
-		/// <summary>
-		/// Create an snapshot/restore repository that points to an HDFS filesystem
-		/// </summary>
+		/// <summary> Create an snapshot/restore repository that points to an HDFS filesystem </summary>
 		public CreateRepositoryDescriptor Hdfs(Func<HdfsRepositoryDescriptor, IHdfsRepository> selector) =>
 			Assign(a => a.Repository = selector?.Invoke(new HdfsRepositoryDescriptor()));
 
-		/// <summary>
-		/// Snapshot and restore to an Amazon S3 bucket
-		/// </summary>
+		/// <summary> Snapshot and restore to an Amazon S3 bucket </summary>
 		public CreateRepositoryDescriptor S3(Func<S3RepositoryDescriptor, IS3Repository> selector) =>
 			Assign(a => a.Repository = selector?.Invoke(new S3RepositoryDescriptor()));
+
+		/// <summary> Snapshot and restore to an Amazon S3 bucket </summary>
+		public CreateRepositoryDescriptor SourceOnly(Func<SourceOnlyRepositoryDescriptor, ISourceOnlyRepository> selector) =>
+			Assign(a => a.Repository = selector?.Invoke(new SourceOnlyRepositoryDescriptor()));
 
 		/// <summary>
 		/// Register a custom repository

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/FileSystemRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/FileSystemRepository.cs
@@ -10,6 +10,7 @@ namespace Nest
 		public FileSystemRepository(FileSystemRepositorySettings settings) => Settings = settings;
 
 		public IFileSystemRepositorySettings Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Settings;
 		public string Type { get; } = "fs";
 	}
 
@@ -109,6 +110,7 @@ namespace Nest
 		: DescriptorBase<FileSystemRepositoryDescriptor, IFileSystemRepository>, IFileSystemRepository
 	{
 		IFileSystemRepositorySettings IRepository<IFileSystemRepositorySettings>.Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 		string ISnapshotRepository.Type { get; } = "fs";
 
 		public FileSystemRepositoryDescriptor Settings(string location,

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/HdfsRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/HdfsRepository.cs
@@ -11,6 +11,7 @@ namespace Nest
 		public HdfsRepository(HdfsRepositorySettings settings) => Settings = settings;
 
 		public IHdfsRepositorySettings Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Settings;
 		public string Type { get; } = "hdfs";
 	}
 
@@ -127,6 +128,7 @@ namespace Nest
 		: DescriptorBase<HdfsRepositoryDescriptor, IHdfsRepository>, IHdfsRepository
 	{
 		IHdfsRepositorySettings IRepository<IHdfsRepositorySettings>.Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 		string ISnapshotRepository.Type => "hdfs";
 
 		public HdfsRepositoryDescriptor Settings(string path, Func<HdfsRepositorySettingsDescriptor, IHdfsRepositorySettings> settingsSelector = null

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/ISnapshotRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/ISnapshotRepository.cs
@@ -8,7 +8,13 @@ namespace Nest
 		string Type { get; }
 	}
 
-	public interface IRepository<TSettings> : ISnapshotRepository
+	public interface IRepositoryWithSettings: ISnapshotRepository
+	{
+		[JsonIgnore]
+		object DelegateSettings { get; }
+	}
+
+	public interface IRepository<TSettings> : IRepositoryWithSettings
 		where TSettings : class, IRepositorySettings
 	{
 		[JsonProperty("settings")]

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/ReadOnlyUrlRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/ReadOnlyUrlRepository.cs
@@ -10,6 +10,7 @@ namespace Nest
 		public ReadOnlyUrlRepository(ReadOnlyUrlRepositorySettings settings) => Settings = settings;
 
 		public IReadOnlyUrlRepositorySettings Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Settings;
 		public string Type { get; } = "url";
 	}
 
@@ -57,6 +58,7 @@ namespace Nest
 		: DescriptorBase<ReadOnlyUrlRepositoryDescriptor, IReadOnlyUrlRepository>, IReadOnlyUrlRepository
 	{
 		IReadOnlyUrlRepositorySettings IRepository<IReadOnlyUrlRepositorySettings>.Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 		string ISnapshotRepository.Type => "url";
 
 		public ReadOnlyUrlRepositoryDescriptor Settings(string location,

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
@@ -10,6 +10,7 @@ namespace Nest
 		public S3Repository(S3RepositorySettings settings) => Settings = settings;
 
 		public IS3RepositorySettings Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Settings;
 		public string Type { get; } = "s3";
 	}
 
@@ -205,6 +206,7 @@ namespace Nest
 		: DescriptorBase<S3RepositoryDescriptor, IS3Repository>, IS3Repository
 	{
 		IS3RepositorySettings IRepository<IS3RepositorySettings>.Settings { get; set; }
+		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 		string ISnapshotRepository.Type { get; } = "s3";
 
 		public S3RepositoryDescriptor Settings(string bucket, Func<S3RepositorySettingsDescriptor, IS3RepositorySettings> settingsSelector = null) =>

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/SourceOnlyRepository .cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/SourceOnlyRepository .cs
@@ -1,0 +1,137 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Nest
+{
+
+	[JsonConverter(typeof(SourceOnlyRepositorySerializer))]
+	public interface ISourceOnlyRepository : IRepositoryWithSettings
+	{
+		[JsonIgnore]
+		string DelegateType { get; }
+	}
+
+	public class SourceOnlyRepository : ISourceOnlyRepository
+	{
+		private readonly object _delegateSettings;
+		private readonly string _delegateType;
+
+		internal SourceOnlyRepository() { }
+
+		internal SourceOnlyRepository(string delegateType, object settings)
+		{
+			_delegateType = delegateType;
+			_delegateSettings = settings;
+		}
+
+		public SourceOnlyRepository(IRepositoryWithSettings repositoryToDelegateTo)
+		{
+			if (repositoryToDelegateTo == null) throw new ArgumentNullException(nameof(repositoryToDelegateTo));
+
+			_delegateType = repositoryToDelegateTo.Type;
+			_delegateSettings = repositoryToDelegateTo.DelegateSettings;
+		}
+
+		object IRepositoryWithSettings.DelegateSettings => _delegateSettings;
+		string ISourceOnlyRepository.DelegateType => _delegateType;
+		string ISnapshotRepository.Type { get; } = "source";
+	}
+
+	public class SourceOnlyRepositoryDescriptor
+		: DescriptorBase<SourceOnlyRepositoryDescriptor, ISourceOnlyRepository>, ISourceOnlyRepository
+	{
+		private object _delegateSettings;
+		private string _delegateType;
+
+		object IRepositoryWithSettings.DelegateSettings => _delegateSettings;
+		string ISourceOnlyRepository.DelegateType => _delegateType;
+		string ISnapshotRepository.Type { get; } = "source";
+
+		private SourceOnlyRepositoryDescriptor DelegateTo<TDescriptor>(Func<TDescriptor, IRepositoryWithSettings> selector)
+			where TDescriptor : IRepositoryWithSettings, new() => Custom(selector?.Invoke(new TDescriptor()));
+
+		/// <inheritdoc cref="CreateRepositoryDescriptor.FileSystem" />
+		public SourceOnlyRepositoryDescriptor FileSystem(Func<FileSystemRepositoryDescriptor, IFileSystemRepository> selector) =>
+			DelegateTo(selector);
+
+		/// <inheritdoc cref="CreateRepositoryDescriptor.ReadOnlyUrl" />
+		public SourceOnlyRepositoryDescriptor ReadOnlyUrl(Func<ReadOnlyUrlRepositoryDescriptor, IReadOnlyUrlRepository> selector) =>
+			DelegateTo(selector);
+
+		/// <inheritdoc cref="CreateRepositoryDescriptor.ReadOnlyUrl" />
+		public SourceOnlyRepositoryDescriptor Azure(Func<AzureRepositoryDescriptor, IAzureRepository> selector = null) =>
+			DelegateTo(selector);
+
+		/// <inheritdoc cref="CreateRepositoryDescriptor.ReadOnlyUrl" />
+		public SourceOnlyRepositoryDescriptor Hdfs(Func<HdfsRepositoryDescriptor, IHdfsRepository> selector) =>
+			DelegateTo(selector);
+
+		/// <inheritdoc cref="CreateRepositoryDescriptor.ReadOnlyUrl" />
+		public SourceOnlyRepositoryDescriptor S3(Func<S3RepositoryDescriptor, IS3Repository> selector) =>
+			DelegateTo(selector);
+
+		/// <inheritdoc cref="CreateRepositoryDescriptor.ReadOnlyUrl" />
+		public SourceOnlyRepositoryDescriptor Custom(IRepositoryWithSettings repository)
+		{
+			_delegateType = repository?.Type;
+			_delegateSettings = repository?.DelegateSettings;
+			return this;
+		}
+	}
+
+	internal class SourceOnlyRepositorySerializer : ReserializeJsonConverter<SourceOnlyRepository, ISourceOnlyRepository>
+	{
+		protected override void SerializeJson(JsonWriter writer, object value, ISourceOnlyRepository castValue, JsonSerializer serializer)
+		{
+			if (castValue.DelegateType.IsNullOrEmpty())
+			{
+				writer.WriteNull();
+				return;
+			}
+			writer.WriteStartObject();
+			writer.WriteProperty(serializer, "type", "source");
+			if (castValue.DelegateSettings != null)
+			{
+				writer.WritePropertyName("settings");
+				writer.WriteStartObject();
+				writer.WriteProperty(serializer, "delegate_type", castValue.DelegateType);
+				var properties = castValue.DelegateSettings.GetType().GetCachedObjectProperties();
+				foreach (var p in properties)
+				{
+					if (p.Ignored) continue;
+
+					var vv = p.ValueProvider.GetValue(castValue.DelegateSettings);
+					if (vv == null) continue;
+
+					writer.WritePropertyName(p.PropertyName);
+					serializer.Serialize(writer, vv);
+				}
+				writer.WriteEndObject();
+			}
+			writer.WriteEndObject();
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType != JsonToken.StartObject) return null;
+
+			var o = JObject.Load(reader);
+			if (o == null) return null;
+
+			if (!o.TryGetValue("settings", out var token))
+				return null;
+
+			if (!(token is JObject settingsObject))
+				return null;
+
+			if (!settingsObject.TryGetValue("delegate_type", out var delegateTypeToken))
+				return null;
+
+			settingsObject.Remove("delegate_type");
+
+			var settings = settingsObject.ToObject<object>(serializer);
+			return new SourceOnlyRepository(delegateTypeToken.Value<string>(), settings);
+		}
+	}
+}


### PR DESCRIPTION
elastic/elasticsearch#32844

This one was tricky to implement since `delegate_type` indicates which settings one can send. Came up with   a way to reuse existing typed classes for the other repository settings in the end although its not the cleanest.