### PR TITLE
Fix/ml close job

### DIFF
--- a/src/CodeGeneration/ApiGenerator/RestSpecification/XPack/MachineLearning/xpack.ml.close_job.replace.json
+++ b/src/CodeGeneration/ApiGenerator/RestSpecification/XPack/MachineLearning/xpack.ml.close_job.replace.json
@@ -1,0 +1,33 @@
+{
+  "xpack.ml.close_job": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html",
+    "methods": [ "POST" ],
+    "url": {
+      "path": "/_xpack/ml/anomaly_detectors/{job_id}/_close",
+      "paths": [ "/_xpack/ml/anomaly_detectors/{job_id}/_close" ],
+      "parts": {
+        "job_id": {
+          "type": "string",
+          "required": true,
+          "description": "The name of the job to close"
+        }
+      },
+      "params": {
+        "allow_no_jobs": {
+          "type": "boolean",
+          "required": false,
+          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
+        },
+        "force": {
+          "type": "boolean",
+          "required": false,
+          "description": "True if the job should be forcefully closed"
+        },
+        "timeout": {
+          "type": "time",
+          "description": "Controls the time to wait until a job has closed. Default to 30 minutes"
+        }
+      }
+    }
+  }
+}

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Generated.cs
@@ -3306,16 +3306,14 @@ namespace Elasticsearch.Net
 			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(POST, Url($"_xpack/license/start_trial"), ctx, null, _params(requestParameters));
 		///<summary>POST on /_xpack/ml/anomaly_detectors/{job_id}/_close <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</para></summary>
 		///<param name="job_id">The name of the job to close</param>
-		///<param name="body">The URL params optionally sent in the body</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public TResponse XpackMlCloseJob<TResponse>(string job_id, PostData body, CloseJobRequestParameters requestParameters = null)
-			where TResponse : class, IElasticsearchResponse, new() => this.DoRequest<TResponse>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_close"), body, _params(requestParameters));
+		public TResponse XpackMlCloseJob<TResponse>(string job_id, CloseJobRequestParameters requestParameters = null)
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequest<TResponse>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_close"), null, _params(requestParameters));
 		///<summary>POST on /_xpack/ml/anomaly_detectors/{job_id}/_close <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</para></summary>
 		///<param name="job_id">The name of the job to close</param>
-		///<param name="body">The URL params optionally sent in the body</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		public Task<TResponse> XpackMlCloseJobAsync<TResponse>(string job_id, PostData body, CloseJobRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
-			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_close"), ctx, body, _params(requestParameters));
+		public Task<TResponse> XpackMlCloseJobAsync<TResponse>(string job_id, CloseJobRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken))
+			where TResponse : class, IElasticsearchResponse, new() => this.DoRequestAsync<TResponse>(POST, Url($"_xpack/ml/anomaly_detectors/{job_id.NotNull("job_id")}/_close"), ctx, null, _params(requestParameters));
 		///<summary>DELETE on /_xpack/ml/calendars/{calendar_id} <para></para></summary>
 		///<param name="calendar_id">The ID of the calendar to delete</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
