### PR TITLE
Use ContractJsonConverterAttribute where possible

### DIFF
--- a/src/Nest/Cat/CatFielddata/CatFielddataRecord.cs
+++ b/src/Nest/Cat/CatFielddata/CatFielddataRecord.cs
@@ -3,7 +3,7 @@
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(CatFielddataRecordJsonConverter))]
+	[ContractJsonConverter(typeof(CatFielddataRecordJsonConverter))]
 	public class CatFielddataRecord : ICatRecord
 	{
 		public string Field { get; set; }

--- a/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
@@ -53,6 +53,9 @@ namespace Nest
 			return closedType.CreateInstance(args);
 		}
 
+		internal static T CreateGenericInstance<T>(this Type t, Type[] closeOver, params object[] args) =>
+			(T)CreateGenericInstance(t, closeOver, args);
+
 		internal static T CreateInstance<T>(this Type t, params object[] args) => (T)t.CreateInstance(args);
 
 		internal static object CreateInstance(this Type t, params object[] args)

--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -11,7 +11,7 @@ namespace Nest
 	/// <summary>
 	/// A field within Elasticsearch
 	/// </summary>
-	[JsonConverter(typeof(FieldJsonConverter))]
+	[ContractJsonConverter(typeof(FieldJsonConverter))]
 	[DebuggerDisplay("{DebugDisplay,nq}")]
 	public class Field : IEquatable<Field>, IUrlParameter
 	{

--- a/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
+++ b/src/Nest/CommonAbstractions/Infer/Fields/Fields.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(FieldsJsonConverter))]
+	[ContractJsonConverter(typeof(FieldsJsonConverter))]
 	[DebuggerDisplay("{DebugDisplay,nq}")]
 	public class Fields : IUrlParameter, IEnumerable<Field>, IEquatable<Fields>
 	{

--- a/src/Nest/CommonAbstractions/Infer/Id/Id.cs
+++ b/src/Nest/CommonAbstractions/Infer/Id/Id.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(IdJsonConverter))]
+	[ContractJsonConverter(typeof(IdJsonConverter))]
 	[DebuggerDisplay("{DebugDisplay,nq}")]
 	public class Id : IEquatable<Id>, IUrlParameter
 	{

--- a/src/Nest/CommonAbstractions/Infer/JoinFieldRouting/Routing.cs
+++ b/src/Nest/CommonAbstractions/Infer/JoinFieldRouting/Routing.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(RoutingJsonConverter))]
+	[ContractJsonConverter(typeof(RoutingJsonConverter))]
 	[DebuggerDisplay("{DebugDisplay,nq}")]
 	public class Routing : IEquatable<Routing>, IUrlParameter
 	{

--- a/src/Nest/CrossPlatform/TypeExtensions.cs
+++ b/src/Nest/CrossPlatform/TypeExtensions.cs
@@ -8,7 +8,6 @@ namespace Nest
 {
 	internal static class DotNetCoreTypeExtensions
 	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsGeneric(this Type type)
 		{
 #if DOTNETCORE
@@ -18,7 +17,6 @@ namespace Nest
 #endif
 		}
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static Assembly Assembly(this Type type)
 		{
 #if DOTNETCORE
@@ -52,7 +50,6 @@ namespace Nest
 			return true;
 		}
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsValue(this Type type)
 		{
 #if DOTNETCORE
@@ -62,7 +59,6 @@ namespace Nest
 #endif
 		}
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsClass(this Type type)
 		{
 #if DOTNETCORE
@@ -72,7 +68,6 @@ namespace Nest
 #endif
 		}
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static TypeCode GetTypeCode(this Type type)
 		{
 #if !DOTNETCORE
@@ -118,11 +113,9 @@ namespace Nest
 		}
 
 #if DOTNETCORE
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsAssignableFrom(this Type t, Type other) => t.GetTypeInfo().IsAssignableFrom(other.GetTypeInfo());
 #endif
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsEnumType(this Type type)
 		{
 #if DOTNETCORE
@@ -133,11 +126,9 @@ namespace Nest
 		}
 
 #if DOTNETCORE
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static IEnumerable<Type> GetInterfaces(this Type type) => type.GetTypeInfo().ImplementedInterfaces;
 #endif
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static IEnumerable<TAttribute> GetAttributes<TAttribute>(this Type t)
 			where TAttribute : Attribute
 		{

--- a/src/Nest/CrossPlatform/TypeExtensions.cs
+++ b/src/Nest/CrossPlatform/TypeExtensions.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Nest
 {
 	internal static class DotNetCoreTypeExtensions
 	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsGeneric(this Type type)
 		{
 #if DOTNETCORE
@@ -16,6 +18,7 @@ namespace Nest
 #endif
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static Assembly Assembly(this Type type)
 		{
 #if DOTNETCORE
@@ -49,6 +52,7 @@ namespace Nest
 			return true;
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsValue(this Type type)
 		{
 #if DOTNETCORE
@@ -58,6 +62,7 @@ namespace Nest
 #endif
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsClass(this Type type)
 		{
 #if DOTNETCORE
@@ -67,6 +72,7 @@ namespace Nest
 #endif
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static TypeCode GetTypeCode(this Type type)
 		{
 #if !DOTNETCORE
@@ -112,9 +118,11 @@ namespace Nest
 		}
 
 #if DOTNETCORE
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsAssignableFrom(this Type t, Type other) => t.GetTypeInfo().IsAssignableFrom(other.GetTypeInfo());
 #endif
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsEnumType(this Type type)
 		{
 #if DOTNETCORE
@@ -125,9 +133,11 @@ namespace Nest
 		}
 
 #if DOTNETCORE
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static IEnumerable<Type> GetInterfaces(this Type type) => type.GetTypeInfo().ImplementedInterfaces;
 #endif
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static IEnumerable<TAttribute> GetAttributes<TAttribute>(this Type t)
 			where TAttribute : Attribute
 		{

--- a/src/Nest/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
+++ b/src/Nest/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<LikeDocument<object>>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<LikeDocument<object>>))]
 	public interface ILikeDocument
 	{
 		[JsonProperty("doc")]

--- a/src/Nest/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisQuery.cs
+++ b/src/Nest/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisQuery.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<MoreLikeThisQueryDescriptor<object>>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<MoreLikeThisQueryDescriptor<object>>))]
 	public interface IMoreLikeThisQuery : IQuery
 	{
 		[JsonProperty("analyzer")]

--- a/src/Nest/QueryDsl/Specialized/Percolate/PercolateQuery.cs
+++ b/src/Nest/QueryDsl/Specialized/Percolate/PercolateQuery.cs
@@ -10,7 +10,7 @@ namespace Nest
 	/// The percolate query can be used to match queries stored in an index
 	/// </summary>
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<PercolateQuery>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<PercolateQuery>))]
 	public interface IPercolateQuery : IQuery
 	{
 		/// <summary>

--- a/src/Nest/QueryDsl/Specialized/Script/ScriptQuery.cs
+++ b/src/Nest/QueryDsl/Specialized/Script/ScriptQuery.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(ScriptQueryConverter))]
+	[ContractJsonConverter(typeof(ScriptQueryConverter))]
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	public interface IScriptQuery : IQuery
 	{

--- a/src/Nest/QueryDsl/TermLevel/Regexp/RegexpQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Regexp/RegexpQuery.cs
@@ -3,7 +3,7 @@
 namespace Nest
 {
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	[JsonConverter(typeof(FieldNameQueryJsonConverter<RegexpQuery>))]
+	[ContractJsonConverter(typeof(FieldNameQueryJsonConverter<RegexpQuery>))]
 	public interface IRegexpQuery : IFieldNameQuery
 	{
 		[JsonProperty("flags")]

--- a/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	[JsonConverter(typeof(FieldNameQueryJsonConverter<WildcardQuery>))]
+	[ContractJsonConverter(typeof(FieldNameQueryJsonConverter<WildcardQuery>))]
 	public interface IWildcardQuery : ITermQuery
 	{
 		[JsonProperty("rewrite")]

--- a/src/Nest/Search/SearchTemplate/SearchTemplateRequest.cs
+++ b/src/Nest/Search/SearchTemplate/SearchTemplateRequest.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<SearchTemplateRequest>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<SearchTemplateRequest>))]
 	public partial interface ISearchTemplateRequest : ICovariantSearchRequest
 	{
 		[JsonProperty("id")]

--- a/src/Nest/XPack/MachineLearning/Job/Config/DataDescription.cs
+++ b/src/Nest/XPack/MachineLearning/Job/Config/DataDescription.cs
@@ -8,7 +8,7 @@ namespace Nest
 	/// Defines the format of the input data when you send data to the machine learning job.
 	/// Note that when configure a datafeed, these properties are automatically set.
 	/// </summary>
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<DataDescription>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<DataDescription>))]
 	public interface IDataDescription
 	{
 		/// <summary>

--- a/src/Nest/XPack/MachineLearning/Job/Config/ModelPlotConfig.cs
+++ b/src/Nest/XPack/MachineLearning/Job/Config/ModelPlotConfig.cs
@@ -7,7 +7,7 @@ namespace Nest
 	/// Stores model information along with the results.
 	/// It provides a more detailed view into anomaly detection.
 	/// </summary>
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<ModelPlotConfig>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<ModelPlotConfig>))]
 	public interface IModelPlotConfig : IModelPlotConfigEnabled
 	{
 		/// <summary>
@@ -52,7 +52,7 @@ namespace Nest
 	/// Stores model information along with the results.
 	/// It provides a more detailed view into anomaly detection.
 	/// </summary>
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<ModelPlotConfigEnabled>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<ModelPlotConfigEnabled>))]
 	public interface IModelPlotConfigEnabled
 	{
 		/// <summary>

--- a/src/Nest/XPack/Security/Role/FieldSecurity.cs
+++ b/src/Nest/XPack/Security/Role/FieldSecurity.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<FieldSecurity>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<FieldSecurity>))]
 	public interface IFieldSecurity
 	{
 		[JsonProperty("except")]

--- a/src/Nest/XPack/Security/Role/GetRole/GetRoleResponse.cs
+++ b/src/Nest/XPack/Security/Role/GetRole/GetRoleResponse.cs
@@ -9,7 +9,7 @@ namespace Nest
 	}
 
 	[JsonObject(MemberSerialization.OptIn)]
