### PR TITLE
fix #3582 low level client sniffing

### DIFF
--- a/src/Elasticsearch.Net/Serialization/SimpleJson.cs
+++ b/src/Elasticsearch.Net/Serialization/SimpleJson.cs
@@ -48,7 +48,6 @@
 
 // original json parsing code from http://techblog.procurios.nl/k/618/news/view/14605/14863/How-do-I-write-my-own-parser-for-JSON.html
 
-#define SIMPLE_JSON_TYPEINFO
 using System;
 using System.CodeDom.Compiler;
 using System.Collections;

--- a/src/Tests/Tests/ClientConcepts/LowLevel/SniffOnLowLevelClient.cs
+++ b/src/Tests/Tests/ClientConcepts/LowLevel/SniffOnLowLevelClient.cs
@@ -21,7 +21,7 @@ namespace Tests.ClientConcepts.LowLevel
 			var sniffingConnectionPool = new SniffingConnectionPool(new[] { uri });
 			var elasticClient = new ElasticLowLevelClient(new ConnectionConfiguration(sniffingConnectionPool));
 
-			Func<DynamicResponse> act = () => elasticClient.ClusterHealth<DynamicResponse>();
+			Func<ElasticsearchResponse<DynamicResponse>> act = () => elasticClient.ClusterHealth<DynamicResponse>();
 			act.Invoking(s => s.Invoke()).ShouldNotThrow();
 		}
 

--- a/src/Tests/Tests/ClientConcepts/LowLevel/SniffOnLowLevelClient.cs
+++ b/src/Tests/Tests/ClientConcepts/LowLevel/SniffOnLowLevelClient.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Tests.Core.Client.Settings;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Framework;
+
+namespace Tests.ClientConcepts.LowLevel
+{
+	public class SniffOnLowLevelClient : IClusterFixture<ReadOnlyCluster>
+	{
+		private readonly ReadOnlyCluster _cluster;
+
+		public SniffOnLowLevelClient(ReadOnlyCluster cluster) => _cluster = cluster;
+
+		[I] public void CanSniffUsingJustTheLowLevelClient()
+		{
+			var uri = TestConnectionSettings.CreateUri(_cluster.Nodes.First().Port ?? 9200);
+			var sniffingConnectionPool = new SniffingConnectionPool(new[] { uri });
+			var elasticClient = new ElasticLowLevelClient(new ConnectionConfiguration(sniffingConnectionPool));
+
+			Func<DynamicResponse> act = () => elasticClient.ClusterHealth<DynamicResponse>();
+			act.Invoking(s => s.Invoke()).ShouldNotThrow();
+		}
+
+	}
+}


### PR DESCRIPTION
#3483 introduced SIMPLE_JSON_TYPEDEF pragma to be defined which caused netstandard and netfx exceptions when deserializing sniff responses, but would light up in different places as well.

This affects the low level client starting from 6.4.1 and 5.6.5 on the 5.x releases. 
The high level client or using the high level client through client.LowLevel are not affected.