### PR TITLE
Add fuzzy auto length support for NEST

### DIFF
--- a/src/Nest/CommonOptions/Fuzziness/Fuzziness.cs
+++ b/src/Nest/CommonOptions/Fuzziness/Fuzziness.cs
@@ -3,12 +3,22 @@
 	public class Fuzziness : IFuzziness
 	{
 		private bool _auto;
+		private int? _low;
+		private int? _high;
 		private int? _editDistance;
 		private double? _ratio;
 
 		public static Fuzziness Auto => new Fuzziness { _auto = true };
+		public static Fuzziness AutoLength(int low, int high) => new Fuzziness
+		{
+			_auto = true,
+			_low = low,
+			_high = high
+		};
 
 		bool IFuzziness.Auto => _auto;
+		int? IFuzziness.Low => _low;
+		int? IFuzziness.High => _high;
 		int? IFuzziness.EditDistance => _editDistance;
 		double? IFuzziness.Ratio => _ratio;
 

--- a/src/Nest/CommonOptions/Fuzziness/Fuzziness.cs
+++ b/src/Nest/CommonOptions/Fuzziness/Fuzziness.cs
@@ -8,7 +8,19 @@
 		private int? _editDistance;
 		private double? _ratio;
 
+		/// <summary>
+		/// Generates an edit distance based on the length of the term.
+		/// </summary>
+		/// <remarks>
+		/// <para>Equivalent to <see cref="AutoLength"/> with parameters 3 and 6.</para>
+		/// <para><see cref="Auto"/> should generally be the preferred value for <see cref="Fuzziness"/></para>
+		/// </remarks>
 		public static Fuzziness Auto => new Fuzziness { _auto = true };
+		/// <summary>
+		/// Generates an edit distance based on the length of the term.
+		/// </summary>
+		/// <param name="low">Must match exactly for terms with less length</param>
+		/// <param name="high">Two edits allowed for terms with greater length</param>
 		public static Fuzziness AutoLength(int low, int high) => new Fuzziness
 		{
 			_auto = true,
@@ -22,6 +34,10 @@
 		int? IFuzziness.EditDistance => _editDistance;
 		double? IFuzziness.Ratio => _ratio;
 
+		/// <summary>
+		/// The maximum allowed Levenshtein Edit Distance (or number of edits)
+		/// </summary>
+		/// <param name="distance">Levenshtein Edit Distance</param>
 		public static Fuzziness EditDistance(int distance) => new Fuzziness { _editDistance = distance };
 
 		public static Fuzziness Ratio(double ratio) => new Fuzziness { _ratio = ratio };

--- a/src/Nest/CommonOptions/Fuzziness/FuzzinessJsonConverter.cs
+++ b/src/Nest/CommonOptions/Fuzziness/FuzzinessJsonConverter.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
 namespace Nest
 {
 	internal class FuzzinessJsonConverter : JsonConverter
 	{
-		private static readonly Regex AutoLengthRegex = new Regex(@"^AUTO:(?<low>\+?\d+),(?<high>\+?\d+)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
 		public override bool CanRead => true;
 		public override bool CanWrite => true;
 
@@ -33,12 +30,13 @@ namespace Nest
 			if (reader.TokenType == JsonToken.String)
 			{
 				var rawAuto = (string)reader.Value;
-				var match = AutoLengthRegex.Match(rawAuto);
-				if (!match.Success)
+				var colonIndex = rawAuto.IndexOf(':');
+				var commaIndex = rawAuto.IndexOf(',');
+				if (colonIndex == -1 || commaIndex == -1)
 					return Fuzziness.Auto;
 
-				var low = int.Parse(match.Groups["low"].Value);
-				var high = int.Parse(match.Groups["high"].Value);
+				var low = int.Parse(rawAuto.Substring(colonIndex + 1, commaIndex - colonIndex - 1));
+				var high = int.Parse(rawAuto.Substring(commaIndex + 1));
 				return Fuzziness.AutoLength(low, high);
 			}
 

--- a/src/Nest/CommonOptions/Fuzziness/FuzzinessJsonConverter.cs
+++ b/src/Nest/CommonOptions/Fuzziness/FuzzinessJsonConverter.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
 namespace Nest
 {
 	internal class FuzzinessJsonConverter : JsonConverter
 	{
+		private static readonly Regex AutoLengthRegex = new Regex(@"^AUTO:(?<low>\+?\d+),(?<high>\+?\d+)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
 		public override bool CanRead => true;
 		public override bool CanWrite => true;
 
@@ -12,8 +15,14 @@ namespace Nest
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
-			var v = value as IFuzziness;
-			if (v.Auto) writer.WriteValue("AUTO");
+			var v = (IFuzziness)value;
+			if (v.Auto)
+			{
+				if (!v.Low.HasValue || !v.High.HasValue)
+					writer.WriteValue("AUTO");
+				else
+					writer.WriteValue($"AUTO:{v.Low},{v.High}");
+			}
 			else if (v.EditDistance.HasValue) writer.WriteValue(v.EditDistance.Value);
 			else if (v.Ratio.HasValue) writer.WriteValue(v.Ratio.Value);
 			else writer.WriteNull();
@@ -22,7 +31,16 @@ namespace Nest
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			if (reader.TokenType == JsonToken.String)
-				return Fuzziness.Auto;
+			{
+				var rawAuto = (string)reader.Value;
+				var match = AutoLengthRegex.Match(rawAuto);
+				if (!match.Success)
+					return Fuzziness.Auto;
+
+				var low = int.Parse(match.Groups["low"].Value);
+				var high = int.Parse(match.Groups["high"].Value);
+				return Fuzziness.AutoLength(low, high);
+			}
 
 			if (reader.TokenType == JsonToken.Integer)
 			{

--- a/src/Nest/CommonOptions/Fuzziness/IFuzziness.cs
+++ b/src/Nest/CommonOptions/Fuzziness/IFuzziness.cs
@@ -6,6 +6,8 @@ namespace Nest
 	public interface IFuzziness
 	{
 		bool Auto { get; }
+		int? Low { get; }
+		int? High { get; }
 		int? EditDistance { get; }
 		double? Ratio { get; }
 	}

--- a/src/Tests/Tests/QueryDsl/FullText/Match/MatchUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/FullText/Match/MatchUsageTests.cs
@@ -25,7 +25,7 @@ namespace Tests.QueryDsl.FullText.Match
 			Name = "named_query",
 			CutoffFrequency = 0.001,
 			Query = "hello world",
-			Fuzziness = Fuzziness.Auto,
+			Fuzziness = Fuzziness.AutoLength(3, 6),
 			FuzzyTranspositions = true,
 			MinimumShouldMatch = 2,
 			FuzzyRewrite = MultiTermQueryRewrite.TopTermsBlendedFreqs(10),
@@ -45,7 +45,7 @@ namespace Tests.QueryDsl.FullText.Match
 					query = "hello world",
 					analyzer = "standard",
 					fuzzy_rewrite = "top_terms_blended_freqs_10",
-					fuzziness = "AUTO",
+					fuzziness = "AUTO:3,6",
 					fuzzy_transpositions = true,
 					cutoff_frequency = 0.001,
 					lenient = true,
@@ -63,7 +63,7 @@ namespace Tests.QueryDsl.FullText.Match
 				.Boost(1.1)
 				.CutoffFrequency(0.001)
 				.Query("hello world")
-				.Fuzziness(Fuzziness.Auto)
+				.Fuzziness(Fuzziness.AutoLength(3, 6))
 				.Lenient()
 				.FuzzyTranspositions()
 				.MinimumShouldMatch(2)


### PR DESCRIPTION
As of now fuzziness AUTO parameter does not support custom length behaviour added in https://github.com/elastic/elasticsearch/issues/25528 and described on https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness

This PR contains simple implementation for that to NEST. It could be easily ported to the new JSON serialization implementation: https://github.com/elastic/elasticsearch-net/pull/3583