@@ -2676,14 +2676,12 @@ namespace Elasticsearch.Net
 		Task<TResponse> XpackLicensePostStartTrialAsync<TResponse>(StartTrialLicenseRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
 		///<summary>POST on /_xpack/ml/anomaly_detectors/{job_id}/_close <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</para></summary>
 		///<param name="job_id">The name of the job to close</param>
-		///<param name="body">The URL params optionally sent in the body</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		TResponse XpackMlCloseJob<TResponse>(string job_id, PostData body, CloseJobRequestParameters requestParameters = null) where TResponse : class, IElasticsearchResponse, new();
+		TResponse XpackMlCloseJob<TResponse>(string job_id, CloseJobRequestParameters requestParameters = null) where TResponse : class, IElasticsearchResponse, new();
 		///<summary>POST on /_xpack/ml/anomaly_detectors/{job_id}/_close <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</para></summary>
 		///<param name="job_id">The name of the job to close</param>
-		///<param name="body">The URL params optionally sent in the body</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>
-		Task<TResponse> XpackMlCloseJobAsync<TResponse>(string job_id, PostData body, CloseJobRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
+		Task<TResponse> XpackMlCloseJobAsync<TResponse>(string job_id, CloseJobRequestParameters requestParameters = null, CancellationToken ctx = default(CancellationToken)) where TResponse : class, IElasticsearchResponse, new();
 		///<summary>DELETE on /_xpack/ml/calendars/{calendar_id} <para></para></summary>
 		///<param name="calendar_id">The ID of the calendar to delete</param>
 		///<param name="requestParameters">A func that allows you to describe the querystring parameters &amp; request specific connection settings.</param>

--- a/src/Nest/XPack/MachineLearning/CloseJob/ElasticClient-CloseJob.cs
+++ b/src/Nest/XPack/MachineLearning/CloseJob/ElasticClient-CloseJob.cs
@@ -35,7 +35,7 @@ namespace Nest
 		public ICloseJobResponse CloseJob(ICloseJobRequest request) =>
 			Dispatcher.Dispatch<ICloseJobRequest, CloseJobRequestParameters, CloseJobResponse>(
 				request,
-				(p, d) => LowLevelDispatch.XpackMlCloseJobDispatch<CloseJobResponse>(p, d)
+				(p, d) => LowLevelDispatch.XpackMlCloseJobDispatch<CloseJobResponse>(p)
 			);
 
 		/// <inheritdoc />
@@ -49,7 +49,7 @@ namespace Nest
 			Dispatcher.DispatchAsync<ICloseJobRequest, CloseJobRequestParameters, CloseJobResponse, ICloseJobResponse>(
 				request,
 				cancellationToken,
-				(p, d, c) => LowLevelDispatch.XpackMlCloseJobDispatchAsync<CloseJobResponse>(p, d, c)
+				(p, d, c) => LowLevelDispatch.XpackMlCloseJobDispatchAsync<CloseJobResponse>(p, c)
 			);
 	}
 }

--- a/src/Nest/_Generated/_LowLevelDispatch.generated.cs
+++ b/src/Nest/_Generated/_LowLevelDispatch.generated.cs
@@ -3594,23 +3594,23 @@ namespace Nest
 			throw InvalidDispatch("XpackLicensePostStartTrial", p, new [] { POST }, "/_xpack/license/start_trial");
 		}
 		
-		internal TResponse XpackMlCloseJobDispatch<TResponse>(IRequest<CloseJobRequestParameters> p,SerializableData<ICloseJobRequest> body) where TResponse : class, IElasticsearchResponse, new()
+		internal TResponse XpackMlCloseJobDispatch<TResponse>(IRequest<CloseJobRequestParameters> p) where TResponse : class, IElasticsearchResponse, new()
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlCloseJob<TResponse>(p.RouteValues.JobId,body,p.RequestParameters);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlCloseJob<TResponse>(p.RouteValues.JobId,p.RequestParameters);
 					break;
 			}
 			throw InvalidDispatch("XpackMlCloseJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_close");
 		}
 		
-		internal Task<TResponse> XpackMlCloseJobDispatchAsync<TResponse>(IRequest<CloseJobRequestParameters> p,SerializableData<ICloseJobRequest> body, CancellationToken ct) where TResponse : class, IElasticsearchResponse, new()
+		internal Task<TResponse> XpackMlCloseJobDispatchAsync<TResponse>(IRequest<CloseJobRequestParameters> p, CancellationToken ct) where TResponse : class, IElasticsearchResponse, new()
 		{
 			switch(p.HttpMethod)
 			{
 				case POST:
-					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlCloseJobAsync<TResponse>(p.RouteValues.JobId,body,p.RequestParameters,ct);
+					if (AllSetNoFallback(p.RouteValues.JobId)) return _lowLevel.XpackMlCloseJobAsync<TResponse>(p.RouteValues.JobId,p.RequestParameters,ct);
 					break;
 			}
 			throw InvalidDispatch("XpackMlCloseJob", p, new [] { POST }, "/_xpack/ml/anomaly_detectors/{job_id}/_close");


### PR DESCRIPTION
Removes the optional body declaration from the REST JSON spec as introduced in 6.7.0

- https://github.com/elastic/elasticsearch/blob/6.6/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ml.close_job.json
- https://github.com/elastic/elasticsearch/blob/6.7/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ml.close_job.json

This causes the ApiGenerator to emit a PostData body argument, which breaks binary compatibility between `6.6` and `6.7`.

This fix overwrites the spec with a local patch.