### PR TITLE
Remove generated [Obsolete] parameters

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParametersPatcher.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParametersPatcher.cs
@@ -45,7 +45,8 @@ namespace ApiGenerator.Domain
 
 				if (partialList.Contains(queryStringKey)) kv.Value.RenderPartial = true;
 
-				if (obsoleteLookup.TryGetValue(queryStringKey, out var obsolete)) kv.Value.Obsolete = obsolete;
+				// TODO: Change this back once https://github.com/elastic/elasticsearch/pull/41098 is merged
+				if (obsoleteLookup.TryGetValue(queryStringKey, out var obsolete)) continue;
 
 				//make sure source_enabled takes a boolean only
 				if (preferredName == "source_enabled") kv.Value.Type = "boolean";

--- a/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParametersPatcher.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/ApiQueryParametersPatcher.cs
@@ -45,8 +45,7 @@ namespace ApiGenerator.Domain
 
 				if (partialList.Contains(queryStringKey)) kv.Value.RenderPartial = true;
 
-				// TODO: Change this back once https://github.com/elastic/elasticsearch/pull/41098 is merged
-				if (obsoleteLookup.TryGetValue(queryStringKey, out var obsolete)) continue;
+				if (obsoleteLookup.TryGetValue(queryStringKey, out var obsolete)) kv.Value.Obsolete = obsolete;
 
 				//make sure source_enabled takes a boolean only
 				if (preferredName == "source_enabled") kv.Value.Type = "boolean";

