### PR TITLE
Refactor/test version config

### DIFF
--- a/build/scripts/Building.fs
+++ b/build/scripts/Building.fs
@@ -1,9 +1,6 @@
 ﻿namespace Scripts
 
-open System 
 open System.IO
-
-open FSharp.Data
 
 open Paths
 open Projects

--- a/build/scripts/Cluster.fs
+++ b/build/scripts/Cluster.fs
@@ -15,15 +15,6 @@ module Cluster =
         let testsProjectDirectory = Path.Combine(Path.GetFullPath(Paths.Output("Tests.ClusterLauncher")), "netcoreapp2.1")
         let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         
-        let sourceDir = Paths.Source("Tests/Tests.Configuration");
-        let defaultYaml = Path.Combine(sourceDir, "tests.default.yaml");
-        let userYaml = Path.Combine(sourceDir, "tests.yaml");
-        let e f = File.Exists f;
-        match ((e userYaml), (e defaultYaml)) with
-        | (true, _) -> Environment.setEnvironVar "NEST_YAML_FILE" (Path.GetFullPath(userYaml))
-        | (_, true) -> Environment.setEnvironVar "NEST_YAML_FILE" (Path.GetFullPath(defaultYaml))
-        | _ -> failwithf "Expected to find a tests.default.yaml or tests.yaml in %s" sourceDir
-        
         printfn "%s" testsProjectDirectory
         
         Shell.copyDir tempDir testsProjectDirectory (fun s -> true)

--- a/build/scripts/Cluster.fs
+++ b/build/scripts/Cluster.fs
@@ -2,7 +2,6 @@
 
 open System
 open System.IO
-open Fake.Core
 open Fake.IO
 open Commandline
 

--- a/build/scripts/Paths.fs
+++ b/build/scripts/Paths.fs
@@ -28,7 +28,6 @@ module Paths =
     let Output(folder) = sprintf "%s/%s" BuildOutput folder
     let Source(folder) = sprintf "%s/%s" SourceFolder folder
     let TestsSource(folder) = sprintf "%s/Tests/%s" SourceFolder folder
-    let Build(folder) = sprintf "%s/%s" BuildFolder folder
     
     let ProjFile(project:DotNetProject) =
         match project with 

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -58,7 +58,7 @@ module Main =
 
         conditional (not parsed.SkipDocs) "documentation" <| fun _ -> Documentation.Generate parsed
 
-        conditional (not parsed.SkipTests) "test" <| fun _ -> Tests.RunUnitTests parsed
+        conditional (not parsed.SkipTests) "test" <| fun _ -> Tests.RunUnitTests parsed |> ignore
         
         target "version" <| fun _ -> printfn "Artifacts Version: %O" artifactsVersion
 
@@ -69,7 +69,7 @@ module Main =
         target "test-nuget-package" <| fun _ -> 
             //run release unit tests puts packages in the system cache prevent this from happening locally
             if not Commandline.runningOnCi then ignore ()
-            else Tests.RunReleaseUnitTests artifactsVersion
+            else Tests.RunReleaseUnitTests artifactsVersion |> ignore
             
         target "nuget-pack" <| fun _ -> Release.NugetPack artifactsVersion
 

--- a/build/scripts/Testing.fs
+++ b/build/scripts/Testing.fs
@@ -24,7 +24,6 @@ module Tests =
         env "NEST_INTEGRATION_CLUSTER" clusterFilter
         env "NEST_TEST_FILTER" testFilter
         env "NEST_TEST_SEED" (Some <| args.Seed)
-        env "NEST_COMMAND_LINE_BUILD" <| Some "1"
 
         for random in args.RandomArguments do 
             let tokens = random.Split [|':'|]

--- a/build/scripts/Testing.fs
+++ b/build/scripts/Testing.fs
@@ -53,7 +53,10 @@ module Tests =
             | (true) -> [ "--logger"; "trx"; "--collect"; "\"Code Coverage\""; "-v"; "m"] |> List.append command
             | _  -> command
             
