### PR TITLE
Add Machine Learning filter APIs and detector custom rules

### DIFF
--- a/src/CodeGeneration/ApiGenerator/ApiGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/ApiGenerator.cs
@@ -21,10 +21,6 @@ namespace ApiGenerator
 		private static string[] IgnoredApis { get; } =
 		{
 			// these API's are not ready for primetime yet
-			"xpack.ml.delete_filter.json",
-			"xpack.ml.get_filters.json",
-			"xpack.ml.put_filter.json",
-			"xpack.ml.update_filter.json",
 			"rank_eval.json",
 
 			// these API's are new and need to be mapped

--- a/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParameters.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParameters.cs
@@ -104,6 +104,7 @@ namespace ApiGenerator.Domain
 				{
 					case "boolean": return "bool?";
 					case "list": return "string[]";
+					case "int":
 					case "integer": return "int?";
 					case "date": return "DateTimeOffset?";
 					case "enum": return $"{ClsName}?";

--- a/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParameters.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParameters.cs
@@ -104,8 +104,7 @@ namespace ApiGenerator.Domain
 				{
 					case "boolean": return "bool?";
 					case "list": return "string[]";
-					case "int":
-					case "integer": return "int?";
+					case "int": return "int?";
 					case "date": return "DateTimeOffset?";
 					case "enum": return $"{ClsName}?";
 					case "number":

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -2395,6 +2395,11 @@ namespace Elasticsearch.Net
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
+	///<summary>Request options for XpackMlDeleteFilter<pre></pre></summary>
+	public partial class DeleteFilterRequestParameters : RequestParameters<DeleteFilterRequestParameters> 
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
+	}
 	///<summary>Request options for XpackMlDeleteForecast<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</pre></summary>
 	public partial class DeleteForecastRequestParameters : RequestParameters<DeleteForecastRequestParameters> 
 	{
@@ -2469,6 +2474,15 @@ namespace Elasticsearch.Net
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 		///<summary>Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)</summary>
 		public bool? AllowNoDatafeeds { get => Q<bool?>("allow_no_datafeeds"); set => Q("allow_no_datafeeds", value); }
+	}
+	///<summary>Request options for XpackMlGetFilters<pre></pre></summary>
+	public partial class GetFiltersRequestParameters : RequestParameters<GetFiltersRequestParameters> 
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
+		///<summary>skips a number of filters</summary>
+		public int? From { get => Q<int?>("from"); set => Q("from", value); }
+		///<summary>specifies a max number of filters to get</summary>
+		public int? Size { get => Q<int?>("size"); set => Q("size", value); }
 	}
 	///<summary>Request options for XpackMlGetInfluencers<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</pre></summary>
 	public partial class GetInfluencersRequestParameters : RequestParameters<GetInfluencersRequestParameters> 
@@ -2548,6 +2562,11 @@ namespace Elasticsearch.Net
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
+	///<summary>Request options for XpackMlPutFilter<pre></pre></summary>
+	public partial class PutFilterRequestParameters : RequestParameters<PutFilterRequestParameters> 
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
+	}
 	///<summary>Request options for XpackMlPutJob<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</pre></summary>
 	public partial class PutJobRequestParameters : RequestParameters<PutJobRequestParameters> 
 	{
@@ -2572,6 +2591,11 @@ namespace Elasticsearch.Net
 	}
 	///<summary>Request options for XpackMlUpdateDatafeed<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</pre></summary>
 	public partial class UpdateDatafeedRequestParameters : RequestParameters<UpdateDatafeedRequestParameters> 
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
+	}
+	///<summary>Request options for XpackMlUpdateFilter<pre></pre></summary>
+	public partial class UpdateFilterRequestParameters : RequestParameters<UpdateFilterRequestParameters> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
@@ -3236,6 +3236,16 @@ namespace Elasticsearch.Net
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public Task<TResponse> XpackMlDeleteExpiredDataAsync<TResponse>(DeleteExpiredDataRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
 			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(DELETE, Url($"_xpack/ml/_delete_expired_data"), ctx, null, _params(requestParameters));
+		///<summary>DELETE on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to delete</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public TResponse XpackMlDeleteFilter<TResponse>(string filter_id, DeleteFilterRequestParameters requestParameters = null)
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequest<TResponse>(DELETE, Url($"_xpack/ml/filters/{filter_id.NotNull("filter_id")}"), null, _params(requestParameters));
+		///<summary>DELETE on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to delete</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<TResponse> XpackMlDeleteFilterAsync<TResponse>(string filter_id, DeleteFilterRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(DELETE, Url($"_xpack/ml/filters/{filter_id.NotNull("filter_id")}"), ctx, null, _params(requestParameters));
 		///<summary>DELETE on /_xpack/ml/anomaly_detectors/{job_id}/_forecast/{forecast_id} <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</para></summary>
 		///<param name="job_id">The ID of the job from which to delete forecasts</param>
 		///<param name="forecast_id">The ID of the forecast to delete, can be comma delimited list or `_all`</param>
@@ -3448,6 +3458,24 @@ namespace Elasticsearch.Net
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public Task<TResponse> XpackMlGetDatafeedStatsAsync<TResponse>(GetDatafeedStatsRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
 			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(GET, Url($"_xpack/ml/datafeeds/_stats"), ctx, null, _params(requestParameters));
+		///<summary>GET on /_xpack/ml/filters <para></para></summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public TResponse XpackMlGetFilters<TResponse>(GetFiltersRequestParameters requestParameters = null)
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequest<TResponse>(GET, Url($"_xpack/ml/filters"), null, _params(requestParameters));
+		///<summary>GET on /_xpack/ml/filters <para></para></summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<TResponse> XpackMlGetFiltersAsync<TResponse>(GetFiltersRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(GET, Url($"_xpack/ml/filters"), ctx, null, _params(requestParameters));
+		///<summary>GET on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to fetch</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public TResponse XpackMlGetFilters<TResponse>(string filter_id, GetFiltersRequestParameters requestParameters = null)
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequest<TResponse>(GET, Url($"_xpack/ml/filters/{filter_id.NotNull("filter_id")}"), null, _params(requestParameters));
+		///<summary>GET on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to fetch</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<TResponse> XpackMlGetFiltersAsync<TResponse>(string filter_id, GetFiltersRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(GET, Url($"_xpack/ml/filters/{filter_id.NotNull("filter_id")}"), ctx, null, _params(requestParameters));
 		///<summary>GET on /_xpack/ml/anomaly_detectors/{job_id}/results/influencers <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</para></summary>
 		///<param name="job_id"></param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -3686,6 +3714,18 @@ namespace Elasticsearch.Net
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public Task<TResponse> XpackMlPutDatafeedAsync<TResponse>(string datafeed_id, PostData body, PutDatafeedRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
 			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(PUT, Url($"_xpack/ml/datafeeds/{datafeed_id.NotNull("datafeed_id")}"), ctx, body, _params(requestParameters));
+		///<summary>PUT on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to create</param>
+		///<param name="body">The filter details</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public TResponse XpackMlPutFilter<TResponse>(string filter_id, PostData body, PutFilterRequestParameters requestParameters = null)
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequest<TResponse>(PUT, Url($"_xpack/ml/filters/{filter_id.NotNull("filter_id")}"), body, _params(requestParameters));
+		///<summary>PUT on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to create</param>
+		///<param name="body">The filter details</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<TResponse> XpackMlPutFilterAsync<TResponse>(string filter_id, PostData body, PutFilterRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(PUT, Url($"_xpack/ml/filters/{filter_id.NotNull("filter_id")}"), ctx, body, _params(requestParameters));
 		///<summary>PUT on /_xpack/ml/anomaly_detectors/{job_id} <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</para></summary>
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job</param>
@@ -3746,6 +3786,18 @@ namespace Elasticsearch.Net
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		public Task<TResponse> XpackMlUpdateDatafeedAsync<TResponse>(string datafeed_id, PostData body, UpdateDatafeedRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
 			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(POST, Url($"_xpack/ml/datafeeds/{datafeed_id.NotNull("datafeed_id")}/_update"), ctx, body, _params(requestParameters));
+		///<summary>POST on /_xpack/ml/filters/{filter_id}/_update <para></para></summary>
+		///<param name="filter_id">The ID of the filter to update</param>
+		///<param name="body">The filter update</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public TResponse XpackMlUpdateFilter<TResponse>(string filter_id, PostData body, UpdateFilterRequestParameters requestParameters = null)
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequest<TResponse>(POST, Url($"_xpack/ml/filters/{filter_id.NotNull("filter_id")}/_update"), body, _params(requestParameters));
+		///<summary>POST on /_xpack/ml/filters/{filter_id}/_update <para></para></summary>
+		///<param name="filter_id">The ID of the filter to update</param>
+		///<param name="body">The filter update</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		public Task<TResponse> XpackMlUpdateFilterAsync<TResponse>(string filter_id, PostData body, UpdateFilterRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(POST, Url($"_xpack/ml/filters/{filter_id.NotNull("filter_id")}/_update"), ctx, body, _params(requestParameters));
 		///<summary>POST on /_xpack/ml/anomaly_detectors/{job_id}/_update <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</para></summary>
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job update settings</param>

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
@@ -2620,6 +2620,14 @@ namespace Elasticsearch.Net
 		///<summary>DELETE on /_xpack/ml/_delete_expired_data <para></para></summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<TResponse> XpackMlDeleteExpiredDataAsync<TResponse>(DeleteExpiredDataRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>DELETE on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to delete</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		TResponse XpackMlDeleteFilter<TResponse>(string filter_id, DeleteFilterRequestParameters requestParameters = null) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>DELETE on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to delete</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<TResponse> XpackMlDeleteFilterAsync<TResponse>(string filter_id, DeleteFilterRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
 		///<summary>DELETE on /_xpack/ml/anomaly_detectors/{job_id}/_forecast/{forecast_id} <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</para></summary>
 		///<param name="job_id">The ID of the job from which to delete forecasts</param>
 		///<param name="forecast_id">The ID of the forecast to delete, can be comma delimited list or `_all`</param>
@@ -2792,6 +2800,20 @@ namespace Elasticsearch.Net
 		///<summary>GET on /_xpack/ml/datafeeds/_stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</para></summary>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<TResponse> XpackMlGetDatafeedStatsAsync<TResponse>(GetDatafeedStatsRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>GET on /_xpack/ml/filters <para></para></summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		TResponse XpackMlGetFilters<TResponse>(GetFiltersRequestParameters requestParameters = null) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>GET on /_xpack/ml/filters <para></para></summary>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<TResponse> XpackMlGetFiltersAsync<TResponse>(GetFiltersRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>GET on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to fetch</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		TResponse XpackMlGetFilters<TResponse>(string filter_id, GetFiltersRequestParameters requestParameters = null) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>GET on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to fetch</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<TResponse> XpackMlGetFiltersAsync<TResponse>(string filter_id, GetFiltersRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
 		///<summary>GET on /_xpack/ml/anomaly_detectors/{job_id}/results/influencers <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</para></summary>
 		///<param name="job_id"></param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
@@ -2986,6 +3008,16 @@ namespace Elasticsearch.Net
 		///<param name="body">The datafeed config</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<TResponse> XpackMlPutDatafeedAsync<TResponse>(string datafeed_id, PostData body, PutDatafeedRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>PUT on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to create</param>
+		///<param name="body">The filter details</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		TResponse XpackMlPutFilter<TResponse>(string filter_id, PostData body, PutFilterRequestParameters requestParameters = null) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>PUT on /_xpack/ml/filters/{filter_id} <para></para></summary>
+		///<param name="filter_id">The ID of the filter to create</param>
+		///<param name="body">The filter details</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<TResponse> XpackMlPutFilterAsync<TResponse>(string filter_id, PostData body, PutFilterRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
 		///<summary>PUT on /_xpack/ml/anomaly_detectors/{job_id} <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</para></summary>
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job</param>
@@ -3036,6 +3068,16 @@ namespace Elasticsearch.Net
 		///<param name="body">The datafeed update settings</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
 		Task<TResponse> XpackMlUpdateDatafeedAsync<TResponse>(string datafeed_id, PostData body, UpdateDatafeedRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>POST on /_xpack/ml/filters/{filter_id}/_update <para></para></summary>
+		///<param name="filter_id">The ID of the filter to update</param>
+		///<param name="body">The filter update</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		TResponse XpackMlUpdateFilter<TResponse>(string filter_id, PostData body, UpdateFilterRequestParameters requestParameters = null) where TResponse : class, IElasticsearchResponse, new();
+		///<summary>POST on /_xpack/ml/filters/{filter_id}/_update <para></para></summary>
+		///<param name="filter_id">The ID of the filter to update</param>
+		///<param name="body">The filter update</param>
+		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
+		Task<TResponse> XpackMlUpdateFilterAsync<TResponse>(string filter_id, PostData body, UpdateFilterRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
 		///<summary>POST on /_xpack/ml/anomaly_detectors/{job_id}/_update <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</para></summary>
 		///<param name="job_id">The ID of the job to create</param>
 		///<param name="body">The job update settings</param>

--- a/src/Nest/XPack/MachineLearning/DeleteFilter/DeleteFilterRequest.cs
+++ b/src/Nest/XPack/MachineLearning/DeleteFilter/DeleteFilterRequest.cs
@@ -1,9 +1,14 @@
 namespace Nest
 {
+	/// <summary>
+	/// Deletes a machine learning filter
+	/// </summary>
 	public partial interface IDeleteFilterRequest { }
 
+	/// <inheritdoc cref="IDeleteFilterRequest"/>
 	public partial class DeleteFilterRequest { }
 
+	/// <inheritdoc cref="IDeleteFilterRequest"/>
 	[DescriptorFor("XpackMlDeleteFilter")]
 	public partial class DeleteFilterDescriptor { }
 }

--- a/src/Nest/XPack/MachineLearning/DeleteFilter/DeleteFilterRequest.cs
+++ b/src/Nest/XPack/MachineLearning/DeleteFilter/DeleteFilterRequest.cs
@@ -1,0 +1,9 @@
+namespace Nest
+{
+	public partial interface IDeleteFilterRequest { }
+
+	public partial class DeleteFilterRequest { }
+
+	[DescriptorFor("XpackMlDeleteFilter")]
+	public partial class DeleteFilterDescriptor { }
+}

--- a/src/Nest/XPack/MachineLearning/DeleteFilter/DeleteFilterResponse.cs
+++ b/src/Nest/XPack/MachineLearning/DeleteFilter/DeleteFilterResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace Nest
+{
+	public interface IDeleteFilterResponse : IAcknowledgedResponse { }
+
+	public class DeleteFilterResponse : AcknowledgedResponseBase, IDeleteFilterResponse { }
+}

--- a/src/Nest/XPack/MachineLearning/DeleteFilter/ElasticClient-DeleteFilter.cs
+++ b/src/Nest/XPack/MachineLearning/DeleteFilter/ElasticClient-DeleteFilter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <summary>
+		/// Deletes a machine learning filter.
+		/// If a machine learning job references the filter, you cannot delete the filter.
+		/// You must update or delete the job before you can delete the filter.
+		/// </summary>
+		IDeleteFilterResponse DeleteFilter(Id filterId, Func<DeleteFilterDescriptor, IDeleteFilterRequest> selector = null);
+
+		/// <inheritdoc cref="DeleteFilter(Nest.Id,System.Func{Nest.DeleteFilterDescriptor,Nest.IDeleteFilterRequest})" />
+		IDeleteFilterResponse DeleteFilter(IDeleteFilterRequest request);
+
+		/// <inheritdoc cref="DeleteFilter(Nest.Id,System.Func{Nest.DeleteFilterDescriptor,Nest.IDeleteFilterRequest})" />
+		Task<IDeleteFilterResponse> DeleteFilterAsync(Id filterId, Func<DeleteFilterDescriptor, IDeleteFilterRequest> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		);
+
+		/// <inheritdoc cref="DeleteFilter(Nest.Id,System.Func{Nest.DeleteFilterDescriptor,Nest.IDeleteFilterRequest})" />
+		Task<IDeleteFilterResponse> DeleteFilterAsync(IDeleteFilterRequest request, CancellationToken cancellationToken = default(CancellationToken));
+	}
+
+	public partial class ElasticClient
+	{
+		/// <inheritdoc />
+		public IDeleteFilterResponse DeleteFilter(Id filterId, Func<DeleteFilterDescriptor, IDeleteFilterRequest> selector = null) =>
+			DeleteFilter(selector.InvokeOrDefault(new DeleteFilterDescriptor(filterId)));
+
+		/// <inheritdoc />
+		public IDeleteFilterResponse DeleteFilter(IDeleteFilterRequest request) =>
+			Dispatcher.Dispatch<IDeleteFilterRequest, DeleteFilterRequestParameters, DeleteFilterResponse>(
+				request,
+				(p, d) => LowLevelDispatch.XpackMlDeleteFilterDispatch<DeleteFilterResponse>(p)
+			);
+
+		/// <inheritdoc />
+		public Task<IDeleteFilterResponse> DeleteFilterAsync(Id filterId, Func<DeleteFilterDescriptor, IDeleteFilterRequest> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		) =>
+			DeleteFilterAsync(selector.InvokeOrDefault(new DeleteFilterDescriptor(filterId)), cancellationToken);
+
+		/// <inheritdoc />
+		public Task<IDeleteFilterResponse> DeleteFilterAsync(IDeleteFilterRequest request, CancellationToken cancellationToken = default(CancellationToken)) =>
+			Dispatcher.DispatchAsync<IDeleteFilterRequest, DeleteFilterRequestParameters, DeleteFilterResponse, IDeleteFilterResponse>(
+				request,
+				cancellationToken,
+				(p, d, c) => LowLevelDispatch.XpackMlDeleteFilterDispatchAsync<DeleteFilterResponse>(p, c)
+			);
+	}
+}

--- a/src/Nest/XPack/MachineLearning/GetFilters/ElasticClient-GetFilters.cs
+++ b/src/Nest/XPack/MachineLearning/GetFilters/ElasticClient-GetFilters.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <summary>
+		/// Retrieves machine learning filters
+		/// </summary>
+		IGetFiltersResponse GetFilters(Func<GetFiltersDescriptor, IGetFiltersRequest> selector = null);
+
+
+		/// <inheritdoc cref="GetFilters(System.Func{Nest.GetFiltersDescriptor,Nest.IGetFiltersRequest})" />
+		IGetFiltersResponse GetFilters(IGetFiltersRequest request);
+
+		/// <inheritdoc cref="GetFilters(System.Func{Nest.GetFiltersDescriptor,Nest.IGetFiltersRequest})" />
+		Task<IGetFiltersResponse> GetFiltersAsync(Func<GetFiltersDescriptor, IGetFiltersRequest> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		);
+
+		/// <inheritdoc cref="GetFilters(System.Func{Nest.GetFiltersDescriptor,Nest.IGetFiltersRequest})" />
+		Task<IGetFiltersResponse> GetFiltersAsync(IGetFiltersRequest request, CancellationToken cancellationToken = default(CancellationToken));
+	}
+
+	public partial class ElasticClient
+	{
+		/// <inheritdoc />
+		public IGetFiltersResponse GetFilters(Func<GetFiltersDescriptor, IGetFiltersRequest> selector = null) =>
+			GetFilters(selector.InvokeOrDefault(new GetFiltersDescriptor()));
+
+		/// <inheritdoc />
+		public IGetFiltersResponse GetFilters(IGetFiltersRequest request) =>
+			Dispatcher.Dispatch<IGetFiltersRequest, GetFiltersRequestParameters, GetFiltersResponse>(
+				request,
+				(p, d) => LowLevelDispatch.XpackMlGetFiltersDispatch<GetFiltersResponse>(p)
+			);
+
+		/// <inheritdoc />
+		public Task<IGetFiltersResponse> GetFiltersAsync(Func<GetFiltersDescriptor, IGetFiltersRequest> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		) =>
+			GetFiltersAsync(selector.InvokeOrDefault(new GetFiltersDescriptor()), cancellationToken);
+
+		/// <inheritdoc />
+		public Task<IGetFiltersResponse> GetFiltersAsync(IGetFiltersRequest request, CancellationToken cancellationToken = default(CancellationToken)) =>
+			Dispatcher.DispatchAsync<IGetFiltersRequest, GetFiltersRequestParameters, GetFiltersResponse, IGetFiltersResponse>(
+				request,
+				cancellationToken,
+				(p, d, c) => LowLevelDispatch.XpackMlGetFiltersDispatchAsync<GetFiltersResponse>(p, c)
+			);
+	}
+}

--- a/src/Nest/XPack/MachineLearning/GetFilters/GetFiltersRequest.cs
+++ b/src/Nest/XPack/MachineLearning/GetFilters/GetFiltersRequest.cs
@@ -1,0 +1,21 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// Retrieves configuration information for calendars.
+	/// </summary>
+	public partial interface IGetFiltersRequest
+	{
+	}
+
+	public partial class GetFiltersRequest
+	{
+	}
+
+	[DescriptorFor("XpackMlGetFilters")]
+	public partial class GetFiltersDescriptor
+	{
+	}
+}

--- a/src/Nest/XPack/MachineLearning/GetFilters/GetFiltersResponse.cs
+++ b/src/Nest/XPack/MachineLearning/GetFilters/GetFiltersResponse.cs
@@ -21,14 +21,26 @@ namespace Nest
 		IReadOnlyCollection<Filter> Filters { get; }
 	}
 
