### PR TITLE
Avoid doing string concat when not needed

### DIFF
--- a/src/Nest/Document/Multiple/Bulk/BulkRequestJsonConverter.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequestJsonConverter.cs
@@ -29,7 +29,11 @@ namespace Nest
 				op.Routing = op.GetRoutingForOperation(settings.Inferrer);
 
 				var opJson = requestResponseSerializer.SerializeToString(op, SerializationFormatting.None);
-				writer.WriteRaw($"{{\"{op.Operation}\":" + opJson + "}\n");
+				writer.WriteRaw("{\"");
+				writer.WriteRaw(op.Operation);
+				writer.WriteRaw("\":");
+				writer.WriteRaw(opJson);
+				writer.WriteRaw("}\n");
 				var body = op.GetBody();
 				if (body == null) continue;
 
@@ -40,7 +44,8 @@ namespace Nest
 					)
 					.SerializeToString(body, SerializationFormatting.None);
 
-				writer.WriteRaw(bodyJson + "\n");
+				writer.WriteRaw(bodyJson);
+				writer.WriteRaw("\n");
 			}
 		}
 


### PR DESCRIPTION
I noticed this OOM exception and saw string concat in the call stack.
No need to do concat when we are putting the result into a JsonWriter anyway.

I can see that you have improved the serialization in other branches, but I guess that is not coming in the near future.

> Inner exception System.OutOfMemoryException handled at Elasticsearch.Net.Transport`1+<RequestAsync>d__15`1.MoveNext:
>    at System.String.Concat (System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
>    at Nest.BulkRequestJsonConverter.WriteJson (Nest, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d)