### PR TITLE
Add keywords_pattern to Keyword Marker Token Filter.

### DIFF
--- a/src/Nest/Analysis/TokenFilters/KeywordMarkerTokenFilter.cs
+++ b/src/Nest/Analysis/TokenFilters/KeywordMarkerTokenFilter.cs
@@ -25,6 +25,12 @@ namespace Nest
 		/// </summary>
 		[JsonProperty("keywords_path")]
 		string KeywordsPath { get; set; }
+
+		/// <summary>
+		/// A regular expression pattern to match against words in the text.
+		/// </summary>
+		[JsonProperty("keywords_pattern")]
+		string KeywordsPattern { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -40,6 +46,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public string KeywordsPath { get; set; }
+
+		/// <inheritdoc />
+		public string KeywordsPattern { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -52,11 +61,16 @@ namespace Nest
 		IEnumerable<string> IKeywordMarkerTokenFilter.Keywords { get; set; }
 		string IKeywordMarkerTokenFilter.KeywordsPath { get; set; }
 
+		string IKeywordMarkerTokenFilter.KeywordsPattern { get; set; }
+
 		/// <inheritdoc />
 		public KeywordMarkerTokenFilterDescriptor IgnoreCase(bool? ignoreCase = true) => Assign(a => a.IgnoreCase = ignoreCase);
 
 		/// <inheritdoc />
 		public KeywordMarkerTokenFilterDescriptor KeywordsPath(string path) => Assign(a => a.KeywordsPath = path);
+
+		/// <inheritdoc />
+		public KeywordMarkerTokenFilterDescriptor KeywordsPattern(string pattern) => Assign(a => a.KeywordsPattern = pattern);
 
 		/// <inheritdoc />
 		public KeywordMarkerTokenFilterDescriptor Keywords(IEnumerable<string> keywords) => Assign(a => a.Keywords = keywords);

--- a/src/Tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
+++ b/src/Tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
@@ -334,15 +334,19 @@ namespace Tests.Analysis.TokenFilters
 				.KeywordMarker("marker", t => t
 					.IgnoreCase()
 					.Keywords("a", "b")
+					.KeywordsPattern(".*")
+					.KeywordsPath("path")
 				);
 
-			public override ITokenFilter Initializer => new KeywordMarkerTokenFilter { IgnoreCase = true, Keywords = new[] { "a", "b" } };
+			public override ITokenFilter Initializer => new KeywordMarkerTokenFilter { IgnoreCase = true, Keywords = new[] { "a", "b" }, KeywordsPath = "path", KeywordsPattern = ".*" };
 
 			public override object Json => new
 			{
 				type = "keyword_marker",
 				keywords = new[] { "a", "b" },
-				ignore_case = true
+				ignore_case = true,
+				keywords_path = "path",
+				keywords_pattern = ".*"
 			};
 
 			public override string Name => "marker";


### PR DESCRIPTION
Add keywords_pattern to Keyword Marker Token Filter. A regular expression pattern to match against words in the text.

Addresses: https://github.com/elastic/elasticsearch-net/issues/3551

Port to `master` on merge.
Will be released in `6.6.0`