-        Tooling.DotNet.ExecInWithTimeout "src/Tests/Tests" commandWithCodeCoverage (TimeSpan.FromMinutes 30.) 
+        // using std redirection since that foces vstest not to redirect Console.Write from Elastic.Xunit somehow
+        // still trying to work out whats going on there
+        // No fancy colors on the command line using this though 
+        Tooling.DotNet.ReadInWithTimeout "src/Tests/Tests" commandWithCodeCoverage (TimeSpan.FromMinutes 30.) 
 
     let RunReleaseUnitTests (ArtifactsVersion(version)) =
         //xUnit always does its own build, this env var is picked up by Tests.csproj

--- a/build/scripts/Testing.fs
+++ b/build/scripts/Testing.fs
@@ -1,11 +1,10 @@
 ﻿namespace Scripts
 
 open System
-open Tooling
-open Commandline
-open Versioning
 open Fake.Core
 open System.IO
+open Commandline
+open Versioning
 
 module Tests =
 
@@ -53,10 +52,7 @@ module Tests =
             | (true) -> [ "--logger"; "trx"; "--collect"; "\"Code Coverage\""; "-v"; "m"] |> List.append command
             | _  -> command
             
-        // using std redirection since that foces vstest not to redirect Console.Write from Elastic.Xunit somehow
-        // still trying to work out whats going on there
-        // No fancy colors on the command line using this though 
-        Tooling.DotNet.ReadInWithTimeout "src/Tests/Tests" commandWithCodeCoverage (TimeSpan.FromMinutes 30.) 
+        Tooling.DotNet.ExecInWithTimeout "src/Tests/Tests" commandWithCodeCoverage (TimeSpan.FromMinutes 30.) 
 
     let RunReleaseUnitTests (ArtifactsVersion(version)) =
         //xUnit always does its own build, this env var is picked up by Tests.csproj

--- a/build/scripts/Testing.fs
+++ b/build/scripts/Testing.fs
@@ -76,5 +76,6 @@ module Tests =
         | None -> failwith "No versions specified to run integration tests against"
         | Some esVersions ->
             for esVersion in esVersions do
+                Environment.setEnvironVar "NEST_INTEGRATION_TEST" "1"
                 Environment.setEnvironVar "NEST_INTEGRATION_VERSION" esVersion
                 dotnetTest args.MultiTarget |> ignore

--- a/build/scripts/Tooling.fs
+++ b/build/scripts/Tooling.fs
@@ -41,6 +41,7 @@ module Tooling =
     type BuildTooling(timeout, path) =
         let timeout = match timeout with | Some t -> t | None -> defaultTimeout
         member this.Path = path
+        member this.ReadInWithTimeout workingDirectory arguments timeout = readInWithTimeout timeout (Some workingDirectory) this.Path arguments
         member this.ExecInWithTimeout workingDirectory arguments timeout = execInWithTimeout timeout (Some workingDirectory) this.Path arguments
         member this.ExecWithTimeout arguments timeout = execInWithTimeout timeout None this.Path arguments
         member this.ExecIn workingDirectory arguments = this.ExecInWithTimeout workingDirectory arguments timeout

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <VersionPrefix>7.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <NoWarn>NU1701,NU1605</NoWarn>
   </PropertyGroup>

--- a/src/Tests/Tests.ClusterLauncher/ClusterLaunchProgram.cs
+++ b/src/Tests/Tests.ClusterLauncher/ClusterLaunchProgram.cs
@@ -26,10 +26,23 @@ namespace Tests.ClusterLauncher
 				return 3;
 			}
 
+			// Force TestConfiguration to load as if started from the command line even if we are actually starting
+			// from the IDE. Also force configuration mode to integration test so the seeders run
+			Environment.SetEnvironmentVariable("NEST_COMMAND_LINE_BUILD", "1", EnvironmentVariableTarget.Process);
+			Environment.SetEnvironmentVariable("NEST_INTEGRATION_TEST", "1", EnvironmentVariableTarget.Process);
+
+			if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NEST_YAML_FILE")))
+			{
+				// build always sets previous argument, assume we are running from the IDE or dotnet run
+                var yamlFile = TestConfiguration.LocateTestYamlFile();
+                Environment.SetEnvironmentVariable("NEST_YAML_FILE", yamlFile, EnvironmentVariableTarget.Process);
+			}
+
+			// if version is passed this will take precedence over the version in the yaml file
+			// in the constructor of EnvironmentConfiguration
 			var clusterName = arguments[0];
 			if (arguments.Length > 1)
 				Environment.SetEnvironmentVariable("NEST_INTEGRATION_VERSION", arguments[1], EnvironmentVariableTarget.Process);