-	[JsonConverter(typeof(DictionaryResponseJsonConverter<GetRoleResponse, string, XPackRole>))]
+	[ContractJsonConverter(typeof(DictionaryResponseJsonConverter<GetRoleResponse, string, XPackRole>))]
 	public class GetRoleResponse : DictionaryResponseBase<string, XPackRole>, IGetRoleResponse
 	{
 		[JsonIgnore]

--- a/src/Nest/XPack/Security/Role/PutRole/IndicesPrivileges.cs
+++ b/src/Nest/XPack/Security/Role/PutRole/IndicesPrivileges.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<IndicesPrivileges>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<IndicesPrivileges>))]
 	public interface IIndicesPrivileges
 	{
 		[JsonProperty("field_security")]

--- a/src/Nest/XPack/Security/RoleMapping/GetRoleMapping/GetRoleMappingResponse.cs
+++ b/src/Nest/XPack/Security/RoleMapping/GetRoleMapping/GetRoleMappingResponse.cs
@@ -9,7 +9,7 @@ namespace Nest
 	}
 
 	[JsonObject(MemberSerialization.OptIn)]
-	[JsonConverter(typeof(DictionaryResponseJsonConverter<GetRoleMappingResponse, string, XPackRoleMapping>))]
+	[ContractJsonConverter(typeof(DictionaryResponseJsonConverter<GetRoleMappingResponse, string, XPackRoleMapping>))]
 	public class GetRoleMappingResponse : DictionaryResponseBase<string, XPackRoleMapping>, IGetRoleMappingResponse
 	{
 		[JsonIgnore]

--- a/src/Nest/XPack/Security/RoleMapping/Rules/Role/RoleMappingRuleBase.cs
+++ b/src/Nest/XPack/Security/RoleMapping/Rules/Role/RoleMappingRuleBase.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(RoleMappingRuleBaseJsonConverter))]
+	[ContractJsonConverter(typeof(RoleMappingRuleBaseJsonConverter))]
 	public abstract class RoleMappingRuleBase
 	{
 		[JsonProperty("all")]

--- a/src/Nest/XPack/Security/User/GetUser/GetUserResponse.cs
+++ b/src/Nest/XPack/Security/User/GetUser/GetUserResponse.cs
@@ -9,7 +9,7 @@ namespace Nest
 	}
 
 	[JsonObject(MemberSerialization.OptIn)]