--- a/src/CodeGeneration/ApiGenerator/Overrides/GlobalOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Overrides/GlobalOverrides.cs
@@ -49,6 +49,8 @@ namespace ApiGenerator.Overrides
 
 		public override IEnumerable<string> SkipQueryStringParams { get; } = new[]
 		{
+			"parent", //can be removed once https://github.com/elastic/elasticsearch/pull/41098 is in
+			"copy_settings", //this still needs a PR?
 			"source", // allows the body to be specified as a request param, we do not want to advertise this with a strongly typed method
 			"ttl",
 			"timestamp",

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -609,9 +609,6 @@ namespace Elasticsearch.Net
 		/// shard (number of replicas + 1)
 		///</summary>
 		public string WaitForActiveShards { get => Q<string>("wait_for_active_shards"); set => Q("wait_for_active_shards", value); }
-		///<summary>ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>
 		/// If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this
 		/// operation visible to search, if `false` (the default) then do nothing with refreshes.
@@ -638,9 +635,6 @@ namespace Elasticsearch.Net
 		/// shard (number of replicas + 1)
 		///</summary>
 		public string WaitForActiveShards { get => Q<string>("wait_for_active_shards"); set => Q("wait_for_active_shards", value); }
-		///<summary>ID of parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>
 		/// If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this
 		/// operation visible to search, if `false` (the default) then do nothing with refreshes.
@@ -757,9 +751,6 @@ namespace Elasticsearch.Net
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
 		///<summary>A comma-separated list of stored fields to return in the response</summary>
 		public string[] StoredFields { get => Q<string[]>("stored_fields"); set => Q("stored_fields", value); }
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -783,9 +774,6 @@ namespace Elasticsearch.Net
 	public class SourceExistsRequestParameters : RequestParameters<SourceExistsRequestParameters> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -821,9 +809,6 @@ namespace Elasticsearch.Net
 		public string[] StoredFields { get => Q<string[]>("stored_fields"); set => Q("stored_fields", value); }
 		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
 		public bool? Lenient { get => Q<bool?>("lenient"); set => Q("lenient", value); }
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Query in the Lucene query string syntax</summary>
@@ -859,9 +844,6 @@ namespace Elasticsearch.Net
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 		///<summary>A comma-separated list of stored fields to return in the response</summary>
 		public string[] StoredFields { get => Q<string[]>("stored_fields"); set => Q("stored_fields", value); }
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -892,9 +874,6 @@ namespace Elasticsearch.Net
 	public class SourceRequestParameters : RequestParameters<SourceRequestParameters> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -926,9 +905,6 @@ namespace Elasticsearch.Net
 		public string WaitForActiveShards { get => Q<string>("wait_for_active_shards"); set => Q("wait_for_active_shards", value); }
 		///<summary>Explicit operation type</summary>
 		public OpType? OpType { get => Q<OpType?>("op_type"); set => Q("op_type", value); }
-		///<summary>ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>
 		/// If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this
 		/// operation visible to search, if `false` (the default) then do nothing with refreshes.
@@ -1448,9 +1424,6 @@ namespace Elasticsearch.Net
 	public class ShrinkIndexRequestParameters : RequestParameters<ShrinkIndexRequestParameters> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
-		///<summary>whether or not to copy settings from the source index (defaults to false)</summary>
-		[Obsolete("Scheduled to be removed in 7.0, Elasticsearch 6.4 will throw an exception if this is turned off see elastic/elasticsearch#30404")]
-		public bool? CopySettings { get => Q<bool?>("copy_settings"); set => Q("copy_settings", value); }
 		///<summary>Explicit operation timeout</summary>
 		public TimeSpan Timeout { get => Q<TimeSpan>("timeout"); set => Q("timeout", value); }
 		///<summary>Specify timeout for connection to master</summary>
@@ -1462,9 +1435,6 @@ namespace Elasticsearch.Net
 	public class SplitIndexRequestParameters : RequestParameters<SplitIndexRequestParameters> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
-		///<summary>whether or not to copy settings from the source index (defaults to false)</summary>
-		[Obsolete("Scheduled to be removed in 7.0, Elasticsearch 6.4 will throw an exception if this is turned off see elastic/elasticsearch#30404")]
-		public bool? CopySettings { get => Q<bool?>("copy_settings"); set => Q("copy_settings", value); }
 		///<summary>Explicit operation timeout</summary>
 		public TimeSpan Timeout { get => Q<TimeSpan>("timeout"); set => Q("timeout", value); }
 		///<summary>Specify timeout for connection to master</summary>
@@ -1682,9 +1652,6 @@ namespace Elasticsearch.Net
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specific routing value. Applies to all returned documents unless otherwise specified in body "params" or "docs".</summary>
 		public string Routing { get => Q<string>("routing"); set => Q("routing", value); }
-		///<summary>Parent id of documents. Applies to all returned documents unless otherwise specified in body "params" or "docs".</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specifies if requests are real-time as opposed to near-real-time (default: true).</summary>
 		public bool? Realtime { get => Q<bool?>("realtime"); set => Q("realtime", value); }
 		///<summary>Explicit version number for concurrency control</summary>
@@ -2097,9 +2064,6 @@ namespace Elasticsearch.Net
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specific routing value.</summary>
 		public string Routing { get => Q<string>("routing"); set => Q("routing", value); }
-		///<summary>Parent id of documents.</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specifies if request is real-time as opposed to near-real-time (default: true).</summary>
 		public bool? Realtime { get => Q<bool?>("realtime"); set => Q("realtime", value); }
 		///<summary>Explicit version number for concurrency control</summary>
@@ -2121,9 +2085,6 @@ namespace Elasticsearch.Net
 		public bool? SourceEnabled { get => Q<bool?>("_source"); set => Q("_source", value); }
 		///<summary>The script language (default: painless)</summary>
 		public string Lang { get => Q<string>("lang"); set => Q("lang", value); }
-		///<summary>ID of the parent document. Is is only used for routing and when for the upsert request</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>
 		/// If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this
 		/// operation visible to search, if `false` (the default) then do nothing with refreshes.

--- a/src/Elasticsearch.Net/Extensions/Fluent.cs
+++ b/src/Elasticsearch.Net/Extensions/Fluent.cs
@@ -4,14 +4,6 @@ namespace Elasticsearch.Net
 {
 	internal static class Fluent
 	{
-		[Obsolete("Use the overload that accepts TValue")]
-		internal static TDescriptor Assign<TDescriptor, TInterface>(TDescriptor self, Action<TInterface> assign)
-			where TDescriptor : class, TInterface
-		{
-			assign(self);
-			return self;
-		}
-
 		internal static TDescriptor Assign<TDescriptor, TInterface, TValue>(TDescriptor self, TValue value, Action<TInterface, TValue> assign)
 			where TDescriptor : class, TInterface
 		{

--- a/src/Nest/Aggregations/Bucket/BucketAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/BucketAggregation.cs
@@ -31,10 +31,6 @@ namespace Nest
 
 		string IAggregation.Name { get; set; }
 
-		[Obsolete("Use the overload that accepts TValue")]
-		protected TBucketAggregation Assign(Action<TBucketAggregationInterface> assigner) =>
-			Fluent.Assign((TBucketAggregation)this, assigner);
-
 		protected TBucketAggregation Assign<TValue>(TValue value, Action<TBucketAggregationInterface, TValue> assigner) =>
 			Fluent.Assign((TBucketAggregation)this, value, assigner);
 

--- a/src/Nest/Aggregations/Bucket/Terms/TermsOrder.cs
+++ b/src/Nest/Aggregations/Bucket/Terms/TermsOrder.cs
@@ -14,11 +14,5 @@ namespace Nest
 		public static TermsOrder KeyAscending => new TermsOrder { Key = "_key", Order = SortOrder.Ascending };
 		public static TermsOrder KeyDescending => new TermsOrder { Key = "_key", Order = SortOrder.Descending };
 		public SortOrder Order { get; set; }
-
-		[Obsolete("Deprecated in Elasticsearch 6.0. Use KeyAscending")]
-		public static TermsOrder TermAscending => new TermsOrder { Key = "_key", Order = SortOrder.Ascending };
-
-		[Obsolete("Deprecated in Elasticsearch 6.0. Use KeyDescending")]
-		public static TermsOrder TermDescending => new TermsOrder { Key = "_key", Order = SortOrder.Descending };
 	}
 }

--- a/src/Nest/Analysis/TokenFilters/Synonym/SynonymGraphTokenFilter.cs
+++ b/src/Nest/Analysis/TokenFilters/Synonym/SynonymGraphTokenFilter.cs
@@ -18,11 +18,6 @@ namespace Nest
 		[DataMember(Name ="format")]
 		SynonymFormat? Format { get; set; }
 
-		[DataMember(Name ="ignore_case")]
-		[Obsolete("Will be removed in Elasticsearch 7.x, if you need to ignore case add a lowercase filter before this synonym filter")]
-		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
-		bool? IgnoreCase { get; set; }
-
 		/// <inheritdoc cref="ISynonymTokenFilter.Lenient" />
 		[DataMember(Name ="lenient")]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
@@ -52,10 +47,6 @@ namespace Nest
 		/// <inheritdoc />
 		public SynonymFormat? Format { get; set; }
 
-		/// <inheritdoc />
-		[Obsolete("Will be removed in Elasticsearch 7.x, if you need to ignore case add a lowercase filter before this synonym filter")]
-		public bool? IgnoreCase { get; set; }
-
 		/// <inheritdoc cref="ISynonymTokenFilter.Lenient" />
 		public bool? Lenient { get; set; }
 
@@ -77,16 +68,11 @@ namespace Nest
 		bool? ISynonymGraphTokenFilter.Expand { get; set; }
 		SynonymFormat? ISynonymGraphTokenFilter.Format { get; set; }
 
-		bool? ISynonymGraphTokenFilter.IgnoreCase { get; set; }
 		bool? ISynonymGraphTokenFilter.Lenient { get; set; }
 
 		IEnumerable<string> ISynonymGraphTokenFilter.Synonyms { get; set; }
 		string ISynonymGraphTokenFilter.SynonymsPath { get; set; }
 		string ISynonymGraphTokenFilter.Tokenizer { get; set; }
-
-		/// <inheritdoc />
-		[Obsolete("Will be removed in Elasticsearch 7.x, if you need to ignore case add a lowercase filter before this synonym filter")]
-		public SynonymGraphTokenFilterDescriptor IgnoreCase(bool? ignoreCase = true) => Assign(ignoreCase, (a, v) => a.IgnoreCase = v);
 
 		/// <inheritdoc />
 		public SynonymGraphTokenFilterDescriptor Expand(bool? expand = true) => Assign(expand, (a, v) => a.Expand = v);

--- a/src/Nest/Analysis/TokenFilters/Synonym/SynonymTokenFilter.cs
+++ b/src/Nest/Analysis/TokenFilters/Synonym/SynonymTokenFilter.cs
@@ -17,14 +17,9 @@ namespace Nest
 		[DataMember(Name ="format")]
 		SynonymFormat? Format { get; set; }
 
-		[DataMember(Name ="ignore_case")]
-		[Obsolete("Will be removed in Elasticsearch 7.x, if you need to ignore case add a lowercase filter before this synonym filter")]
-		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
-		bool? IgnoreCase { get; set; }
-
 		/// <summary>
 		/// If `true` ignores exceptions while parsing the synonym configuration. It is important
-		// to note that only those synonym rules which cannot get parsed are ignored.
+		/// to note that only those synonym rules which cannot get parsed are ignored.
 		/// </summary>
 		[DataMember(Name ="lenient")]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
@@ -54,10 +49,6 @@ namespace Nest
 		/// <inheritdoc />
 		public SynonymFormat? Format { get; set; }
 
-		/// <inheritdoc />
-		[Obsolete("Will be removed in Elasticsearch 7.x, if you need to ignore case add a lowercase filter before this synonym filter")]
-		public bool? IgnoreCase { get; set; }
-
 		/// <inheritdoc cref="ISynonymTokenFilter.Lenient" />
 		public bool? Lenient { get; set; }
 
@@ -78,16 +69,10 @@ namespace Nest
 		protected override string Type => "synonym";
 		bool? ISynonymTokenFilter.Expand { get; set; }
 		SynonymFormat? ISynonymTokenFilter.Format { get; set; }
-
-		bool? ISynonymTokenFilter.IgnoreCase { get; set; }
 		bool? ISynonymTokenFilter.Lenient { get; set; }
 		IEnumerable<string> ISynonymTokenFilter.Synonyms { get; set; }
 		string ISynonymTokenFilter.SynonymsPath { get; set; }
 		string ISynonymTokenFilter.Tokenizer { get; set; }
-
-		/// <inheritdoc />
-		[Obsolete("Will be removed in Elasticsearch 7.x, if you need to ignore case add a lowercase filter before this synonym filter")]
-		public SynonymTokenFilterDescriptor IgnoreCase(bool? ignoreCase = true) => Assign(ignoreCase, (a, v) => a.IgnoreCase = v);
 
 		/// <inheritdoc />
 		public SynonymTokenFilterDescriptor Expand(bool? expand = true) => Assign(expand, (a, v) => a.Expand = v);

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -244,12 +244,6 @@ namespace Nest
 		/// The mapping can infer the index, type, id and relation name for a given CLR type, as well as control
 		/// serialization behaviour for CLR properties.
 		/// </summary>
-		[Obsolete("Please use " + nameof(DefaultMappingFor))]
-		public TConnectionSettings InferMappingFor<TDocument>(Func<ClrTypeMappingDescriptor<TDocument>, IClrTypeMapping<TDocument>> selector)
-			where TDocument : class =>
-			DefaultMappingFor<TDocument>(selector);
-
-		/// <inheritdoc cref="InferMappingFor{TDocument}"/>
 		public TConnectionSettings DefaultMappingFor<TDocument>(Func<ClrTypeMappingDescriptor<TDocument>, IClrTypeMapping<TDocument>> selector)
 			where TDocument : class
 		{

--- a/src/Nest/CommonAbstractions/Fluent/DescriptorBase.cs
+++ b/src/Nest/CommonAbstractions/Fluent/DescriptorBase.cs
@@ -18,9 +18,6 @@ namespace Nest
 		[IgnoreDataMember]
 		protected TInterface Self => _self;
 
-		[Obsolete("Use the overload that accepts TValue")]
-		protected TDescriptor Assign(Action<TInterface> assigner) => Fluent.Assign(_self, assigner);
-
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		protected TDescriptor Assign<TValue>(TValue value, Action<TInterface, TValue> assigner) => Fluent.Assign(_self, value, assigner);
 

--- a/src/Nest/CommonAbstractions/Fluent/Fluent.cs
+++ b/src/Nest/CommonAbstractions/Fluent/Fluent.cs
@@ -5,14 +5,6 @@ namespace Nest
 {
 	internal static class Fluent
 	{
-		[Obsolete("Use the overload that accepts TValue")]
-		internal static TDescriptor Assign<TDescriptor, TInterface>(TDescriptor self, Action<TInterface> assign)
-			where TDescriptor : class, TInterface
-		{
-			assign(self);
-			return self;
-		}
-
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static TDescriptor Assign<TDescriptor, TInterface, TValue>(TDescriptor self, TValue value, Action<TInterface, TValue> assign)
 			where TDescriptor : class, TInterface

--- a/src/Nest/CommonAbstractions/Request/RequestBase.cs
+++ b/src/Nest/CommonAbstractions/Request/RequestBase.cs
@@ -91,9 +91,6 @@ namespace Nest
 
 		protected TInterface Self => _descriptor;
 
-		[Obsolete("Use the overload that accepts TValue")]
-		protected TDescriptor Assign(Action<TInterface> assign) => Fluent.Assign(_descriptor, assign);
-
 		protected TDescriptor Assign<TValue>(TValue value, Action<TInterface, TValue> assign) => Fluent.Assign(_descriptor, value, assign);
 
 		protected TDescriptor AssignParam(Action<TParameters> assigner)

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkOperationBase.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkOperationBase.cs
@@ -8,9 +8,6 @@ namespace Nest
 		public Id Id { get; set; }
 		public IndexName Index { get; set; }
 
-		[Obsolete("This property is no longer available in indices created in Elasticsearch 6.x and up")]
-		public Id Parent { get; set; }
-
 		public int? RetriesOnConflict { get; set; }
 		public Routing Routing { get; set; }
 		public long? Version { get; set; }
@@ -48,9 +45,6 @@ namespace Nest
 
 		IndexName IBulkOperation.Index { get; set; }
 		string IBulkOperation.Operation => BulkOperationType;
-
-		[Obsolete("This feature is no longer supported on indices created in Elasticsearch 6.x and up")]
-		Id IBulkOperation.Parent { get; set; }
 
 		int? IBulkOperation.RetriesOnConflict { get; set; }
 		Routing IBulkOperation.Routing { get; set; }
@@ -90,8 +84,5 @@ namespace Nest
 		public TDescriptor VersionType(VersionType? versionType) => Assign(versionType, (a, v) => a.VersionType = v);
 
 		public TDescriptor Routing(Routing routing) => Assign(routing, (a, v) => a.Routing = v);
-
-		[Obsolete("This feature is no longer supported on indices created in Elasticsearch 6.x and up")]
-		public TDescriptor Parent(Id parent) => Assign(parent, (a, v) => a.Parent = v);
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/IBulkOperation.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/IBulkOperation.cs
@@ -17,9 +17,6 @@ namespace Nest
 
 		string Operation { get; }
 
-		[DataMember(Name = "parent")]
-		Id Parent { get; set; }
-
 		[DataMember(Name = "retry_on_conflict")]
 		int? RetriesOnConflict { get; set; }
 

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -119,9 +119,6 @@ namespace Nest
 					if (request.BufferToBulk != null) request.BufferToBulk(s, buffer);
 					else s.IndexMany(buffer);
 					if (!string.IsNullOrEmpty(request.Pipeline)) s.Pipeline(request.Pipeline);
-#pragma warning disable 618
-					if (request.Refresh.HasValue) s.Refresh(request.Refresh.Value);
-#pragma warning restore 618
 					if (request.Routing != null) s.Routing(request.Routing);
 					if (request.WaitForActiveShards.HasValue) s.WaitForActiveShards(request.WaitForActiveShards.ToString());
 

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllRequest.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllRequest.cs
@@ -57,10 +57,6 @@ namespace Nest
 		///<summary>The pipeline id to preprocess all the incoming documents with</summary>
 		string Pipeline { get; set; }
 
-		///<summary>Refresh the index after performing each operation (Elasticsearch will refresh locally)</summary>
-		[Obsolete("This option is scheduled for deletion in 7.0, refreshing on each _bulk makes little sense for BulkAll")]
-		Refresh? Refresh { get; set; }
-
 		/// <summary>The indices you wish to refresh after the bulk all completes, defaults to <see cref="Index" /> </summary>
 		Indices RefreshIndices { get; set; }
 
@@ -132,9 +128,6 @@ namespace Nest
 		public string Pipeline { get; set; }
 
 		/// <inheritdoc />
-		public Refresh? Refresh { get; set; }
-
-		/// <inheritdoc />
 		public Indices RefreshIndices { get; set; }
 
 		/// <inheritdoc />
@@ -178,7 +171,6 @@ namespace Nest
 		IndexName IBulkAllRequest<T>.Index { get; set; }
 		int? IBulkAllRequest<T>.MaxDegreeOfParallelism { get; set; }
 		string IBulkAllRequest<T>.Pipeline { get; set; }
-		Refresh? IBulkAllRequest<T>.Refresh { get; set; }
 		Indices IBulkAllRequest<T>.RefreshIndices { get; set; }
 		bool IBulkAllRequest<T>.RefreshOnCompleted { get; set; }
 		Func<IBulkResponseItem, T, bool> IBulkAllRequest<T>.RetryDocumentPredicate { get; set; }
@@ -209,11 +201,6 @@ namespace Nest
 
 		/// <inheritdoc cref="IBulkAllRequest{T}.RefreshOnCompleted" />
 		public BulkAllDescriptor<T> RefreshOnCompleted(bool refresh = true) => Assign(refresh, (a, v) => a.RefreshOnCompleted = v);
-
-		/// <inheritdoc cref="IBulkAllRequest{T}.Refresh" />
-#pragma warning disable 618
-		public BulkAllDescriptor<T> Refresh(Refresh? refresh) => Assign(refresh, (a, v) => a.Refresh = v);
-#pragma warning restore 618
 
 		/// <inheritdoc cref="IBulkAllRequest{T}.RefreshIndices" />
 		public BulkAllDescriptor<T> RefreshIndices(Indices indicesToRefresh) => Assign(indicesToRefresh, (a, v) => a.RefreshIndices = v);

--- a/src/Nest/Document/Multiple/MultiGet/Response/MultiGetHit.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Response/MultiGetHit.cs
@@ -15,10 +15,8 @@ namespace Nest
 
 		string Index { get; }
 
-		[Obsolete("This feature is no longer supported on indices created in Elasticsearch 6.x and up, use Routing instead.")]
-		string Parent { get; }
-
 		string Routing { get; }
+
 		TDocument Source { get; }
 
 		string Type { get; }
@@ -44,9 +42,6 @@ namespace Nest
 
 		[DataMember(Name = "_index")]
 		public string Index { get; internal set; }
-
-		[DataMember(Name = "_parent")]
-		public string Parent { get; internal set; }
 
 		[DataMember(Name = "_routing")]
 		public string Routing { get; internal set; }

--- a/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
+++ b/src/Nest/Document/Multiple/Reindex/ReindexObservable.cs
@@ -113,11 +113,6 @@ namespace Nest
 						Id = hit.Id,
 						Routing = hit.Routing,
 					};
-#pragma warning disable 618
-					//if the source still has parent provide it as a routing key instead
-					if (hit.Parent != null)
-						item.Routing = hit.Parent;
-#pragma warning restore 618
 					bulk.AddOperation(item);
 				}
 			};

--- a/src/Nest/Document/Single/Get/GetResponse.cs
+++ b/src/Nest/Document/Single/Get/GetResponse.cs
@@ -18,10 +18,6 @@ namespace Nest
 		[DataMember(Name = "_index")]
 		string Index { get; }
 
-		[DataMember(Name = "_parent")]
-		[Obsolete("No longer returned on indices created in Elasticsearch 6.0")]
-		string Parent { get; }
-
 		[DataMember(Name = "_routing")]
 		string Routing { get; }
 
@@ -43,7 +39,6 @@ namespace Nest
 		public bool Found { get; internal set; }
 		public string Id { get; internal set; }
 		public string Index { get; internal set; }
-		public string Parent { get; internal set; }
 		public string Routing { get; internal set; }
 		public TDocument Source { get; internal set; }
 		public string Type { get; internal set; }

--- a/src/Nest/Document/Single/Update/UpdateRequest.cs
+++ b/src/Nest/Document/Single/Update/UpdateRequest.cs
@@ -51,14 +51,6 @@ namespace Nest
 		public bool? DocAsUpsert { get; set; }
 
 		/// <inheritdoc />
-		[Obsolete("Removed in Elasticsearch 7.x, use source filtering instead")]
-		public Fields Fields
-		{
-			get => Self.RequestParameters.GetQueryStringValue<Fields>("fields");
-			set => Self.RequestParameters.SetQueryString("fields", value);
-		}
-
-		/// <inheritdoc />
 		public IScript Script { get; set; }
 
 		/// <inheritdoc />
@@ -109,20 +101,9 @@ namespace Nest
 		public UpdateDescriptor<TDocument, TPartialDocument> Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
 			Assign(scriptSelector, (a, v) => a.Script = v?.Invoke(new ScriptDescriptor()));
 
-		public UpdateDescriptor<TDocument, TPartialDocument> Fields(Fields fields) =>
-			Assign(fields, (a, v) => a.RequestParameters.SetQueryString("fields", v));
-
 		public UpdateDescriptor<TDocument, TPartialDocument> Source(bool? enabled = true) => Assign(enabled, (a, v) => a.Source = v);
 
 		public UpdateDescriptor<TDocument, TPartialDocument> Source(Func<SourceFilterDescriptor<TDocument>, ISourceFilter> selector) =>
 			Assign(selector, (a, v) => a.Source = new Union<bool, ISourceFilter>(v?.Invoke(new SourceFilterDescriptor<TDocument>())));
-
-		[Obsolete("Removed in Elasticsearch 7.x, use source filtering instead")]
-		public UpdateDescriptor<TDocument, TPartialDocument> Fields(params Expression<Func<TPartialDocument, object>>[] typedPathLookups) =>
-			Assign(typedPathLookups,(a, v) => a.RequestParameters.SetQueryString("fields", v));
-
-		[Obsolete("Removed in Elasticsearch 7.x, use source filtering instead")]
-		public UpdateDescriptor<TDocument, TPartialDocument> Fields(params string[] fields) =>
-			Assign(fields,(a, v) => a.RequestParameters.SetQueryString("fields", v));
 	}
 }

