### PR TITLE
Add SequenceNumber and PrimaryTerm to Hits, Get and MulitGetHit

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Overrides/GlobalOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Overrides/GlobalOverrides.cs
@@ -38,6 +38,8 @@ namespace ApiGenerator.Overrides
 			{ "s", "sort_by_columns" },
 			{ "v", "verbose" },
 			{ "ts", "include_timestamp" },
+			{ "if_seq_no", "if_sequence_number" },
+			{ "seq_no_primary_term", "sequence_number_primary_term" },
 		};
 
 		public override IEnumerable<string> RenderPartial => new[]

--- a/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
+++ b/src/Elasticsearch.Net/Domain/RequestParameters/RequestParameters.Generated.cs
@@ -645,7 +645,7 @@ namespace Elasticsearch.Net
 		///<summary>Explicit operation timeout</summary>
 		public TimeSpan Timeout { get => Q<TimeSpan>("timeout"); set => Q("timeout", value); }
 		///<summary>only perform the delete operation if the last operation that has changed the document has the specified sequence number</summary>
-		public long? IfSeqNo { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
+		public long? IfSequenceNumber { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
 		///<summary>only perform the delete operation if the last operation that has changed the document has the specified primary term</summary>
 		public long? IfPrimaryTerm { get => Q<long?>("if_primary_term"); set => Q("if_primary_term", value); }
 		///<summary>Explicit version number for concurrency control</summary>
@@ -919,7 +919,7 @@ namespace Elasticsearch.Net
 		///<summary>Specific version type</summary>
 		public VersionType? VersionType { get => Q<VersionType?>("version_type"); set => Q("version_type", value); }
 		///<summary>only perform the index operation if the last operation that has changed the document has the specified sequence number</summary>
-		public long? IfSeqNo { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
+		public long? IfSequenceNumber { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
 		///<summary>only perform the index operation if the last operation that has changed the document has the specified primary term</summary>
 		public long? IfPrimaryTerm { get => Q<long?>("if_primary_term"); set => Q("if_primary_term", value); }
 		///<summary>The pipeline id to preprocess incoming documents with</summary>
@@ -1839,7 +1839,7 @@ namespace Elasticsearch.Net
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public bool? TypedKeys { get => Q<bool?>("typed_keys"); set => Q("typed_keys", value); }
 		///<summary>Specify whether to return sequence number and primary term of the last modification of each hit</summary>
-		public bool? SeqNoPrimaryTerm { get => Q<bool?>("seq_no_primary_term"); set => Q("seq_no_primary_term", value); }
+		public bool? SequenceNumberPrimaryTerm { get => Q<bool?>("seq_no_primary_term"); set => Q("seq_no_primary_term", value); }
 		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
 		public bool? RequestCache { get => Q<bool?>("request_cache"); set => Q("request_cache", value); }
 		///<summary>
@@ -2097,7 +2097,7 @@ namespace Elasticsearch.Net
 		///<summary>Explicit operation timeout</summary>
 		public TimeSpan Timeout { get => Q<TimeSpan>("timeout"); set => Q("timeout", value); }
 		///<summary>only perform the update operation if the last operation that has changed the document has the specified sequence number</summary>
-		public long? IfSeqNo { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
+		public long? IfSequenceNumber { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
 		///<summary>only perform the update operation if the last operation that has changed the document has the specified primary term</summary>
 		public long? IfPrimaryTerm { get => Q<long?>("if_primary_term"); set => Q("if_primary_term", value); }
 	}
@@ -2834,7 +2834,7 @@ namespace Elasticsearch.Net
 		///<summary>Explicit version number for concurrency control</summary>
 		public long? Version { get => Q<long?>("version"); set => Q("version", value); }
 		///<summary>only update the watch if the last operation that has changed the watch has the specified sequence number</summary>
-		public long? IfSeqNo { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
+		public long? IfSequenceNumber { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
 		///<summary>only update the watch if the last operation that has changed the watch has the specified primary term</summary>
 		public long? IfPrimaryTerm { get => Q<long?>("if_primary_term"); set => Q("if_primary_term", value); }
 	}

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkDelete.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkDelete.cs
@@ -11,7 +11,7 @@ namespace Nest
 		T Document { get; set; }
 
 		[DataMember(Name = "if_seq_no")]
-		long? IfSeqNo { get; set; }
+		long? IfSequenceNumber { get; set; }
 
 		[DataMember(Name = "if_primary_term")]
 		long? IfPrimaryTerm { get; set; }
@@ -27,7 +27,7 @@ namespace Nest
 
 		public T Document { get; set; }
 
-		public long? IfSeqNo { get; set; }
+		public long? IfSequenceNumber { get; set; }
 
 		public long? IfPrimaryTerm { get; set; }
 
@@ -48,7 +48,7 @@ namespace Nest
 	{
 		protected override Type BulkOperationClrType => typeof(T);
 		protected override string BulkOperationType => "delete";
-		long? IBulkDeleteOperation<T>.IfSeqNo { get; set; }
+		long? IBulkDeleteOperation<T>.IfSequenceNumber { get; set; }
 		long? IBulkDeleteOperation<T>.IfPrimaryTerm { get; set; }
 
 		T IBulkDeleteOperation<T>.Document { get; set; }
@@ -64,7 +64,7 @@ namespace Nest
 		/// </summary>
 		public BulkDeleteDescriptor<T> Document(T @object) => Assign(@object, (a, v) => a.Document = v);
 
-		public BulkDeleteDescriptor<T> IfSeqNo(long? seqNo) => Assign(seqNo, (a, v) => a.IfSeqNo = v);
+		public BulkDeleteDescriptor<T> IfSequenceNumber(long? sequenceNumber) => Assign(sequenceNumber, (a, v) => a.IfSequenceNumber = v);
 
 		public BulkDeleteDescriptor<T> IfPrimaryTerm(long? primaryTerm) => Assign(primaryTerm, (a, v) => a.IfPrimaryTerm = v);
 	}

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkIndex.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkIndex.cs
@@ -17,7 +17,7 @@ namespace Nest
 		string Pipeline { get; set; }
 
 		[DataMember(Name = "if_seq_no")]
-		long? IfSeqNo { get; set; }
+		long? IfSequenceNumber { get; set; }
 
 		[DataMember(Name = "if_primary_term")]
 		long? IfPrimaryTerm { get; set; }
@@ -35,7 +35,7 @@ namespace Nest
 
 		public string Pipeline { get; set; }
 
-		public long? IfSeqNo { get; set; }
+		public long? IfSequenceNumber { get; set; }
 
 		public long? IfPrimaryTerm { get; set; }
 
@@ -59,7 +59,7 @@ namespace Nest
 		T IBulkIndexOperation<T>.Document { get; set; }
 		string IBulkIndexOperation<T>.Percolate { get; set; }
 		string IBulkIndexOperation<T>.Pipeline { get; set; }
-		long? IBulkIndexOperation<T>.IfSeqNo { get; set; }
+		long? IBulkIndexOperation<T>.IfSequenceNumber { get; set; }
 		long? IBulkIndexOperation<T>.IfPrimaryTerm { get; set; }
 
 		protected override object GetBulkOperationBody() => Self.Document;
@@ -80,8 +80,8 @@ namespace Nest
 
 		public BulkIndexDescriptor<T> Percolate(string percolate) => Assign(percolate, (a, v) => a.Percolate = v);
 
-		public BulkIndexDescriptor<T> IfSeqNo(long? seqNo) => Assign(seqNo, (a, v) => a.IfSeqNo = v);
+		public BulkIndexDescriptor<T> IfSequenceNumber(long? seqNo) => Assign(seqNo, (a, v) => a.IfSequenceNumber = v);
 
-		public BulkIndexDescriptor<T> IfPrimaryTerm(long? primaryTerm) => Assign(primaryTerm, (a, v) => a.IfSeqNo = v);
+		public BulkIndexDescriptor<T> IfPrimaryTerm(long? primaryTerm) => Assign(primaryTerm, (a, v) => a.IfSequenceNumber = v);
 	}
 }

--- a/src/Nest/Document/Multiple/MultiGet/Response/MultiGetHit.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Response/MultiGetHit.cs
@@ -22,6 +22,10 @@ namespace Nest
 		string Type { get; }
 
 		long Version { get; }
+
+		long? SequenceNumber { get; }
+
+		long? PrimaryTerm { get; }
 	}
 
 	[DataContract]
@@ -55,5 +59,11 @@ namespace Nest
 
 		[DataMember(Name = "_version")]
 		public long Version { get; internal set; }
+
+		[DataMember(Name = "_seq_no")]
+		public long? SequenceNumber { get; internal set; }
+
+		[DataMember(Name = "_primary_term")]
+		public long? PrimaryTerm { get; internal set; }
 	}
 }

--- a/src/Nest/Document/Single/Get/GetResponse.cs
+++ b/src/Nest/Document/Single/Get/GetResponse.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Elasticsearch.Net;
 
 namespace Nest
 {
+	// TODO: Looks like this can be removed?
 	public interface IGetResponse<out TDocument> : IResponse where TDocument : class
 	{
 		TDocument Source { get; }
 	}
+
 	public class GetResponse<TDocument> : ResponseBase, IGetResponse<TDocument> where TDocument : class
 	{
 		[DataMember(Name = "fields")]
@@ -22,8 +23,14 @@ namespace Nest
 		[DataMember(Name = "_index")]
 		public string Index { get; internal set; }
 
+		[DataMember(Name = "_primary_term")]
+		public long? PrimaryTerm { get; internal set; }
+
 		[DataMember(Name = "_routing")]
 		public string Routing { get; internal set; }
+
+		[DataMember(Name = "_seq_no")]
+		public long? SequenceNumber { get; internal set; }
 
 		[DataMember(Name = "_source")]
 		[JsonFormatter(typeof(SourceFormatter<>))]

--- a/src/Nest/Search/Search/Hits/Hit.cs
+++ b/src/Nest/Search/Search/Hits/Hit.cs
@@ -11,10 +11,18 @@ namespace Nest
 	{
 		[DataMember(Name = "_id")]
 		string Id { get; }
+
 		[DataMember(Name = "_index")]
 		string Index { get; }
+
+		[DataMember(Name = "_primary_term")]
+		long? PrimaryTerm { get; }
+
 		[DataMember(Name = "_routing")]
 		string Routing { get; }
+
+		[DataMember(Name = "_seq_no")]
+		long? SequenceNumber { get; }
 
 		[DataMember(Name = "_source")]
 		[JsonFormatter(typeof(SourceFormatter<>))]
@@ -25,7 +33,7 @@ namespace Nest
 		string Type { get; }
 
 		[DataMember(Name = "_version")]
-		long? Version { get; }
+		long Version { get; }
 	}
 
 	internal static class HitMetadataConversionExtensions
@@ -39,9 +47,7 @@ namespace Nest
 				Type = source.Type,
 				Index = source.Index,
 				Id = source.Id,
-#pragma warning disable 618
 				Routing = source.Routing,
-#pragma warning restore 618
 				Source = mapper(source.Source)
 			};
 		}
@@ -58,31 +64,31 @@ namespace Nest
 		[DataMember(Name = "fields")]
 		FieldValues Fields { get; }
 
+		/// <summary> see <see cref="Highlights" /> for easier access into this data structure </summary>
+		[DataMember(Name = "highlight")]
+		[JsonFormatter(typeof(VerbatimDictionaryKeysBaseFormatter<Dictionary<string, List<string>>, string, List<string>>))]
+		Dictionary<string, List<string>> Highlight { get; }
+
+		// TODO investigate this mapping
+		/// <summary> This provides easier access into <see cref="Highlight" /> </summary>
+		[IgnoreDataMember]
+		HighlightFieldDictionary Highlights { get; }
+
 		[DataMember(Name = "inner_hits")]
 		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, InnerHitsResult>))]
 		IReadOnlyDictionary<string, InnerHitsResult> InnerHits { get; }
 