+	/// <summary>
+	/// A machine learning filter
+	/// </summary>
 	public class Filter
 	{
+		/// <summary>
+		/// The filter ID
+		/// </summary>
 		[JsonProperty("filter_id")]
 		public string FilterId { get; set; }
 
+		/// <summary>
+		/// The items of the filter
+		/// </summary>
 		[JsonProperty("items")]
 		public IReadOnlyCollection<string> Items { get; set; } = EmptyReadOnly<string>.Collection;
 
+		/// <summary>
+		/// A description of the filter
+		/// </summary>
 		[JsonProperty("description")]
 		public string Description { get; set; }
 	}

--- a/src/Nest/XPack/MachineLearning/GetFilters/GetFiltersResponse.cs
+++ b/src/Nest/XPack/MachineLearning/GetFilters/GetFiltersResponse.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// Retrieves configuration information for machine learning filters.
+	/// </summary>
+	public interface IGetFiltersResponse : IResponse
+	{
+		/// <summary>
+		/// The count of filters.
+		/// </summary>
+		[JsonProperty("count")]
+		long Count { get; }
+
+		/// <summary>
+		/// An array of filters resources
+		/// </summary>
+		[JsonProperty("filters")]
+		IReadOnlyCollection<Filter> Filters { get; }
+	}
+
+	public class Filter
+	{
+		[JsonProperty("filter_id")]
+		public string FilterId { get; set; }
+
+		[JsonProperty("items")]
+		public IReadOnlyCollection<string> Items { get; set; } = EmptyReadOnly<string>.Collection;
+
+		[JsonProperty("description")]
+		public string Description { get; set; }
+	}
+
+	public class GetFiltersResponse : ResponseBase, IGetFiltersResponse
+	{
+		/// <inheritdoc cref="IGetFiltersResponse.Count" />
+		public long Count { get; internal set; }
+
+		/// <inheritdoc cref="IGetFiltersResponse.Filters" />
+		public IReadOnlyCollection<Filter> Filters { get; internal set; } = EmptyReadOnly<Filter>.Collection;
+	}
+}

