### PR TITLE
Avoid doing multiple dictionary lookups

### DIFF
--- a/src/Elasticsearch.Net/Responses/Sniff/SniffResponse.cs
+++ b/src/Elasticsearch.Net/Responses/Sniff/SniffResponse.cs
@@ -78,8 +78,8 @@ namespace Elasticsearch.Net
 		{
 			get
 			{
-				if (settings != null && settings.ContainsKey("http.enabled"))
-					return Convert.ToBoolean(settings["http.enabled"]);
+				if (settings != null && settings.TryGetValue("http.enabled", out object httpEnabled))
+					return Convert.ToBoolean(httpEnabled);
 
 				return http != null;
 			}

--- a/src/Elasticsearch.Net/Serialization/SimpleJson.cs
+++ b/src/Elasticsearch.Net/Serialization/SimpleJson.cs
@@ -267,7 +267,7 @@ namespace Elasticsearch.Net
 		/// </returns>
 		public bool Contains(KeyValuePair<string, object> item)
 		{
-			return _members.ContainsKey(item.Key) && _members[item.Key] == item.Value;
+			return _members.TryGetValue(item.Key, out object value) && value == item.Value;
 		}
 
 		/// <summary>

--- a/src/Nest/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationJsonConverter.cs
+++ b/src/Nest/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationJsonConverter.cs
@@ -17,8 +17,8 @@ namespace Nest
 			var percentileRanks = new PercentileRanksAggregation();
 			ReadMetricProperties(percentileRanks, properties);
 			percentileRanks.Method = ReadMethodProperty(properties);
-			if (properties.ContainsKey("values"))
-				percentileRanks.Values = properties["values"].ToObject<List<double>>();
+			if (properties.TryGetValue("values", out JToken valuesToken))
+				percentileRanks.Values = valuesToken.ToObject<List<double>>();
 			return percentileRanks;
 
 			;

--- a/src/Nest/Aggregations/Metric/Percentiles/PercentilesAggregationJsonConverter.cs
+++ b/src/Nest/Aggregations/Metric/Percentiles/PercentilesAggregationJsonConverter.cs
@@ -17,37 +17,37 @@ namespace Nest
 			var percentiles = new PercentilesAggregation();
 			ReadMetricProperties(percentiles, properties);
 			percentiles.Method = ReadMethodProperty(properties);
-			if (properties.ContainsKey("percents"))
-				percentiles.Percents = properties["percents"].ToObject<List<double>>();
+			if (properties.TryGetValue("percents", out JToken percentsToken))
+				percentiles.Percents = percentsToken.ToObject<List<double>>();
 			return percentiles;
 		}
 
 		protected IPercentilesMethod ReadMethodProperty(Dictionary<string, JToken> properties)
 		{
 			IPercentilesMethod method = null;
-			if (properties.ContainsKey("hdr"))
-				method = properties["hdr"].ToObject<HDRHistogramMethod>();
-			else if (properties.ContainsKey("tdigest"))
-				method = properties["tdigest"].ToObject<TDigestMethod>();
+			if (properties.TryGetValue("hdr", out JToken hdrToken))
+				method = hdrToken.ToObject<HDRHistogramMethod>();
+			else if (properties.TryGetValue("tdigest", out JToken tdigestToken))
+				method = tdigestToken.ToObject<TDigestMethod>();
 			return method;
 		}
 
 		protected void ReadMetricProperties(IMetricAggregation metric, Dictionary<string, JToken> properties)
 		{
-			if (properties.ContainsKey("field"))
-				metric.Field = properties["field"].ToString();
+			if (properties.TryGetValue("field", out JToken fieldToken))
+				metric.Field = fieldToken.ToString();
 
-			if (properties.ContainsKey("script"))
+			if (properties.TryGetValue("script", out JToken scriptToken))
 			{
-				var scriptProps = JObject.FromObject(properties["script"]).Properties().ToDictionary(p => p.Name, p => p.Value);
+				var scriptProps = JObject.FromObject(scriptToken).Properties().ToDictionary(p => p.Name, p => p.Value);
 				if (scriptProps.ContainsKey("source") || scriptProps.ContainsKey("inline"))
-					metric.Script = properties["script"].ToObject<InlineScript>();
-				else if (scriptProps.ContainsKey("id"))
-					metric.Script = properties["id"].ToObject<IndexedScript>();
+					metric.Script = scriptToken.ToObject<InlineScript>();
+				else if (scriptProps.TryGetValue("id", out JToken idToken))
+					metric.Script = idToken.ToObject<IndexedScript>();
 			}
 
-			if (properties.ContainsKey("missing"))
-				metric.Missing = double.Parse(properties["missing"].ToString());
+			if (properties.TryGetValue("missing", out JToken missingToken))
+				metric.Missing = double.Parse(missingToken.ToString());
 		}
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/Nest/Aggregations/Pipeline/MovingAverage/MovingAverageAggregationJsonConverter.cs
+++ b/src/Nest/Aggregations/Pipeline/MovingAverage/MovingAverageAggregationJsonConverter.cs
@@ -83,11 +83,11 @@ namespace Nest
 
 		private T GetOrDefault<T>(string key, Dictionary<string, JToken> properties)
 		{
-			if (!properties.ContainsKey(key)) return default(T);
+			if (!properties.TryGetValue(key, out JToken value)) return default(T);
 #if DOTNETCORE
-			return properties[key].ToObject<T>();
+			return value.ToObject<T>();
 #else
-			return (T)Convert.ChangeType(properties[key], typeof(T));
+			return (T)Convert.ChangeType(value, typeof(T));
 #endif
 		}
 

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -173,9 +173,9 @@ namespace Nest
 			var memberInfo = new MemberInfoResolver(objectPath);
 			var fieldName = memberInfo.Members.Single().Name;
 
