### PR TITLE
Support deprecate Name property on ElasticsearchTypeAttribute

### DIFF
--- a/src/Nest/Mapping/AttributeBased/ElasticsearchTypeAttribute.cs
+++ b/src/Nest/Mapping/AttributeBased/ElasticsearchTypeAttribute.cs
@@ -5,22 +5,43 @@ using System.Reflection;
 
 namespace Nest
 {
+	/// <summary>
+	/// Applied to a CLR type to override the name of a CLR type and the property from which an _id is inferred
+	/// when serializing an instance of the type.
+	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 	public class ElasticsearchTypeAttribute : Attribute
 	{
 		private static readonly ConcurrentDictionary<Type, ElasticsearchTypeAttribute> CachedTypeLookups =
 			new ConcurrentDictionary<Type, ElasticsearchTypeAttribute>();
 
+		/// <summary>
+		/// The property on CLR type to use as the _id of the document
+		/// </summary>
 		public string IdProperty { get; set; }
 
+		/// <summary>
+		/// The name of the CLR type for serialization
+		/// </summary>
 		public string RelationName { get; set; }
 
+		/// <inheritdoc cref="RelationName"/>
+		[Obsolete("Deprecated. Please use " + nameof(RelationName))]
+		public string Name
+		{
+			get => RelationName;
+			set => RelationName = value;
+		}
+
+		/// <summary>
+		/// Gets the first <see cref="ElasticsearchTypeAttribute"/> from a given CLR type
+		/// </summary>
 		public static ElasticsearchTypeAttribute From(Type type)
 		{
 			if (CachedTypeLookups.TryGetValue(type, out var attr))
 				return attr;
 
-			var attributes = type.GetTypeInfo().GetCustomAttributes(typeof(ElasticsearchTypeAttribute), true);
+			var attributes = type.GetCustomAttributes(typeof(ElasticsearchTypeAttribute), true);
 			if (attributes.HasAny())
 				attr = (ElasticsearchTypeAttribute)attributes.First();
 			CachedTypeLookups.TryAdd(type, attr);


### PR DESCRIPTION
This commit reintroduces the Name property on ElasticsearchTypeAttribute, which gets/sets the RelationName property. The reintroduction is marked as Obsolete as it will be removed in 8.x

Closes #3681