### PR TITLE
Consistent Sort type names

### DIFF
--- a/src/Nest/CommonOptions/Sorting/SortFormatter.cs
+++ b/src/Nest/CommonOptions/Sorting/SortFormatter.cs
@@ -62,7 +62,7 @@ namespace Nest
 				else
 				{
 					var field = sortProperty.Utf8String();
-					var sortField = formatterResolver.GetFormatter<SortField>()
+					var sortField = formatterResolver.GetFormatter<FieldSort>()
 						.Deserialize(ref reader, formatterResolver);
 					sortField.Field = field;
 					sort = sortField;

--- a/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ScrollAllObservable.cs
@@ -30,7 +30,7 @@ namespace Nest
 			_scrollAllRequest = scrollAllRequest;
 			_searchRequest = scrollAllRequest?.Search ?? new SearchRequest<T>();
 			if (_searchRequest.Sort == null)
-				_searchRequest.Sort = SortField.ByDocumentOrder;
+				_searchRequest.Sort = FieldSort.ByDocumentOrder;
 			_searchRequest.RequestParameters.Scroll = _scrollAllRequest.ScrollTime.ToTimeSpan();
 			_client = client;
 			_compositeCancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/Nest/Search/Search/Sort/FieldSort.cs
+++ b/src/Nest/Search/Search/Sort/FieldSort.cs
@@ -17,16 +17,16 @@ namespace Nest
 		FieldType? UnmappedType { get; set; }
 	}
 
-	public class SortField : SortBase, IFieldSort
+	public class FieldSort : SortBase, IFieldSort
 	{
-		public static readonly IList<ISort> ByDocumentOrder = new ReadOnlyCollection<ISort>(new List<ISort> { new SortField { Field = "_doc" } });
+		public static readonly IList<ISort> ByDocumentOrder = new ReadOnlyCollection<ISort>(new List<ISort> { new FieldSort { Field = "_doc" } });
 		public Field Field { get; set; }
 		public bool? IgnoreUnmappedFields { get; set; }
 		public FieldType? UnmappedType { get; set; }
 		protected override Field SortKey => Field;
 	}
 
-	public class SortFieldDescriptor<T> : SortDescriptorBase<SortFieldDescriptor<T>, IFieldSort, T>, IFieldSort where T : class
+	public class FieldSortDescriptor<T> : SortDescriptorBase<FieldSortDescriptor<T>, IFieldSort, T>, IFieldSort where T : class
 	{
 		private Field _field;
 		protected override Field SortKey => _field;
@@ -34,20 +34,20 @@ namespace Nest
 		bool? IFieldSort.IgnoreUnmappedFields { get; set; }
 		FieldType? IFieldSort.UnmappedType { get; set; }
 
-		public virtual SortFieldDescriptor<T> Field(Field field)
+		public virtual FieldSortDescriptor<T> Field(Field field)
 		{
 			_field = field;
 			return this;
 		}
 
-		public virtual SortFieldDescriptor<T> Field(Expression<Func<T, object>> objectPath)
+		public virtual FieldSortDescriptor<T> Field(Expression<Func<T, object>> objectPath)
 		{
 			_field = objectPath;
 			return this;
 		}
 
-		public virtual SortFieldDescriptor<T> UnmappedType(FieldType? type) => Assign(type, (a, v) => a.UnmappedType = v);
+		public virtual FieldSortDescriptor<T> UnmappedType(FieldType? type) => Assign(type, (a, v) => a.UnmappedType = v);
 
-		public virtual SortFieldDescriptor<T> IgnoreUnmappedFields(bool? ignore = true) => Assign(ignore, (a, v) => a.IgnoreUnmappedFields = v);
+		public virtual FieldSortDescriptor<T> IgnoreUnmappedFields(bool? ignore = true) => Assign(ignore, (a, v) => a.IgnoreUnmappedFields = v);
 	}
 }

--- a/src/Nest/Search/Search/Sort/GeoDistanceSort.cs
+++ b/src/Nest/Search/Search/Sort/GeoDistanceSort.cs
@@ -21,7 +21,7 @@ namespace Nest
 
 		/// <summary> The unit to use when computing sort values. The default is m (meters) </summary>
 		[DataMember(Name ="unit")]