-	[JsonConverter(typeof(DictionaryResponseJsonConverter<GetUserResponse, string, XPackUser>))]
+	[ContractJsonConverter(typeof(DictionaryResponseJsonConverter<GetUserResponse, string, XPackUser>))]
 	public class GetUserResponse : DictionaryResponseBase<string, XPackUser>, IGetUserResponse
 	{
 		[JsonIgnore]

--- a/src/Nest/XPack/Watcher/Action/Actions.cs
+++ b/src/Nest/XPack/Watcher/Action/Actions.cs
@@ -7,7 +7,7 @@ namespace Nest
 {
 	public interface IActions : IIsADictionary<string, IAction> { }
 
-	[JsonConverter(typeof(ActionsJsonConverter))]
+	[ContractJsonConverter(typeof(ActionsJsonConverter))]
 	public class Actions : IsADictionaryBase<string, IAction>, IActions
 	{
 		public Actions() { }

--- a/src/Nest/XPack/Watcher/Action/Email/DataAttachment.cs
+++ b/src/Nest/XPack/Watcher/Action/Email/DataAttachment.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Converters;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<DataAttachment>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<DataAttachment>))]
 	public interface IDataAttachment : IEmailAttachment
 	{
 		[JsonProperty("format")]

--- a/src/Nest/XPack/Watcher/Action/Email/EmailAction.cs
+++ b/src/Nest/XPack/Watcher/Action/Email/EmailAction.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonObject]
 	public interface IEmailAction : IAction
 	{
 		[JsonProperty("account")]

--- a/src/Nest/XPack/Watcher/Action/Email/HttpAttachment.cs
+++ b/src/Nest/XPack/Watcher/Action/Email/HttpAttachment.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<HttpAttachment>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<HttpAttachment>))]
 	public interface IHttpAttachment : IEmailAttachment
 	{
 		[JsonProperty("content_type")]

--- a/src/Nest/XPack/Watcher/Action/PagerDuty/PagerDutyContext.cs
+++ b/src/Nest/XPack/Watcher/Action/PagerDuty/PagerDutyContext.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Converters;
 namespace Nest
 {
 	[JsonObject]
-	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<PagerDutyContext>))]
+	[JsonConverter(typeof(ReadAsTypeJsonConverter<PagerDutyContext>))]
 	public interface IPagerDutyContext
 	{
 		[JsonProperty("href")]

--- a/src/Nest/XPack/Watcher/Action/PagerDuty/PagerDutyContext.cs
+++ b/src/Nest/XPack/Watcher/Action/PagerDuty/PagerDutyContext.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Converters;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<PagerDutyContext>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<PagerDutyContext>))]
 	public interface IPagerDutyContext
 	{
 		[JsonProperty("href")]

--- a/src/Nest/XPack/Watcher/Action/Slack/SlackAttachmentField.cs
+++ b/src/Nest/XPack/Watcher/Action/Slack/SlackAttachmentField.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<SlackAttachmentField>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<SlackAttachmentField>))]
 	public interface ISlackAttachmentField
 	{
 		[JsonProperty("short")]

--- a/src/Nest/XPack/Watcher/Action/Slack/SlackDynamicAttachment.cs
+++ b/src/Nest/XPack/Watcher/Action/Slack/SlackDynamicAttachment.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<SlackDynamicAttachment>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<SlackDynamicAttachment>))]
 	public interface ISlackDynamicAttachment
 	{
 		[JsonProperty("attachment_template")]

--- a/src/Nest/XPack/Watcher/Condition/AlwaysCondition.cs
+++ b/src/Nest/XPack/Watcher/Condition/AlwaysCondition.cs
@@ -3,7 +3,7 @@
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<AlwaysCondition>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<AlwaysCondition>))]
 	public interface IAlwaysCondition : ICondition { }
 
 	public class AlwaysCondition : ConditionBase, IAlwaysCondition

