### PR TITLE
6.x

### DIFF
--- a/src/Nest/CommonAbstractions/DictionaryLike/IsAReadOnlyDictionary/IsADictionaryBase.cs
+++ b/src/Nest/CommonAbstractions/DictionaryLike/IsAReadOnlyDictionary/IsADictionaryBase.cs
@@ -9,7 +9,7 @@ namespace Nest
 		{
 			if (backingDictionary == null) return;
 
-			var dictionary = new Dictionary<TKey, TValue>();
+			var dictionary = new Dictionary<TKey, TValue>(backingDictionary.Count);
 			foreach (var key in backingDictionary.Keys)
 				// ReSharper disable once VirtualMemberCallInConstructor
 				// expect all implementations of Sanitize to be pure

--- a/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
@@ -40,8 +40,11 @@ namespace Nest
 
 		internal static object CreateGenericInstance(this Type t, Type[] closeOver, params object[] args)
 		{
-			var argKey = closeOver.Aggregate(new StringBuilder(), (sb, gt) => sb.Append("--" + gt.FullName), sb => sb.ToString());
-			var key = t.FullName + argKey;
+			var key = closeOver.Aggregate(new StringBuilder(t.FullName), (sb, gt) =>
+			{
+				sb.Append("--");
+				return sb.Append(gt.FullName);
+			}, sb => sb.ToString());
 			if (!CachedGenericClosedTypes.TryGetValue(key, out var closedType))
 			{
 				closedType = t.MakeGenericType(closeOver);

--- a/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
@@ -54,15 +54,16 @@ namespace Nest
 
 		internal static object CreateInstance(this Type t, params object[] args)
 		{
+			var key = t.FullName;
 			var argKey = args.Length;
-			var key = argKey + "--" + t.FullName;
+			if (args.Length > 0)
+				key = argKey + "--" + key;
 			if (CachedActivators.TryGetValue(key, out var activator))
 				return activator(args);
 
 			var generic = GetActivatorMethodInfo.MakeGenericMethod(t);
 			var constructors = from c in t.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
 				let p = c.GetParameters()
-				let k = string.Join(",", p.Select(a => a.ParameterType.Name))
 				where p.Length == args.Length
 				select c;
 
@@ -89,7 +90,6 @@ namespace Nest
 		//do not remove this is referenced through GetActivatorMethod
 		private static ObjectActivator<T> GetActivator<T>(ConstructorInfo ctor)
 		{
-			var type = ctor.DeclaringType;
 			var paramsInfo = ctor.GetParameters();
 
 			//create a single param of type object[]

--- a/src/Nest/Search/MultiSearch/MultiSearchJsonConverter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchJsonConverter.cs
@@ -54,9 +54,11 @@ namespace Nest
 				};
 
 				var headerString = elasticsearchSerializer.SerializeToString(header, SerializationFormatting.None);
-				writer.WriteRaw($"{headerString}\n");
+				writer.WriteRaw(headerString);
+				writer.WriteRaw("\n");
 				var bodyString = elasticsearchSerializer.SerializeToString(operation, SerializationFormatting.None);
-				writer.WriteRaw($"{bodyString}\n");
+				writer.WriteRaw(bodyString);
+				writer.WriteRaw("\n");
 			}
 		}
 

--- a/src/Nest/Search/MultiSearchTemplate/MultiSearchTemplateJsonConverter.cs
+++ b/src/Nest/Search/MultiSearchTemplate/MultiSearchTemplateJsonConverter.cs
@@ -57,9 +57,11 @@ namespace Nest
 				};
 
 				var headerString = elasticsearchSerializer.SerializeToString(header, SerializationFormatting.None);
-				writer.WriteRaw($"{headerString}\n");
+				writer.WriteRaw(headerString);
+				writer.WriteRaw("\n");
 				var bodyString = elasticsearchSerializer.SerializeToString(operation, SerializationFormatting.None);
-				writer.WriteRaw($"{bodyString}\n");
+				writer.WriteRaw(bodyString);
+				writer.WriteRaw("\n");
 			}
 			;
 		}

--- a/src/Nest/XPack/MachineLearning/PostJobData/PostJobDataRequest.cs
+++ b/src/Nest/XPack/MachineLearning/PostJobData/PostJobDataRequest.cs
@@ -64,7 +64,8 @@ namespace Nest
 			foreach (var data in request.Data)
 			{
 				var bodyJson = elasticsearchSerializer.SerializeToString(data, SerializationFormatting.None);
-				writer.WriteRaw(bodyJson + "\n");
+				writer.WriteRaw(bodyJson);
+				writer.WriteRaw("\n");
 			}
 		}
 


### PR DESCRIPTION
Noticed some unneeded string concat.
Avoid concat when params count is 0, which my guess is most of the time?
Found when I saw this:
Inner exception System.OutOfMemoryException handled at Elasticsearch.Net.Transport`1+<RequestAsync>d__15`1.MoveNext:
  at System.Number.UInt32ToDecStr (System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
  at System.Number.FormatInt32 (System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
  at System.Int32.ToString (System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
  at System.String.Concat (System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
  at Nest.TypeExtensions.CreateInstance (Nest, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d)