### PR TITLE
Add backwards compatible overloads for Field format

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -110,7 +110,8 @@ namespace Nest
 		public Fields And<T>(Expression<Func<T, object>> field, double? boost, string format = null) where T : class =>
 			new Fields(new[] { this, new Field(field, boost, format) });
 
-		public Fields And(string field, double? boost = null) => new Fields(new[] { this, new Field(field, boost, format: null) });
+		public Fields And(string field, double? boost = null) =>
+			new Fields(new[] { this, new Field(field, boost, format: null) });
 
 		public Fields And(string field, double? boost, string format = null) =>
 			new Fields(new[] { this, new Field(field, boost, format) });

--- a/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
@@ -56,21 +56,39 @@ namespace Nest
 
 		public static implicit operator Fields(Field[] fields) => fields.IsEmpty() ? null : new Fields(fields);
 
-		public Fields And<T>(Expression<Func<T, object>> field, double? boost = null, string format = null) where T : class
+		public Fields And<T>(Expression<Func<T, object>> field, double? boost, string format = null) where T : class
 		{
 			ListOfFields.Add(new Field(field, boost, format));
 			return this;
 		}
 
-		public Fields And(string field, double? boost = null, string format = null)
+		public Fields And<T>(Expression<Func<T, object>> field, double? boost = null) where T : class
+		{
+			ListOfFields.Add(new Field(field, boost));
+			return this;
+		}
+
+		public Fields And(string field, double? boost, string format = null)
 		{
 			ListOfFields.Add(new Field(field, boost, format));
+			return this;
+		}
+
+		public Fields And(string field, double? boost = null)
+		{
+			ListOfFields.Add(new Field(field, boost));
 			return this;
 		}
 
 		public Fields And(PropertyInfo property, double? boost = null)
 		{
 			ListOfFields.Add(new Field(property, boost));
+			return this;
+		}
+
+		public Fields And(PropertyInfo property, double? boost, string format = null)
+		{
+			ListOfFields.Add(new Field(property, boost, format));
 			return this;
 		}
 

--- a/src/Nest/CommonAbstractions/Infer/Fields/FieldsDescriptor.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/FieldsDescriptor.cs
@@ -15,11 +15,17 @@ namespace Nest
 
 		public FieldsDescriptor<T> Fields(IEnumerable<Field> fields) => Assign(f => f.ListOfFields.AddRange(fields));
 
-		public FieldsDescriptor<T> Field(Expression<Func<T, object>> field, double? boost = null, string format = null) =>
+		public FieldsDescriptor<T> Field(Expression<Func<T, object>> field, double? boost, string format = null) =>
 			Assign(f => f.And(field, boost, format));
 
-		public FieldsDescriptor<T> Field(string field, double? boost = null, string format = null) =>
+		public FieldsDescriptor<T> Field(Expression<Func<T, object>> field, double? boost = null) =>
+			Assign(f => f.And(field, boost));
+
+		public FieldsDescriptor<T> Field(string field, double? boost, string format = null) =>
 			Assign(f => f.And(field, boost, format));
+
+		public FieldsDescriptor<T> Field(string field, double? boost = null) =>
+			Assign(f => f.And(field, boost));
 
 		public FieldsDescriptor<T> Field(Field field) => Assign(f => f.And(field));
 	}

--- a/src/Tests/Tests/Search/Search/SearchApiTests.cs
+++ b/src/Tests/Tests/Search/Search/SearchApiTests.cs
@@ -254,8 +254,8 @@ namespace Tests.Search.Search
 				.Term(p => p.State, StateOfBeing.Stable)
 			)
 			.DocValueFields(fs => fs
-				.Field(p => p.Name, format: "use_field_mapping")
-				.Field(p => p.LastActivity, format: "weekyear")
+				.Field(p => p.Name, null, format: "use_field_mapping")
+				.Field(p => p.LastActivity, null, format: "weekyear")
 			);
 
 		protected override SearchRequest<Project> Initializer => new SearchRequest<Project>()


### PR DESCRIPTION
This PRadds backwards binary compatibility with 6.4.0
for method overloads on Field related types that can accept
a format parameter.