--- a/src/Nest/XPack/MachineLearning/Job/Detectors/DetectionRule.cs
+++ b/src/Nest/XPack/MachineLearning/Job/Detectors/DetectionRule.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Nest
+{
+	/// <summary>
+	/// A machine learning detection rule
+	/// </summary>
+	[JsonConverter(typeof(ReadAsTypeJsonConverter<DetectionRule>))]
+	public interface IDetectionRule
+	{
+		/// <summary>
+		/// The actions to take when rule is satisfied
+		/// </summary>
+		[JsonProperty("actions")]
+		IEnumerable<RuleAction> Actions { get; set; }
+
+		/// <summary>
+		/// The conditions of the rule
+		/// </summary>
+		[JsonProperty("conditions")]
+		IEnumerable<IRuleCondition> Conditions { get; set; }
+
+		/// <summary>
+		/// The scopes of the rule
+		/// </summary>
+		[JsonProperty("scope")]
+		IReadOnlyDictionary<Field, FilterRef> Scope { get; set; }
+	}
+
+	/// <inheritdoc />
+	public class DetectionRule : IDetectionRule
+	{
+		/// <inheritdoc />
+		public IEnumerable<RuleAction> Actions { get; set; }
+
+		/// <inheritdoc />
+		public IEnumerable<IRuleCondition> Conditions { get; set; }
+
+		/// <inheritdoc />
+		public IReadOnlyDictionary<Field, FilterRef> Scope { get; set; }
+	}
+
+	public class DetectionRulesDescriptor
+		: DescriptorPromiseBase<DetectionRulesDescriptor, List<IDetectionRule>>
+	{
+		public DetectionRulesDescriptor() : base(new List<IDetectionRule>()) { }
+
+		private DetectionRulesDescriptor Add(IDetectionRule m)
+		{
+			PromisedValue.Add(m);
+			return this;
+		}
+
+		public DetectionRulesDescriptor Rule(Func<DetectionRuleDescriptor, IDetectionRule> selector) =>
+			Add(selector.Invoke(new DetectionRuleDescriptor()));
+	}
+
+	public class DetectionRuleDescriptor : DescriptorBase<DetectionRuleDescriptor, IDetectionRule>, IDetectionRule
+	{
+		IEnumerable<RuleAction> IDetectionRule.Actions { get; set; }
+		IEnumerable<IRuleCondition> IDetectionRule.Conditions { get; set; }
+		IReadOnlyDictionary<Field, FilterRef> IDetectionRule.Scope { get; set; }
+
+		public DetectionRuleDescriptor Actions(IEnumerable<RuleAction> actions) => Assign(a => a.Actions = actions);
+
+		public DetectionRuleDescriptor Actions(params RuleAction[] actions) => Assign(a => a.Actions = actions);
+
+		public DetectionRuleDescriptor Scope<T>(Func<ScopeDescriptor<T>, IPromise<IReadOnlyDictionary<Field, FilterRef>>> selector) where T : class =>
+			Assign(a => a.Scope = selector.Invoke(new ScopeDescriptor<T>()).Value);
+
+		public DetectionRuleDescriptor Conditions(Func<RuleConditionsDescriptor, IPromise<List<IRuleCondition>>> selector) =>
+			Assign(a => a.Conditions = selector?.Invoke(new RuleConditionsDescriptor())?.Value);
+	}
+
+	public class RuleConditionsDescriptor : DescriptorPromiseBase<RuleConditionsDescriptor, List<IRuleCondition>>
+	{
+		public RuleConditionsDescriptor() : base(new List<IRuleCondition>()) { }
+
+		public RuleConditionsDescriptor Condition(Func<RuleConditionDescriptor, IRuleCondition> selector)
+		{
+			PromisedValue.AddIfNotNull(selector?.Invoke(new RuleConditionDescriptor()));
+			return this;
+		}
+	}
+
+	public class RuleConditionDescriptor : DescriptorBase<RuleConditionDescriptor, IRuleCondition>, IRuleCondition
+	{
+		AppliesTo IRuleCondition.AppliesTo { get; set; }
+		ConditionOperator IRuleCondition.Operator { get; set; }
+		double IRuleCondition.Value { get; set; }
+
+		public RuleConditionDescriptor AppliesTo(AppliesTo appliesTo) => Assign(a => a.AppliesTo = appliesTo);
+
+		public RuleConditionDescriptor Operator(ConditionOperator @operator) => Assign(a => a.Operator = @operator);
+
+		public RuleConditionDescriptor Value(double value) => Assign(a => a.Value = value);
+	}
+
+	public class ScopeDescriptor<T> : DescriptorPromiseBase<ScopeDescriptor<T>, IReadOnlyDictionary<Field, FilterRef>> where T : class
+	{
+		public ScopeDescriptor() : base(new Dictionary<Field, FilterRef>()) { }
+
+		private Dictionary<Field, FilterRef> Dictionary => (Dictionary<Field, FilterRef>)PromisedValue;
+
+		public ScopeDescriptor<T> Scope(Field field, FilterRef filterRef)
+		{
+			Dictionary[field] = filterRef;
+			return this;
+		}
+
+		public ScopeDescriptor<T> Scope(Expression<Func<T, object>> field, FilterRef filterRef)
+		{
+			Dictionary[field] = filterRef;
+			return this;
+		}
+	}
+
+	public class FilterRef
+	{
+		[JsonProperty("filter_id")]
+		public Id FilterId { get; set; }
+
+		[JsonProperty("filter_type")]
+		public RuleFilterType? FilterType { get; set; }
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum RuleFilterType
+	{
+		[EnumMember(Value = "include")]
+		Include,
+
+		[EnumMember(Value = "exclude")]
+		Exclude
+	}
+
+	[JsonConverter(typeof(ReadAsTypeJsonConverter<RuleCondition>))]
+	public interface IRuleCondition
+	{
+		[JsonProperty("applies_to")]
+		AppliesTo AppliesTo { get; set; }
+
+		[JsonProperty("operator")]
+		ConditionOperator Operator { get; set; }
+
+		[JsonProperty("value")]
+		double Value { get; set; }
+	}
+
+	public class RuleCondition : IRuleCondition
+	{
+		public AppliesTo AppliesTo { get; set; }
+
+		public ConditionOperator Operator { get; set; }
+
+		public double Value { get; set; }
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum ConditionOperator
+	{
+		[EnumMember(Value = "gt")]
+		GreaterThan,
+
+		[EnumMember(Value = "gte")]
+		GreaterThanOrEqual,
+
+		[EnumMember(Value = "lt")]
+		LessThan,
+
+		[EnumMember(Value = "lte")]
+		LessThanOrEqual,
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum RuleAction
+	{
+		[EnumMember(Value = "skip_result")]
+		SkipResult,
+
+		[EnumMember(Value = "skip_model_update")]
+		SkipModelUpdate
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum AppliesTo
+	{
+		[EnumMember(Value = "actual")]
+		Actual,
+
+		[EnumMember(Value = "typical")]
+		Typical,
+
+		[EnumMember(Value = "diff_from_typical")]
+		DiffFromTypical,
+
+		[EnumMember(Value = "time")]
+		Time
+	}
+}

--- a/src/Nest/XPack/MachineLearning/Job/Detectors/Detector.cs
+++ b/src/Nest/XPack/MachineLearning/Job/Detectors/Detector.cs
@@ -1,27 +1,64 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace Nest
 {
+	/// <summary>
+	/// A machine learning detector
+	/// </summary>
 	[ContractJsonConverter(typeof(DetectorConverter))]
 	public interface IDetector
 	{
+		/// <summary>
+		/// A description of the detector. For example, "Low event rate".
+		/// </summary>
 		[JsonProperty("detector_description")]
 		string DetectorDescription { get; set; }
 
+		/// <summary>
+		/// A unique identifier for the detector. This identifier is based on the order of the
+		/// detectors in the analysis config, starting at zero. You can use this
+		/// identifier when you want to update a specific detector.
+		/// </summary>
 		[JsonProperty("detector_index")]
 		int? DetectorIndex { get; set; }
 
+		/// <summary>
+		/// If set, frequent entities are excluded from influencing the anomaly results.
+		/// Entities can be considered frequent over time or frequent in a population.
+		/// If you are working with both over and by fields, then you can set exclude_frequent
+		/// to all for both fields, or to by or over for those specific fields.
+		/// </summary>
 		[JsonProperty("exclude_frequent")]
 		ExcludeFrequent? ExcludeFrequent { get; set; }
 
+		/// <summary>
+		/// The analysis function used
+		/// </summary>
 		[JsonProperty("function")]
 		string Function { get; }
 
+		/// <summary>
+		/// Defines whether a new series is used as the null series when there
+		/// is no value for the by or partition fields. The default value is <c>false</c>.
+		/// </summary>
 		[JsonProperty("use_null")]
 		bool? UseNull { get; set; }
+
+		/// <summary>
+		/// Custom rules enable you to change the behaviour of anomaly detectors based on domain-specific knowledge.
+		/// Custom rules describe when a detector should take a certain action instead of following its default behaviour.
+		/// To specify the "when", a rule uses a scope and conditions. You can think of scope as the categorical
+		/// specification of a rule, while conditions are the numerical part. A rule can have a scope,
+		/// one or more conditions, or a combination of scope and conditions.
+		/// </summary>
+		[JsonProperty("custom_rules")]
+		IEnumerable<IDetectionRule> CustomRules { get; set; }
 	}
 
 	internal class DetectorConverter : JsonConverter
@@ -119,41 +156,78 @@ namespace Nest
 		public override bool CanConvert(Type objectType) => true;
 	}
 
+	/// <summary>
+	/// A machine learning detector with a field name
+	/// </summary>
 	public interface IFieldNameDetector : IDetector
 	{
+		/// <summary>
+		/// The field that the detector uses in the function. If you use an event
+		/// rate function such as count or rare, do not specify this field.
+		/// </summary>
 		[JsonProperty("field_name")]
 		Field FieldName { get; set; }
 	}
 
+	/// <summary>
+	/// A machine learning detector with a by field
+	/// </summary>
 	public interface IByFieldNameDetector : IDetector
 	{
+		/// <summary>
+		/// The field used to split the data. In particular, this property is used for analyzing the splits with
+		/// respect to their own history. It is used for finding unusual values in the context of the split.
+		/// </summary>
 		[JsonProperty("by_field_name")]
 		Field ByFieldName { get; set; }
 	}
 
+	/// <summary>
+	/// A machine learning detector with an over field
+	/// </summary>
 	public interface IOverFieldNameDetector : IDetector
 	{
+		/// <summary>
+		/// The field used to split the data. In particular, this property is used for analyzing the splits
+		/// with respect to the history of all splits. It is used for finding unusual values in the population of all splits.
+		/// </summary>
 		[JsonProperty("over_field_name")]
 		Field OverFieldName { get; set; }
 	}
 
+	/// <summary>
+	/// A machine learning detector with a partition field
+	/// </summary>
 	public interface IPartitionFieldNameDetector : IDetector
 	{
+		/// <summary>
+		/// The field used to segment the analysis. When you use this property, you have completely
+		/// independent baselines for each value of this field.
+		/// </summary>
 		[JsonProperty("partition_field_name")]
 		Field PartitionFieldName { get; set; }
 	}
 
+	/// <inheritdoc />
 	public abstract class DetectorBase : IDetector
 	{
 		protected DetectorBase(string function) => Function = function;
 
+		/// <inheritdoc />
 		public string DetectorDescription { get; set; }
+		/// <inheritdoc />
 		public int? DetectorIndex { get; set; }
+		/// <inheritdoc />
 		public ExcludeFrequent? ExcludeFrequent { get; set; }
+		/// <inheritdoc />
 		public string Function { get; }
+		/// <inheritdoc />
 		public bool? UseNull { get; set; }
+		/// <inheritdoc />
+		public IEnumerable<IDetectionRule> CustomRules { get; set; }
 	}
 
+	/// <inheritdoc cref="IDetector" />
 	public abstract class DetectorDescriptorBase<TDetectorDescriptor, TDetectorInterface>
 		: DescriptorBase<TDetectorDescriptor, TDetectorInterface>, IDetector
 		where TDetectorDescriptor : DetectorDescriptorBase<TDetectorDescriptor, TDetectorInterface>, TDetectorInterface
@@ -168,14 +242,23 @@ namespace Nest
 		ExcludeFrequent? IDetector.ExcludeFrequent { get; set; }
 		string IDetector.Function => _function;
 		bool? IDetector.UseNull { get; set; }
+		IEnumerable<IDetectionRule> IDetector.CustomRules { get; set; }
 
+		/// <inheritdoc cref="IDetector.DetectorDescription" />
 		public TDetectorDescriptor DetectorDescription(string description) => Assign(a => a.DetectorDescription = description);
 
+		/// <inheritdoc cref="IDetector.ExcludeFrequent" />
 		public TDetectorDescriptor ExcludeFrequent(ExcludeFrequent? excludeFrequent) => Assign(a => a.ExcludeFrequent = excludeFrequent);
 
+		/// <inheritdoc cref="IDetector.UseNull" />
 		public TDetectorDescriptor UseNull(bool? useNull = true) => Assign(a => a.UseNull = useNull);
 
+		/// <inheritdoc cref="IDetector.DetectorIndex" />
 		public TDetectorDescriptor DetectorIndex(int? detectorIndex) => Assign(a => a.DetectorIndex = detectorIndex);
+
+		/// <inheritdoc cref="IDetector.CustomRules" />
+		public TDetectorDescriptor CustomRules(Func<DetectionRulesDescriptor, IPromise<List<IDetectionRule>>> selector) =>
+			Assign(a => a.CustomRules = selector.Invoke(new DetectionRulesDescriptor()).Value);
 	}
 
 	public class DetectorsDescriptor<T> : DescriptorPromiseBase<DetectorsDescriptor<T>, IList<IDetector>> where T : class

--- a/src/Nest/XPack/MachineLearning/PutFilter/ElasticClient-PutFilter.cs
+++ b/src/Nest/XPack/MachineLearning/PutFilter/ElasticClient-PutFilter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <summary>
+		/// Creates a machine learning filter.
+		/// </summary>
+		IPutFilterResponse PutFilter(Id filterId, Func<PutFilterDescriptor, IPutFilterRequest> selector = null);
+
+		/// <inheritdoc cref="PutFilter(Nest.Id,System.Func{Nest.PutFilterDescriptor,Nest.IPutFilterRequest})" />
+		IPutFilterResponse PutFilter(IPutFilterRequest request);
+
+		/// <inheritdoc cref="PutFilter(Nest.Id,System.Func{Nest.PutFilterDescriptor,Nest.IPutFilterRequest})" />
+		Task<IPutFilterResponse> PutFilterAsync(Id filterId, Func<PutFilterDescriptor, IPutFilterRequest> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		);
+
+		/// <inheritdoc cref="PutFilter(Nest.Id,System.Func{Nest.PutFilterDescriptor,Nest.IPutFilterRequest})" />
+		Task<IPutFilterResponse> PutFilterAsync(IPutFilterRequest request, CancellationToken cancellationToken = default(CancellationToken));
+	}
+
+	public partial class ElasticClient
+	{
+		/// <inheritdoc />
+		public IPutFilterResponse PutFilter(Id filterId, Func<PutFilterDescriptor, IPutFilterRequest> selector = null)
+			=> PutFilter(selector.InvokeOrDefault(new PutFilterDescriptor(filterId)));
+
+		/// <inheritdoc />
+		public IPutFilterResponse PutFilter(IPutFilterRequest request) =>
+			Dispatcher.Dispatch<IPutFilterRequest, PutFilterRequestParameters, PutFilterResponse>(
+				request,
+				LowLevelDispatch.XpackMlPutFilterDispatch<PutFilterResponse>
+			);
+
+		/// <inheritdoc />
+		public Task<IPutFilterResponse> PutFilterAsync(Id filterId, Func<PutFilterDescriptor, IPutFilterRequest> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		) =>
+			PutFilterAsync(selector.InvokeOrDefault(new PutFilterDescriptor(filterId)), cancellationToken);
+
+		/// <inheritdoc />
+		public Task<IPutFilterResponse> PutFilterAsync(IPutFilterRequest request,
+			CancellationToken cancellationToken = default(CancellationToken)
+		) =>
+			Dispatcher.DispatchAsync<IPutFilterRequest, PutFilterRequestParameters, PutFilterResponse, IPutFilterResponse>(
+				request,
+				cancellationToken,
+				LowLevelDispatch.XpackMlPutFilterDispatchAsync<PutFilterResponse>
+			);
+	}
+}

--- a/src/Nest/XPack/MachineLearning/PutFilter/PutFilterRequest.cs
+++ b/src/Nest/XPack/MachineLearning/PutFilter/PutFilterRequest.cs
@@ -9,9 +9,16 @@ namespace Nest
 	/// </summary>
 	public partial interface IPutFilterRequest
 	{
+		/// <summary>
+		/// A description of the filter.
+		/// </summary>
 		[JsonProperty("description")]
 		string Description { get; set; }
 
+		/// <summary>
+		/// The items of the filter. A wildcard * can be used at the beginning or
+		/// the end of an item. Up to 10000 items are allowed in each filter.
+		/// </summary>
 		[JsonProperty("items")]
 		IEnumerable<string> Items { get; set; }
 	}
@@ -19,8 +26,10 @@ namespace Nest
 	/// <inheritdoc cref="PutFilterRequest" />
 	public partial class PutFilterRequest : IPutFilterRequest
 	{
+		/// <inheritdoc />
 		public string Description { get; set; }
 
+		/// <inheritdoc />
 		public IEnumerable<string> Items { get; set; }
 	}
 
@@ -33,8 +42,10 @@ namespace Nest
 		/// <inheritdoc cref="IPutFilterRequest.Description" />
 		public PutFilterDescriptor Description(string description) => Assign(a => a.Description = description);
 
+		/// <inheritdoc cref="IPutFilterRequest.Items" />
 		public PutFilterDescriptor Items(params string[] items) => Assign(a => a.Items = items);
 
+		/// <inheritdoc cref="IPutFilterRequest.Items" />
 		public PutFilterDescriptor Items(IEnumerable<string> items) => Assign(a => a.Items = items);
 	}
 }

