### PR TITLE
[DOCS] Changed URL from 6.4 to 6.5

### DIFF
--- a/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/6.4
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/6.5
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
@@ -24,7 +24,7 @@ NOTE: When specifying a `format` **and** `extended_bounds` or `missing`, in orde
 the serialized `DateTime` of `extended_bounds` or `missing` correctly, the `date_optional_time` format is included
 as part of the `format` value.
 
-//Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-autodatehistogram-aggregation.html[Auto Date Histogram Aggregation].
+Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-autodatehistogram-aggregation.html[Auto Date Histogram Aggregation].
 
 ==== Fluent DSL example
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch-net/commit/2234d5be612a77f94832bf0917b2bf164e500317

In particular, the documentation build was failing with these broken links:
09:33:56 Bad cross-document links:
09:33:56   html/en/elasticsearch/client/net-api/6.x/auto-date-histogram-aggregation-usage.html:
09:33:56    - en/elasticsearch/reference/6.4/search-aggregations-bucket-autodatehistogram-aggregation.html
09:33:56   html/en/elasticsearch/client/net-api/current/auto-date-histogram-aggregation-usage.html:
09:33:56    - en/elasticsearch/reference/6.4/search-aggregations-bucket-autodatehistogram-aggregation.html