### PR TITLE
Fix utf8json escape characters

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
@@ -1015,19 +1015,24 @@ namespace Elasticsearch.Net
                     offset += 1; // position is "\"";
                     for (int i = offset; i < bytes.Length; i++)
                     {
-                        if (bytes[i] == (char)'\"')
+                        if (bytes[i] == '\"')
                         {
-							// is escape?
-							// ... and that escape is not escaped?
-							if (bytes[i - 1] == (char)'\\' && bytes[i - 2] != (char)'\\')
-                            {
-                                continue;
-                            }
-                            else
-                            {
-                                offset = i + 1;
-                                return; // end
-                            }
+							// backtrack and count escape characters
+							var count = 0;
+							for (var j = i - 1; j >= offset; j--)
+							{
+								if (bytes[j] != '\\')
+									break;
+
+								count++;
+							}
+
+							// even number of escape characters means this " is not escaped.
+							if (count % 2 == 0)
+							{
+								offset = i + 1;
+								return; // end
+							}
                         }
                     }
                     throw CreateParsingExceptionMessage("not found end string.");


### PR DESCRIPTION
This commit fixes the logic for determining whether a double quote character is escaped when reading inside of a JSON string. the current implementation checks that the previous character is `\`, and that the character before this is not `\`, but does not take into account whether that last character itself is part is escaped. The fix is to backtrack from the double quote and count the number of sequential backslash characters; an even number implies that the double quote is not escaped and therefore the end of the JSON string.