--- a/src/Nest/XPack/Watcher/Condition/ArrayCompareConditionBase.cs
+++ b/src/Nest/XPack/Watcher/Condition/ArrayCompareConditionBase.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Converters;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ArrayCompareConditionConverter))]
+	[ContractJsonConverter(typeof(ArrayCompareConditionConverter))]
 	public interface IArrayCompareCondition
 	{
 		string ArrayPath { get; set; }

--- a/src/Nest/XPack/Watcher/Condition/CompareConditionBase.cs
+++ b/src/Nest/XPack/Watcher/Condition/CompareConditionBase.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(CompareConditionConverter))]
+	[ContractJsonConverter(typeof(CompareConditionConverter))]
 	public interface ICompareCondition : ICondition
 	{
 		string Comparison { get; }

--- a/src/Nest/XPack/Watcher/Condition/ConditionContainer.cs
+++ b/src/Nest/XPack/Watcher/Condition/ConditionContainer.cs
@@ -7,7 +7,7 @@ namespace Nest
 	/// Conditions for a watch
 	/// </summary>
 	[JsonObject]
-	[JsonConverter(typeof(ReserializeJsonConverter<ConditionContainer, IConditionContainer>))]
+	[ContractJsonConverter(typeof(ReserializeJsonConverter<ConditionContainer, IConditionContainer>))]
 	public interface IConditionContainer
 	{
 		/// <summary>

--- a/src/Nest/XPack/Watcher/Condition/NeverCondition.cs
+++ b/src/Nest/XPack/Watcher/Condition/NeverCondition.cs
@@ -3,7 +3,7 @@
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<NeverCondition>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<NeverCondition>))]
 	public interface INeverCondition : ICondition { }
 
 	public class NeverCondition : ConditionBase, INeverCondition

