### PR TITLE
Docs: Fix the delimiter on a code block

### DIFF
--- a/docs/elasticsearch-net/building-requests.asciidoc
+++ b/docs/elasticsearch-net/building-requests.asciidoc
@@ -72,7 +72,7 @@ line_of_json_with_no_enters \n
 json_payload_with_enters
 line_of_json_with_no_enters \n
 json_payload_with_enters
-.....
+....
 
 Examples of such endpoints are the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html#docs-bulk[bulk api]. 
 In `Elasticsearch.Net` you can call these with


### PR DESCRIPTION
Fixes the delimiter on a code block that Asciidoctor is not a fan of.
This should let us convert all of these docs from the unmaintained
AsciiDoc project to the actively maintained Asciidoctor project.