### PR TITLE
Fix ActionIds type

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/ActionIds/ActionIds.cs
+++ b/src/Nest/CommonAbstractions/Infer/ActionIds/ActionIds.cs
@@ -34,9 +34,10 @@ namespace Nest
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings) => string.Join(",", _actionIds);
 
 		public static implicit operator ActionIds(string actionIds) =>
-			actionIds.IsNullOrEmptyCommaSeparatedList(out var list) ? new ActionIds(null) : new ActionIds(list);
+			actionIds.IsNullOrEmptyCommaSeparatedList(out var list) ? new ActionIds((string)null) : new ActionIds(list);
 
-		public static implicit operator ActionIds(string[] actionIds) => actionIds.IsEmpty() ? new ActionIds(null) : new ActionIds(actionIds);
+		public static implicit operator ActionIds(string[] actionIds) =>
+			actionIds.IsEmpty() ? new ActionIds((string)null) : new ActionIds(actionIds);
 
 		public override bool Equals(object obj) => obj is ActionIds other && Equals(other);
 

--- a/src/Nest/CommonAbstractions/Infer/ActionIds/ActionIds.cs
+++ b/src/Nest/CommonAbstractions/Infer/ActionIds/ActionIds.cs
@@ -11,37 +11,48 @@ namespace Nest
 	{
 		private readonly List<string> _actionIds;
 
-		public ActionIds(IEnumerable<string> actionIds) => _actionIds = actionIds?.ToList() ?? new List<string>();
+		public ActionIds(IEnumerable<string> actionIds) => _actionIds = actionIds?.ToList();
 
-		public ActionIds(string actionIds) => _actionIds = actionIds.IsNullOrEmpty()
-			? new List<string>()
-			: actionIds.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
-				.Select(s => s.Trim())
-				.ToList();
-
-		internal IReadOnlyList<string> Ids => _actionIds;
+		public ActionIds(string actionIds)
+		{
+			if (!actionIds.IsNullOrEmptyCommaSeparatedList(out var arr))
+				_actionIds = arr.ToList();
+		}
 
 		private string DebugDisplay => ((IUrlParameter)this).GetString(null);
 
 		public bool Equals(ActionIds other)
 		{
-			if (Ids == null && other.Ids == null) return true;
-			if (Ids == null || other.Ids == null) return false;
+			if (other == null) return false;
+			if (_actionIds == null && other._actionIds == null) return true;
+			if (_actionIds == null || other._actionIds == null) return false;
 
-			return Ids.Count == other.Ids.Count && !Ids.Except(other.Ids).Any();
+			return _actionIds.Count == other._actionIds.Count &&
+				_actionIds.OrderBy(id => id).SequenceEqual(other._actionIds.OrderBy(id => id));
 		}
 
-		string IUrlParameter.GetString(IConnectionConfigurationValues settings) => string.Join(",", _actionIds);
+		string IUrlParameter.GetString(IConnectionConfigurationValues settings) =>
+			string.Join(",", _actionIds ?? Enumerable.Empty<string>());
 
 		public static implicit operator ActionIds(string actionIds) =>
-			actionIds.IsNullOrEmptyCommaSeparatedList(out var list) ? new ActionIds((string)null) : new ActionIds(list);
+			actionIds.IsNullOrEmptyCommaSeparatedList(out var arr) ? null : new ActionIds(arr);
 
 		public static implicit operator ActionIds(string[] actionIds) =>
-			actionIds.IsEmpty() ? new ActionIds((string)null) : new ActionIds(actionIds);
+			actionIds.IsEmpty() ? null : new ActionIds(actionIds);
 
 		public override bool Equals(object obj) => obj is ActionIds other && Equals(other);
 
-		public override int GetHashCode() => _actionIds.OrderBy(s => s).GetHashCode();
+		public override int GetHashCode()
+		{
+			if (_actionIds == null) return 0;
+			unchecked
+			{
+				var hc = 0;
+				foreach (var id in _actionIds.OrderBy(id => id))
+					hc = hc * 17 + id.GetHashCode();
+				return hc;
+			}
+		}
 
 		public static bool operator ==(ActionIds left, ActionIds right) => Equals(left, right);
 

--- a/src/Nest/CommonAbstractions/Infer/ActionIds/ActionIds.cs
+++ b/src/Nest/CommonAbstractions/Infer/ActionIds/ActionIds.cs
@@ -34,13 +34,13 @@ namespace Nest
 		string IUrlParameter.GetString(IConnectionConfigurationValues settings) => string.Join(",", _actionIds);
 
 		public static implicit operator ActionIds(string actionIds) =>
-			actionIds.IsNullOrEmptyCommaSeparatedList(out var list) ? null : new ActionIds(list);
+			actionIds.IsNullOrEmptyCommaSeparatedList(out var list) ? new ActionIds(null) : new ActionIds(list);
 
-		public static implicit operator ActionIds(string[] actionIds) => actionIds.IsEmpty() ? null : new ActionIds(actionIds);
+		public static implicit operator ActionIds(string[] actionIds) => actionIds.IsEmpty() ? new ActionIds(null) : new ActionIds(actionIds);
 
 		public override bool Equals(object obj) => obj is ActionIds other && Equals(other);
 
-		public override int GetHashCode() => _actionIds.GetHashCode();
+		public override int GetHashCode() => _actionIds.OrderBy(s => s).GetHashCode();
 
 		public static bool operator ==(ActionIds left, ActionIds right) => Equals(left, right);
 

--- a/src/Tests/Tests/CommonOptions/ActionIdsTests.cs
+++ b/src/Tests/Tests/CommonOptions/ActionIdsTests.cs
@@ -1,0 +1,27 @@
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.CommonOptions
+{
+	public class ActionIdsTests
+	{
+		[U] public void Equal()
+		{
+			var actionIds1 = new ActionIds("1,2,3");
+			var actionIds2 = new ActionIds(new [] { "3", "2", "1" });
+
+			actionIds1.Should().Be(actionIds2);
+			actionIds1.GetHashCode().Should().Be(actionIds2.GetHashCode());
+		}
+
+		[U] public void NotEqual()
+		{
+			var actionIds1 = new ActionIds("1,2,3,3");
+			var actionIds2 = new ActionIds(new [] { "3", "2", "1" });
+
+			actionIds1.Should().NotBe(actionIds2);
+			actionIds1.GetHashCode().Should().NotBe(actionIds2.GetHashCode());
+		}
+	}
+}


### PR DESCRIPTION
- Ensure GetHashcode() returns same value for out of order lists.
- Prefer empty lists over nulls for internal _actionIds collection.