### PR TITLE
update "Searching" DSL

### DIFF
--- a/docs/client-concepts/low-level/getting-started.asciidoc
+++ b/docs/client-concepts/low-level/getting-started.asciidoc
@@ -177,8 +177,7 @@ var searchResponse = lowlevelClient.Search<StringResponse>("people", "person", P
     {
         match = new
         {
-            field = "firstName",
-            query = "Martijn"
+            firstName = "Martijn"
         }
     }
 }));
@@ -201,8 +200,7 @@ var searchResponse = lowlevelClient.Search<BytesResponse>("people", "person", @"
     ""size"": 10,
     ""query"": {
         ""match"": {
-            ""field"": ""firstName"",
-            ""query"": ""Martijn""
+            ""firstName"": ""Martijn""
         }
     }
 }");


### PR DESCRIPTION
the old "Searching" syntax for ES 6.* is wrong, so I commit the right one