--- a/src/Nest/XPack/Watcher/Condition/ScriptConditionBase.cs
+++ b/src/Nest/XPack/Watcher/Condition/ScriptConditionBase.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ScriptConditionJsonConverter))]
+	[ContractJsonConverter(typeof(ScriptConditionJsonConverter))]
 	public interface IScriptCondition : ICondition
 	{
 		[JsonProperty("lang")]

--- a/src/Nest/XPack/Watcher/Execution/SimulatedActions.cs
+++ b/src/Nest/XPack/Watcher/Execution/SimulatedActions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(SimulatedActionsConverter))]
+	[ContractJsonConverter(typeof(SimulatedActionsConverter))]
 	public class SimulatedActions
 	{
 		private SimulatedActions() { }

--- a/src/Nest/XPack/Watcher/Input/ChainInput.cs
+++ b/src/Nest/XPack/Watcher/Input/ChainInput.cs
@@ -8,7 +8,7 @@ namespace Nest
 	///  input to load data from multiple sources into the watch execution context when the watch is triggered.
 	/// </summary>
 	[JsonObject]
-	[JsonConverter(typeof(ChainInputJsonConverter))]
+	[ContractJsonConverter(typeof(ChainInputJsonConverter))]
 	public interface IChainInput : IInput
 	{
 		/// <summary>

--- a/src/Nest/XPack/Watcher/Input/HttpInput.cs
+++ b/src/Nest/XPack/Watcher/Input/HttpInput.cs
@@ -8,7 +8,7 @@ namespace Nest
 	/// input to submit a request to an HTTP endpoint and load the response
 	/// into the watch execution context when a watch is triggered.
 	/// </summary>
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<HttpInput>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<HttpInput>))]
 	public interface IHttpInput : IInput
 	{
 		/// <summary>

--- a/src/Nest/XPack/Watcher/Input/HttpInputProxy.cs
+++ b/src/Nest/XPack/Watcher/Input/HttpInputProxy.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<HttpInputProxy>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<HttpInputProxy>))]
 	public interface IHttpInputProxy
 	{
 		string Host { get; set; }

--- a/src/Nest/XPack/Watcher/Input/IndicesOptions.cs
+++ b/src/Nest/XPack/Watcher/Input/IndicesOptions.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Converters;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<IndicesOptions>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<IndicesOptions>))]
 	public interface IIndicesOptions
 	{
 		[JsonProperty("allow_no_indices")]

--- a/src/Nest/XPack/Watcher/Input/InputContainer.cs
+++ b/src/Nest/XPack/Watcher/Input/InputContainer.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject(MemberSerialization.OptIn)]
-	[JsonConverter(typeof(ReserializeJsonConverter<InputContainer, IInputContainer>))]
+	[ContractJsonConverter(typeof(ReserializeJsonConverter<InputContainer, IInputContainer>))]
 	public interface IInputContainer
 	{
 		[JsonProperty("chain")]

--- a/src/Nest/XPack/Watcher/Input/SearchInput.cs
+++ b/src/Nest/XPack/Watcher/Input/SearchInput.cs
@@ -9,7 +9,7 @@ namespace Nest
 	/// context when a watch is triggered.
 	/// </summary>
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<SearchInput>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<SearchInput>))]
 	public interface ISearchInput : IInput
 	{
 		/// <summary>

--- a/src/Nest/XPack/Watcher/Input/SearchInputRequest.cs
+++ b/src/Nest/XPack/Watcher/Input/SearchInputRequest.cs
@@ -7,11 +7,10 @@ using Newtonsoft.Json.Converters;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<SearchInputRequest>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<SearchInputRequest>))]
 	public interface ISearchInputRequest
 	{
 		[JsonProperty("body")]
-		[JsonConverter(typeof(ReadAsTypeJsonConverter<SearchRequest>))]
 		ISearchRequest Body { get; set; }
 
 		[JsonProperty("indices")]
@@ -25,7 +24,6 @@ namespace Nest
 		SearchType? SearchType { get; set; }
 
 		[JsonProperty("template")]
-		[JsonConverter(typeof(ReadAsTypeJsonConverter<SearchTemplateRequest>))]
 		ISearchTemplateRequest Template { get; set; }
 
 		[JsonProperty("types")]

--- a/src/Nest/XPack/Watcher/Input/SimpleInput.cs
+++ b/src/Nest/XPack/Watcher/Input/SimpleInput.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(SimpleInputJsonConverter))]
+	[ContractJsonConverter(typeof(SimpleInputJsonConverter))]
 	public interface ISimpleInput : IInput
 	{
 		IDictionary<string, object> Payload { get; }

--- a/src/Nest/XPack/Watcher/PutWatch/PutWatchResponse.cs
+++ b/src/Nest/XPack/Watcher/PutWatch/PutWatchResponse.cs
@@ -3,7 +3,7 @@
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<PutWatchResponse>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<PutWatchResponse>))]
 	public interface IPutWatchResponse : IResponse
 	{
 		[JsonProperty("created")]

--- a/src/Nest/XPack/Watcher/Schedule/CronExpression.cs
+++ b/src/Nest/XPack/Watcher/Schedule/CronExpression.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(CronExpressionJsonConverter))]
+	[ContractJsonConverter(typeof(CronExpressionJsonConverter))]
 	public class CronExpression : ScheduleBase, IEquatable<CronExpression>
 	{
 		private readonly string _expression;

--- a/src/Nest/XPack/Watcher/Schedule/DailySchedule.cs
+++ b/src/Nest/XPack/Watcher/Schedule/DailySchedule.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<TimeOfDay>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<TimeOfDay>))]
 	public interface ITimeOfDay
 	{
 		[JsonProperty("hour")]

--- a/src/Nest/XPack/Watcher/Schedule/HourlySchedule.cs
+++ b/src/Nest/XPack/Watcher/Schedule/HourlySchedule.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<HourlySchedule>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<HourlySchedule>))]
 	public interface IHourlySchedule : ISchedule
 	{
 		[JsonProperty("minute")]

--- a/src/Nest/XPack/Watcher/Schedule/Interval.cs
+++ b/src/Nest/XPack/Watcher/Schedule/Interval.cs
@@ -27,7 +27,7 @@ namespace Nest
 		Week,
 	}
 