-			Environment.SetEnvironmentVariable("NEST_INTEGRATION_SHOW_OUTPUT_AFTER_START", "1", EnvironmentVariableTarget.Process);
 
 			var cluster = clusters.FirstOrDefault(c => c.Name.StartsWith(clusterName, StringComparison.OrdinalIgnoreCase));
 			if (cluster == null)

--- a/src/Tests/Tests.Configuration/ConfigurationLoader.cs
+++ b/src/Tests/Tests.Configuration/ConfigurationLoader.cs
@@ -7,28 +7,36 @@ namespace Tests.Configuration
 {
 	public static class TestConfiguration
 	{
-		private static readonly Lazy<ITestConfiguration> Lazy
-			= new Lazy<ITestConfiguration>(LoadConfiguration, LazyThreadSafetyMode.ExecutionAndPublication);
+		private static readonly Lazy<TestConfigurationBase> Lazy
+			= new Lazy<TestConfigurationBase>(LoadConfiguration, LazyThreadSafetyMode.ExecutionAndPublication);
 
-		public static ITestConfiguration Instance => Lazy.Value;
+		public static TestConfigurationBase Instance => Lazy.Value;
 
-		private static ITestConfiguration LoadConfiguration()
+		private static TestConfigurationBase LoadConfiguration() =>
+			!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NEST_COMMAND_LINE_BUILD"))
+				? (TestConfigurationBase)LoadCommandLineConfiguration()
+				: LoadYamlConfiguration();
+
+		/// <summary>
+		/// Loads configuration by reading from the yaml and overriding specific configuration settings through
+		/// environment variables set by the command line build
+		/// </summary>
+		private static EnvironmentConfiguration LoadCommandLineConfiguration()
 		{
-			// The build script sets a NEST_COMMAND_LINE_BUILD env variable, so if it exists then
-			// we must be running tests from the build script
-			if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NEST_COMMAND_LINE_BUILD")))
-			{
-				var yamlFile = Environment.GetEnvironmentVariable("NEST_YAML_FILE");
-				if (!string.IsNullOrWhiteSpace(yamlFile) && File.Exists(yamlFile))
-				{
-					//load the test seed from the explicitly passed yaml file when running from FAKE
-					var tempYamlConfiguration = new YamlConfiguration(yamlFile);
-					return new EnvironmentConfiguration(tempYamlConfiguration);
-				}
-				return new EnvironmentConfiguration();
-			}
+			var yamlFile = Environment.GetEnvironmentVariable("NEST_YAML_FILE");
+			if (string.IsNullOrWhiteSpace(yamlFile))
+				throw new Exception("expected NEST_YAML_FILE to be set when calling build.bat or build.sh");
+			if (!File.Exists(yamlFile))
+				throw new Exception($"expected {yamlFile} to exist on disk NEST_YAML_FILE seems misconfigured");
 
+			//load the test seed from the explicitly passed yaml file when running from FAKE
+			var tempYamlConfiguration = new YamlConfiguration(yamlFile);
+			return new EnvironmentConfiguration(tempYamlConfiguration);
+		}
 
+		/// <summary> The test configuration loaded when you run the tests in your IDE or if you call dotnet test directly </summary>
+		private static YamlConfiguration LoadYamlConfiguration()
+		{
 			var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
 			var testsConfigurationFolder = FindTestsConfigurationFolder(directory);
 			if (testsConfigurationFolder == null)

--- a/src/Tests/Tests.Configuration/ConfigurationLoader.cs
+++ b/src/Tests/Tests.Configuration/ConfigurationLoader.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.IO;
 using System.Threading;
 
@@ -19,7 +18,7 @@ namespace Tests.Configuration
 
 		/// <summary>
 		/// Loads configuration by reading from the yaml and overriding specific configuration settings through
-		/// environment variables set by the command line build
+		/// environment variables set by the command line build.
 		/// </summary>
 		private static EnvironmentConfiguration LoadCommandLineConfiguration()
 		{
@@ -34,8 +33,7 @@ namespace Tests.Configuration
 			return new EnvironmentConfiguration(tempYamlConfiguration);
 		}
 
-		/// <summary> The test configuration loaded when you run the tests in your IDE or if you call dotnet test directly </summary>
-		private static YamlConfiguration LoadYamlConfiguration()
+		public static string LocateTestYamlFile()
 		{
 			var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
 			var testsConfigurationFolder = FindTestsConfigurationFolder(directory);
@@ -43,14 +41,24 @@ namespace Tests.Configuration
 				throw new Exception($"Tried to locate a parent test folder starting from  pwd:{directory.FullName}");
 
 			var localYamlFile = Path.Combine(testsConfigurationFolder.FullName, "tests.yaml");
-			if (File.Exists(localYamlFile))
-				return new YamlConfiguration(localYamlFile);
-
 			var defaultYamlFile = Path.Combine(testsConfigurationFolder.FullName, "tests.default.yaml");
-			if (File.Exists(defaultYamlFile))
-				return new YamlConfiguration(defaultYamlFile);
+			if (File.Exists(localYamlFile)) return localYamlFile;
+
+			if (File.Exists(defaultYamlFile)) return defaultYamlFile;
 
 			throw new Exception($"Tried to load a yaml file from {testsConfigurationFolder.FullName}");
+
+		}
+
+		/// <summary>
+		/// The test configuration loaded when you run the tests
+		/// <para> - from the IDE </para>
+		/// <para> - when calling dotnet test in the tests directory </para>
+		/// </summary>
+		private static YamlConfiguration LoadYamlConfiguration()
+		{
+			var yamlFile = LocateTestYamlFile();
+			return new YamlConfiguration(yamlFile);
 		}
 
 		private static DirectoryInfo FindTestsConfigurationFolder(DirectoryInfo directoryInfo)

--- a/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
@@ -8,7 +8,6 @@ namespace Tests.Configuration
 		{
 			ClusterFilter = Environment.GetEnvironmentVariable("NEST_INTEGRATION_CLUSTER");
 			TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
-			ShowElasticsearchOutputAfterStarted = Environment.GetEnvironmentVariable("NEST_INTEGRATION_SHOW_OUTPUT_AFTER_START") == "1";
 
 			var version = Environment.GetEnvironmentVariable("NEST_INTEGRATION_VERSION");
 			if (!string.IsNullOrEmpty(version)) Mode = TestMode.Integration;

--- a/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
@@ -4,46 +4,33 @@ namespace Tests.Configuration
 {
 	public class EnvironmentConfiguration : TestConfigurationBase
 	{
-		public EnvironmentConfiguration(YamlConfiguration tempYamlConfiguration) : this()
+		public EnvironmentConfiguration(YamlConfiguration yamlConfiguration)
 		{
-			ElasticsearchVersion = tempYamlConfiguration.ElasticsearchVersion;
-			Seed = tempYamlConfiguration.Seed;
-		}
+			ClusterFilter = Environment.GetEnvironmentVariable("NEST_INTEGRATION_CLUSTER");
+			TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
+			ShowElasticsearchOutputAfterStarted = Environment.GetEnvironmentVariable("NEST_INTEGRATION_SHOW_OUTPUT_AFTER_START") == "1";
 
-		public EnvironmentConfiguration()
-		{
-			//if env var NEST_INTEGRATION_VERSION is set assume integration mode used by the build script FAKE
 			var version = Environment.GetEnvironmentVariable("NEST_INTEGRATION_VERSION");
 			if (!string.IsNullOrEmpty(version)) Mode = TestMode.Integration;
 
-			ElasticsearchVersion = string.IsNullOrWhiteSpace(version) ? DefaultVersion : version;
-			ClusterFilter = Environment.GetEnvironmentVariable("NEST_INTEGRATION_CLUSTER");
-			ShowElasticsearchOutputAfterStarted = Environment.GetEnvironmentVariable("NEST_INTEGRATION_SHOW_OUTPUT_AFTER_START") == "1";
-			TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
+			ElasticsearchVersion = string.IsNullOrWhiteSpace(version) ? yamlConfiguration.ElasticsearchVersion : version;
+			if (string.IsNullOrWhiteSpace(ElasticsearchVersion))
+				throw new Exception("Elasticsearch Version could not be determined from env var NEST_INTEGRATION_VERSION nor the test yaml configuration");
 
-			var newRandom = new Random().Next(1, 100000);
-
-			Seed = TryGetEnv("NEST_TEST_SEED", out var seed) ? int.Parse(seed) : newRandom;
-			var randomizer = new Random(Seed);
+			var externalSeed = TryGetEnv("NEST_TEST_SEED", out var seed)
+				? int.Parse(seed)
+				: yamlConfiguration.SeedProvidedExternally
+					? yamlConfiguration.Seed
+					: (int?)null;
+			SetExternalSeed(externalSeed, out var randomizer);
 
 			TestOnlyOne = RandomBoolConfig("TEST_ONLY_ONE", randomizer, false);
-
 			Random = new RandomConfiguration
 			{
 				SourceSerializer = RandomBoolConfig("SOURCESERIALIZER", randomizer),
 				TypedKeys = RandomBoolConfig("TYPEDKEYS", randomizer),
 			};
 		}
-
-		public sealed override string ClusterFilter { get; protected set; }
-		public sealed override string ElasticsearchVersion { get; protected set; }
-		public sealed override bool ForceReseed { get; protected set; } = true;
-		public sealed override bool TestOnlyOne { get; protected set; } = false;
-		public sealed override TestMode Mode { get; protected set; } = TestMode.Unit;
-		public sealed override int Seed { get; protected set; }
-		public sealed override bool ShowElasticsearchOutputAfterStarted { get; protected set; }
-		public sealed override bool TestAgainstAlreadyRunningElasticsearch { get; protected set; } = false;
-		public sealed override string TestFilter { get; protected set; }
 
 		private static bool RandomBoolConfig(string key, Random randomizer, bool? @default = null)
 		{

--- a/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
@@ -6,12 +6,12 @@ namespace Tests.Configuration
 	{
 		public EnvironmentConfiguration(YamlConfiguration yamlConfiguration)
 		{
+			Mode = Environment.GetEnvironmentVariable("NEST_INTEGRATION_TEST") != null ? TestMode.Integration : TestMode.Unit;
+
 			ClusterFilter = Environment.GetEnvironmentVariable("NEST_INTEGRATION_CLUSTER");
 			TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
 
 			var version = Environment.GetEnvironmentVariable("NEST_INTEGRATION_VERSION");
-			if (!string.IsNullOrEmpty(version)) Mode = TestMode.Integration;
-
 			ElasticsearchVersion = string.IsNullOrWhiteSpace(version) ? yamlConfiguration.ElasticsearchVersion : version;
 			if (string.IsNullOrWhiteSpace(ElasticsearchVersion))
 				throw new Exception("Elasticsearch Version could not be determined from env var NEST_INTEGRATION_VERSION nor the test yaml configuration");

--- a/src/Tests/Tests.Configuration/TestConfigurationBase.cs
+++ b/src/Tests/Tests.Configuration/TestConfigurationBase.cs
@@ -4,21 +4,49 @@ namespace Tests.Configuration
 {
 	public abstract class TestConfigurationBase
 	{
+		/// <summary> If specified will only run integration test against these comma separated clusters </summary>
 		public string ClusterFilter { get; protected set; }
+
+		/// <summary> comma separated list of test method names to execute </summary>
+		public string TestFilter { get; protected set; }
+
+		/// <summary> The elasticsearch version to test against, defined for both unit and integration tests</summary>
 		public string ElasticsearchVersion { get; protected set; }
-		public bool ForceReseed { get; protected set; } = true;
+
+		/// <summary> Force a reseed (bootstrap) of the cluster even if checks indicate bootstrap already ran </summary>
+		public bool ForceReseed { get; protected set; }
+
+		/// <summary>
+		/// Signals to our test framework that the cluster was started externally. The framework will assert this before
+		/// attempting to spin up a cluster. If no node is found the framework will still spin up a node.
+		/// </summary>
+		public bool TestAgainstAlreadyRunningElasticsearch { get; protected set; }
+
+		/// <summary> The mode to run the tests under <see cref="TestMode"/></summary>
 		public TestMode Mode { get; protected set; }
+
+		/// <summary> Some test parameters are randomized, these are found under this property</summary>
 		public RandomConfiguration Random { get; protected set; }
 
+		/// <summary> The current configuration signals integration tests should be run </summary>
 		public bool RunIntegrationTests => Mode == TestMode.Mixed || Mode == TestMode.Integration;
+
+		/// <summary> The current configuration signals unit tests should be run </summary>
 		public bool RunUnitTests => Mode == TestMode.Mixed || Mode == TestMode.Unit;
 
+		/// <summary> The current configured seed used for random configuration </summary>
 		public int Seed { get; private set; }
+
+		/// <summary> whether the seed was provided externally to be fixated </summary>
 		public bool SeedProvidedExternally { get; private set; }
 
-		public bool ShowElasticsearchOutputAfterStarted { get; protected set; } = true;
-		public bool TestAgainstAlreadyRunningElasticsearch { get; protected set; }
-		public string TestFilter { get; protected set; }
+		/// <summary>
+		/// This is fixed for now, specifying false leads to flaky tests, warrants deeper investigation
+		/// in our abstractions project
+		/// </summary>
+		public bool ShowElasticsearchOutputAfterStarted { get; } = true;
+
+		/// <summary> When specified will only run one overload in API tests, helpful when debugging locally </summary>
 		public bool TestOnlyOne { get; protected set; }
 
 		private static int CurrentSeed { get; } = new Random().Next(1, 1_00_000);
@@ -33,7 +61,10 @@ namespace Tests.Configuration
 
 	public class RandomConfiguration
 	{
+		/// <summary> Run tests with a custom source serializer rather than the build in one </summary>
 		public bool SourceSerializer { get; set; }
+
+		/// <summary> Randomly enable typed keys on searches (defaults to true) on NEST search requests</summary>
 		public bool TypedKeys { get; set; }
 	}
 }

--- a/src/Tests/Tests.Configuration/TestConfigurationBase.cs
+++ b/src/Tests/Tests.Configuration/TestConfigurationBase.cs
@@ -1,22 +1,39 @@
-﻿namespace Tests.Configuration
+﻿using System;
+
+namespace Tests.Configuration
 {
-	public abstract class TestConfigurationBase : ITestConfiguration
+	public abstract class TestConfigurationBase
 	{
-		protected const string DefaultVersion = "6.0.0";
-		public abstract string ClusterFilter { get; protected set; }
-		public abstract string ElasticsearchVersion { get; protected set; }
-		public abstract bool ForceReseed { get; protected set; }
-		public abstract bool TestOnlyOne { get; protected set; }
-		public abstract TestMode Mode { get; protected set; }
+		public string ClusterFilter { get; protected set; }
+		public string ElasticsearchVersion { get; protected set; }
+		public bool ForceReseed { get; protected set; } = true;
+		public TestMode Mode { get; protected set; }
 		public RandomConfiguration Random { get; protected set; }
 
+		public bool RunIntegrationTests => Mode == TestMode.Mixed || Mode == TestMode.Integration;
+		public bool RunUnitTests => Mode == TestMode.Mixed || Mode == TestMode.Unit;
 
-		public virtual bool RunIntegrationTests => Mode == TestMode.Mixed || Mode == TestMode.Integration;
-		public virtual bool RunUnitTests => Mode == TestMode.Mixed || Mode == TestMode.Unit;
+		public int Seed { get; private set; }
+		public bool SeedProvidedExternally { get; private set; }
 
-		public abstract int Seed { get; protected set; }
-		public abstract bool ShowElasticsearchOutputAfterStarted { get; protected set; }
-		public abstract bool TestAgainstAlreadyRunningElasticsearch { get; protected set; }
-		public abstract string TestFilter { get; protected set; }
+		public bool ShowElasticsearchOutputAfterStarted { get; protected set; } = true;
+		public bool TestAgainstAlreadyRunningElasticsearch { get; protected set; }
+		public string TestFilter { get; protected set; }
+		public bool TestOnlyOne { get; protected set; }
+
+		private static int CurrentSeed { get; } = new Random().Next(1, 1_00_000);
+
+		protected void SetExternalSeed(int? seed, out Random randomizer)
+		{
+			SeedProvidedExternally = seed.HasValue;
+			Seed = seed.GetValueOrDefault(CurrentSeed);
+			randomizer = new Random(Seed);
+		}
+	}
+
+	public class RandomConfiguration
+	{
+		public bool SourceSerializer { get; set; }
+		public bool TypedKeys { get; set; }
 	}
 }

--- a/src/Tests/Tests.Configuration/TestConfigurationExtensions.cs
+++ b/src/Tests/Tests.Configuration/TestConfigurationExtensions.cs
@@ -1,35 +1,10 @@
-﻿using System;
+using System;
 
 namespace Tests.Configuration
 {
-	public interface ITestConfiguration
-	{
-		string ClusterFilter { get; }
-		string ElasticsearchVersion { get; }
-		bool ForceReseed { get; }
-		bool TestOnlyOne { get; }
-		TestMode Mode { get; }
-
-		RandomConfiguration Random { get; }
-
-		bool RunIntegrationTests { get; }
-		bool RunUnitTests { get; }
-
-		int Seed { get; }
-		bool ShowElasticsearchOutputAfterStarted { get; }
-		bool TestAgainstAlreadyRunningElasticsearch { get; }
-		string TestFilter { get; }
-	}
-
-	public class RandomConfiguration
-	{
-		public bool SourceSerializer { get; set; }
-		public bool TypedKeys { get; set; }
-	}
-
 	public static class TestConfigurationExtensions
 	{
-		public static void DumpConfiguration(this ITestConfiguration config)
+		public static void DumpConfiguration(this TestConfigurationBase config)
 		{
 			Console.WriteLine(new string('-', 20));
 			Console.WriteLine("Starting tests using config:");

--- a/src/Tests/Tests.Configuration/TestMode.cs
+++ b/src/Tests/Tests.Configuration/TestMode.cs
@@ -1,9 +1,16 @@
 ﻿namespace Tests.Configuration
 {
+	/// <summary>
+	/// Our tests can run in the following modes. Depending on which mode is selected
+	/// some tests won't be discovered. This is not the same as skipping as undiscovered tests are not reported.
+	/// </summary>
 	public enum TestMode
 	{
+		/// <summary> Only run unit tests</summary>
 		Unit,
+		/// <summary> Only run integration tests </summary>
 		Integration,
+		/// <summary> Run both unit and integration test, due note not all classes are written with this mode in mind </summary>
 		Mixed
 	}
 }

--- a/src/Tests/Tests.Configuration/YamlConfiguration.cs
+++ b/src/Tests/Tests.Configuration/YamlConfiguration.cs
@@ -25,7 +25,6 @@ namespace Tests.Configuration
 			ForceReseed = BoolConfig("force_reseed", false);
 			TestOnlyOne = BoolConfig("test_only_one", false);
 			TestAgainstAlreadyRunningElasticsearch = BoolConfig("test_against_already_running_elasticsearch", true);
-			ShowElasticsearchOutputAfterStarted = BoolConfig("elasticsearch_out_after_started", false);
 			ClusterFilter = _config.ContainsKey("cluster_filter") ? _config["cluster_filter"] : null;
 			TestFilter = _config.ContainsKey("test_filter") ? _config["test_filter"] : null;
 

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -17,7 +17,6 @@ elasticsearch_version: 7.0.0
 # do not spawn nodes as part of the test setup if we find a node is already running
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true
-# elasticsearch_out_after_started: true
 
 #random_source_serializer: true
 #random_old_connection: true

--- a/src/Tests/Tests.Core/Client/TestClient.cs
+++ b/src/Tests/Tests.Core/Client/TestClient.cs
@@ -8,7 +8,7 @@ namespace Tests.Core.Client
 {
 	public static class TestClient
 	{
-		public static readonly ITestConfiguration Configuration = TestConfiguration.Instance;
+		public static readonly TestConfigurationBase Configuration = TestConfiguration.Instance;
 		public static readonly IElasticClient Default = new ElasticClient(new TestConnectionSettings().ApplyDomainSettings());
 		public static readonly IElasticClient DefaultInMemoryClient = new ElasticClient(new AlwaysInMemoryConnectionSettings().ApplyDomainSettings());
 

--- a/src/Tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
+++ b/src/Tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
@@ -6,13 +6,13 @@ namespace Tests.Core.Extensions
 {
 	public static class TestConfigurationExtensions
 	{
-		private static IConnection CreateLiveConnection(this ITestConfiguration configuration) =>
+		private static IConnection CreateLiveConnection(this TestConfigurationBase configuration) =>
 			new HttpConnection();
 
-		public static IConnection CreateConnection(this ITestConfiguration configuration, bool forceInMemory = false) =>
+		public static IConnection CreateConnection(this TestConfigurationBase configuration, bool forceInMemory = false) =>
 			configuration.RunIntegrationTests && !forceInMemory ? configuration.CreateLiveConnection() : new InMemoryConnection();
 
-		public static bool InRange(this ITestConfiguration configuration, string range) =>
+		public static bool InRange(this TestConfigurationBase configuration, string range) =>
 			ElasticsearchVersion.From(configuration.ElasticsearchVersion).InRange(range);
 	}
 }

--- a/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/ClientTestClusterBase.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/ClientTestClusterBase.cs
@@ -34,7 +34,7 @@ namespace Tests.Core.ManagedElasticsearch.Clusters
 			: base(TestClient.Configuration.ElasticsearchVersion, features, new ElasticsearchPlugins(plugins), numberOfNodes)
 		{
 			TestConfiguration = TestClient.Configuration;
-			ShowElasticsearchOutputAfterStarted = true; //this.TestConfiguration.ShowElasticsearchOutputAfterStarted;
+			ShowElasticsearchOutputAfterStarted = TestConfiguration.ShowElasticsearchOutputAfterStarted;
 			HttpFiddlerAware = true;
 
 			CacheEsHomeInstallation = true;
@@ -55,6 +55,6 @@ namespace Tests.Core.ManagedElasticsearch.Clusters
 		}
 
 		public string AnalysisFolder => Path.Combine(FileSystem.ConfigPath, "analysis");
-		public ITestConfiguration TestConfiguration { get; }
+		public TestConfigurationBase TestConfiguration { get; }
 	}
 }

--- a/src/Tests/Tests.Core/Xunit/NestXunitRunOptions.cs
+++ b/src/Tests/Tests.Core/Xunit/NestXunitRunOptions.cs
@@ -87,7 +87,7 @@ namespace Tests.Core.Xunit
 			Console.WriteLine("--------");
 		}
 
-		private static string ReproduceCommandLine(ConcurrentBag<Tuple<string, string>> failedCollections, ITestConfiguration config,
+		private static string ReproduceCommandLine(ConcurrentBag<Tuple<string, string>> failedCollections, TestConfigurationBase config,
 			bool runningIntegrations
 		)
 		{

--- a/src/Tests/Tests/Search/SearchUsageTestBase.cs
+++ b/src/Tests/Tests/Search/SearchUsageTestBase.cs
@@ -23,7 +23,7 @@ namespace Tests.Search
 		protected SearchUsageTestBase(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override bool ExpectIsValid => true;
-		protected override int ExpectStatusCode => 200;
+		protected override int ExpectStatusCode => 201;
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
 		protected override string UrlPath => "/project/_search";
 
@@ -43,7 +43,7 @@ namespace Tests.Search
 
 		[U] protected override void SerializesFluent() => base.SerializesFluent();
 
-		[I] public override Task ReturnsExpectedStatusCode() => base.ReturnsExpectedResponse();
+		[I] public override Task ReturnsExpectedStatusCode() => base.ReturnsExpectedStatusCode();
 
 		[I] public override Task ReturnsExpectedIsValid() => base.ReturnsExpectedIsValid();
 

--- a/src/Tests/Tests/Tests.csproj
+++ b/src/Tests/Tests/Tests.csproj
@@ -3,8 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Artifacts.build.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <VersionPrefix>7.0.0</VersionPrefix>
-    <VersionSuffix>alpha</VersionSuffix>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>


### PR DESCRIPTION
- Simplifies `ITestConfiguration` and its implementations. 
- Default version resolutions is now driven by the yaml file rather than also having baked in fallback in code.