### PR TITLE
Fix 3698: Update ClusterHealthResponse.cs to align with ClusterHealthResponse.java

### DIFF
--- a/src/Nest/Cluster/ClusterHealth/ClusterHealthResponse.cs
+++ b/src/Nest/Cluster/ClusterHealth/ClusterHealthResponse.cs
@@ -69,7 +69,7 @@ namespace Nest
 		public Health Status { get; internal set; }
 
 		[JsonProperty("task_max_waiting_in_queue_millis")]
-		public long TaskMaxWaitTimeInQueueInMillis { get; internal set; }
+		public long TaskMaxWaitTimeInQueueInMilliseconds { get; internal set; }
 
 		[JsonProperty("timed_out")]
 		public bool TimedOut { get; internal set; }

--- a/src/Nest/Cluster/ClusterHealth/ClusterHealthResponse.cs
+++ b/src/Nest/Cluster/ClusterHealth/ClusterHealthResponse.cs
@@ -19,7 +19,7 @@ namespace Nest
 		int NumberOfPendingTasks { get; }
 		int RelocatingShards { get; }
 		Health Status { get; }
-		long TaskMaxWaitTimeInQueueInMillis { get;  }
+		long TaskMaxWaitTimeInQueueInMilliseconds { get;  }
 		bool TimedOut { get; }
 		int UnassignedShards { get; }
 	}

--- a/src/Nest/Cluster/ClusterHealth/ClusterHealthResponse.cs
+++ b/src/Nest/Cluster/ClusterHealth/ClusterHealthResponse.cs
@@ -8,14 +8,18 @@ namespace Nest
 	{
 		int ActivePrimaryShards { get; }
 		int ActiveShards { get; }
+		double ActiveShardsPercentAsNumber { get; }
 		string ClusterName { get; }
+		int DelayedUnassignedShards { get; }
 		IReadOnlyDictionary<IndexName, IndexHealthStats> Indices { get; }
 		int InitializingShards { get; }
 		int NumberOfDataNodes { get; }
+		int NumberOfInFlightFetch { get; }
 		int NumberOfNodes { get; }
 		int NumberOfPendingTasks { get; }
 		int RelocatingShards { get; }
 		Health Status { get; }
+		long TaskMaxWaitTimeInQueueInMillis { get;  }
 		bool TimedOut { get; }
 		int UnassignedShards { get; }
 	}
@@ -29,8 +33,14 @@ namespace Nest
 		[JsonProperty("active_shards")]
 		public int ActiveShards { get; internal set; }
 
+		[JsonProperty("active_shards_percent_as_number")]
+		public double ActiveShardsPercentAsNumber { get; internal set; }
+
 		[JsonProperty("cluster_name")]
 		public string ClusterName { get; internal set; }
+
+		[JsonProperty("delayed_unassigned_shards")]
+		public int DelayedUnassignedShards { get; internal set; }
 
 		[JsonProperty("indices")]
 		[JsonConverter(typeof(ResolvableDictionaryJsonConverter<IndexName, IndexHealthStats>))]
@@ -43,6 +53,9 @@ namespace Nest
 		[JsonProperty("number_of_data_nodes")]
 		public int NumberOfDataNodes { get; internal set; }
 
+		[JsonProperty("number_of_in_flight_fetch")]
+		public int NumberOfInFlightFetch { get; internal set; }
+
 		[JsonProperty("number_of_nodes")]
 		public int NumberOfNodes { get; internal set; }
 
@@ -54,6 +67,9 @@ namespace Nest
 
 		[JsonProperty("status")]
 		public Health Status { get; internal set; }
+
+		[JsonProperty("task_max_waiting_in_queue_millis")]
+		public long TaskMaxWaitTimeInQueueInMillis { get; internal set; }
 
 		[JsonProperty("timed_out")]
 		public bool TimedOut { get; internal set; }

--- a/src/Tests/Tests/Cluster/ClusterHealth/ClusterHealthApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterHealth/ClusterHealthApiTests.cs
@@ -69,6 +69,11 @@ namespace Tests.Cluster.ClusterHealth
 			response.NumberOfDataNodes.Should().BeGreaterOrEqualTo(1);
 			response.ActivePrimaryShards.Should().BeGreaterOrEqualTo(1);
 			response.ActiveShards.Should().BeGreaterOrEqualTo(1);
+			response.ActiveShardsPercentAsNumber.Should().BePositive();
+			response.DelayedUnassignedShards.Should().Equals(0);
+			response.NumberOfInFlightFetch.Should().BeGreaterOrEqualTo(0);
+			response.TaskMaxWaitTimeInQueueInMillis.Should().BeGreaterOrEqualTo(0);
+
 			response.Indices.Should()
 				.NotBeEmpty()
 				.And.ContainKey(Index<Developer>());

--- a/src/Tests/Tests/Cluster/ClusterHealth/ClusterHealthApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterHealth/ClusterHealthApiTests.cs
@@ -72,7 +72,7 @@ namespace Tests.Cluster.ClusterHealth
 			response.ActiveShardsPercentAsNumber.Should().BePositive();
 			response.DelayedUnassignedShards.Should().Equals(0);
 			response.NumberOfInFlightFetch.Should().BeGreaterOrEqualTo(0);
-			response.TaskMaxWaitTimeInQueueInMillis.Should().BeGreaterOrEqualTo(0);
+			response.TaskMaxWaitTimeInQueueInMilliseconds.Should().BeGreaterOrEqualTo(0);
 
 			response.Indices.Should()
 				.NotBeEmpty()


### PR DESCRIPTION
Updated ClusterHealthResponse.cs to align with ClusterHealthResponse.java (https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java). Previously missing fields included "ActiveShardsPerecentAsNumber", "DelayedUnassignedShards", "NumberOfInFlightFetch", and "TaskMaxWaitTimeInQueueInMillis".