### PR TITLE
Return overloads that do not take format on Field in 6.x, 

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -102,13 +102,21 @@ namespace Nest
 
 		public Fields And(Field field) => new Fields(new[] { this, field });
 
-		public Fields And<T>(Expression<Func<T, object>> field, double? boost = null, string format = null) where T : class =>
+		public Fields And<T>(Expression<Func<T, object>> field, double? boost = null) where T : class =>
+			new Fields(new[] { this, new Field(field, boost, format: null) });
+
+		public Fields And<T>(Expression<Func<T, object>> field, double? boost, string format = null) where T : class =>
 			new Fields(new[] { this, new Field(field, boost, format) });
 
-		public Fields And(string field, double? boost = null, string format = null) =>
+		public Fields And(string field, double? boost = null) => new Fields(new[] { this, new Field(field, boost, format: null) });
+
+		public Fields And(string field, double? boost, string format = null) =>
 			new Fields(new[] { this, new Field(field, boost, format) });
 
-		public Fields And(PropertyInfo property, double? boost = null, string format = null) =>
+		public Fields And(PropertyInfo property, double? boost = null) =>
+			new Fields(new[] { this, new Field(property, boost, format: null) });
+
+		public Fields And(PropertyInfo property, double? boost, string format = null) =>
 			new Fields(new[] { this, new Field(property, boost, format) });
 
 		private static string ParseFieldName(string name, out double? boost)

--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -27,6 +27,8 @@ namespace Nest
 			_comparisonValue = Name;
 		}
 
+		public Field(Expression expression, double? boost = null) : this(expression, boost, format: null) { }
+
 		public Field(Expression expression, double? boost = null, string format = null)
 		{
 			Expression = expression ?? throw new ArgumentNullException(nameof(expression));
@@ -36,6 +38,8 @@ namespace Nest
 			_type = type;
 			CachableExpression = !new HasVariableExpressionVisitor(expression).Found;
 		}
+
+		public Field(PropertyInfo property, double? boost = null) : this(property, boost, format: null) { }
 
 		public Field(PropertyInfo property, double? boost = null, string format = null)
 		{

--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -29,7 +29,7 @@ namespace Nest
 
 		public Field(Expression expression, double? boost = null) : this(expression, boost, format: null) { }
 
-		public Field(Expression expression, double? boost = null, string format = null)
+		public Field(Expression expression, double? boost, string format = null)
 		{
 			Expression = expression ?? throw new ArgumentNullException(nameof(expression));
 			Boost = boost;
@@ -41,7 +41,7 @@ namespace Nest
 
 		public Field(PropertyInfo property, double? boost = null) : this(property, boost, format: null) { }
 
-		public Field(PropertyInfo property, double? boost = null, string format = null)
+		public Field(PropertyInfo property, double? boost, string format = null)
 		{
 			Property = property ?? throw new ArgumentNullException(nameof(property));
 			Boost = boost;

--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -18,7 +18,9 @@ namespace Nest
 		private readonly object _comparisonValue;
 		private readonly Type _type;
 
-		public Field(string name, double? boost = null, string format = null)
+		public Field(string name, double? boost = null) : this(name, boost, format: null) {}
+
+		public Field(string name, double? boost, string format = null)
 		{
 			name.ThrowIfNullOrEmpty(nameof(name));
 			Name = ParseFieldName(name, out var b);

--- a/src/Nest/CommonAbstractions/Static/Infer.cs
+++ b/src/Nest/CommonAbstractions/Static/Infer.cs
@@ -56,12 +56,16 @@ namespace Nest
 		/// Create a strongly typed string field name representation of the path to a property
 		/// <para>e.g. p => p.Array.First().SubProperty.Field will return 'array.subProperty.field'</para>
 		/// </summary>
-		public static Field Field<T>(Expression<Func<T, object>> path, double? boost = null, string format = null)
+		public static Field Field<T>(Expression<Func<T, object>> path, double? boost = null) where T : class => Field(path, boost, null);
+
+		public static Field Field<T>(Expression<Func<T, object>> path, double? boost, string format = null)
 			where T : class => new Field(path, boost, format);
 
-		public static Field Field(string field, double? boost = null, string format = null) =>
-			new Field(field, boost, format);
+		public static Field Field(string field, double? boost = null) => Field(field, boost, format: null);
 
+		public static Field Field(string field, double? boost, string format = null) => new Field(field, boost, format);
+
+		public static Field Field(PropertyInfo property, double? boost = null) => Field(property, boost, format: null);
 		public static Field Field(PropertyInfo property, double? boost = null, string format = null) =>
 			new Field(property, boost, format);
 

--- a/src/Nest/CommonAbstractions/Static/Infer.cs
+++ b/src/Nest/CommonAbstractions/Static/Infer.cs
@@ -66,7 +66,7 @@ namespace Nest
 		public static Field Field(string field, double? boost, string format = null) => new Field(field, boost, format);
 
 		public static Field Field(PropertyInfo property, double? boost = null) => Field(property, boost, format: null);
-		public static Field Field(PropertyInfo property, double? boost = null, string format = null) =>
+		public static Field Field(PropertyInfo property, double? boost, string format = null) =>
 			new Field(property, boost, format);
 
 		public static PropertyName Property(string property) => property;

--- a/src/Tests/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs
@@ -500,7 +500,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			usingSettings.Expect("data").ForField(Field<Precedence>(p => p.DataMember));
 			usingSettings.Expect("DEFAULTFIELDNAMEINFERRER").ForField(Field<Precedence>(p => p.DefaultFieldNameInferrer));
 
-
+			var x = Field<Project>(p => p.Name, 1.0);
 			/** The same naming rules also apply when indexing a document */
 			usingSettings.Expect(new []
 			{

--- a/src/Tests/Tests/Search/Search/SearchApiTests.cs
+++ b/src/Tests/Tests/Search/Search/SearchApiTests.cs
@@ -272,8 +272,8 @@ namespace Tests.Search.Search
 				Field = "state",
 				Value = "Stable"
 			}),
-			DocValueFields = Infer.Field<Project>(p => p.Name, format: "use_field_mapping")
-				.And<Project>(p => p.LastActivity, format: "weekyear")
+			DocValueFields = Infer.Field<Project>(p => p.Name, boost: null, format: "use_field_mapping")
+				.And<Project>(p => p.LastActivity, boost: null, format: "weekyear")
 		};
 
 		protected override void ExpectResponse(ISearchResponse<Project> response)


### PR DESCRIPTION
removing thm was a bwc breaking change.

cc @codebrain @russcam 