### PR TITLE
Add is_write_index to aliases on create index API

### DIFF
--- a/src/Nest/Indices/AliasManagement/Alias.cs
+++ b/src/Nest/Indices/AliasManagement/Alias.cs
@@ -3,44 +3,83 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// An alias to one or more indices
+	/// </summary>
 	[JsonConverter(typeof(ReadAsTypeJsonConverter<Alias>))]
 	public interface IAlias
 	{
+		/// <summary>
+		/// Provides an easy way to create different "views" of the same index. A filter can be defined using Query DSL and is
+		/// applied to all Search, Count, Delete By Query and More Like This operations with this alias.
+		/// </summary>
 		[JsonProperty("filter")]
 		QueryContainer Filter { get; set; }
 
+		/// <summary>
+		/// Associates routing values with aliases for index operations. This feature can be used together
+		/// with filtering aliases in order to avoid unnecessary shard operations.
+		/// </summary>
 		[JsonProperty("index_routing")]
 		Routing IndexRouting { get; set; }
 
+		/// <inheritdoc cref="AliasAddOperation.IsWriteIndex" />
+		[JsonProperty("is_write_index")]
+		bool? IsWriteIndex { get; set; }
+
+		/// <summary>
+		/// Associates routing values with aliases for both index and search operations. This feature can be used together
+		/// with filtering aliases in order to avoid unnecessary shard operations.
+		/// </summary>
 		[JsonProperty("routing")]
 		Routing Routing { get; set; }
 
+		/// <summary>
+		/// Associates routing values with aliases for search operations. This feature can be used together
+		/// with filtering aliases in order to avoid unnecessary shard operations.
+		/// </summary>
 		[JsonProperty("search_routing")]
 		Routing SearchRouting { get; set; }
 	}
 
+	/// <inheritdoc />
 	public class Alias : IAlias
 	{
+		/// <inheritdoc />
 		public QueryContainer Filter { get; set; }
+		/// <inheritdoc />
 		public Routing IndexRouting { get; set; }
+		/// <inheritdoc />
+		public bool? IsWriteIndex { get; set; }
+		/// <inheritdoc />
 		public Routing Routing { get; set; }
+		/// <inheritdoc />
 		public Routing SearchRouting { get; set; }
 	}
 
+	/// <inheritdoc cref="IAlias" />
 	public class AliasDescriptor : DescriptorBase<AliasDescriptor, IAlias>, IAlias
 	{
 		QueryContainer IAlias.Filter { get; set; }
 		Routing IAlias.IndexRouting { get; set; }
+		bool? IAlias.IsWriteIndex { get; set; }
 		Routing IAlias.Routing { get; set; }
 		Routing IAlias.SearchRouting { get; set; }
 
-		public AliasDescriptor Routing(Routing routing) => Assign(routing, (a, v) => a.Routing = v);
-
-		public AliasDescriptor IndexRouting(Routing indexRouting) => Assign(indexRouting, (a, v) => a.IndexRouting = v);
-
-		public AliasDescriptor SearchRouting(Routing searchRouting) => Assign(searchRouting, (a, v) => a.SearchRouting = v);
-
+		/// <inheritdoc cref="IAlias.Filter" />
 		public AliasDescriptor Filter<T>(Func<QueryContainerDescriptor<T>, QueryContainer> filterSelector) where T : class =>
 			Assign(filterSelector, (a, v) => a.Filter = v?.Invoke(new QueryContainerDescriptor<T>()));
+
+		/// <inheritdoc cref="IAlias.IndexRouting" />
+		public AliasDescriptor IndexRouting(Routing indexRouting) => Assign(indexRouting, (a, v) => a.IndexRouting = v);
+
+		/// <inheritdoc cref="IAlias.IsWriteIndex" />
+		public AliasDescriptor IsWriteIndex(bool? isWriteIndex = true) => Assign(isWriteIndex, (a, v) => a.IsWriteIndex = v);
+
+		/// <inheritdoc cref="IAlias.Routing" />
+		public AliasDescriptor Routing(Routing routing) => Assign(routing, (a, v) => a.Routing = v);
+
+		/// <inheritdoc cref="IAlias.SearchRouting" />
+		public AliasDescriptor SearchRouting(Routing searchRouting) => Assign(searchRouting, (a, v) => a.SearchRouting = v);
 	}
 }

--- a/src/Nest/Indices/AliasManagement/PutAlias/PutAliasRequest.cs
+++ b/src/Nest/Indices/AliasManagement/PutAlias/PutAliasRequest.cs
@@ -3,37 +3,48 @@ using Newtonsoft.Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// A request to put an alias to one or more indices
+	/// </summary>
 	public partial interface IPutAliasRequest
 	{
+		/// <inheritdoc cref="IAlias.Filter"/>
 		[JsonProperty("filter")]
 		QueryContainer Filter { get; set; }
 
+		/// <inheritdoc cref="IAlias.IndexRouting"/>
 		[JsonProperty("index_routing")]
 		Routing IndexRouting { get; set; }
 
-		/// <inheritdoc cref="AliasAddOperation.IsWriteIndex" />
+		/// <inheritdoc cref="IAlias.IsWriteIndex" />
 		[JsonProperty("is_write_index")]
 		bool? IsWriteIndex { get; set; }
 
+		/// <inheritdoc cref="IAlias.Routing"/>
 		[JsonProperty("routing")]
 		Routing Routing { get; set; }
 
+		/// <inheritdoc cref="IAlias.SearchRouting"/>
 		[JsonProperty("search_routing")]
 		Routing SearchRouting { get; set; }
 	}
 