--- a/src/Nest/XPack/MachineLearning/PutFilter/PutFilterRequest.cs
+++ b/src/Nest/XPack/MachineLearning/PutFilter/PutFilterRequest.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// Creates a machine learning filter.
+	/// </summary>
+	public partial interface IPutFilterRequest
+	{
+		[JsonProperty("description")]
+		string Description { get; set; }
+
+		[JsonProperty("items")]
+		IEnumerable<string> Items { get; set; }
+	}
+
+	/// <inheritdoc cref="PutFilterRequest" />
+	public partial class PutFilterRequest : IPutFilterRequest
+	{
+		public string Description { get; set; }
+
+		public IEnumerable<string> Items { get; set; }
+	}
+
+	[DescriptorFor("XpackMlPutFilter")]
+	public partial class PutFilterDescriptor : IPutFilterRequest
+	{
+		string IPutFilterRequest.Description { get; set; }
+		IEnumerable<string> IPutFilterRequest.Items { get; set; }
+
+		/// <inheritdoc cref="IPutFilterRequest.Description" />
+		public PutFilterDescriptor Description(string description) => Assign(a => a.Description = description);
+
+		public PutFilterDescriptor Items(params string[] items) => Assign(a => a.Items = items);
+
+		public PutFilterDescriptor Items(IEnumerable<string> items) => Assign(a => a.Items = items);
+	}
+}

--- a/src/Nest/XPack/MachineLearning/PutFilter/PutFilterResponse.cs
+++ b/src/Nest/XPack/MachineLearning/PutFilter/PutFilterResponse.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// The response from creating a machine learning filter.
+	/// </summary>
+	public partial interface IPutFilterResponse : IResponse
+	{
+		[JsonProperty("filter_id")]
+		string FilterId { get; }
+
+		[JsonProperty("description")]
+		string Description { get; }
+
+		[JsonProperty("items")]
+		IReadOnlyCollection<string> Items { get; }
+	}
+
+	/// <inheritdoc cref="IPutFilterResponse" />
+	public class PutFilterResponse : ResponseBase, IPutFilterResponse
+	{
+		public string FilterId { get; internal set; }
+
+		public string Description { get; internal set; }
+
+		public IReadOnlyCollection<string> Items { get; internal set; } = EmptyReadOnly<string>.Collection;
+	}
+}

--- a/src/Nest/XPack/MachineLearning/UpdateFilter/ElasticClient-UpdateFilter.cs
+++ b/src/Nest/XPack/MachineLearning/UpdateFilter/ElasticClient-UpdateFilter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	public partial interface IElasticClient
+	{
+		/// <summary>
+		/// Updates the description of a machine learning filter, adds items, or removes items.
+		/// </summary>
+		IUpdateFilterResponse UpdateFilter(Id filterId, Func<UpdateFilterDescriptor, IUpdateFilterRequest> selector = null);
+
+		/// <inheritdoc cref="UpdateFilter(Nest.Id,System.Func{Nest.UpdateFilterDescriptor,Nest.IUpdateFilterRequest})" />
+		IUpdateFilterResponse UpdateFilter(IUpdateFilterRequest request);
+
+		/// <inheritdoc cref="UpdateFilter(Nest.Id,System.Func{Nest.UpdateFilterDescriptor,Nest.IUpdateFilterRequest})" />
+		Task<IUpdateFilterResponse> UpdateFilterAsync(Id filterId, Func<UpdateFilterDescriptor, IUpdateFilterRequest> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		);
+
+		/// <inheritdoc cref="UpdateFilter(Nest.Id,System.Func{Nest.UpdateFilterDescriptor,Nest.IUpdateFilterRequest})" />
+		Task<IUpdateFilterResponse> UpdateFilterAsync(IUpdateFilterRequest request, CancellationToken cancellationToken = default(CancellationToken));
+	}
+
+	public partial class ElasticClient
+	{
+		/// <inheritdoc />
+		public IUpdateFilterResponse UpdateFilter(Id filterId, Func<UpdateFilterDescriptor, IUpdateFilterRequest> selector = null) =>
+			UpdateFilter(selector.InvokeOrDefault(new UpdateFilterDescriptor(filterId)));
+
+		/// <inheritdoc />
+		public IUpdateFilterResponse UpdateFilter(IUpdateFilterRequest request) =>
+			Dispatcher.Dispatch<IUpdateFilterRequest, UpdateFilterRequestParameters, UpdateFilterResponse>(
+				request,
+				LowLevelDispatch.XpackMlUpdateFilterDispatch<UpdateFilterResponse>
+			);
+
+		/// <inheritdoc />
+		public Task<IUpdateFilterResponse> UpdateFilterAsync(Id filterId, Func<UpdateFilterDescriptor, IUpdateFilterRequest> selector = null,
+			CancellationToken cancellationToken = default(CancellationToken)
+		) =>
+			UpdateFilterAsync(selector.InvokeOrDefault(new UpdateFilterDescriptor(filterId)), cancellationToken);
+
+		/// <inheritdoc />
+		public Task<IUpdateFilterResponse> UpdateFilterAsync(IUpdateFilterRequest request, CancellationToken cancellationToken = default(CancellationToken)) =>
+			Dispatcher.DispatchAsync<IUpdateFilterRequest, UpdateFilterRequestParameters, UpdateFilterResponse, IUpdateFilterResponse>(
+				request,
+				cancellationToken,
+				LowLevelDispatch.XpackMlUpdateFilterDispatchAsync<UpdateFilterResponse>
+			);
+	}
+}