-	[JsonConverter(typeof(IntervalJsonConverter))]
+	[ContractJsonConverter(typeof(IntervalJsonConverter))]
 	public class Interval : ScheduleBase, IComparable<Interval>, IEquatable<Interval>
 	{
 		private const long DaySeconds = 86400;

--- a/src/Nest/XPack/Watcher/Schedule/MonthlySchedule.cs
+++ b/src/Nest/XPack/Watcher/Schedule/MonthlySchedule.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ScheduleJsonConverter<IMonthlySchedule, MonthlySchedule, ITimeOfMonth>))]
+	[ContractJsonConverter(typeof(ScheduleJsonConverter<IMonthlySchedule, MonthlySchedule, ITimeOfMonth>))]
 	public interface IMonthlySchedule : ISchedule, IEnumerable<ITimeOfMonth> { }
 
 	public class MonthlySchedule : ScheduleBase, IMonthlySchedule

--- a/src/Nest/XPack/Watcher/Schedule/ScheduleContainer.cs
+++ b/src/Nest/XPack/Watcher/Schedule/ScheduleContainer.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject(MemberSerialization.OptIn)]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<ScheduleContainer>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<ScheduleContainer>))]
 	public interface IScheduleContainer
 	{
 		[JsonProperty("cron")]

--- a/src/Nest/XPack/Watcher/Schedule/ScheduleTriggerEvent.cs
+++ b/src/Nest/XPack/Watcher/Schedule/ScheduleTriggerEvent.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<ScheduleTriggerEvent>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<ScheduleTriggerEvent>))]
 	public interface IScheduleTriggerEvent : ITriggerEvent
 	{
 		[JsonProperty("scheduled_time")]

--- a/src/Nest/XPack/Watcher/Schedule/TimeOfMonth.cs
+++ b/src/Nest/XPack/Watcher/Schedule/TimeOfMonth.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<TimeOfMonth>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<TimeOfMonth>))]
 	public interface ITimeOfMonth
 	{
 		[JsonProperty("at")]

--- a/src/Nest/XPack/Watcher/Schedule/TimeOfWeek.cs
+++ b/src/Nest/XPack/Watcher/Schedule/TimeOfWeek.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<TimeOfWeek>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<TimeOfWeek>))]
 	public interface ITimeOfWeek
 	{
 		[JsonProperty("at")]

--- a/src/Nest/XPack/Watcher/Schedule/TimeOfYear.cs
+++ b/src/Nest/XPack/Watcher/Schedule/TimeOfYear.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<TimeOfYear>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<TimeOfYear>))]
 	public interface ITimeOfYear
 	{
 		[JsonProperty("at")]

--- a/src/Nest/XPack/Watcher/Schedule/WeeklySchedule.cs
+++ b/src/Nest/XPack/Watcher/Schedule/WeeklySchedule.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ScheduleJsonConverter<IWeeklySchedule, WeeklySchedule, ITimeOfWeek>))]
+	[ContractJsonConverter(typeof(ScheduleJsonConverter<IWeeklySchedule, WeeklySchedule, ITimeOfWeek>))]
 	public interface IWeeklySchedule : ISchedule, IEnumerable<ITimeOfWeek> { }
 
 	public class WeeklySchedule : ScheduleBase, IWeeklySchedule