-		[DataMember(Name = "_nested")]
-		NestedIdentity Nested { get; }
-
 		[DataMember(Name = "matched_queries")]
 		IReadOnlyCollection<string> MatchedQueries { get; }
+
+		[DataMember(Name = "_nested")]
+		NestedIdentity Nested { get; }
 
 		[DataMember(Name = "_score")]
 		double? Score { get; }
 
 		[DataMember(Name = "sort")]
 		IReadOnlyCollection<object> Sorts { get; }
-
-		// TODO investigate this mapping
-		/// <summary> This provides easier access into <see cref="Highlight"/> </summary>
-		[IgnoreDataMember]
-		HighlightFieldDictionary Highlights { get; }
-
-		/// <summary> see <see cref="Highlights"/> for easier access into this data structure </summary>
-		[DataMember(Name = "highlight")]
-		[JsonFormatter(typeof(VerbatimDictionaryKeysBaseFormatter<Dictionary<string, List<string>>, string, List<string>>))]
-		Dictionary<string, List<string>> Highlight { get; }
 	}
 
 	public class Hit<TDocument> : IHit<TDocument>
@@ -90,20 +96,6 @@ namespace Nest
 	{
 		public Explanation Explanation { get; internal set; }
 		public FieldValues Fields { get; internal set; }
-		public string Id { get; internal set; }
-		public string Index { get; internal set; }
-		public IReadOnlyDictionary<string, InnerHitsResult> InnerHits { get; internal set; } =
-			EmptyReadOnly<string, InnerHitsResult>.Dictionary;
-		public IReadOnlyCollection<string> MatchedQueries { get; internal set; }
-			= EmptyReadOnly<string>.Collection;
-		public NestedIdentity Nested { get; internal set; }
-		public string Routing { get; internal set; }
-		public double? Score { get; set; }
-		public IReadOnlyCollection<object> Sorts { get; internal set; }
-			= EmptyReadOnly<object>.Collection;
-		public TDocument Source { get; internal set; }
-		public string Type { get; internal set; }
-		public long? Version { get; internal set; }
 
 		public Dictionary<string, List<string>> Highlight { get; set; }
 
@@ -114,17 +106,33 @@ namespace Nest
 				if (Highlight == null)
 					return new HighlightFieldDictionary();
 
-				var highlights = Highlight.Select(kv => new HighlightHit
-					{
-						DocumentId = Id,
-						Field = kv.Key,
-						Highlights = kv.Value
-					})
+				var highlights = Highlight.Select(kv => new HighlightHit { DocumentId = Id, Field = kv.Key, Highlights = kv.Value })
 					.ToDictionary(k => k.Field, v => v);
 
 				return new HighlightFieldDictionary(highlights);
 			}
 		}
 