-		DistanceUnit? GeoUnit { get; set; }
+		DistanceUnit? Unit { get; set; }
 
 		/// <summary>
 		/// Indicates if the unmapped field should be treated as a missing value. Setting it to `true` is equivalent to specifying
@@ -41,8 +41,8 @@ namespace Nest
 
 		public Field Field { get; set; }
 
-		/// <inheritdoc cref="IGeoDistanceSort.GeoUnit" />
-		public DistanceUnit? GeoUnit { get; set; }
+		/// <inheritdoc cref="IGeoDistanceSort.Unit" />
+		public DistanceUnit? Unit { get; set; }
 
 		/// <inheritdoc cref="IGeoDistanceSort.IgnoreUnmapped" />
 		public bool? IgnoreUnmapped { get; set; }
@@ -52,32 +52,32 @@ namespace Nest
 	}
 
 	/// <inheritdoc cref="IGeoDistanceSort" />
-	public class SortGeoDistanceDescriptor<T> : SortDescriptorBase<SortGeoDistanceDescriptor<T>, IGeoDistanceSort, T>, IGeoDistanceSort
+	public class GeoDistanceSortDescriptor<T> : SortDescriptorBase<GeoDistanceSortDescriptor<T>, IGeoDistanceSort, T>, IGeoDistanceSort
 		where T : class
 	{
 		protected override Field SortKey => "_geo_distance";
 		GeoDistanceType? IGeoDistanceSort.DistanceType { get; set; }
 
 		Field IGeoDistanceSort.Field { get; set; }
-		DistanceUnit? IGeoDistanceSort.GeoUnit { get; set; }
+		DistanceUnit? IGeoDistanceSort.Unit { get; set; }
 		bool? IGeoDistanceSort.IgnoreUnmapped { get; set; }
 		IEnumerable<GeoLocation> IGeoDistanceSort.Points { get; set; }
 
-		public SortGeoDistanceDescriptor<T> Points(params GeoLocation[] geoLocations) => Assign(geoLocations, (a, v) => a.Points = v);
+		public GeoDistanceSortDescriptor<T> Points(params GeoLocation[] geoLocations) => Assign(geoLocations, (a, v) => a.Points = v);
 
-		public SortGeoDistanceDescriptor<T> Points(IEnumerable<GeoLocation> geoLocations) => Assign(geoLocations, (a, v) => a.Points = v);
+		public GeoDistanceSortDescriptor<T> Points(IEnumerable<GeoLocation> geoLocations) => Assign(geoLocations, (a, v) => a.Points = v);
 
-		/// <inheritdoc cref="IGeoDistanceSort.GeoUnit" />
-		public SortGeoDistanceDescriptor<T> Unit(DistanceUnit? unit) => Assign(unit, (a, v) => a.GeoUnit = v);
+		/// <inheritdoc cref="IGeoDistanceSort.Unit" />
+		public GeoDistanceSortDescriptor<T> Unit(DistanceUnit? unit) => Assign(unit, (a, v) => a.Unit = v);
 
 		/// <inheritdoc cref="IGeoDistanceSort.DistanceType" />
-		public SortGeoDistanceDescriptor<T> DistanceType(GeoDistanceType? distanceType) => Assign(distanceType, (a, v) => a.DistanceType = v);
+		public GeoDistanceSortDescriptor<T> DistanceType(GeoDistanceType? distanceType) => Assign(distanceType, (a, v) => a.DistanceType = v);
 
-		public SortGeoDistanceDescriptor<T> Field(Field field) => Assign(field, (a, v) => a.Field = v);
+		public GeoDistanceSortDescriptor<T> Field(Field field) => Assign(field, (a, v) => a.Field = v);
 
-		public SortGeoDistanceDescriptor<T> Field(Expression<Func<T, object>> objectPath) => Assign(objectPath, (a, v) => a.Field = v);
+		public GeoDistanceSortDescriptor<T> Field(Expression<Func<T, object>> objectPath) => Assign(objectPath, (a, v) => a.Field = v);
 
 		/// <inheritdoc cref="IGeoDistanceSort.IgnoreUnmapped" />
-		public SortGeoDistanceDescriptor<T> IgnoreUnmapped(bool? ignoreUnmapped = true) => Assign(ignoreUnmapped, (a, v) => a.IgnoreUnmapped = v);
+		public GeoDistanceSortDescriptor<T> IgnoreUnmapped(bool? ignoreUnmapped = true) => Assign(ignoreUnmapped, (a, v) => a.IgnoreUnmapped = v);
 	}
 }

