### PR TITLE
Use HttpMessageHandler on HttpConnection

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -74,7 +74,7 @@ namespace Elasticsearch.Net
 			}
 			responseStream = responseStream ?? Stream.Null;
 			var response = ResponseBuilder.ToResponse<TResponse>(requestData, ex, statusCode, warnings, responseStream, mimeType);
-			//var response = builder.ToResponse();
+
 			//explicit dispose of response not needed (as documented on MSDN) on desktop CLR
 			//but we can not guarantee this is true for all HttpMessageHandler implementations
 			if (typeof(TResponse) != typeof(ElasticsearchResponse<Stream>)) responseMessage?.Dispose();
@@ -150,7 +150,7 @@ namespace Elasticsearch.Net
 			return client;
 		}
 
-		protected virtual HttpClientHandler CreateHttpClientHandler(RequestData requestData)
+		protected virtual HttpMessageHandler CreateHttpClientHandler(RequestData requestData)
 		{
 			var handler = new HttpClientHandler
 			{

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -212,7 +212,12 @@ namespace Elasticsearch.Net
 			var method = ConvertHttpMethod(requestData.Method);
 			var requestMessage = new HttpRequestMessage(method, requestData.Uri);
 
-			foreach (string key in requestData.Headers) requestMessage.Headers.TryAddWithoutValidation(key, requestData.Headers.GetValues(key));
+			if (requestData.Headers != null)
+			{
+				foreach (string key in requestData.Headers)
+					requestMessage.Headers.TryAddWithoutValidation(key, requestData.Headers.GetValues(key));
+			}
+
 			requestMessage.Headers.Connection.Clear();
 			requestMessage.Headers.ConnectionClose = false;
 			requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(requestData.Accept));

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -138,15 +138,22 @@ namespace Elasticsearch.Net
 	{
 		internal static string ToQueryString(this NameValueCollection nv)
 		{
-			if (nv == null) return string.Empty;
-			if (nv.AllKeys.Length == 0) return string.Empty;
+			if (nv == null || nv.AllKeys.Length == 0) return string.Empty;
 
-			string E(string v)
+			// initialize with capacity for number of key/values with length 5 each
+			var builder = new StringBuilder("?", nv.AllKeys.Length * 2 * 5);
+			for (int i = 0; i < nv.AllKeys.Length; i++)
 			{
-				return Uri.EscapeDataString(v);
+				if (i != 0)
+					builder.Append("&");
+
+				var key = nv.AllKeys[i];
+				builder.Append(Uri.EscapeDataString(key));
+				builder.Append("=");
+				builder.Append(Uri.EscapeDataString(nv[key]));
 			}
 
-			return "?" + string.Join("&", nv.AllKeys.Select(key => $"{E(key)}={E(nv[key])}"));
+			return builder.ToString();
 		}
 
 		internal static void UpdateFromDictionary(this NameValueCollection queryString, Dictionary<string, object> queryStringUpdates,

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -90,7 +90,7 @@ namespace Elasticsearch.Net
 
 			using (responseStream)
 			{
-				if (SetSpecialTypes<TResponse>(bytes, out var r))
+				if (SetSpecialTypes<TResponse>(requestData, bytes, out var r))
 					return r;
 
 				if (details.HttpStatusCode.HasValue && requestData.SkipDeserializationForStatusCodes.Contains(details.HttpStatusCode.Value))
@@ -121,7 +121,7 @@ namespace Elasticsearch.Net
 
 			using (responseStream)
 			{
-				if (SetSpecialTypes<TResponse>(bytes, out var r)) return r;
+				if (SetSpecialTypes<TResponse>(requestData, bytes, out var r)) return r;
 
 				if (details.HttpStatusCode.HasValue && requestData.SkipDeserializationForStatusCodes.Contains(details.HttpStatusCode.Value))
 					return null;
@@ -136,7 +136,7 @@ namespace Elasticsearch.Net
 			}
 		}
 
-		private static bool SetSpecialTypes<TResponse>(byte[] bytes, out TResponse cs)
+		private static bool SetSpecialTypes<TResponse>(RequestData requestData, byte[] bytes, out TResponse cs)
 			where TResponse : class, IElasticsearchResponse, new()
 		{
 			cs = null;
@@ -151,7 +151,7 @@ namespace Elasticsearch.Net
 				cs = new VoidResponse() as TResponse;
 			else if (responseType == typeof(DynamicResponse))
 			{
-				using (var ms = new MemoryStream(bytes))
+				using (var ms = requestData.MemoryStreamFactory.Create(bytes))
 				{
 					var body = LowLevelRequestResponseSerializer.Instance.Deserialize<DynamicBody>(ms);
 					cs = new DynamicResponse(body) as TResponse;

--- a/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -127,9 +127,9 @@ namespace Tests.ClientConcepts.Connection
 				return base.RequestAsync<TResponse>(requestData, cancellationToken);
 			}
 
-			protected override HttpClientHandler CreateHttpClientHandler(RequestData requestData)
+			protected override HttpMessageHandler CreateHttpClientHandler(RequestData requestData)
 			{
-				LastUsedHttpClientHandler = base.CreateHttpClientHandler(requestData);
+				LastUsedHttpClientHandler = (HttpClientHandler)base.CreateHttpClientHandler(requestData);
 				return LastUsedHttpClientHandler;
 			}
 		}


### PR DESCRIPTION
- return `HttpMessageHandler` when creating a handler for a `HttpClient` in `HttpConnection`

Fixes #3415

- Use `MemoryStreamFactory`  to create a Memory Stream when the response is an Elasticsearch.Net response type.
- replace the use of `string.Join` and the capturing delegate to instead use
a `StringBuilder` and for loop. It also uses a simple heuristic to intialize the `StringBuilder` capacity.
- avoid allocating a `NameValueCollection` for `Headers` if there are no headers to send