### PR TITLE
Fix CCR Tests.

### DIFF
--- a/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/IntrusiveOperationSeededCluster.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/Clusters/IntrusiveOperationSeededCluster.cs
@@ -1,0 +1,24 @@
+using Elastic.Managed.Ephemeral.Plugins;
+using Tests.Core.ManagedElasticsearch.NodeSeeders;
+
+namespace Tests.Core.ManagedElasticsearch.Clusters
+{
+	/// <summary>
+	/// Use this cluster for heavy API's, either on ES's side or the client (intricate setup etc)
+	/// </summary>
+	public class IntrusiveOperationSeededCluster : ClientTestClusterBase
+	{
+		public IntrusiveOperationSeededCluster() : base(new ClientTestClusterConfiguration(
+			ElasticsearchPlugin.IngestGeoIp, ElasticsearchPlugin.IngestAttachment
+		)
+		{
+			MaxConcurrency = 1
+		}) { }
+
+		protected override void SeedCluster()
+		{
+			var seeder = new DefaultSeeder(Client);
+			seeder.SeedNode();
+		}
+	}
+}

--- a/src/Tests/Tests/Cluster/ClusterReroute/ClusterRerouteApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterReroute/ClusterRerouteApiTests.cs
@@ -12,10 +12,10 @@ using Tests.Framework.Integration;
 namespace Tests.Cluster.ClusterReroute
 {
 	public class ClusterRerouteApiTests
-		: ApiIntegrationTestBase<IntrusiveOperationCluster, IClusterRerouteResponse, IClusterRerouteRequest, ClusterRerouteDescriptor,
+		: ApiIntegrationTestBase<IntrusiveOperationSeededCluster, IClusterRerouteResponse, IClusterRerouteRequest, ClusterRerouteDescriptor,
 			ClusterRerouteRequest>
 	{
-		public ClusterRerouteApiTests(IntrusiveOperationCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public ClusterRerouteApiTests(IntrusiveOperationSeededCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override bool ExpectIsValid => false;
 


### PR DESCRIPTION
- WaitForActiveShards is a new feature in 6.7.0, which defaults to false, this is opposite behaviour of 6.6.0 (which implicitly waits for active shards)
- Unfollowing a closed index in 6.7.0 now throws an exception