+		public string Id { get; internal set; }
+		public string Index { get; internal set; }
+
+		public IReadOnlyDictionary<string, InnerHitsResult> InnerHits { get; internal set; } =
+			EmptyReadOnly<string, InnerHitsResult>.Dictionary;
+
+		public IReadOnlyCollection<string> MatchedQueries { get; internal set; }
+			= EmptyReadOnly<string>.Collection;
+
+		public NestedIdentity Nested { get; internal set; }
+		public long? PrimaryTerm { get; internal set; }
+		public string Routing { get; internal set; }
+		public double? Score { get; set; }
+		public long? SequenceNumber { get; internal set; }
+
+		public IReadOnlyCollection<object> Sorts { get; internal set; }
+			= EmptyReadOnly<object>.Collection;
+
+		public TDocument Source { get; internal set; }
+		public string Type { get; internal set; }
+		public long Version { get; internal set; }
 	}
 }

--- a/src/Nest/_Generated/_Descriptors.generated.cs
+++ b/src/Nest/_Generated/_Descriptors.generated.cs
@@ -1042,7 +1042,7 @@ namespace Nest
 		///<summary>Explicit operation timeout</summary>
 		public DeleteDescriptor<TDocument> Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>only perform the delete operation if the last operation that has changed the document has the specified sequence number</summary>