--- a/src/Nest/Search/Search/Sort/ScriptSort.cs
+++ b/src/Nest/Search/Search/Sort/ScriptSort.cs
@@ -24,7 +24,7 @@ namespace Nest
 		protected override Field SortKey => "_script";
 	}
 
-	public class SortScriptDescriptor<T> : SortDescriptorBase<SortScriptDescriptor<T>, IScriptSort, T>, IScriptSort
+	public class ScriptSortDescriptor<T> : SortDescriptorBase<ScriptSortDescriptor<T>, IScriptSort, T>, IScriptSort
 		where T : class
 	{
 		protected override Field SortKey => "_script";
@@ -33,9 +33,9 @@ namespace Nest
 
 		string IScriptSort.Type { get; set; }
 
-		public virtual SortScriptDescriptor<T> Type(string type) => Assign(type, (a, v) => a.Type = v);
+		public virtual ScriptSortDescriptor<T> Type(string type) => Assign(type, (a, v) => a.Type = v);
 
-		public SortScriptDescriptor<T> Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
+		public ScriptSortDescriptor<T> Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
 			Assign(scriptSelector, (a, v) => a.Script = v?.Invoke(new ScriptDescriptor()));
 	}
 }

--- a/src/Nest/Search/Search/Sort/SortBase.cs
+++ b/src/Nest/Search/Search/Sort/SortBase.cs
@@ -26,25 +26,8 @@ namespace Nest
 		/// <summary>
 		/// Specifies the path and filter to apply when sorting on a nested field
 		/// </summary>
-		/// <remarks>
-		/// Valid in Elasticsearch 6.1.0+
-		/// </remarks>
 		[DataMember(Name ="nested")]
 		INestedSort Nested { get; set; }
-
-		/// <summary>
-		/// Specifies the filter to apply when sorting on a nested field
-		/// </summary>
-		[DataMember(Name ="nested_filter")]
-		[Obsolete("Deprecated in 6.1.0. Use Nested. Will be removed in 7.x")]
-		QueryContainer NestedFilter { get; set; }
-
-		/// <summary>
-		/// Specifies the path to apply when sorting on a nested field
-		/// </summary>
-		[DataMember(Name ="nested_path")]
-		[Obsolete("Deprecated in 6.1.0. Use Nested. Will be removed in 7.x")]
-		Field NestedPath { get; set; }
 
 		/// <summary>
 		/// Controls the order of sorting
@@ -71,14 +54,6 @@ namespace Nest
 		public INestedSort Nested { get; set; }
 
 		/// <inheritdoc />
-		[Obsolete("Deprecated in 6.1.0. Use Nested. Will be removed in 7.x")]
-		public QueryContainer NestedFilter { get; set; }
-
-		/// <inheritdoc />
-		[Obsolete("Deprecated in 6.1.0. Use Nested. Will be removed in 7.x")]
-		public Field NestedPath { get; set; }
-
-		/// <inheritdoc />
 		public SortOrder? Order { get; set; }
 
 		/// <summary>
@@ -103,8 +78,6 @@ namespace Nest
 		object ISort.Missing { get; set; }
 		SortMode? ISort.Mode { get; set; }
 		INestedSort ISort.Nested { get; set; }
-		QueryContainer ISort.NestedFilter { get; set; }
-		Field ISort.NestedPath { get; set; }
 		SortOrder? ISort.Order { get; set; }
 		Field ISort.SortKey => SortKey;
 
@@ -123,19 +96,6 @@ namespace Nest
 
 		/// <inheritdoc cref="ISort.Mode" />
 		public virtual TDescriptor Mode(SortMode? mode) => Assign(mode, (a, v) => a.Mode = v);