-			if (_idProperties.ContainsKey(typeof(TDocument)))
+			if (_idProperties.TryGetValue(typeof(TDocument), out string idPropertyFieldName))
 			{
-				if (_idProperties[typeof(TDocument)].Equals(fieldName)) return;
+				if (idPropertyFieldName.Equals(fieldName)) return;
 
 				throw new ArgumentException(
 					$"Cannot map '{fieldName}' as the id property for type '{typeof(TDocument).Name}': it already has '{_idProperties[typeof(TDocument)]}' mapped.");
@@ -191,9 +191,9 @@ namespace Nest
 			var memberInfo = new MemberInfoResolver(objectPath);
 			var fieldName = memberInfo.Members.Single().Name;
 
-			if (_routeProperties.ContainsKey(typeof(TDocument)))
+			if (_routeProperties.TryGetValue(typeof(TDocument), out string routePropertyFieldName))
 			{
-				if (_routeProperties[typeof(TDocument)].Equals(fieldName)) return;
+				if (routePropertyFieldName.Equals(fieldName)) return;
 
 				throw new ArgumentException(
 					$"Cannot map '{fieldName}' as the route property for type '{typeof(TDocument).Name}': it already has '{_routeProperties[typeof(TDocument)]}' mapped.");
@@ -216,10 +216,10 @@ namespace Nest
 					throw new ArgumentException($"Expression {e} does contain any member access");
 
 				var memberInfo = memberInfoResolver.Members.Last();
-				if (_propertyMappings.ContainsKey(memberInfo))
+				if (_propertyMappings.TryGetValue(memberInfo, out IPropertyMapping propertyMapping))
 				{
 					var newName = mapping.NewName;
-					var mappedAs = _propertyMappings[memberInfo].Name;
+					var mappedAs = propertyMapping.Name;
 					var typeName = typeof(TDocument).Name;
 					if (mappedAs.IsNullOrEmpty() && newName.IsNullOrEmpty())
 						throw new ArgumentException($"Property mapping '{e}' on type is already ignored");

--- a/src/Nest/CommonOptions/Scripting/ScriptJsonConverter.cs
+++ b/src/Nest/CommonOptions/Scripting/ScriptJsonConverter.cs
@@ -20,28 +20,28 @@ namespace Nest
 			if (!dict.HasAny()) return null;
 
 			IScript script = null;
-			if (dict.ContainsKey("inline"))
+			if (dict.TryGetValue("inline", out JToken inlineToken))
 			{
-				var inline = dict["inline"].ToString();
+				var inline = inlineToken.ToString();
 				script = new InlineScript(inline);
 			}
-			if (dict.ContainsKey("source"))
+			if (dict.TryGetValue("source", out JToken sourceToken))
 			{
-				var inline = dict["source"].ToString();
+				var inline = sourceToken.ToString();
 				script = new InlineScript(inline);
 			}
-			if (dict.ContainsKey("id"))
+			if (dict.TryGetValue("id", out JToken idToken))
 			{
-				var id = dict["id"].ToString();
+				var id = idToken.ToString();
 				script = new IndexedScript(id);
 			}
 
 			if (script == null) return null;
 
-			if (dict.ContainsKey("lang"))
-				script.Lang = dict["lang"].ToString();
-			if (dict.ContainsKey("params"))
-				script.Params = dict["params"].ToObject<Dictionary<string, object>>();
+			if (dict.TryGetValue("lang", out JToken langToken))
+				script.Lang = langToken.ToString();
+			if (dict.TryGetValue("params", out JToken paramsToken))
+				script.Params = paramsToken.ToObject<Dictionary<string, object>>();
 
 			return script;
 		}

--- a/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsConverter.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsConverter.cs
@@ -256,9 +256,8 @@ namespace Nest
 			JsonSerializer serializer = null
 		)
 		{
-			if (!settings.ContainsKey(key)) return;
+			if (!settings.TryGetValue(key, out JProperty v)) return;
 
-			var v = settings[key];
 			var value = serializer == null ? v.Value.ToObject<T>() : v.Value.ToObject<T>(serializer);
 			assign(value);
 			s.Add(key, value);
@@ -269,9 +268,8 @@ namespace Nest
 			Action<TItem> assign2, JsonSerializer serializer = null
 		)
 		{
-			if (!settings.ContainsKey(key)) return;
+			if (!settings.TryGetValue(key, out JProperty v)) return;
 
-			var v = settings[key];
 			if (v.Value is JArray)
 			{
 				var value = serializer == null ? v.Value.ToObject<TArray>() : v.Value.ToObject<TArray>(serializer);

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryResponse.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryResponse.cs
@@ -40,9 +40,9 @@ namespace Nest
 			where TRepository : class, ISnapshotRepository
 		{
 			if (Repositories == null) return null;
-			if (!Repositories.ContainsKey(name)) return null;
+			if (!Repositories.TryGetValue(name, out ISnapshotRepository repository)) return null;
 
-			return Repositories[name] as TRepository;
+			return repository as TRepository;
 		}
 	}
 }

--- a/src/Nest/XPack/Watcher/Condition/ScriptConditionBase.cs
+++ b/src/Nest/XPack/Watcher/Condition/ScriptConditionBase.cs
@@ -68,28 +68,28 @@ namespace Nest
 			if (!dict.HasAny()) return null;
 
 			IScriptCondition scriptCondition = null;
-			if (dict.ContainsKey("inline"))
+			if (dict.TryGetValue("inline", out JToken inlineToken))
 			{
-				var inline = dict["inline"].ToString();
+				var inline = inlineToken.ToString();
 				scriptCondition = new InlineScriptCondition(inline);
 			}
-			if (dict.ContainsKey("source"))
+			if (dict.TryGetValue("source", out JToken sourceToken))
 			{
-				var inline = dict["source"].ToString();
+				var inline = sourceToken.ToString();
 				scriptCondition = new InlineScriptCondition(inline);
 			}
-			if (dict.ContainsKey("id"))
+			if (dict.TryGetValue("id", out JToken idToken))
 			{
-				var id = dict["id"].ToString();
+				var id = idToken.ToString();
 				scriptCondition = new IndexedScriptCondition(id);
 			}
 
 			if (scriptCondition == null) return null;
 
-			if (dict.ContainsKey("lang"))
-				scriptCondition.Lang = dict["lang"].ToString();
-			if (dict.ContainsKey("params"))
-				scriptCondition.Params = dict["params"].ToObject<Dictionary<string, object>>();
+			if (dict.TryGetValue("lang", out JToken langToken))
+				scriptCondition.Lang = langToken.ToString();
+			if (dict.TryGetValue("params", out JToken paramsToken))
+				scriptCondition.Params = paramsToken.ToObject<Dictionary<string, object>>();
 
 			return scriptCondition;
 		}