-		public DeleteDescriptor<TDocument> IfSeqNo(long? ifSeqNo) => Qs("if_seq_no", ifSeqNo);
+		public DeleteDescriptor<TDocument> IfSequenceNumber(long? ifSequenceNumber) => Qs("if_seq_no", ifSequenceNumber);
 		///<summary>only perform the delete operation if the last operation that has changed the document has the specified primary term</summary>
 		public DeleteDescriptor<TDocument> IfPrimaryTerm(long? ifPrimaryTerm) => Qs("if_primary_term", ifPrimaryTerm);
 		///<summary>Explicit version number for concurrency control</summary>
@@ -1622,7 +1622,7 @@ namespace Nest
 		///<summary>Specific version type</summary>
 		public IndexDescriptor<TDocument> VersionType(VersionType? versionType) => Qs("version_type", versionType);
 		///<summary>only perform the index operation if the last operation that has changed the document has the specified sequence number</summary>
-		public IndexDescriptor<TDocument> IfSeqNo(long? ifSeqNo) => Qs("if_seq_no", ifSeqNo);
+		public IndexDescriptor<TDocument> IfSequenceNumber(long? ifSequenceNumber) => Qs("if_seq_no", ifSequenceNumber);
 		///<summary>only perform the index operation if the last operation that has changed the document has the specified primary term</summary>
 		public IndexDescriptor<TDocument> IfPrimaryTerm(long? ifPrimaryTerm) => Qs("if_primary_term", ifPrimaryTerm);
 		///<summary>The pipeline id to preprocess incoming documents with</summary>