-
-		/// <inheritdoc cref="ISort.NestedFilter" />
-		[Obsolete("Deprecated in 6.1.0. Use Nested. Will be removed in 7.x")]
-		public virtual TDescriptor NestedFilter(Func<QueryContainerDescriptor<T>, QueryContainer> filterSelector) =>
-			Assign(filterSelector, (a, v) => a.NestedFilter = v?.Invoke(new QueryContainerDescriptor<T>()));
-
-		/// <inheritdoc cref="ISort.NestedPath" />
-		[Obsolete("Deprecated in 6.1.0. Use Nested. Will be removed in 7.x")]
-		public virtual TDescriptor NestedPath(Field path) => Assign(path, (a, v) => a.NestedPath = v);
-
-		/// <inheritdoc cref="ISort.NestedPath" />
-		[Obsolete("Deprecated in 6.1.0. Use Nested. Will be removed in 7.x")]
-		public virtual TDescriptor NestedPath(Expression<Func<T, object>> objectPath) => Assign(objectPath, (a, v) => a.NestedPath = v);
 
 		/// <summary>
 		/// Specifies that documents which are missing the sort field should be ordered last

--- a/src/Nest/Search/Search/Sort/SortDescriptor.cs
+++ b/src/Nest/Search/Search/Sort/SortDescriptor.cs
@@ -11,34 +11,34 @@ namespace Nest
 		public SortDescriptor() : base(new List<ISort>()) { }
 
 		public SortDescriptor<T> Ascending(Expression<Func<T, object>> objectPath) =>
-			Assign(objectPath, (a, v) => a.Add(new SortField { Field = v, Order = SortOrder.Ascending }));
+			Assign(objectPath, (a, v) => a.Add(new FieldSort { Field = v, Order = SortOrder.Ascending }));
 
 		public SortDescriptor<T> Descending(Expression<Func<T, object>> objectPath) =>
-			Assign(objectPath, (a, v) => a.Add(new SortField { Field = v, Order = SortOrder.Descending }));
+			Assign(objectPath, (a, v) => a.Add(new FieldSort { Field = v, Order = SortOrder.Descending }));
 
-		public SortDescriptor<T> Ascending(Field field) => Assign(field, (a, v) => a.Add(new SortField { Field = v, Order = SortOrder.Ascending }));
+		public SortDescriptor<T> Ascending(Field field) => Assign(field, (a, v) => a.Add(new FieldSort { Field = v, Order = SortOrder.Ascending }));
 
-		public SortDescriptor<T> Descending(Field field) => Assign(field, (a, v) => a.Add(new SortField { Field = v, Order = SortOrder.Descending }));
+		public SortDescriptor<T> Descending(Field field) => Assign(field, (a, v) => a.Add(new FieldSort { Field = v, Order = SortOrder.Descending }));
 
 		public SortDescriptor<T> Ascending(SortSpecialField field) =>
-			Assign(field.GetStringValue(), (a, v) => a.Add(new SortField { Field = v, Order = SortOrder.Ascending }));
+			Assign(field.GetStringValue(), (a, v) => a.Add(new FieldSort { Field = v, Order = SortOrder.Ascending }));
 
 		public SortDescriptor<T> Descending(SortSpecialField field) =>
-			Assign(field.GetStringValue(), (a, v) => a.Add(new SortField { Field = v, Order = SortOrder.Descending }));
+			Assign(field.GetStringValue(), (a, v) => a.Add(new FieldSort { Field = v, Order = SortOrder.Descending }));
 
-		public SortDescriptor<T> Field(Func<SortFieldDescriptor<T>, IFieldSort> sortSelector) =>
-			AddSort(sortSelector?.Invoke(new SortFieldDescriptor<T>()));
+		public SortDescriptor<T> Field(Func<FieldSortDescriptor<T>, IFieldSort> sortSelector) =>
+			AddSort(sortSelector?.Invoke(new FieldSortDescriptor<T>()));
 
-		public SortDescriptor<T> Field(Field field, SortOrder order) => AddSort(new SortField { Field = field, Order = order });
+		public SortDescriptor<T> Field(Field field, SortOrder order) => AddSort(new FieldSort { Field = field, Order = order });
 
 		public SortDescriptor<T> Field(Expression<Func<T, object>> field, SortOrder order) =>
-			AddSort(new SortField { Field = field, Order = order });
+			AddSort(new FieldSort { Field = field, Order = order });
 
