### PR TITLE
Add IpRangeBucket for IpRangeAggregation

### DIFF
--- a/src/Nest/Aggregations/AggregateDictionary.cs
+++ b/src/Nest/Aggregations/AggregateDictionary.cs
@@ -175,7 +175,7 @@ namespace Nest
 
 		public MultiBucketAggregate<RangeBucket> DateRange(string key) => GetMultiBucketAggregate<RangeBucket>(key);
 
-		public MultiBucketAggregate<RangeBucket> IpRange(string key) => GetMultiBucketAggregate<RangeBucket>(key);
+		public MultiBucketAggregate<IpRangeBucket> IpRange(string key) => GetMultiBucketAggregate<IpRangeBucket>(key);
 
 		public MultiBucketAggregate<RangeBucket> GeoDistance(string key) => GetMultiBucketAggregate<RangeBucket>(key);
 

--- a/src/Nest/Aggregations/Bucket/IpRange/IpRangeBucket.cs
+++ b/src/Nest/Aggregations/Bucket/IpRange/IpRangeBucket.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Nest
+{
+	/// <summary>
+	/// A bucket for an <see cref="IpRangeAggregation"/>
+	/// </summary>
+	public class IpRangeBucket : BucketBase
+	{
+		public IpRangeBucket(IReadOnlyDictionary<string, IAggregate> dict) : base(dict) { }
+
+		/// <summary>
+		/// The count of documents in the bucket
+		/// </summary>
+		public long DocCount { get; set; }
+
+		/// <summary>
+		/// The IP address from
+		/// </summary>
+		public string From { get; set; }
+
+		/// <summary>
+		/// The key for the bucket
+		/// </summary>
+		public string Key { get; set; }
+
+		/// <summary>
+		/// The IP address to
+		/// </summary>
+		public string To { get; set; }
+	}
+}

--- a/src/Tests/Tests/Aggregations/Bucket/IpRange/IpRangeAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/IpRange/IpRangeAggregationUsageTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Nest;
 using Tests.Configuration;
@@ -57,12 +58,12 @@ namespace Tests.Aggregations.Bucket.IpRange
 			var ipRanges = response.Aggregations.IpRange("ip_ranges");
 			ipRanges.Should().NotBeNull();
 			ipRanges.Buckets.Should().NotBeNull();
-			ipRanges.Buckets.Count.Should().BeGreaterThan(0);
+			ipRanges.Buckets.Count.Should().Be(2);
+			ipRanges.Buckets.First().To.Should().Be("127.0.0.1");
+			ipRanges.Buckets.Last().From.Should().Be("127.0.0.1");
 			foreach (var range in ipRanges.Buckets)
 			{
-				if (TestConfiguration.Instance.InRange("6.4.0"))
-					range.Key.Should().NotBeNullOrEmpty();
-
+				range.Key.Should().NotBeNullOrEmpty();
 				range.DocCount.Should().BeGreaterThan(0);
 			}
 		}


### PR DESCRIPTION
This commit adds an IpRangeBucket for the IpRangeAggregation, allowing the To and From string fields to be deserialized and set on each bucket instance.

Fixes #3550