### PR TITLE
Add node count to ML usage response

### DIFF
--- a/src/Nest/XPack/Info/XPackUsage/XPackUsageResponse.cs
+++ b/src/Nest/XPack/Info/XPackUsage/XPackUsageResponse.cs
@@ -164,6 +164,7 @@ namespace Nest
 
 	public class MachineLearningUsage : XPackUsage
 	{
+	    /// <remarks>Valid only for Elasticsearch 6.5.0+</remarks>
 		[JsonProperty("node_count")]
 		public int NodeCount { get; internal set; }
 

--- a/src/Nest/XPack/Info/XPackUsage/XPackUsageResponse.cs
+++ b/src/Nest/XPack/Info/XPackUsage/XPackUsageResponse.cs
@@ -164,6 +164,9 @@ namespace Nest
 
 	public class MachineLearningUsage : XPackUsage
 	{
+		[JsonProperty("node_count")]
+		public int NodeCount { get; internal set; }
+
 		[JsonProperty("datafeeds")]
 		public IReadOnlyDictionary<string, DataFeed> Datafeeds { get; set; } = EmptyReadOnly<string, DataFeed>.Dictionary;
 


### PR DESCRIPTION
Relates to: https://github.com/elastic/elasticsearch/pull/33863