--- a/src/Nest/XPack/MachineLearning/UpdateFilter/UpdateFilterRequest.cs
+++ b/src/Nest/XPack/MachineLearning/UpdateFilter/UpdateFilterRequest.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// Updates the description of a machine learning filter, adds items, or removes items.
+	/// </summary>
+	public partial interface IUpdateFilterRequest
+	{
+		/// <summary>
+		/// A description for the filter
+		/// </summary>
+		[JsonProperty("description")]
+		string Description { get; set; }
+
+		/// <summary>
+		/// The items to add to the filter
+		/// </summary>
+		[JsonProperty("add_items")]
+		IEnumerable<string> AddItems { get; set; }
+
+		/// <summary>
+		/// The items to remove from the filter
+		/// </summary>
+		[JsonProperty("remove_items")]
+		IEnumerable<string> RemoveItems { get; set; }
+	}
+
+	/// <inheritdoc cref="UpdateFilterRequest" />
+	public partial class UpdateFilterRequest : IUpdateFilterRequest
+	{
+		/// <inheritdoc />
+		public string Description { get; set; }
+
+		/// <inheritdoc />
+		public IEnumerable<string> AddItems { get; set; }
+
+		/// <inheritdoc />
+		public IEnumerable<string> RemoveItems { get; set; }
+	}
+
+	[DescriptorFor("XpackMlUpdateFilter")]
+	public partial class UpdateFilterDescriptor : IUpdateFilterRequest
+	{
+		string IUpdateFilterRequest.Description { get; set; }
+		IEnumerable<string> IUpdateFilterRequest.AddItems { get; set; }
+		IEnumerable<string> IUpdateFilterRequest.RemoveItems { get; set; }
+
+		/// <inheritdoc cref="IUpdateFilterRequest.Description" />
+		public UpdateFilterDescriptor Description(string description) => Assign(a => a.Description = description);
+
+		/// <inheritdoc cref="IUpdateFilterRequest.AddItems" />
+		public UpdateFilterDescriptor AddItems(params string[] items) => Assign(a => a.AddItems = items);
+
+		/// <inheritdoc cref="IUpdateFilterRequest.AddItems" />
+		public UpdateFilterDescriptor AddItems(IEnumerable<string> items) => Assign(a => a.AddItems = items);
+
+		/// <inheritdoc cref="IUpdateFilterRequest.RemoveItems" />
+		public UpdateFilterDescriptor RemoveItems(params string[] items) => Assign(a => a.RemoveItems = items);
+
+		/// <inheritdoc cref="IUpdateFilterRequest.RemoveItems" />
+		public UpdateFilterDescriptor RemoveItems(IEnumerable<string> items) => Assign(a => a.RemoveItems = items);
+	}
+}

--- a/src/Nest/XPack/MachineLearning/UpdateFilter/UpdateFilterResponse.cs
+++ b/src/Nest/XPack/MachineLearning/UpdateFilter/UpdateFilterResponse.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// The response from updating a machine learning filter.
+	/// </summary>
+	public partial interface IUpdateFilterResponse : IResponse
+	{
+		[JsonProperty("filter_id")]
+		string FilterId { get; }
+
+		[JsonProperty("description")]
+		string Description { get; }
+
+		[JsonProperty("items")]
+		IReadOnlyCollection<string> Items { get; }
+	}
+
+	/// <inheritdoc cref="IUpdateFilterResponse" />
+	public class UpdateFilterResponse : ResponseBase, IUpdateFilterResponse
+	{
+		public string FilterId { get; internal set; }
+
+		public string Description { get; internal set; }
+
+		public IReadOnlyCollection<string> Items { get; internal set; } = EmptyReadOnly<string>.Collection;
+	}
+}

--- a/src/Nest/_Generated/_Descriptors.generated.cs
+++ b/src/Nest/_Generated/_Descriptors.generated.cs
@@ -4232,6 +4232,18 @@ namespace Nest
 		// Request parameters
 
 	}
+	///<summary>descriptor for XpackMlDeleteFilter <pre></pre></summary>
+	public partial class DeleteFilterDescriptor  : RequestDescriptorBase<DeleteFilterDescriptor,DeleteFilterRequestParameters, IDeleteFilterRequest>, IDeleteFilterRequest
+	{ 
+		/// <summary>/_xpack/ml/filters/{filter_id}</summary>
+		///<param name="filter_id"> this parameter is required</param>
+		public DeleteFilterDescriptor(Id filter_id) : base(r=>r.Required("filter_id", filter_id)){}
+		// values part of the url path
+		Id IDeleteFilterRequest.FilterId => Self.RouteValues.Get<Id>("filter_id");
+
+		// Request parameters
+
+	}
 	///<summary>descriptor for XpackMlDeleteForecast <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</pre></summary>
 	public partial class DeleteForecastDescriptor  : RequestDescriptorBase<DeleteForecastDescriptor,DeleteForecastRequestParameters, IDeleteForecastRequest>, IDeleteForecastRequest
 	{ 
@@ -4397,6 +4409,24 @@ namespace Nest
 
 		///<summary>Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)</summary>
 		public GetDatafeedStatsDescriptor AllowNoDatafeeds(bool? allowNoDatafeeds = true) => Qs("allow_no_datafeeds", allowNoDatafeeds);
+	}
+	///<summary>descriptor for XpackMlGetFilters <pre></pre></summary>
+	public partial class GetFiltersDescriptor  : RequestDescriptorBase<GetFiltersDescriptor,GetFiltersRequestParameters, IGetFiltersRequest>, IGetFiltersRequest
+	{ 
+		/// <summary>/_xpack/ml/filters</summary>
+		public GetFiltersDescriptor() : base(){}
+		// values part of the url path
+		Id IGetFiltersRequest.FilterId => Self.RouteValues.Get<Id>("filter_id");
+
+		///<summary>The ID of the filter to fetch</summary>
+		public GetFiltersDescriptor FilterId(Id filterId) => Assign(a=>a.RouteValues.Optional("filter_id", filterId));
+
+		// Request parameters
+
+		///<summary>skips a number of filters</summary>
+		public GetFiltersDescriptor From(int? from) => Qs("from", from);
+		///<summary>specifies a max number of filters to get</summary>
+		public GetFiltersDescriptor Size(int? size) => Qs("size", size);
 	}
 	///<summary>descriptor for XpackMlGetInfluencers <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</pre></summary>
 	public partial class GetInfluencersDescriptor  : RequestDescriptorBase<GetInfluencersDescriptor,GetInfluencersRequestParameters, IGetInfluencersRequest>, IGetInfluencersRequest
@@ -4581,6 +4611,18 @@ namespace Nest
 		// Request parameters
 
 	}
+	///<summary>descriptor for XpackMlPutFilter <pre></pre></summary>
+	public partial class PutFilterDescriptor  : RequestDescriptorBase<PutFilterDescriptor,PutFilterRequestParameters, IPutFilterRequest>, IPutFilterRequest
+	{ 
+		/// <summary>/_xpack/ml/filters/{filter_id}</summary>
+		///<param name="filter_id"> this parameter is required</param>
+		public PutFilterDescriptor(Id filter_id) : base(r=>r.Required("filter_id", filter_id)){}
+		// values part of the url path
+		Id IPutFilterRequest.FilterId => Self.RouteValues.Get<Id>("filter_id");
+
+		// Request parameters
+
+	}
 	///<summary>descriptor for XpackMlPutJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</pre></summary>
 	public partial class PutJobDescriptor<T>  : RequestDescriptorBase<PutJobDescriptor<T>,PutJobRequestParameters, IPutJobRequest>, IPutJobRequest
 	{ 
@@ -4642,6 +4684,18 @@ namespace Nest
 		{ Self.Indices = typeof(T); Self.Types = typeof(T);  }
 		// values part of the url path
 		Id IUpdateDatafeedRequest.DatafeedId => Self.RouteValues.Get<Id>("datafeed_id");
+
+		// Request parameters
+
+	}
+	///<summary>descriptor for XpackMlUpdateFilter <pre></pre></summary>
+	public partial class UpdateFilterDescriptor  : RequestDescriptorBase<UpdateFilterDescriptor,UpdateFilterRequestParameters, IUpdateFilterRequest>, IUpdateFilterRequest
+	{ 
+		/// <summary>/_xpack/ml/filters/{filter_id}/_update</summary>
+		///<param name="filter_id"> this parameter is required</param>
+		public UpdateFilterDescriptor(Id filter_id) : base(r=>r.Required("filter_id", filter_id)){}
+		// values part of the url path
+		Id IUpdateFilterRequest.FilterId => Self.RouteValues.Get<Id>("filter_id");
 
 		// Request parameters
 

--- a/src/Nest/_Generated/_LowLevelDispatch.generated.cs
+++ b/src/Nest/_Generated/_LowLevelDispatch.generated.cs
@@ -3506,6 +3506,28 @@ namespace Nest
 			throw InvalidDispatch("XpackMlDeleteExpiredData", p, new [] { DELETE }, "/_xpack/ml/_delete_expired_data");
 		}
 		
+		internal TResponse XpackMlDeleteFilterDispatch<TResponse>(IRequest<DeleteFilterRequestParameters> p) where TResponse : class, IElasticsearchResponse, new()
+		{
+			switch(p.HttpMethod)
+			{
+				case DELETE:
+					if (AllSetNoFallback(p.RouteValues.FilterId)) return _lowLevel.XpackMlDeleteFilter<TResponse>(p.RouteValues.FilterId,p.RequestParameters);
+					break;
+			}
+			throw InvalidDispatch("XpackMlDeleteFilter", p, new [] { DELETE }, "/_xpack/ml/filters/{filter_id}");
+		}
+		
+		internal Task<TResponse> XpackMlDeleteFilterDispatchAsync<TResponse>(IRequest<DeleteFilterRequestParameters> p, CancellationToken ct) where TResponse : class, IElasticsearchResponse, new()
+		{
+			switch(p.HttpMethod)
+			{
+				case DELETE:
+					if (AllSetNoFallback(p.RouteValues.FilterId)) return _lowLevel.XpackMlDeleteFilterAsync<TResponse>(p.RouteValues.FilterId,p.RequestParameters,ct);
+					break;
+			}
+			throw InvalidDispatch("XpackMlDeleteFilter", p, new [] { DELETE }, "/_xpack/ml/filters/{filter_id}");
+		}
+		
 		internal TResponse XpackMlDeleteForecastDispatch<TResponse>(IRequest<DeleteForecastRequestParameters> p) where TResponse : class, IElasticsearchResponse, new()
 		{
 			switch(p.HttpMethod)
@@ -3768,6 +3790,28 @@ namespace Nest
 						return _lowLevel.XpackMlGetDatafeedStatsAsync<TResponse>(p.RequestParameters,ct);
 			}
 			throw InvalidDispatch("XpackMlGetDatafeedStats", p, new [] { GET }, "/_xpack/ml/datafeeds/{datafeed_id}/_stats", "/_xpack/ml/datafeeds/_stats");
