### PR TITLE
Consistent use of TimeZone

### DIFF
--- a/src/Nest/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
@@ -28,7 +28,7 @@ namespace Nest
 		/// or as a timezone id, an identifier used in the TZ database like America/Los_Angeles.
 		/// </summary>
 		[DataMember(Name ="time_zone")]
-		string Timezone { get; set; }
+		string TimeZone { get; set; }
 	}
 
 	/// <inheritdoc cref="IDateHistogramCompositeAggregationSource" />
@@ -43,7 +43,7 @@ namespace Nest
 		public Union<DateInterval?, Time> Interval { get; set; }
 
 		/// <inheritdoc />
-		public string Timezone { get; set; }
+		public string TimeZone { get; set; }
 
 		/// <inheritdoc />
 		protected override string SourceType => "date_histogram";
@@ -58,7 +58,7 @@ namespace Nest
 
 		string IDateHistogramCompositeAggregationSource.Format { get; set; }
 		Union<DateInterval?, Time> IDateHistogramCompositeAggregationSource.Interval { get; set; }
-		string IDateHistogramCompositeAggregationSource.Timezone { get; set; }
+		string IDateHistogramCompositeAggregationSource.TimeZone { get; set; }
 
 		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.Interval" />
 		public DateHistogramCompositeAggregationSourceDescriptor<T> Interval(DateInterval? interval) =>
@@ -68,10 +68,10 @@ namespace Nest
 		public DateHistogramCompositeAggregationSourceDescriptor<T> Interval(Time interval) =>
 			Assign(interval, (a, v) => a.Interval = v);
 
-		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.Timezone" />
-		public DateHistogramCompositeAggregationSourceDescriptor<T> Timezone(string timezone) => Assign(timezone, (a, v) => a.Timezone = v);
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.TimeZone" />
+		public DateHistogramCompositeAggregationSourceDescriptor<T> TimeZone(string timezone) => Assign(timezone, (a, v) => a.TimeZone = v);
 
-		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.Timezone" />
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.TimeZone" />
 		public DateHistogramCompositeAggregationSourceDescriptor<T> Format(string format) => Assign(format, (a, v) => a.Format = v);
 	}
 }

--- a/src/Nest/Ingest/Processors/DateProcessor.cs
+++ b/src/Nest/Ingest/Processors/DateProcessor.cs
@@ -22,7 +22,7 @@ namespace Nest
 		Field TargetField { get; set; }
 
 		[DataMember(Name ="timezone")]
-		string Timezone { get; set; }
+		string TimeZone { get; set; }
 	}
 
 	public class DateProcessor : ProcessorBase, IDateProcessor
@@ -35,7 +35,7 @@ namespace Nest
 
 		public Field TargetField { get; set; }
 
-		public string Timezone { get; set; }
+		public string TimeZone { get; set; }
 		protected override string Name => "date";
 	}
 
@@ -49,7 +49,7 @@ namespace Nest
 		IEnumerable<string> IDateProcessor.Formats { get; set; }
 		string IDateProcessor.Locale { get; set; }
 		Field IDateProcessor.TargetField { get; set; }
-		string IDateProcessor.Timezone { get; set; }
+		string IDateProcessor.TimeZone { get; set; }
 
 		public DateProcessorDescriptor<T> Field(Field field) => Assign(field, (a, v) => a.Field = v);
 
@@ -65,7 +65,7 @@ namespace Nest
 
 		public DateProcessorDescriptor<T> Formats(params string[] matchFormats) => Assign(matchFormats, (a, v) => a.Formats = v);
 
-		public DateProcessorDescriptor<T> Timezone(string timezone) => Assign(timezone, (a, v) => a.Timezone = v);
+		public DateProcessorDescriptor<T> TimeZone(string timezone) => Assign(timezone, (a, v) => a.TimeZone = v);
 
 		public DateProcessorDescriptor<T> Locale(string locale) => Assign(locale, (a, v) => a.Locale = v);
 	}

--- a/src/Nest/QueryDsl/FullText/QueryString/QueryStringQuery.cs
+++ b/src/Nest/QueryDsl/FullText/QueryString/QueryStringQuery.cs
@@ -173,7 +173,7 @@ namespace Nest
 		/// Time Zone to be applied to any range query related to dates.
 		/// </summary>
 		[DataMember(Name = "time_zone")]
-		string Timezone { get; set; }
+		string TimeZone { get; set; }
 
 		/// <summary>
 		/// How the fields should be combined to build the text query.
@@ -257,7 +257,7 @@ namespace Nest
 		public double? TieBreaker { get; set; }
 
 		/// <inheritdoc />
-		public string Timezone { get; set; }
+		public string TimeZone { get; set; }
 
 		/// <inheritdoc />
 		public TextQueryType? Type { get; set; }
@@ -299,7 +299,7 @@ namespace Nest
 		string IQueryStringQuery.QuoteFieldSuffix { get; set; }
 		MultiTermQueryRewrite IQueryStringQuery.Rewrite { get; set; }
 		double? IQueryStringQuery.TieBreaker { get; set; }
-		string IQueryStringQuery.Timezone { get; set; }
+		string IQueryStringQuery.TimeZone { get; set; }
 
 		TextQueryType? IQueryStringQuery.Type { get; set; }
 
@@ -385,8 +385,8 @@ namespace Nest
 		public QueryStringQueryDescriptor<T> EnablePositionIncrements(bool? enablePositionIncrements = true) =>
 			Assign(enablePositionIncrements, (a, v) => a.EnablePositionIncrements = v);
 
-		/// <inheritdoc cref="IQueryStringQuery.Timezone" />
-		public QueryStringQueryDescriptor<T> Timezone(string timezone) => Assign(timezone, (a, v) => a.Timezone = v);
+		/// <inheritdoc cref="IQueryStringQuery.TimeZone" />
+		public QueryStringQueryDescriptor<T> TimeZone(string timezone) => Assign(timezone, (a, v) => a.TimeZone = v);
 
 		/// <inheritdoc cref="IQueryStringQuery.AutoGenerateSynonymsPhraseQuery" />
 		public QueryStringQueryDescriptor<T> AutoGenerateSynonymsPhraseQuery(bool? autoGenerateSynonymsPhraseQuery = true) =>

--- a/src/Tests/Tests/Ingest/ProcessorAssertions.cs
+++ b/src/Tests/Tests/Ingest/ProcessorAssertions.cs
@@ -103,7 +103,7 @@ namespace Tests.Ingest
 					.Field(p => p.StartedOn)
 					.TargetField("timestamp")
 					.Formats("dd/MM/yyyy hh:mm:ss")
-					.Timezone("Europe/Amsterdam")
+					.TimeZone("Europe/Amsterdam")
 				);
 
 			public override IProcessor Initializer => new DateProcessor
@@ -111,7 +111,7 @@ namespace Tests.Ingest
 				Field = "startedOn",
 				TargetField = "timestamp",
 				Formats = new string[] { "dd/MM/yyyy hh:mm:ss" },
-				Timezone = "Europe/Amsterdam"
+				TimeZone = "Europe/Amsterdam"
 			};
 
 			public override object Json => new


### PR DESCRIPTION
This commit updates usage of Timezone to TimeZone, for consistency.

Fixes #3622