-		public SortDescriptor<T> GeoDistance(Func<SortGeoDistanceDescriptor<T>, IGeoDistanceSort> sortSelector) =>
-			AddSort(sortSelector?.Invoke(new SortGeoDistanceDescriptor<T>()));
+		public SortDescriptor<T> GeoDistance(Func<GeoDistanceSortDescriptor<T>, IGeoDistanceSort> sortSelector) =>
+			AddSort(sortSelector?.Invoke(new GeoDistanceSortDescriptor<T>()));
 
-		public SortDescriptor<T> Script(Func<SortScriptDescriptor<T>, IScriptSort> sortSelector) =>
-			AddSort(sortSelector?.Invoke(new SortScriptDescriptor<T>()));
+		public SortDescriptor<T> Script(Func<ScriptSortDescriptor<T>, IScriptSort> sortSelector) =>
+			AddSort(sortSelector?.Invoke(new ScriptSortDescriptor<T>()));
 
 		private SortDescriptor<T> AddSort(ISort sort) => sort == null ? this : Assign(sort, (a, v) => a.Add(v));
 	}

--- a/src/Tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
@@ -144,7 +144,7 @@ namespace Tests.Aggregations.Metric.TopHits
 				{
 					Sort = new List<ISort>
 					{
-						new SortField { Field = Field<Project>(p => p.StartedOn), Order = SortOrder.Descending },
+						new FieldSort { Field = Field<Project>(p => p.StartedOn), Order = SortOrder.Descending },
 						new ScriptSort
 						{
 							Type = "number",

--- a/src/Tests/Tests/Aggregations/Pipeline/BucketSort/BucketSortAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Pipeline/BucketSort/BucketSortAggregationUsageTests.cs
@@ -80,7 +80,7 @@ namespace Tests.Aggregations.Pipeline.BucketSort
 					{
 						Sort = new List<ISort>
 						{
-							new SortField { Field = "commits", Order = SortOrder.Descending }
+							new FieldSort { Field = "commits", Order = SortOrder.Descending }
 						},
 						From = 0,
 						Size = 3,

--- a/src/Tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
@@ -78,7 +78,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 			{
 				Index = CallIsolatedValue,
 				Query = new MatchQuery { Field = Field<Test>(p => p.Flag), Query = "bar" },
-				Sort = new List<ISort> { new SortField { Field = "id", Order = SortOrder.Ascending } },
+				Sort = new List<ISort> { new FieldSort { Field = "id", Order = SortOrder.Ascending } },
 				Size = 100
 			},
 			Destination = new ReindexDestination

--- a/src/Tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSliceApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSliceApiTests.cs
@@ -79,7 +79,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 			{
 				Index = CallIsolatedValue,
 				Query = new MatchAllQuery(),
-				Sort = new List<ISort> { new SortField { Field = "id", Order = SortOrder.Ascending } },
+				Sort = new List<ISort> { new FieldSort { Field = "id", Order = SortOrder.Ascending } },
 				Size = 100,
 				Slice = new SlicedScroll { Field = "id", Id = 0, Max = 2 }
 			},

--- a/src/Tests/Tests/Search/Request/SearchAfterUsageTests.cs
+++ b/src/Tests/Tests/Search/Request/SearchAfterUsageTests.cs
@@ -43,8 +43,8 @@ namespace Tests.Search.Request
 			{
 				Sort = new List<ISort>
 				{
-					new SortField { Field = Field<Project>(p => p.NumberOfCommits), Order = SortOrder.Descending },
-					new SortField { Field = Field<Project>(p => p.Name), Order = SortOrder.Descending }
+					new FieldSort { Field = Field<Project>(p => p.NumberOfCommits), Order = SortOrder.Descending },
+					new FieldSort { Field = Field<Project>(p => p.Name), Order = SortOrder.Descending }
 				},
 				SearchAfter = new List<object>
 				{

--- a/src/Tests/Tests/Search/Request/SortUsageTests.cs
+++ b/src/Tests/Tests/Search/Request/SortUsageTests.cs
@@ -138,11 +138,11 @@ namespace Tests.Search.Request
 			{
 				Sort = new List<ISort>
 				{
-					new SortField { Field = "startedOn", Order = SortOrder.Ascending },
-					new SortField { Field = "name", Order = SortOrder.Descending },
-					new SortField { Field = "_score", Order = SortOrder.Descending },
-					new SortField { Field = "_doc", Order = SortOrder.Ascending },
-					new SortField
+					new FieldSort { Field = "startedOn", Order = SortOrder.Ascending },
+					new FieldSort { Field = "name", Order = SortOrder.Descending },
+					new FieldSort { Field = "_score", Order = SortOrder.Descending },
+					new FieldSort { Field = "_doc", Order = SortOrder.Ascending },
+					new FieldSort
 					{
 						Field = Field<Project>(p => p.Tags.First().Added),
 						Order = SortOrder.Descending,
@@ -154,7 +154,7 @@ namespace Tests.Search.Request
 						NestedFilter = new MatchAllQuery(),
 #pragma warning restore 618
 					},
-					new SortField
+					new FieldSort
 					{
 						Field = Field<Project>(p => p.NumberOfCommits),
 						Order = SortOrder.Descending,
@@ -165,7 +165,7 @@ namespace Tests.Search.Request
 						Field = "location",
 						Order = SortOrder.Ascending,
 						DistanceType = GeoDistanceType.Arc,
-						GeoUnit = DistanceUnit.Centimeters,
+						Unit = DistanceUnit.Centimeters,
 						Mode = SortMode.Min,
 						Points = new[] { new GeoLocation(70, -70), new GeoLocation(-12, 12) }
 					},
@@ -247,7 +247,7 @@ namespace Tests.Search.Request
 			{
 				Sort = new List<ISort>
 				{
-					new SortField
+					new FieldSort
 					{
 						Field = Field<Project>(p => p.Tags.First().Added),
 						Order = SortOrder.Descending,
@@ -318,7 +318,7 @@ namespace Tests.Search.Request
 						IgnoreUnmapped = true,
 						Order = SortOrder.Ascending,
 						DistanceType = GeoDistanceType.Arc,
-						GeoUnit = DistanceUnit.Centimeters,
+						Unit = DistanceUnit.Centimeters,
 						Mode = SortMode.Min,
 						Points = new[] { new GeoLocation(70, -70), new GeoLocation(-12, 12) }
 					},

--- a/src/Tests/Tests/Search/Request/SortUsageTests.cs
+++ b/src/Tests/Tests/Search/Request/SortUsageTests.cs
@@ -35,10 +35,13 @@ namespace Tests.Search.Request
 								missing = "_last",
 								order = "desc",
 								mode = "avg",
-								nested_path = "tags",
-								nested_filter = new
+								nested = new
 								{
-									match_all = new { }
+									path = "tags",
+									filter = new
+									{
+										match_all = new { }
+									}
 								},
 								unmapped_type = "date"
 							}
@@ -106,8 +109,10 @@ namespace Tests.Search.Request
 					.MissingLast()
 					.UnmappedType(FieldType.Date)
 					.Mode(SortMode.Average)
-					.NestedPath(p => p.Tags)
-					.NestedFilter(q => q.MatchAll())
+					.Nested(n => n
+						.Path(p => p.Tags)
+						.Filter(q => q.MatchAll())
+					)
 				)
 				.Field(f => f
 					.Field(p => p.NumberOfCommits)
@@ -149,10 +154,11 @@ namespace Tests.Search.Request
 						Missing = "_last",
 						UnmappedType = FieldType.Date,
 						Mode = SortMode.Average,
-#pragma warning disable 618
-						NestedPath = Field<Project>(p => p.Tags),
-						NestedFilter = new MatchAllQuery(),
-#pragma warning restore 618
+						Nested = new NestedSort
+						{
+							Path = Field<Project>(p => p.Tags),
+							Filter = new MatchAllQuery()
+						}
 					},
 					new FieldSort
 					{


### PR DESCRIPTION
This PR updates sort type names for consistency

- Rename SortGeoDistance to GeoDistanceSort
- Rename SortField to FieldSort
- Rename SortScript to ScriptSort
- Rename property GeoUnit to Unit on GeoDistanceSort

Also remove deprecated `NestedPath` and `NestedFilter`

Fixes #3454