+		}
+		
+		internal TResponse XpackMlGetFiltersDispatch<TResponse>(IRequest<GetFiltersRequestParameters> p) where TResponse : class, IElasticsearchResponse, new()
+		{
+			switch(p.HttpMethod)
+			{
+				case GET:
+					if (AllSet(p.RouteValues.FilterId)) return _lowLevel.XpackMlGetFilters<TResponse>(p.RouteValues.FilterId,p.RequestParameters);
+						return _lowLevel.XpackMlGetFilters<TResponse>(p.RequestParameters);
+			}
+			throw InvalidDispatch("XpackMlGetFilters", p, new [] { GET }, "/_xpack/ml/filters", "/_xpack/ml/filters/{filter_id}");
+		}
+		
+		internal Task<TResponse> XpackMlGetFiltersDispatchAsync<TResponse>(IRequest<GetFiltersRequestParameters> p, CancellationToken ct) where TResponse : class, IElasticsearchResponse, new()
+		{
+			switch(p.HttpMethod)
+			{
+				case GET:
+					if (AllSet(p.RouteValues.FilterId)) return _lowLevel.XpackMlGetFiltersAsync<TResponse>(p.RouteValues.FilterId,p.RequestParameters,ct);
+						return _lowLevel.XpackMlGetFiltersAsync<TResponse>(p.RequestParameters,ct);
+			}
+			throw InvalidDispatch("XpackMlGetFilters", p, new [] { GET }, "/_xpack/ml/filters", "/_xpack/ml/filters/{filter_id}");
 		}
 		
 		internal TResponse XpackMlGetInfluencersDispatch<TResponse>(IRequest<GetInfluencersRequestParameters> p,SerializableData<IGetInfluencersRequest> body) where TResponse : class, IElasticsearchResponse, new()
@@ -4104,6 +4148,28 @@ namespace Nest
 			throw InvalidDispatch("XpackMlPutDatafeed", p, new [] { PUT }, "/_xpack/ml/datafeeds/{datafeed_id}");
 		}
 		
+		internal TResponse XpackMlPutFilterDispatch<TResponse>(IRequest<PutFilterRequestParameters> p,SerializableData<IPutFilterRequest> body) where TResponse : class, IElasticsearchResponse, new()
+		{
+			switch(p.HttpMethod)
+			{
+				case PUT:
+					if (AllSetNoFallback(p.RouteValues.FilterId)) return _lowLevel.XpackMlPutFilter<TResponse>(p.RouteValues.FilterId,body,p.RequestParameters);
+					break;
+			}
+			throw InvalidDispatch("XpackMlPutFilter", p, new [] { PUT }, "/_xpack/ml/filters/{filter_id}");
+		}
+		
+		internal Task<TResponse> XpackMlPutFilterDispatchAsync<TResponse>(IRequest<PutFilterRequestParameters> p,SerializableData<IPutFilterRequest> body, CancellationToken ct) where TResponse : class, IElasticsearchResponse, new()
+		{
+			switch(p.HttpMethod)
+			{
+				case PUT:
+					if (AllSetNoFallback(p.RouteValues.FilterId)) return _lowLevel.XpackMlPutFilterAsync<TResponse>(p.RouteValues.FilterId,body,p.RequestParameters,ct);
+					break;
+			}
+			throw InvalidDispatch("XpackMlPutFilter", p, new [] { PUT }, "/_xpack/ml/filters/{filter_id}");
+		}
+		
 		internal TResponse XpackMlPutJobDispatch<TResponse>(IRequest<PutJobRequestParameters> p,SerializableData<IPutJobRequest> body) where TResponse : class, IElasticsearchResponse, new()
 		{
 			switch(p.HttpMethod)
@@ -4212,6 +4278,28 @@ namespace Nest
 					break;
 			}
 			throw InvalidDispatch("XpackMlUpdateDatafeed", p, new [] { POST }, "/_xpack/ml/datafeeds/{datafeed_id}/_update");
+		}
+		
+		internal TResponse XpackMlUpdateFilterDispatch<TResponse>(IRequest<UpdateFilterRequestParameters> p,SerializableData<IUpdateFilterRequest> body) where TResponse : class, IElasticsearchResponse, new()
+		{
+			switch(p.HttpMethod)
+			{
+				case POST:
+					if (AllSetNoFallback(p.RouteValues.FilterId)) return _lowLevel.XpackMlUpdateFilter<TResponse>(p.RouteValues.FilterId,body,p.RequestParameters);
+					break;
+			}
+			throw InvalidDispatch("XpackMlUpdateFilter", p, new [] { POST }, "/_xpack/ml/filters/{filter_id}/_update");
+		}
+		
+		internal Task<TResponse> XpackMlUpdateFilterDispatchAsync<TResponse>(IRequest<UpdateFilterRequestParameters> p,SerializableData<IUpdateFilterRequest> body, CancellationToken ct) where TResponse : class, IElasticsearchResponse, new()
+		{
+			switch(p.HttpMethod)
+			{
+				case POST:
+					if (AllSetNoFallback(p.RouteValues.FilterId)) return _lowLevel.XpackMlUpdateFilterAsync<TResponse>(p.RouteValues.FilterId,body,p.RequestParameters,ct);
+					break;
+			}
+			throw InvalidDispatch("XpackMlUpdateFilter", p, new [] { POST }, "/_xpack/ml/filters/{filter_id}/_update");
 		}
 		
 		internal TResponse XpackMlUpdateJobDispatch<TResponse>(IRequest<UpdateJobRequestParameters> p,SerializableData<IUpdateJobRequest> body) where TResponse : class, IElasticsearchResponse, new()

--- a/src/Nest/_Generated/_Requests.generated.cs
+++ b/src/Nest/_Generated/_Requests.generated.cs
@@ -1893,6 +1893,23 @@ namespace Nest
 		// Request parameters
 	}
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	public partial interface IDeleteFilterRequest : IRequest<DeleteFilterRequestParameters>
+	{
+		Id FilterId { get; }
+	}
+	///<summary>Request parameters for XpackMlDeleteFilter <pre></pre></summary>
+	public partial class DeleteFilterRequest : PlainRequestBase<DeleteFilterRequestParameters>, IDeleteFilterRequest
+	{
+		protected IDeleteFilterRequest Self => this;
+		///<summary>/_xpack/ml/filters/{filter_id}</summary>
+		///<param name="filter_id">this parameter is required</param>
+		public DeleteFilterRequest(Id filter_id) : base(r=>r.Required("filter_id", filter_id)){}
+		// values part of the url path
+		Id IDeleteFilterRequest.FilterId => Self.RouteValues.Get<Id>("filter_id");
+
+		// Request parameters
+	}
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface IDeleteForecastRequest : IRequest<DeleteForecastRequestParameters>
 	{
 		Id JobId { get; }
@@ -3026,6 +3043,29 @@ namespace Nest
 		public ExpandWildcards? ExpandWildcards { get => Q<ExpandWildcards?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public bool? Local { get => Q<bool?>("local"); set => Q("local", value); }
+	}
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	public partial interface IGetFiltersRequest : IRequest<GetFiltersRequestParameters>
+	{
+		Id FilterId { get; }
+	}
+	///<summary>Request parameters for XpackMlGetFilters <pre></pre></summary>
+	public partial class GetFiltersRequest : PlainRequestBase<GetFiltersRequestParameters>, IGetFiltersRequest
+	{
+		protected IGetFiltersRequest Self => this;
+		///<summary>/_xpack/ml/filters</summary>
+		public GetFiltersRequest() : base(){}
+		///<summary>/_xpack/ml/filters/{filter_id}</summary>
+		///<param name="filter_id">Optional, accepts null</param>
+		public GetFiltersRequest(Id filter_id) : base(r=>r.Optional("filter_id", filter_id)){}
+		// values part of the url path
+		Id IGetFiltersRequest.FilterId => Self.RouteValues.Get<Id>("filter_id");
+
+		// Request parameters
+		///<summary>skips a number of filters</summary>
+		public int? From { get => Q<int?>("from"); set => Q("from", value); }
+		///<summary>specifies a max number of filters to get</summary>
+		public int? Size { get => Q<int?>("size"); set => Q("size", value); }
 	}
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public partial interface IGetIndexRequest : IRequest<GetIndexRequestParameters>
@@ -4636,6 +4676,23 @@ namespace Nest
 		public PutDatafeedRequest(Id datafeed_id) : base(r=>r.Required("datafeed_id", datafeed_id)){}
 		// values part of the url path
 		Id IPutDatafeedRequest.DatafeedId => Self.RouteValues.Get<Id>("datafeed_id");
+
+		// Request parameters
+	}
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	public partial interface IPutFilterRequest : IRequest<PutFilterRequestParameters>
+	{
+		Id FilterId { get; }
+	}
+	///<summary>Request parameters for XpackMlPutFilter <pre></pre></summary>
+	public partial class PutFilterRequest : PlainRequestBase<PutFilterRequestParameters>, IPutFilterRequest
+	{
+		protected IPutFilterRequest Self => this;
+		///<summary>/_xpack/ml/filters/{filter_id}</summary>
+		///<param name="filter_id">this parameter is required</param>
+		public PutFilterRequest(Id filter_id) : base(r=>r.Required("filter_id", filter_id)){}
+		// values part of the url path
+		Id IPutFilterRequest.FilterId => Self.RouteValues.Get<Id>("filter_id");
 
 		// Request parameters
 	}
@@ -6445,6 +6502,23 @@ namespace Nest
 		public UpdateDatafeedRequest(Id datafeed_id) : base(r=>r.Required("datafeed_id", datafeed_id)){}
 		// values part of the url path
 		Id IUpdateDatafeedRequest.DatafeedId => Self.RouteValues.Get<Id>("datafeed_id");
+
+		// Request parameters
+	}
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	public partial interface IUpdateFilterRequest : IRequest<UpdateFilterRequestParameters>
+	{
+		Id FilterId { get; }
+	}
+	///<summary>Request parameters for XpackMlUpdateFilter <pre></pre></summary>
+	public partial class UpdateFilterRequest : PlainRequestBase<UpdateFilterRequestParameters>, IUpdateFilterRequest
+	{
+		protected IUpdateFilterRequest Self => this;
+		///<summary>/_xpack/ml/filters/{filter_id}/_update</summary>
+		///<param name="filter_id">this parameter is required</param>
+		public UpdateFilterRequest(Id filter_id) : base(r=>r.Required("filter_id", filter_id)){}
+		// values part of the url path
+		Id IUpdateFilterRequest.FilterId => Self.RouteValues.Get<Id>("filter_id");
 
 		// Request parameters
 	}

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -8,7 +8,7 @@
 mode: u
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
-elasticsearch_version: 6.6.2
+elasticsearch_version: 6.7.0
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
 # cluster_filter:
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running

--- a/src/Tests/Tests/CodeStandards/Descriptors.doc.cs
+++ b/src/Tests/Tests/CodeStandards/Descriptors.doc.cs
@@ -212,6 +212,9 @@ namespace Tests.CodeStandards
 				where !(m.Name == nameof(SortDescriptor<object>.Descending) && dt == typeof(SortDescriptor<>))
 				where !(m.Name == nameof(ClrTypeMappingDescriptor<object>.DisableIdInference) && dt == typeof(ClrTypeMappingDescriptor<>))
 				where !(m.Name == nameof(ClrTypeMappingDescriptor.DisableIdInference) && dt == typeof(ClrTypeMappingDescriptor))
+				where !(m.Name == nameof(RuleConditionDescriptor.AppliesTo) && dt == typeof(RuleConditionDescriptor))
+				where !(m.Name == nameof(RuleConditionDescriptor.Operator) && dt == typeof(RuleConditionDescriptor))
+				where !(m.Name == nameof(RuleConditionDescriptor.Value) && dt == typeof(RuleConditionDescriptor))
 
 				select new {m, d, p};
 