--- a/src/Nest/Indices/MappingManagement/PutMapping/PutMappingRequest.cs
+++ b/src/Nest/Indices/MappingManagement/PutMapping/PutMappingRequest.cs
@@ -75,13 +75,6 @@ namespace Nest
 		ISizeField ITypeMapping.SizeField { get; set; }
 		ISourceField ITypeMapping.SourceField { get; set; }
 
-		[Obsolete("Use the overload that accepts TValue")]
-		protected PutMappingDescriptor<T> Assign(Action<ITypeMapping> assigner)
-		{
-			assigner(this);
-			return this;
-		}
-
 		protected PutMappingDescriptor<T> Assign<TValue>(TValue value, Action<ITypeMapping, TValue> assigner) =>
 			Fluent.Assign(this, value, assigner);
 

--- a/src/Nest/Indices/Monitoring/IndicesSegments/Segment.cs
+++ b/src/Nest/Indices/Monitoring/IndicesSegments/Segment.cs
@@ -29,10 +29,6 @@ namespace Nest
 		[DataMember(Name ="search")]
 		public bool Search { get; internal set; }
 
-		[DataMember(Name ="size")]
-		[Obsolete("Unused. Will be removed in the next major release")]
-		public string Size { get; internal set; }
-
 		[DataMember(Name ="size_in_bytes")]
 		public double SizeInBytes { get; internal set; }
 

