### PR TITLE
Docs: Drop subtitle in Asciidoctor

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,3 +1,5 @@
+:title-separator: |
+
 [[elasticsearch-net-reference]]
 = Elasticsearch.Net and NEST:  the .NET clients
 


### PR DESCRIPTION
When we use Asciidoctor to build the docs for the elasticsearch-net repo
it sees the `:` in the title of the book as a delimiter for a subtitle.
This is probably a nice feature, but we actually intend the title of the
book to have a `:` in it. The simple work around is to use a different
character for the delimiter. This change does that.