@@ -3503,7 +3503,7 @@ namespace Nest
 		///<summary>Specify which field to use for suggestions</summary>
 		public SearchDescriptor<T> SuggestField(Field suggestField) => Qs("suggest_field", suggestField);
 		///<summary>Specify which field to use for suggestions</summary>
-		public SearchDescriptor<T> SuggestField<TValue>(Expression<Func<T, TValue>> field)  => Qs("suggest_field", (Field)field);
+		public SearchDescriptor<T> SuggestField(Expression<Func<T, object>> field)  => Qs("suggest_field", (Field)field);
 		///<summary>Specify suggest mode</summary>
 		public SearchDescriptor<T> SuggestMode(SuggestMode? suggestMode) => Qs("suggest_mode", suggestMode);
 		///<summary>How many suggestions to return in response</summary>
@@ -3517,7 +3517,7 @@ namespace Nest
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public SearchDescriptor<T> TypedKeys(bool? typedKeys = true) => Qs("typed_keys", typedKeys);
 		///<summary>Specify whether to return sequence number and primary term of the last modification of each hit</summary>
-		public SearchDescriptor<T> SeqNoPrimaryTerm(bool? seqNoPrimaryTerm = true) => Qs("seq_no_primary_term", seqNoPrimaryTerm);
+		public SearchDescriptor<T> SequenceNumberPrimaryTerm(bool? sequenceNumberPrimaryTerm = true) => Qs("seq_no_primary_term", sequenceNumberPrimaryTerm);
 		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
 		public SearchDescriptor<T> RequestCache(bool? requestCache = true) => Qs("request_cache", requestCache);
 		///<summary>The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.</summary>
