### PR TITLE
Allow geo_shape types to be coerced into valid shapes.

### DIFF
--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoShapeAttribute.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoShapeAttribute.cs
@@ -63,6 +63,13 @@
 			set => Self.TreeLevels = value;
 		}
 
+		/// <inheritdoc cref="IGeoShapeProperty.Coerce" />
+		public bool Coerce
+		{
+			get => Self.Coerce.GetValueOrDefault(true);
+			set => Self.Coerce = value;
+		}
+
 		double? IGeoShapeProperty.DistanceErrorPercentage { get; set; }
 		bool? IGeoShapeProperty.IgnoreMalformed { get; set; }
 		bool? IGeoShapeProperty.IgnoreZValue { get; set; }
@@ -74,5 +81,7 @@
 
 		GeoTree? IGeoShapeProperty.Tree { get; set; }
 		int? IGeoShapeProperty.TreeLevels { get; set; }
+
+		bool? IGeoShapeProperty.Coerce { get; set; }
 	}
 }

--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoShapeProperty.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoShapeProperty.cs
@@ -97,6 +97,12 @@ namespace Nest
 		/// </summary>
 		[JsonProperty("tree_levels")]
 		int? TreeLevels { get; set; }
+
+		/// <summary>
+		/// Should the data be coerced into becoming a valid geo shape (for instance closing a polygon)
+		/// </summary>
+		[JsonProperty("coerce")]
+		bool? Coerce { get; set; }
 	}
 
 	/// <inheritdoc cref="IGeoShapeProperty" />
@@ -131,6 +137,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public int? TreeLevels { get; set; }
+
+		/// <inheritdoc />
+		public bool? Coerce { get; set; }
 	}
 
 	/// <inheritdoc cref="IGeoShapeProperty" />
@@ -150,6 +159,8 @@ namespace Nest
 		GeoStrategy? IGeoShapeProperty.Strategy { get; set; }
 		GeoTree? IGeoShapeProperty.Tree { get; set; }
 		int? IGeoShapeProperty.TreeLevels { get; set; }
+
+		bool? IGeoShapeProperty.Coerce { get; set; }
 
 		/// <inheritdoc cref="IGeoShapeProperty.Tree" />
 		public GeoShapePropertyDescriptor<T> Tree(GeoTree? tree) => Assign(tree, (a, v) => a.Tree = v);
@@ -181,5 +192,9 @@ namespace Nest
 		/// <inheritdoc cref="IGeoShapeProperty.IgnoreZValue" />
 		public GeoShapePropertyDescriptor<T> IgnoreZValue(bool? ignoreZValue = true) =>
 			Assign(ignoreZValue, (a, v) => a.IgnoreZValue = v);
+
+		/// <inheritdoc cref="IGeoShapeProperty.Coerce" />
+		public GeoShapePropertyDescriptor<T> Coerce(bool? coerce = true) =>
+			Assign(coerce, (a, v) => a.Coerce = v);
 	}
 }

--- a/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeAttributeTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeAttributeTests.cs
@@ -10,7 +10,8 @@ namespace Tests.Mapping.Types.Geo.GeoShape
 			Strategy = GeoStrategy.Recursive,
 			TreeLevels = 3,
 			PointsOnly = true,
-			DistanceErrorPercentage = 1.0)]
+			DistanceErrorPercentage = 1.0,
+			Coerce = true)]
 		public object Full { get; set; }
 
 		[GeoShape]
@@ -31,7 +32,8 @@ namespace Tests.Mapping.Types.Geo.GeoShape
 					strategy = "recursive",
 					tree_levels = 3,
 					points_only = true,
-					distance_error_pct = 1.0
+					distance_error_pct = 1.0,
+					coerce = true
 				},
 				minimal = new
 				{

--- a/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapePropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapePropertyTests.cs
@@ -22,7 +22,8 @@ namespace Tests.Mapping.Types.Core.GeoShape
 					strategy = "recursive",
 					tree_levels = 3,
 					points_only = true,
-					distance_error_pct = 1.0
+					distance_error_pct = 1.0,
+					coerce = true
 				}
 			}
 		};
@@ -36,6 +37,7 @@ namespace Tests.Mapping.Types.Core.GeoShape
 				.TreeLevels(3)
 				.PointsOnly()
 				.DistanceErrorPercentage(1.0)
+				.Coerce()
 			);
 
 
@@ -49,7 +51,8 @@ namespace Tests.Mapping.Types.Core.GeoShape
 					Strategy = GeoStrategy.Recursive,
 					TreeLevels = 3,
 					PointsOnly = true,
-					DistanceErrorPercentage = 1.0
+					DistanceErrorPercentage = 1.0,
+					Coerce = true
 				}
 			}
 		};


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/35059