+	/// <inheritdoc cref="IPutAliasRequest"/>
 	public partial class PutAliasRequest
 	{
+		/// <inheritdoc cref="IPutAliasRequest.Filter"/>
 		public QueryContainer Filter { get; set; }
+		/// <inheritdoc cref="IPutAliasRequest.IndexRouting"/>
 		public Routing IndexRouting { get; set; }
-
-		/// <inheritdoc cref="AliasAddOperation.IsWriteIndex" />
+		/// <inheritdoc cref="IPutAliasRequest.IsWriteIndex" />
 		public bool? IsWriteIndex { get; set; }
-
+		/// <inheritdoc cref="IPutAliasRequest.Routing"/>
 		public Routing Routing { get; set; }
+		/// <inheritdoc cref="IPutAliasRequest.SearchRouting"/>
 		public Routing SearchRouting { get; set; }
 	}
 
+	/// <inheritdoc cref="IPutAliasRequest"/>
 	[DescriptorFor("IndicesPutAlias")]
 	public partial class PutAliasDescriptor
 	{
@@ -43,15 +54,19 @@ namespace Nest
 		Routing IPutAliasRequest.Routing { get; set; }
 		Routing IPutAliasRequest.SearchRouting { get; set; }
 
+		/// <inheritdoc cref="IPutAliasRequest.Routing"/>
 		public PutAliasDescriptor Routing(Routing routing) => Assign(routing, (a, v) => a.Routing = v);
 
+		/// <inheritdoc cref="IPutAliasRequest.IndexRouting"/>
 		public PutAliasDescriptor IndexRouting(Routing routing) => Assign(routing, (a, v) => a.IndexRouting = v);
 
+		/// <inheritdoc cref="IPutAliasRequest.SearchRouting"/>
 		public PutAliasDescriptor SearchRouting(Routing routing) => Assign(routing, (a, v) => a.SearchRouting = v);
 
-		/// <inheritdoc cref="AliasAddOperation.IsWriteIndex" />
+		/// <inheritdoc cref="IPutAliasRequest.IsWriteIndex" />
 		public PutAliasDescriptor IsWriteIndex(bool? isWriteIndex = true) => Assign(isWriteIndex, (a, v) => a.IsWriteIndex = v);
 
+		/// <inheritdoc cref="IPutAliasRequest.Filter"/>
 		public PutAliasDescriptor Filter<T>(Func<QueryContainerDescriptor<T>, QueryContainer> filterSelector) where T : class =>
 			Assign(filterSelector, (a, v) => a.Filter = v?.Invoke(new QueryContainerDescriptor<T>()));
 	}

--- a/src/Tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
+++ b/src/Tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
@@ -331,4 +331,81 @@ namespace Tests.Indices.IndexManagement.CreateIndex
 			((InlineScript)scriptedSimilarity.Script).Source.Should().NotBeNullOrEmpty();
 		}
 	}
+
+	[SkipVersion("<6.4.0", "is_write_index is a new feature")]
+	public class CreateIndexWithAliasApiTests
+		: ApiIntegrationTestBase<WritableCluster, ICreateIndexResponse, ICreateIndexRequest, CreateIndexDescriptor, CreateIndexRequest>
+	{
+		public CreateIndexWithAliasApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override bool ExpectIsValid => true;
+
+		protected override object ExpectJson => new
+		{
+			settings = new Dictionary<string, object>
+			{
+				{ "index.number_of_replicas", 0 },
+				{ "index.number_of_shards", 1 },
+			},
+			aliases = new Dictionary<string, object>
+			{
+				{ CallIsolatedValue + "-alias", new { is_write_index = true } }
+			}
+		};
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<CreateIndexDescriptor, ICreateIndexRequest> Fluent => d => d
+			.Settings(s => s
+				.NumberOfReplicas(0)
+				.NumberOfShards(1)
+			)
+			.Aliases(a => a
+				.Alias(CallIsolatedValue + "-alias", aa => aa
+					.IsWriteIndex()
+				)
+			);
+
+		protected override HttpMethod HttpMethod => HttpMethod.PUT;
+
+		protected override CreateIndexRequest Initializer => new CreateIndexRequest(CallIsolatedValue)
+		{
+			Settings = new Nest.IndexSettings
+			{
+				NumberOfReplicas = 0,
+				NumberOfShards = 1,
+			},
+			Aliases = new Aliases
+			{
+				{ CallIsolatedValue + "-alias", new Alias { IsWriteIndex = true } }
+			}
+		};
+
+		protected override string UrlPath => $"/{CallIsolatedValue}";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.CreateIndex(CallIsolatedValue, f),
+			(client, f) => client.CreateIndexAsync(CallIsolatedValue, f),
+			(client, r) => client.CreateIndex(r),
+			(client, r) => client.CreateIndexAsync(r)
+		);
+
+		protected override CreateIndexDescriptor NewDescriptor() => new CreateIndexDescriptor(CallIsolatedValue);
+
+		protected override void ExpectResponse(ICreateIndexResponse response)
+		{
+			response.ShouldBeValid();
+			response.Acknowledged.Should().BeTrue();
+			response.ShardsAcknowledged.Should().BeTrue();
+
+			var indexResponse = Client.GetIndex(CallIsolatedValue);
+
+			indexResponse.ShouldBeValid();
+			indexResponse.Indices.Should().NotBeEmpty().And.ContainKey(CallIsolatedValue);
+
+			var aliases = indexResponse.Indices[CallIsolatedValue].Aliases;
+			aliases.Count.Should().Be(1);
+			aliases[CallIsolatedValue + "-alias"].IsWriteIndex.Should().BeTrue();
+		}
+	}
 }


### PR DESCRIPTION
This commit adds the ability to add an alias with is_write_index when creating an index using the Create Index API.

Closes #3686