@@ -4016,7 +4016,7 @@ namespace Nest
 		///<summary>Explicit operation timeout</summary>
 		public UpdateDescriptor<TDocument, TPartialDocument> Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>only perform the update operation if the last operation that has changed the document has the specified sequence number</summary>
-		public UpdateDescriptor<TDocument, TPartialDocument> IfSeqNo(long? ifSeqNo) => Qs("if_seq_no", ifSeqNo);
+		public UpdateDescriptor<TDocument, TPartialDocument> IfSequenceNumber(long? ifSequenceNumber) => Qs("if_seq_no", ifSequenceNumber);
 		///<summary>only perform the update operation if the last operation that has changed the document has the specified primary term</summary>
 		public UpdateDescriptor<TDocument, TPartialDocument> IfPrimaryTerm(long? ifPrimaryTerm) => Qs("if_primary_term", ifPrimaryTerm);
 	}
@@ -5881,7 +5881,7 @@ namespace Nest
 		///<summary>Explicit version number for concurrency control</summary>
 		public PutWatchDescriptor Version(long? version) => Qs("version", version);
 		///<summary>only update the watch if the last operation that has changed the watch has the specified sequence number</summary>
-		public PutWatchDescriptor IfSeqNo(long? ifSeqNo) => Qs("if_seq_no", ifSeqNo);
+		public PutWatchDescriptor IfSequenceNumber(long? ifSequenceNumber) => Qs("if_seq_no", ifSequenceNumber);
 		///<summary>only update the watch if the last operation that has changed the watch has the specified primary term</summary>
 		public PutWatchDescriptor IfPrimaryTerm(long? ifPrimaryTerm) => Qs("if_primary_term", ifPrimaryTerm);
 	}

--- a/src/Nest/_Generated/_Requests.generated.cs
+++ b/src/Nest/_Generated/_Requests.generated.cs
@@ -2408,7 +2408,7 @@ namespace Nest
 		///<summary>Explicit operation timeout</summary>
 		public Time Timeout { get => Q<Time>("timeout"); set => Q("timeout", value); }
 		///<summary>only perform the delete operation if the last operation that has changed the document has the specified sequence number</summary>
