### PR TITLE
Use the version number present in the global.json file when generating documentation

### DIFF
--- a/src/CodeGeneration/DocGenerator/Program.cs
+++ b/src/CodeGeneration/DocGenerator/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace DocGenerator
 {
@@ -14,6 +16,7 @@ namespace DocGenerator
 			}
 
 			var currentDirectory = new DirectoryInfo(Directory.GetCurrentDirectory());
+			var globalJson = P(@"..\..\..\global.json");
 			if (currentDirectory.Name == "DocGenerator" && currentDirectory.Parent.Name == "CodeGeneration")
 			{
 				Console.WriteLine("IDE: " + currentDirectory);
@@ -23,11 +26,20 @@ namespace DocGenerator
 			}
 			else
 			{
+			    globalJson = P(@"..\..\..\..\global.json");
 				Console.WriteLine("CMD: " + currentDirectory);
 				InputDirPath = P(@"..\..\..\..\src");
 				OutputDirPath = P(@"..\..\..\..\docs");
 				BuildOutputPath = P(@"..\..\..\..\build\output");
 			}
+
+			var globalJsonVersion = string.Join(".", Regex.Matches(File.ReadAllText(globalJson), "\"version\": \"(.*)\"")
+										 .Last().Groups
+										 .Last().Value
+										 .Split(".")
+										 .Take(2));
+			Console.WriteLine("Using global.json version: " + globalJsonVersion);
+			DocVersion = globalJsonVersion;
 
 			var process = new Process
 			{
@@ -68,7 +80,7 @@ namespace DocGenerator
 		/// <summary>
 		/// The Elasticsearch documentation version to link to
 		/// </summary>
-		public static string DocVersion => "6.4";
+		public static string DocVersion { get; set; }
 
 		public static string InputDirPath { get; }
 


### PR DESCRIPTION
This pull request addresses an issue whereby the documentation can be generated for a release with the incorrect version number. The version number is now calculated from the `global.json` file, thereby limiting the chances of the incorrect version number being used on a release.

Regular expressions and basic character manipulation has been used to avoid the need for JSON parsing and Semver libraries.

Backport to `6.x` on merge.