--- a/src/Nest/XPack/Watcher/Input/ChainInput.cs
+++ b/src/Nest/XPack/Watcher/Input/ChainInput.cs
@@ -42,10 +42,13 @@ namespace Nest
 		/// <inheritdoc />
 		public ChainInputDescriptor Input(string name, Func<InputDescriptor, InputContainer> selector)
 		{
-			if (Self.Inputs == null) Self.Inputs = new Dictionary<string, InputContainer>();
-
-			if (Self.Inputs.ContainsKey(name))
-				throw new InvalidOperationException($"An input named '{name}' has already been specified. Choose a different name");
+			if (Self.Inputs != null)
+			{
+				if (Self.Inputs.ContainsKey(name))
+					throw new InvalidOperationException($"An input named '{name}' has already been specified. Choose a different name");
+			}
+			else
+				Self.Inputs = new Dictionary<string, InputContainer>();
 
 			Self.Inputs.Add(name, selector.InvokeOrDefault(new InputDescriptor()));
 			return this;

--- a/src/Nest/XPack/Watcher/Transform/ScriptTransformBase.cs
+++ b/src/Nest/XPack/Watcher/Transform/ScriptTransformBase.cs
@@ -67,28 +67,28 @@ namespace Nest
 			if (!dict.HasAny()) return null;
 
 			IScriptTransform scriptTransform = null;
-			if (dict.ContainsKey("inline"))
+			if (dict.TryGetValue("inline", out JToken inlineToken))
 			{
-				var inline = dict["inline"].ToString();
+				var inline = inlineToken.ToString();
 				scriptTransform = new InlineScriptTransform(inline);
 			}
-			if (dict.ContainsKey("source"))
+			if (dict.TryGetValue("source", out JToken sourceToken))
 			{
-				var inline = dict["source"].ToString();
+				var inline = sourceToken.ToString();
 				scriptTransform = new InlineScriptTransform(inline);
 			}
-			if (dict.ContainsKey("id"))
+			if (dict.TryGetValue("id", out JToken idToken))
 			{
-				var id = dict["id"].ToString();
+				var id = idToken.ToString();
 				scriptTransform = new IndexedScriptTransform(id);
 			}
 
 			if (scriptTransform == null) return null;
 
-			if (dict.ContainsKey("lang"))
-				scriptTransform.Lang = dict["lang"].ToString();
-			if (dict.ContainsKey("params"))
-				scriptTransform.Params = dict["params"].ToObject<Dictionary<string, object>>();
+			if (dict.TryGetValue("lang", out JToken langToken))
+				scriptTransform.Lang = langToken.ToString();
+			if (dict.TryGetValue("params", out JToken paramsToken))
+				scriptTransform.Params = paramsToken.ToObject<Dictionary<string, object>>();
 
 			return scriptTransform;
 		}


### PR DESCRIPTION
Dictionary lookup involves get key hash, find bucket for hash and iterate bucket for key, so look the value up once, instead of checking if the key exists and then using the indexer to look up the value.
It also reduces the amount of duplicate hardcoded keys in the code.

Could not find any documentation for running the benchmark, so I haven't checked if it actually makes any difference. Haven't analyzed how often the code is executed.

Some places ContainsKey is used before Remove. That is not needed for Dictionary<>, as it will just return false for key not found, but I am uncertain of the specification for IDictionary<> void Remove, so I left it in place.