-		public long? IfSeqNo { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
+		public long? IfSequenceNumber { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
 		///<summary>only perform the delete operation if the last operation that has changed the document has the specified primary term</summary>
 		public long? IfPrimaryTerm { get => Q<long?>("if_primary_term"); set => Q("if_primary_term", value); }
 		///<summary>Explicit version number for concurrency control</summary>
@@ -4437,7 +4437,7 @@ namespace Nest
 		///<summary>Specific version type</summary>
 		public VersionType? VersionType { get => Q<VersionType?>("version_type"); set => Q("version_type", value); }
 		///<summary>only perform the index operation if the last operation that has changed the document has the specified sequence number</summary>
-		public long? IfSeqNo { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
+		public long? IfSequenceNumber { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
 		///<summary>only perform the index operation if the last operation that has changed the document has the specified primary term</summary>
 		public long? IfPrimaryTerm { get => Q<long?>("if_primary_term"); set => Q("if_primary_term", value); }
 		///<summary>The pipeline id to preprocess incoming documents with</summary>
@@ -5695,7 +5695,7 @@ namespace Nest
 		///<summary>Explicit version number for concurrency control</summary>
 		public long? Version { get => Q<long?>("version"); set => Q("version", value); }
 		///<summary>only update the watch if the last operation that has changed the watch has the specified sequence number</summary>
-		public long? IfSeqNo { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
+		public long? IfSequenceNumber { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
 		///<summary>only update the watch if the last operation that has changed the watch has the specified primary term</summary>
 		public long? IfPrimaryTerm { get => Q<long?>("if_primary_term"); set => Q("if_primary_term", value); }
 	}
@@ -6175,7 +6175,7 @@ namespace Nest
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public bool? TypedKeys { get => Q<bool?>("typed_keys"); set => Q("typed_keys", value); }
 		///<summary>Specify whether to return sequence number and primary term of the last modification of each hit</summary>
-		public bool? SeqNoPrimaryTerm { get => Q<bool?>("seq_no_primary_term"); set => Q("seq_no_primary_term", value); }
+		public bool? SequenceNumberPrimaryTerm { get => Q<bool?>("seq_no_primary_term"); set => Q("seq_no_primary_term", value); }
 		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
 		public bool? RequestCache { get => Q<bool?>("request_cache"); set => Q("request_cache", value); }
 		///<summary>
@@ -7382,7 +7382,7 @@ namespace Nest
 		///<summary>Explicit operation timeout</summary>
 		public Time Timeout { get => Q<Time>("timeout"); set => Q("timeout", value); }
 		///<summary>only perform the update operation if the last operation that has changed the document has the specified sequence number</summary>
-		public long? IfSeqNo { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
+		public long? IfSequenceNumber { get => Q<long?>("if_seq_no"); set => Q("if_seq_no", value); }
 		///<summary>only perform the update operation if the last operation that has changed the document has the specified primary term</summary>
 		public long? IfPrimaryTerm { get => Q<long?>("if_primary_term"); set => Q("if_primary_term", value); }
 	}

--- a/src/Tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
@@ -198,7 +198,7 @@ namespace Tests.Aggregations.Metric.TopHits
 				var hits = topStateHits.Hits<Project>();
 				hits.Should().NotBeNullOrEmpty();
 				hits.All(h => h.Explanation != null).Should().BeTrue();
-				hits.All(h => h.Version.HasValue).Should().BeTrue();
+				hits.All(h => h.Version >= 0).Should().BeTrue();
 				hits.All(h => h.Fields.ValuesOf<int>("commit_factor").Any()).Should().BeTrue();
 				hits.All(h => h.Fields.ValuesOf<DateTime>("startedOn").Any()).Should().BeTrue();
 				var projects = topStateHits.Documents<Project>();

--- a/src/Tests/Tests/Document/Multiple/Bulk/BulkInvalidVersionApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/Bulk/BulkInvalidVersionApiTests.cs
@@ -31,7 +31,7 @@ namespace Tests.Document.Multiple.Bulk
 		protected override Func<BulkDescriptor, IBulkRequest> Fluent => d => d
 			.Index(CallIsolatedValue)
 			.Index<Project>(i => i.Document(Project.Instance))
-			.Index<Project>(i => i.IfSeqNo(-1).Document(Project.Instance));
+			.Index<Project>(i => i.IfSequenceNumber(-1).Document(Project.Instance));
 
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
 
@@ -40,7 +40,7 @@ namespace Tests.Document.Multiple.Bulk
 			Operations = new List<IBulkOperation>
 			{
 				new BulkIndexOperation<Project>(Project.Instance),
-				new BulkIndexOperation<Project>(Project.Instance) { IfSeqNo = -1 }
+				new BulkIndexOperation<Project>(Project.Instance) { IfSequenceNumber = -1 }
 			}
 		};
 

--- a/src/Tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
@@ -168,6 +168,8 @@ namespace Tests.Document.Multiple.MultiGet
 				hit.Id.Should().NotBeNullOrWhiteSpace();
 				hit.Found.Should().BeTrue();
 				hit.Version.Should().Be(1);
+				hit.SequenceNumber.Should().HaveValue();
+				hit.PrimaryTerm.Should().HaveValue();
 				hit.Source.ShouldAdhereToSourceSerializerWhenSet();
 			}
 		}

--- a/src/Tests/Tests/Document/Single/Get/GetApiTests.cs
+++ b/src/Tests/Tests/Document/Single/Get/GetApiTests.cs
@@ -44,6 +44,8 @@ namespace Tests.Document.Single.Get
 		{
 			response.Source.Should().NotBeNull();
 			response.Source.Name.Should().Be(ProjectId);
+			response.SequenceNumber.Should().HaveValue();
+			response.PrimaryTerm.Should().HaveValue();
 			response.Source.ShouldAdhereToSourceSerializerWhenSet();
 		}
 	}

--- a/src/Tests/Tests/Search/Request/InnerHitsUsageTests.cs
+++ b/src/Tests/Tests/Search/Request/InnerHitsUsageTests.cs
@@ -340,8 +340,7 @@ namespace Tests.Search.Request
 			{
 				hit.Id.Should().NotBeNullOrEmpty();
 				hit.Index.Should().NotBeNullOrEmpty();
-				hit.Version?.Should().Be(1);
-
+				hit.Version.Should().Be(1);
 
 				var princes = hit.InnerHits["princes"].Documents<Prince>();
 				princes.Should().NotBeEmpty();
@@ -359,7 +358,7 @@ namespace Tests.Search.Request
 					var docValueName = princeHit.Fields.ValueOf<Prince, string>(p => p.Name);
 					docValueName.Should().NotBeNullOrWhiteSpace("value of name on Fields");
 
-					princeHit.Version?.Should().Be(1);
+					princeHit.Version.Should().Be(1);
 				}
 
 				var foes = hit.InnerHits["foes"].Documents<King>();

--- a/src/Tests/Tests/Search/Search/SearchApiTests.cs
+++ b/src/Tests/Tests/Search/Search/SearchApiTests.cs
@@ -111,6 +111,54 @@ namespace Tests.Search.Search
 		}
 	}
 