--- a/src/Nest/Ingest/Processors/ScriptProcessor.cs
+++ b/src/Nest/Ingest/Processors/ScriptProcessor.cs
@@ -17,10 +17,6 @@ namespace Nest
 		[DataMember(Name ="id")]
 		string Id { get; set; }
 
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		[IgnoreDataMember]
-		string Inline { get; set; }
-
 		/// <summary>
 		/// The scripting language. Defaults to painless
 		/// </summary>
@@ -51,14 +47,6 @@ namespace Nest
 		/// </summary>
 		public string Id { get; set; }
 
-		/// <summary> An inline script to be executed </summary>
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		public string Inline
-		{
-			get => Source;
-			set => Source = value;
-		}
-
 		/// <summary>
 		/// The scripting language. Defaults to painless
 		/// </summary>
@@ -83,13 +71,6 @@ namespace Nest
 	{
 		protected override string Name => "script";
 		string IScriptProcessor.Id { get; set; }
-
-		string IScriptProcessor.Inline
-		{
-			get => Self.Source;
-			set => Self.Source = value;
-		}
-
 		string IScriptProcessor.Lang { get; set; }
 		Dictionary<string, object> IScriptProcessor.Params { get; set; }
 		string IScriptProcessor.Source { get; set; }
@@ -103,12 +84,6 @@ namespace Nest
 		/// The stored script id to refer to
 		/// </summary>
 		public ScriptProcessorDescriptor Id(string id) => Assign(id, (a, v) => a.Id = v);
-
-		/// <summary>
-		/// An inline script to be executed
-		/// </summary>
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		public ScriptProcessorDescriptor Inline(string inline) => Assign(inline, (a, v) => a.Inline = v);
 
 		/// <summary>
 		/// An inline script to be executed

--- a/src/Nest/Ingest/ProcessorsDescriptor.cs
+++ b/src/Nest/Ingest/ProcessorsDescriptor.cs
@@ -124,10 +124,6 @@ namespace Nest
 		public ProcessorsDescriptor UserAgent<T>(Func<UserAgentProcessorDescriptor<T>, IUserAgentProcessor> selector) where T : class =>
 			Assign(selector, (a, v) => a.AddIfNotNull(v?.Invoke(new UserAgentProcessorDescriptor<T>())));
 
-		[Obsolete("This method takes the wrong descriptor please use Kv")]
-		public ProcessorsDescriptor KeyValue<T>(Func<UserAgentProcessorDescriptor<T>, IUserAgentProcessor> selector) where T : class =>
-			Assign(selector, (a, v) => a.AddIfNotNull(v?.Invoke(new UserAgentProcessorDescriptor<T>())));
-
 		/// <inheritdoc cref="IKeyValueProcessor" />
 		public ProcessorsDescriptor Kv<T>(Func<KeyValueProcessorDescriptor<T>, IKeyValueProcessor> selector) where T : class =>
 			Assign(selector, (a, v) => a.AddIfNotNull(v?.Invoke(new KeyValueProcessorDescriptor<T>())));

--- a/src/Nest/Mapping/AttributeBased/ElasticsearchTypeAttribute.cs
+++ b/src/Nest/Mapping/AttributeBased/ElasticsearchTypeAttribute.cs
@@ -13,9 +13,6 @@ namespace Nest
 
 		public string IdProperty { get; set; }
 
-		[Obsolete("types are gone, if you want to set the join datatype name use RelationName instead")]
-		public string Name { get; set; }
-
 		public string RelationName { get; set; }
 
 		public static ElasticsearchTypeAttribute From(Type type)

--- a/src/Nest/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctions.cs
+++ b/src/Nest/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctions.cs
@@ -58,14 +58,6 @@ namespace Nest
 		public ScoreFunctionsDescriptor<T> RandomScore(Func<RandomScoreFunctionDescriptor<T>, IRandomScoreFunction> selector = null) =>
 			Assign(selector, (a, v) => a.AddIfNotNull(v.InvokeOrDefault(new RandomScoreFunctionDescriptor<T>())));
 
-		[Obsolete("Elasticsearch 7.x will require a field when a seed is provided")]
-		public ScoreFunctionsDescriptor<T> RandomScore(long seed) =>
-			Assign(seed, (a, v) => a.AddIfNotNull(new RandomScoreFunction { Seed = v }));
-
-		[Obsolete("Elasticsearch 7.x will require a field when a seed is provided")]
-		public ScoreFunctionsDescriptor<T> RandomScore(string seed) =>
-			Assign(seed, (a, v) => a.AddIfNotNull(new RandomScoreFunction { Seed = v }));
-
 		public ScoreFunctionsDescriptor<T> Weight(Func<WeightFunctionDescriptor<T>, IWeightFunction> selector) =>
 			Assign(selector, (a, v) => a.AddIfNotNull(v?.Invoke(new WeightFunctionDescriptor<T>())));
 

--- a/src/Nest/Search/Search/Hits/Hit.cs
+++ b/src/Nest/Search/Search/Hits/Hit.cs
@@ -10,10 +10,6 @@ namespace Nest
 	{
 		string Id { get; }
 		string Index { get; }
-
-		[Obsolete("No longer returned on indexes created in Elasticsearch 6.x and up, use Routing instead")]
-		string Parent { get; }
-
 		string Routing { get; }
 
 		[JsonFormatter(typeof(SourceFormatter<>))]
@@ -35,8 +31,7 @@ namespace Nest
 				Index = source.Index,
 				Id = source.Id,
 #pragma warning disable 618
-				Routing = source.Routing ?? source.Parent,
-				Parent = source.Parent,
+				Routing = source.Routing,
 #pragma warning restore 618
 				Source = mapper(source.Source)
 			};
@@ -102,10 +97,6 @@ namespace Nest
 
 		[DataMember(Name = "_nested")]
 		public NestedIdentity Nested { get; internal set; }
-
-		[DataMember(Name = "_parent")]
-		[Obsolete("This property is no longer returned on indices created in Elasticsearch 6.0.0 and up, use Routing instead")]
-		public string Parent { get; internal set; }
 
 		[DataMember(Name = "_routing")]
 		public string Routing { get; internal set; }

--- a/src/Nest/Search/Search/SearchResponse.cs
+++ b/src/Nest/Search/Search/SearchResponse.cs
@@ -116,13 +116,10 @@ namespace Nest
 		private IReadOnlyCollection<FieldValues> _fields;
 
 		private IReadOnlyCollection<IHit<T>> _hits;
+
 		/// <inheritdoc />
 		[DataMember(Name ="aggregations")]
 		public AggregateDictionary Aggregations { get; internal set; } = AggregateDictionary.Default;
-
-		/// <inheritdoc />
-		[IgnoreDataMember]
-		public AggregateDictionary Aggs => Aggregations;
 
 		/// <inheritdoc />
 		[DataMember(Name = "_clusters")]

--- a/src/Nest/Search/Search/SearchResponse.cs
+++ b/src/Nest/Search/Search/SearchResponse.cs
@@ -16,10 +16,6 @@ namespace Nest
 		/// </summary>
 		AggregateDictionary Aggregations { get; }
 
-		/// <inheritdoc cref="Aggregations"/>
-		[Obsolete("Aggs has been renamed to Aggregations and will be removed in NEST 7.x")]
-		AggregateDictionary Aggs { get; }
-
 		/// <summary>
 		/// Gets the statistics about the clusters on which the search query was executed.
 		/// </summary>

--- a/src/Nest/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateRequest.cs
+++ b/src/Nest/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateRequest.cs
@@ -10,10 +10,6 @@ namespace Nest
 		[DataMember(Name = "file")]
 		string File { get; set; }
 
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		[IgnoreDataMember]
-		string Inline { get; set; }
-
 		[DataMember(Name = "params")]
 		[JsonFormatter(typeof(VerbatimDictionaryKeysBaseFormatter<Dictionary<string, object>, string, object>))]
 		Dictionary<string, object> Params { get; set; }
@@ -26,13 +22,6 @@ namespace Nest
 	{
 		public string File { get; set; }
 
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		public string Inline
-		{
-			get => Source;
-			set => Source = value;
-		}
-
 		public Dictionary<string, object> Params { get; set; }
 		public string Source { get; set; }
 	}
@@ -41,17 +30,8 @@ namespace Nest
 	{
 		string IRenderSearchTemplateRequest.File { get; set; }
 
-		string IRenderSearchTemplateRequest.Inline
-		{
-			get => Self.Source;
-			set => Self.Source = value;
-		}
-
 		Dictionary<string, object> IRenderSearchTemplateRequest.Params { get; set; }
 		string IRenderSearchTemplateRequest.Source { get; set; }
-
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		public RenderSearchTemplateDescriptor Inline(string inline) => Assign(inline, (a, v) => a.Inline = v);
 
 		public RenderSearchTemplateDescriptor Source(string source) => Assign(source, (a, v) => a.Source = v);
 

--- a/src/Nest/Search/SearchTemplate/SearchTemplateRequest.cs
+++ b/src/Nest/Search/SearchTemplate/SearchTemplateRequest.cs
@@ -10,10 +10,6 @@ namespace Nest
 		[DataMember(Name ="id")]
 		string Id { get; set; }
 
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		[IgnoreDataMember]
-		string Inline { get; set; }
-
 		[DataMember(Name ="params")]
 		IDictionary<string, object> Params { get; set; }
 
@@ -25,17 +21,9 @@ namespace Nest
 	{
 		public string Id { get; set; }
 
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		public string Inline
-		{
-			get => Source;
-			set => Source = value;
-		}
-
 		public IDictionary<string, object> Params { get; set; }
 
 		public string Source { get; set; }
-		public Func<dynamic, Hit<dynamic>, Type> TypeSelector { get; set; }
 		protected Type ClrType { get; set; }
 		Type ICovariantSearchRequest.ClrType => ClrType;
 
@@ -61,20 +49,11 @@ namespace Nest
 
 		string ISearchTemplateRequest.Id { get; set; }
 
-		string ISearchTemplateRequest.Inline
-		{
-			get => Self.Source;
-			set => Self.Source = value;
-		}
-
 		IDictionary<string, object> ISearchTemplateRequest.Params { get; set; }
 
 		string ISearchTemplateRequest.Source { get; set; }
 
 		protected sealed override void Initialize() => TypedKeys();
-
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		public SearchTemplateDescriptor<T> Inline(string template) => Assign(template, (a, v) => a.Inline = v);
 
 		public SearchTemplateDescriptor<T> Source(string template) => Assign(template, (a, v) => a.Source = v);
 

--- a/src/Nest/XPack/MachineLearning/Job/Detectors/GeographicDetector.cs
+++ b/src/Nest/XPack/MachineLearning/Job/Detectors/GeographicDetector.cs
@@ -39,9 +39,6 @@ namespace Nest
 	public class LatLongDetectorDescriptor<T> : DetectorDescriptorBase<LatLongDetectorDescriptor<T>, IGeographicDetector>, IGeographicDetector
 		where T : class
 	{
-		[Obsolete("Use parameterless constructor")]
-		public LatLongDetectorDescriptor(string function) : base(function) { }
-
 		public LatLongDetectorDescriptor() : base(GeographicFunction.LatLong.GetStringValue()) { }
 
 		Field IByFieldNameDetector.ByFieldName { get; set; }

--- a/src/Nest/XPack/Watcher/Condition/InlineScriptCondition.cs
+++ b/src/Nest/XPack/Watcher/Condition/InlineScriptCondition.cs
@@ -5,10 +5,6 @@ namespace Nest
 {
 	public interface IInlineScriptCondition : IScriptCondition
 	{
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		[IgnoreDataMember]
-		string Inline { get; set; }
-
 		[DataMember(Name ="source")]
 		string Source { get; set; }
 	}
@@ -17,25 +13,13 @@ namespace Nest
 	{
 		public InlineScriptCondition(string script) => Source = script;
 
-		public string Inline
-		{
-			get => Source;
-			set => Source = value;
-		}
-
 		public string Source { get; set; }
 	}
 
 	public class InlineScriptConditionDescriptor
 		: ScriptConditionDescriptorBase<InlineScriptConditionDescriptor, IInlineScriptCondition>, IInlineScriptCondition
 	{
-		public InlineScriptConditionDescriptor(string script) => Self.Source = script;
-
-		string IInlineScriptCondition.Inline
-		{
-			get => Self.Source;
-			set => Self.Source = value;
-		}
+		public InlineScriptConditionDescriptor(string source) => Self.Source = source;
 
 		string IInlineScriptCondition.Source { get; set; }
 	}

--- a/src/Nest/XPack/Watcher/Condition/ScriptConditionBase.cs
+++ b/src/Nest/XPack/Watcher/Condition/ScriptConditionBase.cs
@@ -29,12 +29,6 @@ namespace Nest
 	{
 		public IndexedScriptConditionDescriptor Id(string id) => new IndexedScriptConditionDescriptor(id);
 
-		[Obsolete("Indexed() sets a property named id, this is confusing and thats why we intent to remove this in NEST 7.x please use Id()")]
-		public IndexedScriptConditionDescriptor Indexed(string id) => new IndexedScriptConditionDescriptor(id);
-
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		public InlineScriptConditionDescriptor Inline(string script) => new InlineScriptConditionDescriptor(script);
-
 		public InlineScriptConditionDescriptor Source(string source) => new InlineScriptConditionDescriptor(source);
 	}
 
@@ -59,11 +53,10 @@ namespace Nest
 	{
 		private static readonly AutomataDictionary AutomataDictionary = new AutomataDictionary
 		{
-			{ "inline", 0 },
-			{ "source", 1 },
-			{ "id", 2 },
-			{ "lang", 3 },
-			{ "params", 4 }
+			{ "source", 0 },
+			{ "id", 1 },
+			{ "lang", 2 },
+			{ "params", 3 }
 		};
 
 		public IScriptCondition Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
@@ -83,16 +76,15 @@ namespace Nest
 					switch (value)
 					{
 						case 0:
-						case 1:
 							scriptCondition = new InlineScriptCondition(reader.ReadString());
 							break;
-						case 2:
+						case 1:
 							scriptCondition = new IndexedScriptCondition(reader.ReadString());
 							break;
-						case 3:
+						case 2:
 							language = reader.ReadString();
 							break;
-						case 4:
+						case 3:
 							parameters = formatterResolver.GetFormatter<Dictionary<string, object>>()
 								.Deserialize(ref reader, formatterResolver);
 							break;

--- a/src/Nest/XPack/Watcher/Transform/InlineScriptTransform.cs
+++ b/src/Nest/XPack/Watcher/Transform/InlineScriptTransform.cs
@@ -7,23 +7,13 @@ namespace Nest
 	[InterfaceDataContract]
 	public interface IInlineScriptTransform : IScriptTransform
 	{
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		[IgnoreDataMember]
-		string Inline { get; set; }
-
 		[DataMember(Name ="source")]
 		string Source { get; set; }
 	}
 
 	public class InlineScriptTransform : ScriptTransformBase, IInlineScriptTransform
 	{
-		public InlineScriptTransform(string script) => Source = script;
-
-		public string Inline
-		{
-			get => Source;
-			set => Source = value;
-		}
+		public InlineScriptTransform(string source) => Source = source;
 
 		public string Source { get; set; }
 	}
@@ -32,12 +22,6 @@ namespace Nest
 		: ScriptTransformDescriptorBase<InlineScriptTransformDescriptor, IInlineScriptTransform>, IInlineScriptTransform
 	{
 		public InlineScriptTransformDescriptor(string inline) => Self.Source = inline;
-
-		string IInlineScriptTransform.Inline
-		{
-			get => Self.Source;
-			set => Self.Source = value;
-		}
 
 		string IInlineScriptTransform.Source { get; set; }
 	}

--- a/src/Nest/XPack/Watcher/Transform/ScriptTransformBase.cs
+++ b/src/Nest/XPack/Watcher/Transform/ScriptTransformBase.cs
@@ -45,12 +45,6 @@ namespace Nest
 	{
 		public IndexedScriptTransformDescriptor Id(string id) => new IndexedScriptTransformDescriptor(id);
 
-		[Obsolete("Indexed() sets a property named id, this is confusing and thats why we intend to remove this in NEST 7.x please use Id()")]
-		public IndexedScriptTransformDescriptor Indexed(string id) => new IndexedScriptTransformDescriptor(id);
-
-		[Obsolete("Inline is being deprecated for Source and will be removed in Elasticsearch 7.0")]
-		public InlineScriptTransformDescriptor Inline(string script) => new InlineScriptTransformDescriptor(script);
-
 		public InlineScriptTransformDescriptor Source(string source) => new InlineScriptTransformDescriptor(source);
 	}
 
@@ -58,11 +52,10 @@ namespace Nest
 	{
 		private static readonly AutomataDictionary AutomataDictionary = new AutomataDictionary
 		{
-			{ "inline", 0 },
-			{ "source", 1 },
-			{ "id", 2 },
-			{ "lang", 3 },
-			{ "params", 4 }
+			{ "source", 0 },
+			{ "id", 1 },
+			{ "lang", 2 },
+			{ "params", 3 }
 		};
 
 		public IScriptTransform Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
@@ -82,16 +75,15 @@ namespace Nest
 					switch (value)
 					{
 						case 0:
-						case 1:
 							scriptTransform = new InlineScriptTransform(reader.ReadString());
 							break;
-						case 2:
+						case 1:
 							scriptTransform = new IndexedScriptTransform(reader.ReadString());
 							break;
-						case 3:
+						case 2:
 							language = reader.ReadString();
 							break;
-						case 4:
+						case 3:
 							parameters = formatterResolver.GetFormatter<Dictionary<string, object>>()
 								.Deserialize(ref reader, formatterResolver);
 							break;

--- a/src/Nest/_Generated/_Descriptors.generated.cs
+++ b/src/Nest/_Generated/_Descriptors.generated.cs
@@ -944,9 +944,6 @@ namespace Nest
 
 		///<summary>Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)</summary>
 		public CreateDescriptor<TDocument> WaitForActiveShards(string waitForActiveShards) => Qs("wait_for_active_shards", waitForActiveShards);
-		///<summary>ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public CreateDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.</summary>
 		public CreateDescriptor<TDocument> Refresh(Refresh? refresh) => Qs("refresh", refresh);
 		///<summary>
@@ -998,9 +995,6 @@ namespace Nest
 
 		///<summary>Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)</summary>
 		public DeleteDescriptor<TDocument> WaitForActiveShards(string waitForActiveShards) => Qs("wait_for_active_shards", waitForActiveShards);
-		///<summary>ID of parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public DeleteDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.</summary>
 		public DeleteDescriptor<TDocument> Refresh(Refresh? refresh) => Qs("refresh", refresh);
 		///<summary>
@@ -1192,9 +1186,6 @@ namespace Nest
 		///<summary>A comma-separated list of stored fields to return in the response</summary>
 		public DocumentExistsDescriptor<TDocument> StoredFields(params Expression<Func<TDocument, object>>[] fields)  => Qs("stored_fields", fields?.Select(e=>(Field)e));
 
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public DocumentExistsDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public DocumentExistsDescriptor<TDocument> Preference(string preference) => Qs("preference", preference);
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -1256,9 +1247,6 @@ namespace Nest
 
 		// Request parameters
 
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public SourceExistsDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public SourceExistsDescriptor<TDocument> Preference(string preference) => Qs("preference", preference);
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -1330,9 +1318,6 @@ namespace Nest
 		public ExplainDescriptor<TDocument> Df(string df) => Qs("df", df);
 		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
 		public ExplainDescriptor<TDocument> Lenient(bool? lenient = true) => Qs("lenient", lenient);
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public ExplainDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public ExplainDescriptor<TDocument> Preference(string preference) => Qs("preference", preference);
 		///<summary>Query in the Lucene query string syntax</summary>
@@ -1427,9 +1412,6 @@ namespace Nest
 		///<summary>A comma-separated list of stored fields to return in the response</summary>
 		public GetDescriptor<TDocument> StoredFields(params Expression<Func<TDocument, object>>[] fields)  => Qs("stored_fields", fields?.Select(e=>(Field)e));
 
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public GetDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public GetDescriptor<TDocument> Preference(string preference) => Qs("preference", preference);
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -1508,9 +1490,6 @@ namespace Nest
 
 		// Request parameters
 
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public SourceDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public SourceDescriptor<TDocument> Preference(string preference) => Qs("preference", preference);
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -1581,9 +1560,6 @@ namespace Nest
 		public IndexDescriptor<TDocument> WaitForActiveShards(string waitForActiveShards) => Qs("wait_for_active_shards", waitForActiveShards);
 		///<summary>Explicit operation type</summary>
 		public IndexDescriptor<TDocument> OpType(OpType? opType) => Qs("op_type", opType);
-		///<summary>ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public IndexDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.</summary>
 		public IndexDescriptor<TDocument> Refresh(Refresh? refresh) => Qs("refresh", refresh);
 		///<summary>
@@ -2634,9 +2610,6 @@ namespace Nest
 
 		// Request parameters
 
-		///<summary>whether or not to copy settings from the source index (defaults to false)</summary>
-		[Obsolete("Scheduled to be removed in 7.0, Elasticsearch 6.4 will throw an exception if this is turned off see elastic/elasticsearch#30404")]
-		public ShrinkIndexDescriptor CopySettings(bool? copySettings = true) => Qs("copy_settings", copySettings);
 		///<summary>Explicit operation timeout</summary>
 		public ShrinkIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Specify timeout for connection to master</summary>
@@ -2666,9 +2639,6 @@ namespace Nest
 
 		// Request parameters
 
-		///<summary>whether or not to copy settings from the source index (defaults to false)</summary>
-		[Obsolete("Scheduled to be removed in 7.0, Elasticsearch 6.4 will throw an exception if this is turned off see elastic/elasticsearch#30404")]
-		public SplitIndexDescriptor CopySettings(bool? copySettings = true) => Qs("copy_settings", copySettings);
 		///<summary>Explicit operation timeout</summary>
 		public SplitIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Specify timeout for connection to master</summary>
@@ -3075,9 +3045,6 @@ namespace Nest
 		/// if that document has a <see cref="Nest.JoinField" /> or a routing mapping on for its type exists on <see cref="Nest.ConnectionSettings" /></para> 
 		///</summary>
 		public MultiTermVectorsDescriptor Routing(Routing routing) => Qs("routing", routing);
-		///<summary>Parent id of documents. Applies to all returned documents unless otherwise specified in body "params" or "docs".</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public MultiTermVectorsDescriptor Parent(string parent) => Qs("parent", parent);
 		///<summary>Specifies if requests are real-time as opposed to near-real-time (default: true).</summary>
 		public MultiTermVectorsDescriptor Realtime(bool? realtime = true) => Qs("realtime", realtime);
 		///<summary>Explicit version number for concurrency control</summary>
@@ -3870,9 +3837,6 @@ namespace Nest
 		/// if that document has a <see cref="Nest.JoinField" /> or a routing mapping on for its type exists on <see cref="Nest.ConnectionSettings" /></para> 
 		///</summary>
 		public TermVectorsDescriptor<TDocument> Routing(Routing routing) => Qs("routing", routing);
-		///<summary>Parent id of documents.</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public TermVectorsDescriptor<TDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>Specifies if request is real-time as opposed to near-real-time (default: true).</summary>
 		public TermVectorsDescriptor<TDocument> Realtime(bool? realtime = true) => Qs("realtime", realtime);
 		///<summary>Explicit version number for concurrency control</summary>
@@ -3916,9 +3880,6 @@ namespace Nest
 		public UpdateDescriptor<TDocument, TPartialDocument> SourceEnabled(bool? sourceEnabled = true) => Qs("_source", sourceEnabled);
 		///<summary>The script language (default: painless)</summary>
 		public UpdateDescriptor<TDocument, TPartialDocument> Lang(string lang) => Qs("lang", lang);
-		///<summary>ID of the parent document. Is is only used for routing and when for the upsert request</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public UpdateDescriptor<TDocument, TPartialDocument> Parent(string parent) => Qs("parent", parent);
 		///<summary>If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.</summary>
 		public UpdateDescriptor<TDocument, TPartialDocument> Refresh(Refresh? refresh) => Qs("refresh", refresh);
 		///<summary>Specify how many times should the operation be retried when a conflict occurs (default: 0)</summary>

--- a/src/Nest/_Generated/_Requests.generated.cs
+++ b/src/Nest/_Generated/_Requests.generated.cs
@@ -1566,9 +1566,6 @@ namespace Nest
 		/// shard (number of replicas + 1)
 		///</summary>
 		public string WaitForActiveShards { get => Q<string>("wait_for_active_shards"); set => Q("wait_for_active_shards", value); }
-		///<summary>ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>
 		/// If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this
 		/// operation visible to search, if `false` (the default) then do nothing with refreshes.
@@ -2250,9 +2247,6 @@ namespace Nest
 		/// shard (number of replicas + 1)
 		///</summary>
 		public string WaitForActiveShards { get => Q<string>("wait_for_active_shards"); set => Q("wait_for_active_shards", value); }
-		///<summary>ID of parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>
 		/// If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this
 		/// operation visible to search, if `false` (the default) then do nothing with refreshes.
@@ -2566,9 +2560,6 @@ namespace Nest
 		// Request parameters
 		///<summary>A comma-separated list of stored fields to return in the response</summary>
 		public Fields StoredFields { get => Q<Fields>("stored_fields"); set => Q("stored_fields", value); }
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -2719,9 +2710,6 @@ namespace Nest
 		public string Df { get => Q<string>("df"); set => Q("df", value); }
 		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
 		public bool? Lenient { get => Q<bool?>("lenient"); set => Q("lenient", value); }
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Query in the Lucene query string syntax</summary>
@@ -3671,9 +3659,6 @@ namespace Nest
 		// Request parameters
 		///<summary>A comma-separated list of stored fields to return in the response</summary>
 		public Fields StoredFields { get => Q<Fields>("stored_fields"); set => Q("stored_fields", value); }
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -4157,9 +4142,6 @@ namespace Nest
 		public string WaitForActiveShards { get => Q<string>("wait_for_active_shards"); set => Q("wait_for_active_shards", value); }
 		///<summary>Explicit operation type</summary>
 		public OpType? OpType { get => Q<OpType?>("op_type"); set => Q("op_type", value); }
-		///<summary>ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>
 		/// If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this
 		/// operation visible to search, if `false` (the default) then do nothing with refreshes.
@@ -4600,9 +4582,6 @@ namespace Nest
 		/// /></para>
 		///</summary>
 		public Routing Routing { get => Q<Routing>("routing"); set => Q("routing", value); }
-		///<summary>Parent id of documents. Applies to all returned documents unless otherwise specified in body "params" or "docs".</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specifies if requests are real-time as opposed to near-real-time (default: true).</summary>
 		public bool? Realtime { get => Q<bool?>("realtime"); set => Q("realtime", value); }
 		///<summary>Explicit version number for concurrency control</summary>
@@ -6021,9 +6000,6 @@ namespace Nest
 		IndexName IShrinkIndexRequest.Target => Self.RouteValues.Get<IndexName>("target");
 
 		// Request parameters
-		///<summary>whether or not to copy settings from the source index (defaults to false)</summary>
-		[Obsolete("Scheduled to be removed in 7.0, Elasticsearch 6.4 will throw an exception if this is turned off see elastic/elasticsearch#30404")]
-		public bool? CopySettings { get => Q<bool?>("copy_settings"); set => Q("copy_settings", value); }
 		///<summary>Explicit operation timeout</summary>
 		public Time Timeout { get => Q<Time>("timeout"); set => Q("timeout", value); }
 		///<summary>Specify timeout for connection to master</summary>
@@ -6150,9 +6126,6 @@ namespace Nest
 		Id ISourceExistsRequest.Id => Self.RouteValues.Get<Id>("id");
 
 		// Request parameters
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -6228,9 +6201,6 @@ namespace Nest
 		Id ISourceRequest.Id => Self.RouteValues.Get<Id>("id");
 
 		// Request parameters
-		///<summary>The ID of the parent document</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference { get => Q<string>("preference"); set => Q("preference", value); }
 		///<summary>Specify whether to perform the operation in realtime or search mode</summary>
@@ -6304,9 +6274,6 @@ namespace Nest
 		IndexName ISplitIndexRequest.Target => Self.RouteValues.Get<IndexName>("target");
 
 		// Request parameters
-		///<summary>whether or not to copy settings from the source index (defaults to false)</summary>
-		[Obsolete("Scheduled to be removed in 7.0, Elasticsearch 6.4 will throw an exception if this is turned off see elastic/elasticsearch#30404")]
-		public bool? CopySettings { get => Q<bool?>("copy_settings"); set => Q("copy_settings", value); }
 		///<summary>Explicit operation timeout</summary>
 		public Time Timeout { get => Q<Time>("timeout"); set => Q("timeout", value); }
 		///<summary>Specify timeout for connection to master</summary>
@@ -6556,9 +6523,6 @@ namespace Nest
 		/// /></para>
 		///</summary>
 		public Routing Routing { get => Q<Routing>("routing"); set => Q("routing", value); }
-		///<summary>Parent id of documents.</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>Specifies if request is real-time as opposed to near-real-time (default: true).</summary>
 		public bool? Realtime { get => Q<bool?>("realtime"); set => Q("realtime", value); }
 		///<summary>Explicit version number for concurrency control</summary>
@@ -6957,9 +6921,6 @@ namespace Nest
 		public bool? SourceEnabled { get => Q<bool?>("_source"); set => Q("_source", value); }
 		///<summary>The script language (default: painless)</summary>
 		public string Lang { get => Q<string>("lang"); set => Q("lang", value); }
-		///<summary>ID of the parent document. Is is only used for routing and when for the upsert request</summary>
-		[Obsolete("Scheduled to be removed in 7.0, the parent parameter has been deprecated from elasticsearch, please use routing instead directly.")]
-		public string Parent { get => Q<string>("parent"); set => Q("parent", value); }
 		///<summary>
 		/// If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this
 		/// operation visible to search, if `false` (the default) then do nothing with refreshes.

--- a/src/Tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
@@ -221,9 +221,6 @@ namespace Tests.Document.Multiple.MultiGet
 				hit.Id.Should().NotBeNullOrWhiteSpace();
 				hit.Found.Should().BeTrue();
 				hit.Version.Should().Be(1);
-#pragma warning disable 618
-				hit.Parent.Should().BeNull();
-#pragma warning restore 618
 				hit.Routing.Should().NotBeNullOrEmpty();
 			}
 		}

--- a/src/Tests/Tests/Document/Single/Get/GetApiTests.cs
+++ b/src/Tests/Tests/Document/Single/Get/GetApiTests.cs
@@ -163,9 +163,6 @@ namespace Tests.Document.Single.Get
 			response.Source.Should().NotBeNull();
 			response.Source.Id.Should().Be(CommitActivityId);
 			response.Routing.Should().NotBeNullOrEmpty();
-#pragma warning disable 618
-			response.Parent.Should().BeNullOrEmpty();
-#pragma warning restore 618
 		}
 	}
 


### PR DESCRIPTION
This PR removes the generated obsolete parameters through code generation.

Kept the `[Obsolete]` Mappings for the moment.

Once elastic/elasticsearch#41098 is merged, this can be updated to pull in new
REST API specs and revert the `[Obsolete]` param removal implementation.