--- a/src/Tests/Tests/XPack/MachineLearning/DeleteFilter/DeleteFilterApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/DeleteFilter/DeleteFilterApiTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+
+namespace Tests.XPack.MachineLearning.DeleteFilter
+{
+	[SkipVersion("<6.4.0", "Filter functions for machine learning stabilised in 6.4.0")]
+	public class DeleteFilterApiTests : MachineLearningIntegrationTestBase<IDeleteFilterResponse, IDeleteFilterRequest, DeleteFilterDescriptor, DeleteFilterRequest>
+	{
+		public DeleteFilterApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+				PutFilter(client, callUniqueValue.Value);
+		}
+
+		protected override bool ExpectIsValid => true;
+
+		protected override object ExpectJson => null;
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<DeleteFilterDescriptor, IDeleteFilterRequest> Fluent => f => f;
+
+		protected override HttpMethod HttpMethod => HttpMethod.DELETE;
+
+		protected override DeleteFilterRequest Initializer => new DeleteFilterRequest(CallIsolatedValue);
+
+		protected override bool SupportsDeserialization => false;
+		protected override string UrlPath => $"_xpack/ml/filters/{CallIsolatedValue}";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.DeleteFilter(CallIsolatedValue, f),
+			(client, f) => client.DeleteFilterAsync(CallIsolatedValue, f),
+			(client, r) => client.DeleteFilter(r),
+			(client, r) => client.DeleteFilterAsync(r)
+		);
+
+		protected override DeleteFilterDescriptor NewDescriptor() => new DeleteFilterDescriptor(CallIsolatedValue);
+
+		protected override void ExpectResponse(IDeleteFilterResponse response)
+		{
+			response.ShouldBeValid();
+			response.Acknowledged.Should().BeTrue();
+		}
+	}
+}

--- a/src/Tests/Tests/XPack/MachineLearning/DeleteFilter/DeleteFilterUrlTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/DeleteFilter/DeleteFilterUrlTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework;
+using static Tests.Framework.UrlTester;
+
+namespace Tests.XPack.MachineLearning.DeleteFilter
+{
+	public class DeleteFilterUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls() =>
+			await DELETE("/_xpack/ml/filters/filter_id")
+				.Fluent(c => c.DeleteFilter("filter_id", p => p))
+				.Request(c => c.DeleteFilter(new DeleteFilterRequest("filter_id")))
+				.FluentAsync(c => c.DeleteFilterAsync("filter_id", p => p))
+				.RequestAsync(c => c.DeleteFilterAsync(new DeleteFilterRequest("filter_id")));
+	}
+}

--- a/src/Tests/Tests/XPack/MachineLearning/GetCalendars/GetCalendarsApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/GetCalendars/GetCalendarsApiTests.cs
@@ -109,22 +109,17 @@ namespace Tests.XPack.MachineLearning.GetCalendars
 		protected override string UrlPath => $"_xpack/ml/calendars";
 
 		protected override LazyResponses ClientUsage() => Calls(
-			(client, f) => client.GetCalendars(),
+			(client, f) => client.GetCalendars(f),
 			(client, f) => client.GetCalendarsAsync(f),
 			(client, r) => client.GetCalendars(r),
 			(client, r) => client.GetCalendarsAsync(r)
 		);
 
-		protected override GetCalendarsDescriptor NewDescriptor() => new GetCalendarsDescriptor().Page(p => p.Size(10).From(10));
-
 		protected override void ExpectResponse(IGetCalendarsResponse response)
 		{
 			response.ShouldBeValid();
-
 			response.Count.Should().BeGreaterOrEqualTo(1);
-
 			response.Calendars.Should().NotBeEmpty();
-
 			response.Calendars.Count.Should().BeGreaterOrEqualTo(1);
 		}
 	}

--- a/src/Tests/Tests/XPack/MachineLearning/GetFilters/GetFiltersApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/GetFilters/GetFiltersApiTests.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+
+namespace Tests.XPack.MachineLearning.GetFilters
+{
+	[SkipVersion("<6.4.0", "Filter functions for machine learning stabilised in 6.4.0")]
+	public class GetFiltersApiTests : MachineLearningIntegrationTestBase<IGetFiltersResponse, IGetFiltersRequest, GetFiltersDescriptor, GetFiltersRequest>
+	{
+		public GetFiltersApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+				PutFilter(client, callUniqueValue.Value);
+		}
+
+		protected override bool ExpectIsValid => true;
+
+		protected override object ExpectJson => null;
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<GetFiltersDescriptor, IGetFiltersRequest> Fluent => f => f.FilterId(CallIsolatedValue);
+
+		protected override HttpMethod HttpMethod => HttpMethod.GET;
+
+		protected override GetFiltersRequest Initializer => new GetFiltersRequest(CallIsolatedValue);
+
+		protected override bool SupportsDeserialization => false;
+
+		protected override string UrlPath => $"_xpack/ml/filters/{CallIsolatedValue}";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.GetFilters(f),
+			(client, f) => client.GetFiltersAsync(f),
+			(client, r) => client.GetFilters(r),
+			(client, r) => client.GetFiltersAsync(r)
+		);
+
+		protected override GetFiltersDescriptor NewDescriptor() => new GetFiltersDescriptor().FilterId(CallIsolatedValue);
+
+		protected override void ExpectResponse(IGetFiltersResponse response)
+		{
+			response.ShouldBeValid();
+			response.Filters.Should().NotBeEmpty();
+			var filter = response.Filters.First();
+			filter.FilterId.Should().NotBeNullOrEmpty();
+			filter.Items.Should().NotBeNull()
+				.And.HaveCount(2)
+				.And.Contain("*.google.com")
+				.And.Contain("wikipedia.org");
+			filter.Description.Should().Be("A list of safe domains");
+		}
+	}
+
+	[SkipVersion("<6.4.0", "Filter functions for machine learning stabilised in 6.4.0")]
+	public class GetFiltersPagingApiTests : MachineLearningIntegrationTestBase<IGetFiltersResponse, IGetFiltersRequest, GetFiltersDescriptor, GetFiltersRequest>
+	{
+		public GetFiltersPagingApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+			{
+				for (int i = 0; i < 3; i++)
+					PutFilter(client, callUniqueValue.Value + "_" + (i + 1));
+			}
+		}
+
+		protected override bool ExpectIsValid => true;
+
+		protected override object ExpectJson => null;
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<GetFiltersDescriptor, IGetFiltersRequest> Fluent => f => f
+			.Size(10)
+			.From(10);
+
+		protected override HttpMethod HttpMethod => HttpMethod.GET;
+
+		protected override GetFiltersRequest Initializer => new GetFiltersRequest
+		{
+			Size = 10,
+			From = 10
+		};
+
+		protected override bool SupportsDeserialization => false;
+
+		protected override string UrlPath => $"_xpack/ml/filters?from=10&size=10";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.GetFilters(f),
+			(client, f) => client.GetFiltersAsync(f),
+			(client, r) => client.GetFilters(r),
+			(client, r) => client.GetFiltersAsync(r)
+		);
+
+		protected override void ExpectResponse(IGetFiltersResponse response)
+		{
+			response.ShouldBeValid();
+			response.Filters.Should().NotBeEmpty();
+			var filter = response.Filters.First();
+			filter.FilterId.Should().NotBeNullOrEmpty();
+			filter.Items.Should().NotBeNull()
+				.And.HaveCount(2)
+				.And.Contain("*.google.com")
+				.And.Contain("wikipedia.org");
+			filter.Description.Should().Be("A list of safe domains");
+		}
+	}
+}

--- a/src/Tests/Tests/XPack/MachineLearning/GetFilters/GetFiltersUrlTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/GetFilters/GetFiltersUrlTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework;
+using static Tests.Framework.UrlTester;
+
+namespace Tests.XPack.MachineLearning.GetFilters
+{
+	public class GetFiltersUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls()
+		{
+			await GET("/_xpack/ml/filters")
+				.Fluent(c => c.GetFilters(p => p))
+				.Request(c => c.GetFilters(new GetFiltersRequest()))
+				.FluentAsync(c => c.GetFiltersAsync(p => p))
+				.RequestAsync(c => c.GetFiltersAsync(new GetFiltersRequest()));
+
+			await GET("/_xpack/ml/filters/1")
+				.Request(c => c.GetFilters(new GetFiltersRequest(1)))
+				.Fluent(c => c.GetFilters(r => r.FilterId(1)))
+				.FluentAsync(c => c.GetFiltersAsync(r => r.FilterId(1)))
+				.RequestAsync(c => c.GetFiltersAsync(new GetFiltersRequest(1)));
+		}
+	}
+}

--- a/src/Tests/Tests/XPack/MachineLearning/MachineLearningIntegrationTestBase.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/MachineLearningIntegrationTestBase.cs
@@ -38,6 +38,19 @@ namespace Tests.XPack.MachineLearning
 
 		[I] public override Task ReturnsExpectedResponse() => base.ReturnsExpectedResponse();
 
+		protected IPutFilterResponse PutFilter(IElasticClient client, string filterId)
+		{
+			var putFilterResponse = client.PutFilter(filterId, f => f
+				.Description("A list of safe domains")
+				.Items("*.google.com", "wikipedia.org")
+			);
+
+			if (!putFilterResponse.IsValid)
+				throw new Exception($"Problem putting filter {filterId} for integration test: {putFilterResponse.DebugInformation}");
+
+			return putFilterResponse;
+		}
+
 		protected IPutCalendarResponse PutCalendar(IElasticClient client, string calendarId)
 		{
 			var putCalendarResponse = client.PutCalendar(calendarId, f => f

--- a/src/Tests/Tests/XPack/MachineLearning/PutFilter/PutFilterApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/PutFilter/PutFilterApiTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+
+namespace Tests.XPack.MachineLearning.PutFilter
+{
+	[SkipVersion("<6.4.0", "Filter functions for machine learning stabilised in 6.4.0")]
+	public class PutFilterApiTests : MachineLearningIntegrationTestBase<IPutFilterResponse, IPutFilterRequest, PutFilterDescriptor, PutFilterRequest>
+	{
+		public PutFilterApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override bool ExpectIsValid => true;
+
+		protected override object ExpectJson => new
+		{
+			description = "A list of safe domains",
+			items = new[] { "*.google.com", "wikipedia.org" }
+		};
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<PutFilterDescriptor, IPutFilterRequest> Fluent => f => f
+			.Description("A list of safe domains")
+			.Items("*.google.com", "wikipedia.org");
+
+		protected override HttpMethod HttpMethod => HttpMethod.PUT;
+
+		protected override PutFilterRequest Initializer =>
+			new PutFilterRequest(CallIsolatedValue)
+			{
+				Description = "A list of safe domains",
+				Items = new [] { "*.google.com", "wikipedia.org" }
+			};
+
+		protected override bool SupportsDeserialization => false;
+		protected override string UrlPath => $"_xpack/ml/filters/{CallIsolatedValue}";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.PutFilter(CallIsolatedValue, f),
+			(client, f) => client.PutFilterAsync(CallIsolatedValue, f),
+			(client, r) => client.PutFilter(r),
+			(client, r) => client.PutFilterAsync(r)
+		);
+
+		protected override PutFilterDescriptor NewDescriptor() => new PutFilterDescriptor(CallIsolatedValue);
+
+		protected override void ExpectResponse(IPutFilterResponse response)
+		{
+			response.ShouldBeValid();
+			response.FilterId.Should().Be(CallIsolatedValue);
+			response.Items.Should().NotBeNull()
+				.And.HaveCount(2)
+				.And.Contain("*.google.com")
+				.And.Contain("wikipedia.org");
+
+			response.Description.Should().Be("A list of safe domains");
+		}
+	}
+}

--- a/src/Tests/Tests/XPack/MachineLearning/PutFilter/PutFilterUrlTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/PutFilter/PutFilterUrlTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework;
+using static Tests.Framework.UrlTester;
+
+namespace Tests.XPack.MachineLearning.PutFilter
+{
+	public class PutFilterUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls() =>
+			await PUT("/_xpack/ml/filters/filter_id")
+				.Fluent(c => c.PutFilter("filter_id", p => p))
+				.Request(c => c.PutFilter(new PutFilterRequest("filter_id")))
+				.FluentAsync(c => c.PutFilterAsync("filter_id", p => p))
+				.RequestAsync(c => c.PutFilterAsync(new PutFilterRequest("filter_id")));
+	}
+}

