### PR TITLE
Replace ReferenceLoopHandling with direct method call

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/Field/FieldJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/FieldJsonConverter.cs
@@ -14,6 +14,11 @@ namespace Nest
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
 			var field = (Field)value;
+			WriteField(writer, field, serializer);
+		}
+
+		internal static void WriteField(JsonWriter writer, Field field, JsonSerializer serializer)
+		{
 			if (field == null)
 			{
 				writer.WriteNull();

--- a/src/Nest/CommonAbstractions/Infer/Fields/FieldsJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/FieldsJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Nest
 			writer.WriteStartArray();
 			if (fields != null)
 			{
-				foreach (var field in fields?.ListOfFields)
+				foreach (var field in fields.ListOfFields)
 					FieldJsonConverter.WriteField(writer, field, serializer);
 			}
 			writer.WriteEndArray();

--- a/src/Nest/CommonAbstractions/Infer/Fields/FieldsJsonConverter.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/FieldsJsonConverter.cs
@@ -18,15 +18,8 @@ namespace Nest
 			writer.WriteStartArray();
 			if (fields != null)
 			{
-				// overridden Equals() method means a Fields with only one Field
-				// results in Equality, which triggers Json.NET's Reference loop detection
-				var referenceLoopHandling = serializer.ReferenceLoopHandling;
-				serializer.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
-
-				foreach (var field in fields.ListOfFields)
-					serializer.Serialize(writer, field);
-
-				serializer.ReferenceLoopHandling = referenceLoopHandling;
+				foreach (var field in fields?.ListOfFields)
+					FieldJsonConverter.WriteField(writer, field, serializer);
 			}
 			writer.WriteEndArray();
 		}


### PR DESCRIPTION
This commit replaces the ReferenceLoopHandling property manipulation
in FieldsJsonConverter that is used to circumvent Json.NET's reference
loop detection when Fields contains only a single Field, with a direct
call to the serialization method on FieldJsonConverter for each Field.

Fixes #3617