+	public class SearchApiSequenceNumberPrimaryTermTests
+		: SearchApiTests
+	{
+		public SearchApiSequenceNumberPrimaryTermTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			query = new
+			{
+				match_all = new { }
+			}
+		};
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.SeqNoPrimaryTerm()
+			.Query(q => q
+				.MatchAll()
+			);
+
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+
+		protected override SearchRequest<Project> Initializer => new SearchRequest<Project>()
+		{
+			SeqNoPrimaryTerm = true,
+			Query = new QueryContainer(new MatchAllQuery()),
+		};
+
+		protected override string UrlPath => $"/project/_search?seq_no_primary_term=true";
+
+		protected override void ExpectResponse(SearchResponse<Project> response)
+		{
+			response.Total.Should().BeGreaterThan(0);
+			response.Hits.Count.Should().BeGreaterThan(0);
+			response.HitsMetadata.Total.Value.Should().Be(response.Total);
+			response.HitsMetadata.Total.Relation.Should().Be(TotalHitsRelation.EqualTo);
+
+			foreach (var hit in response.Hits)
+			{
+				hit.Should().NotBeNull();
+				hit.Source.Should().NotBeNull();
+				hit.SequenceNumber.Should().HaveValue();
+				hit.PrimaryTerm.Should().HaveValue();
+			}
+		}
+	}
+
 	public class SearchApiStoredFieldsTests : SearchApiTests
 	{
 		public SearchApiStoredFieldsTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }

--- a/src/Tests/Tests/Search/Search/SearchApiTests.cs
+++ b/src/Tests/Tests/Search/Search/SearchApiTests.cs
@@ -127,7 +127,7 @@ namespace Tests.Search.Search
 		protected override int ExpectStatusCode => 200;
 
 		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
-			.SeqNoPrimaryTerm()
+			.SequenceNumberPrimaryTerm()
 			.Query(q => q
 				.MatchAll()
 			);
@@ -136,7 +136,7 @@ namespace Tests.Search.Search
 
 		protected override SearchRequest<Project> Initializer => new SearchRequest<Project>()
 		{
-			SeqNoPrimaryTerm = true,
+			SequenceNumberPrimaryTerm = true,
 			Query = new QueryContainer(new MatchAllQuery()),
 		};
 


### PR DESCRIPTION
This commit adds the SequenceNumber and PrimaryTerm properties to the Hit<T>, MultiGetHit<T> and GetResponse.

Closes #3708