--- a/src/Nest/XPack/Watcher/Schedule/YearlySchedule.cs
+++ b/src/Nest/XPack/Watcher/Schedule/YearlySchedule.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ScheduleJsonConverter<IYearlySchedule, YearlySchedule, ITimeOfYear>))]
+	[ContractJsonConverter(typeof(ScheduleJsonConverter<IYearlySchedule, YearlySchedule, ITimeOfYear>))]
 	public interface IYearlySchedule : ISchedule, IEnumerable<ITimeOfYear> { }
 
 	public class YearlySchedule : ScheduleBase, IYearlySchedule

--- a/src/Nest/XPack/Watcher/Transform/ChainTransform.cs
+++ b/src/Nest/XPack/Watcher/Transform/ChainTransform.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ChainTransformJsonConverter))]
+	[ContractJsonConverter(typeof(ChainTransformJsonConverter))]
 	public interface IChainTransform : ITransform
 	{
 		ICollection<TransformContainer> Transforms { get; set; }

--- a/src/Nest/XPack/Watcher/Transform/ScriptTransformBase.cs
+++ b/src/Nest/XPack/Watcher/Transform/ScriptTransformBase.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ScriptTransformJsonConverter))]
+	[ContractJsonConverter(typeof(ScriptTransformJsonConverter))]
 	public interface IScriptTransform : ITransform
 	{
 		[JsonProperty("lang")]

--- a/src/Nest/XPack/Watcher/Transform/SearchTransform.cs
+++ b/src/Nest/XPack/Watcher/Transform/SearchTransform.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject]
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<SearchTransform>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<SearchTransform>))]
 	public interface ISearchTransform : ITransform
 	{
 		[JsonProperty("request")]

--- a/src/Nest/XPack/Watcher/Transform/TransformContainer.cs
+++ b/src/Nest/XPack/Watcher/Transform/TransformContainer.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject(MemberSerialization.OptIn)]
-	[JsonConverter(typeof(ReserializeJsonConverter<TransformContainer, ITransformContainer>))]
+	[ContractJsonConverter(typeof(ReserializeJsonConverter<TransformContainer, ITransformContainer>))]
 	public interface ITransformContainer
 	{
 		[JsonProperty("chain")]

--- a/src/Nest/XPack/Watcher/Trigger/TriggerContainer.cs
+++ b/src/Nest/XPack/Watcher/Trigger/TriggerContainer.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Nest
 {
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-	[JsonConverter(typeof(ReserializeJsonConverter<TriggerContainer, ITriggerContainer>))]
+	[ContractJsonConverter(typeof(ReserializeJsonConverter<TriggerContainer, ITriggerContainer>))]
 	public interface ITriggerContainer
 	{
 		[JsonProperty("schedule")]

--- a/src/Nest/XPack/Watcher/Trigger/TriggerEventContainer.cs
+++ b/src/Nest/XPack/Watcher/Trigger/TriggerEventContainer.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
-	[JsonConverter(typeof(ReadAsTypeJsonConverter<TriggerEventContainer>))]
+	[ContractJsonConverter(typeof(ReadAsTypeJsonConverter<TriggerEventContainer>))]
 	public interface ITriggerEventContainer
 	{
 		[JsonProperty("schedule")]

--- a/src/Nest/XPack/Watcher/Watch.cs
+++ b/src/Nest/XPack/Watcher/Watch.cs
@@ -7,7 +7,6 @@ namespace Nest
 	public class Watch
 	{
 		[JsonProperty("actions")]
-		[JsonConverter(typeof(ActionsJsonConverter))]
 		public Actions Actions { get; internal set; }
 
 		[JsonProperty("condition")]

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -12,8 +12,8 @@
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
-    <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20181120T172449" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
+    <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20190328T022354" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -8,7 +8,7 @@
 mode: u
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
-elasticsearch_version: 6.6.2
+elasticsearch_version: 6.7.0
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
 # cluster_filter:
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running

--- a/src/Tests/Tests.Core/Tests.Core.csproj
+++ b/src/Tests/Tests.Core/Tests.Core.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20181126T225021" />
+    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20190328T022354" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />

--- a/src/Tests/Tests.Domain/Tests.Domain.csproj
+++ b/src/Tests/Tests.Domain/Tests.Domain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20181126T225021" />
+    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190328T022354" />
     <ProjectReference Include="..\Tests.Configuration\Tests.Configuration.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/src/Tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
-    <PackageReference Include="BenchMarkDotNet" Version="0.11.3" />
+    <PackageReference Include="BenchMarkDotNet" Version="0.11.4" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests/Search/MultiSearch/MultiSearchApiTests.cs
+++ b/src/Tests/Tests/Search/MultiSearch/MultiSearchApiTests.cs
@@ -15,7 +15,6 @@ using static Tests.Domain.Helpers.TestValueHelper;
 
 namespace Tests.Search.MultiSearch
 {
-	[SkipVersion(">5.0.0-alpha1", "format of percolate query changed.")]
 	public class MultiSearchApiTests
 		: ApiIntegrationTestBase<ReadOnlyCluster, IMultiSearchResponse, IMultiSearchRequest, MultiSearchDescriptor, MultiSearchRequest>
 	{


### PR DESCRIPTION
Use ContractJsonConverterAttribute where possible, and short-circuit `JsonContract` creation when a custom converter is found.