### PR TITLE
[DOCS] Fix broken cross-ref links

### DIFF
--- a/src/Tests/Tests/high-level.asciidoc
+++ b/src/Tests/Tests/high-level.asciidoc
@@ -118,8 +118,8 @@ on using the {ref_current}/search-search.html[Search API].
 NEST exposes a number of important features for indexing documents into Elasticsearch.
 
 - <<indexing-documents, Indexing Documents>>
-- <<ingest-pipelines, Ingest Pipelines>>
-- <<ingest-node, Ingest Node>>
+- <<pipelines, Ingest Pipelines>>
+- <<ingest-nodes, Ingest Node>>
 
 include::{output-dir}/indexing/indexing-documents.asciidoc[]
 include::{output-dir}/indexing/ingest-node.asciidoc[]


### PR DESCRIPTION
Fixes a few links broken with https://github.com/elastic/elasticsearch-net/commit/69a60a6cb9b8c00a0ba3c2e2383f28038bf1c37b. 