--- a/src/Tests/Tests/XPack/MachineLearning/PutJob/PutJobApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/PutJob/PutJobApiTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
@@ -112,6 +114,227 @@ namespace Tests.XPack.MachineLearning.PutJob
 			sumDetector.Function.Should().Be("sum");
 			sumDetector.FieldName.Name.Should().Be("total");
 			sumDetector.DetectorIndex.Should().Be(0);
+
+			response.AnalysisConfig.Influencers.Should().BeEmpty();
+
+			response.DataDescription.TimeField.Name.Should().Be("@timestamp");
+			response.DataDescription.TimeFormat.Should().Be("epoch_ms");
+
+			response.ModelSnapshotRetentionDays.Should().Be(1);
+
+			// User-defined names are prepended with "custom-" by X-Pack ML
+			response.ResultsIndexName.Should().Be("custom-server-metrics");
+		}
+	}
+
+	[SkipVersion("<6.4.0", "Custom rules came in 6.4.0")]
+	public class PutJobWithCustomRulesApiTests : MachineLearningIntegrationTestBase<IPutJobResponse, IPutJobRequest, PutJobDescriptor<Metric>, PutJobRequest>
+	{
+		public PutJobWithCustomRulesApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override bool ExpectIsValid => true;
+
+		protected override object ExpectJson => new
+		{
+			analysis_config = new
+			{
+				bucket_span = "30m",
+				detectors = new[]
+				{
+					new
+					{
+						function = "count",
+						by_field_name = "total",
+						over_field_name = "host",
+						partition_field_name = "service",
+						custom_rules = new []
+						{
+							new
+							{
+								actions = new [] { "skip_result" },
+								conditions = new []
+								{
+									new
+									{
+										applies_to = "actual",
+										@operator = "lt",
+										value = 0.2
+									},
+									new
+									{
+										applies_to = "actual",
+										@operator = "gte",
+										value = 0.1
+									}
+								},
+								scope = new
+								{
+									total = new
+									{
+										filter_id = "filter_1"
+									},
+									host = new
+									{
+										filter_id = "filter_2",
+										filter_type = "include"
+									},
+									service = new
+									{
+										filter_id = "filter_3",
+										filter_type = "exclude"
+									},
+								}
+							}
+						}
+					}
+				},
+				latency = "0s",
+			},
+			data_description = new
+			{
+				time_field = "@timestamp"
+			},
+			description = "Lab 1 - Simple example",
+			results_index_name = "server-metrics"
+		};
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<PutJobDescriptor<Metric>, IPutJobRequest> Fluent => f => f
+			.Description("Lab 1 - Simple example")
+			.ResultsIndexName("server-metrics")
+			.AnalysisConfig(a => a
+				.BucketSpan("30m")
+				.Latency("0s")
+				.Detectors(d => d
+					.Count(c => c
+						.ByFieldName(r => r.Total)
+						.OverFieldName(r => r.Host)
+						.PartitionFieldName(r => r.Service)
+						.CustomRules(cr => cr
+							.Rule(ru => ru
+								.Actions(RuleAction.SkipResult)
+								.Conditions(co => co
+									.Condition(con => con
+										.AppliesTo(AppliesTo.Actual)
+										.Operator(ConditionOperator.LessThan)
+										.Value(0.2)
+									)
+									.Condition(con => con
+										.AppliesTo(AppliesTo.Actual)
+										.Operator(ConditionOperator.GreaterThanOrEqual)
+										.Value(0.1)
+									)
+								)
+								.Scope<Metric>(sc => sc
+									.Scope(r => r.Total, new FilterRef { FilterId = "filter_1" })
+									.Scope(r => r.Host, new FilterRef { FilterId = "filter_2", FilterType = RuleFilterType.Include })
+									.Scope(r => r.Service, new FilterRef { FilterId = "filter_3", FilterType = RuleFilterType.Exclude })
+								)
+							)
+						)
+					)
+				)
+			)
+			.DataDescription(d => d.TimeField(r => r.Timestamp));
+
+		protected override HttpMethod HttpMethod => HttpMethod.PUT;
+
+		protected override PutJobRequest Initializer =>
+			new PutJobRequest(CallIsolatedValue)
+			{
+				Description = "Lab 1 - Simple example",
+				ResultsIndexName = "server-metrics",
+				AnalysisConfig = new AnalysisConfig
+				{
+					BucketSpan = "30m",
+					Latency = "0s",
+					Detectors = new[]
+					{
+						new CountDetector
+						{
+							ByFieldName = Field<Metric>(r => r.Total),
+							OverFieldName = Field<Metric>(r => r.Host),
+							PartitionFieldName = Field<Metric>(r => r.Service),
+							CustomRules = new []
+							{
+								new DetectionRule
+								{
+									Actions = new [] { RuleAction.SkipResult },
+									Conditions = new []
+									{
+										new RuleCondition
+										{
+											AppliesTo = AppliesTo.Actual,
+											Operator = ConditionOperator.LessThan,
+											Value = 0.2
+										},
+										new RuleCondition
+										{
+											AppliesTo = AppliesTo.Actual,
+											Operator = ConditionOperator.GreaterThanOrEqual,
+											Value = 0.1
+										}
+									},
+									Scope = new Dictionary<Field, FilterRef>
+									{
+										{ Field<Metric>(f => f.Total), new FilterRef { FilterId = "filter_1" } },
+										{ Field<Metric>(f => f.Host), new FilterRef { FilterId = "filter_2", FilterType = RuleFilterType.Include } },
+										{ Field<Metric>(f => f.Service), new FilterRef { FilterId = "filter_3", FilterType = RuleFilterType.Exclude } },
+									}
+								}
+							}
+						}
+					}
+				},
+				DataDescription = new DataDescription
+				{
+					TimeField = Field<Metric>(f => f.Timestamp)
+				}
+			};
+
+		protected override bool SupportsDeserialization => false;
+		protected override string UrlPath => $"_xpack/ml/anomaly_detectors/{CallIsolatedValue}";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.PutJob(CallIsolatedValue, f),
+			(client, f) => client.PutJobAsync(CallIsolatedValue, f),
+			(client, r) => client.PutJob(r),
+			(client, r) => client.PutJobAsync(r)
+		);
+
+		protected override PutJobDescriptor<Metric> NewDescriptor() => new PutJobDescriptor<Metric>(CallIsolatedValue);
+
+		protected override void ExpectResponse(IPutJobResponse response)
+		{
+			response.ShouldBeValid();
+
+			response.JobId.Should().Be(CallIsolatedValue);
+			// "job_version" : "5.5.2"
+			response.JobType.Should().Be("anomaly_detector");
+			response.Description.Should().Be("Lab 1 - Simple example");
+			response.CreateTime.Should().BeBefore(DateTimeOffset.UtcNow);
+
+			response.AnalysisConfig.Should().NotBeNull();
+			response.AnalysisConfig.BucketSpan.Should().Be(new Time("30m"));
+			response.AnalysisConfig.Latency.Should().Be(new Time("0s"));
+
+			response.AnalysisConfig.Detectors.Should().NotBeNull();
+			response.AnalysisConfig.Detectors.OfType<CountDetector>().Should().NotBeNull();
+
+			var countDetector = response.AnalysisConfig.Detectors.Cast<CountDetector>().First();
+			countDetector.DetectorDescription.Should().Be("count by total over host partitionfield=service");
+			countDetector.Function.Should().Be("count");
+			countDetector.ByFieldName.Name.Should().Be("total");
+			countDetector.OverFieldName.Name.Should().Be("host");
+			countDetector.PartitionFieldName.Name.Should().Be("service");
+			countDetector.DetectorIndex.Should().Be(0);
+			countDetector.CustomRules.Should().NotBeNullOrEmpty().And.HaveCount(1);
+
+			var customRule = countDetector.CustomRules.First();
+			customRule.Actions.Should().NotBeNullOrEmpty().And.Contain(RuleAction.SkipResult);
+			customRule.Scope.Should().NotBeNull().And.HaveCount(3);
+			customRule.Conditions.Should().NotBeNull().And.HaveCount(2);
 
 			response.AnalysisConfig.Influencers.Should().BeEmpty();
 

--- a/src/Tests/Tests/XPack/MachineLearning/UpdateFilter/UpdateFilterApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/UpdateFilter/UpdateFilterApiTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Framework;
+using Tests.Framework.Integration;
+using Tests.Framework.ManagedElasticsearch.Clusters;
+using static Elasticsearch.Net.HttpMethod;
+
+namespace Tests.XPack.MachineLearning.UpdateFilter
+{
+	[SkipVersion("<6.4.0", "Filter functions for machine learning stabilised in 6.4.0")]
+	public class UpdateFilterApiTests : MachineLearningIntegrationTestBase<IUpdateFilterResponse, IUpdateFilterRequest, UpdateFilterDescriptor, UpdateFilterRequest>
+	{
+		public UpdateFilterApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+				PutFilter(client, callUniqueValue.Value);
+		}
+
+		protected override bool ExpectIsValid => true;
+
+		protected override object ExpectJson => new
+		{
+			description = "A list of safe domains",
+			add_items = new[] { "*.microsoft.com" },
+			remove_items = new[] { "*.google.com" }
+		};
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<UpdateFilterDescriptor, IUpdateFilterRequest> Fluent => f => f
+			.Description("A list of safe domains")
+			.AddItems("*.microsoft.com")
+			.RemoveItems("*.google.com");
+
+		protected override HttpMethod HttpMethod => POST;
+
+		protected override UpdateFilterRequest Initializer =>
+			new UpdateFilterRequest(CallIsolatedValue)
+			{
+				Description = "A list of safe domains",
+				AddItems = new [] { "*.microsoft.com" },
+				RemoveItems = new [] { "*.google.com" }
+			};
+
+		protected override bool SupportsDeserialization => false;
+		protected override string UrlPath => $"_xpack/ml/filters/{CallIsolatedValue}/_update";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.UpdateFilter(CallIsolatedValue, f),
+			(client, f) => client.UpdateFilterAsync(CallIsolatedValue, f),
+			(client, r) => client.UpdateFilter(r),
+			(client, r) => client.UpdateFilterAsync(r)
+		);
+
+		protected override UpdateFilterDescriptor NewDescriptor() => new UpdateFilterDescriptor(CallIsolatedValue);
+
+		protected override void ExpectResponse(IUpdateFilterResponse response)
+		{
+			response.ShouldBeValid();
+			response.FilterId.Should().Be(CallIsolatedValue);
+			response.Items.Should().NotBeNull()
+				.And.HaveCount(2)
+				.And.Contain("*.microsoft.com")
+				.And.Contain("wikipedia.org");
+
+			response.Description.Should().Be("A list of safe domains");
+		}
+	}
+}

--- a/src/Tests/Tests/XPack/MachineLearning/UpdateFilter/UpdateFilterUrlTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/UpdateFilter/UpdateFilterUrlTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework;
+using static Tests.Framework.UrlTester;
+
+namespace Tests.XPack.MachineLearning.UpdateFilter
+{
+	public class UpdateFilterUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls() =>
+			await POST("/_xpack/ml/filters/filter_id/_update")
+				.Fluent(c => c.UpdateFilter("filter_id", p => p))
+				.Request(c => c.UpdateFilter(new UpdateFilterRequest("filter_id")))
+				.FluentAsync(c => c.UpdateFilterAsync("filter_id", p => p))
+				.RequestAsync(c => c.UpdateFilterAsync(new UpdateFilterRequest("filter_id")));
+	}
+}


### PR DESCRIPTION
Relates: #3615

This PR adds 

- the Put, Get, Update and Delete filters APIs, required for working with ML detector custom rules
- custom rules to machine learning detectors. The name of types used closely follows those used in Elasticsearch source.

