### PR TITLE
Correctly serialize Unicode special characters

### DIFF
--- a/src/Elasticsearch.Net/Extensions/CharUtils.cs
+++ b/src/Elasticsearch.Net/Extensions/CharUtils.cs
@@ -1,0 +1,9 @@
+namespace Elasticsearch.Net
+{
+	internal static class CharUtils
+	{
+		// https://referencesource.microsoft.com/#mscorlib/system/security/util/hex.cs,1bfe838f662feef3
+		// converts number to hex digit. Does not do any range checks.
+		internal static char HexDigit(int num) => (char)(num < 10 ? num + 48 : num + 55);
+	}
+}

--- a/src/Elasticsearch.Net/Extensions/X509CertificateExtensions.cs
+++ b/src/Elasticsearch.Net/Extensions/X509CertificateExtensions.cs
@@ -11,10 +11,6 @@ namespace Elasticsearch.Net
 			return EncodeHexString(bytes);
 		}
 
-		// https://referencesource.microsoft.com/#mscorlib/system/security/util/hex.cs,1bfe838f662feef3
-		// converts number to hex digit. Does not do any range checks.
-		private static char HexDigit(int num) => (char)(num < 10 ? num + '0' : num + ('A' - 10));
-
 		private static string EncodeHexString(byte[] sArray)
 		{
 			string result = null;
@@ -26,9 +22,9 @@ namespace Elasticsearch.Net
 			for (int i = 0, j = 0; i < sArray.Length; i++)
 			{
 				var digit = (sArray[i] & 0xf0) >> 4;
-				hexOrder[j++] = HexDigit(digit);
+				hexOrder[j++] = CharUtils.HexDigit(digit);
 				digit = sArray[i] & 0x0f;
-				hexOrder[j++] = HexDigit(digit);
+				hexOrder[j++] = CharUtils.HexDigit(digit);
 			}
 			result = new string(hexOrder);
 			return result;

--- a/src/Elasticsearch.Net/Utf8Json/JsonWriter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonWriter.cs
@@ -390,7 +390,7 @@ namespace Elasticsearch.Net
             // for JIT Optimization, for-loop i < str.Length
             for (int i = 0; i < value.Length; i++)
             {
-                byte escapeChar = default(byte);
+				byte escapeChar = default;
                 switch (value[i])
                 {
                     case '"':
@@ -414,105 +414,54 @@ namespace Elasticsearch.Net
                     case '\t':
                         escapeChar = (byte)'t';
                         break;
-                    // use switch jumptable
-                    case (char)0:
-                    case (char)1:
-                    case (char)2:
-                    case (char)3:
-                    case (char)4:
-                    case (char)5:
-                    case (char)6:
-                    case (char)7:
-                    case (char)11:
-                    case (char)14:
-                    case (char)15:
-                    case (char)16:
-                    case (char)17:
-                    case (char)18:
-                    case (char)19:
-                    case (char)20:
-                    case (char)21:
-                    case (char)22:
-                    case (char)23:
-                    case (char)24:
-                    case (char)25:
-                    case (char)26:
-                    case (char)27:
-                    case (char)28:
-                    case (char)29:
-                    case (char)30:
-                    case (char)31:
-                    case (char)32:
-                    case (char)33:
-                    case (char)35:
-                    case (char)36:
-                    case (char)37:
-                    case (char)38:
-                    case (char)39:
-                    case (char)40:
-                    case (char)41:
-                    case (char)42:
-                    case (char)43:
-                    case (char)44:
-                    case (char)45:
-                    case (char)46:
-                    case (char)47:
-                    case (char)48:
-                    case (char)49:
-                    case (char)50:
-                    case (char)51:
-                    case (char)52:
-                    case (char)53:
-                    case (char)54:
-                    case (char)55:
-                    case (char)56:
-                    case (char)57:
-                    case (char)58:
-                    case (char)59:
-                    case (char)60:
-                    case (char)61:
-                    case (char)62:
-                    case (char)63:
-                    case (char)64:
-                    case (char)65:
-                    case (char)66:
-                    case (char)67:
-                    case (char)68:
-                    case (char)69:
-                    case (char)70:
-                    case (char)71:
-                    case (char)72:
-                    case (char)73:
-                    case (char)74:
-                    case (char)75:
-                    case (char)76:
-                    case (char)77:
-                    case (char)78:
-                    case (char)79:
-                    case (char)80:
-                    case (char)81:
-                    case (char)82:
-                    case (char)83:
-                    case (char)84:
-                    case (char)85:
-                    case (char)86:
-                    case (char)87:
-                    case (char)88:
-                    case (char)89:
-                    case (char)90:
-                    case (char)91:
-                    default:
-                        continue;
-                }
+					case (char)0:
+					case (char)1:
+					case (char)2:
+					case (char)3:
+					case (char)4:
+					case (char)5:
+					case (char)6:
+					case (char)7:
+					case (char)11:
+					case (char)14:
+					case (char)15:
+					case (char)16:
+					case (char)17:
+					case (char)18:
+					case (char)19:
+					case (char)20:
+					case (char)21:
+					case (char)22:
+					case (char)23:
+					case (char)24:
+					case (char)25:
+					case (char)26:
+					case (char)27:
+					case (char)28:
+					case (char)29:
+					case (char)30:
+					case (char)31:
+					case '\u0085':
+					case '\u2028':
+					case '\u2029':
+						break;
+					default:
+						continue;
+				}
 
-                max += 2;
+                max += escapeChar == default ? 6 : 2;
                 BinaryUtil.EnsureCapacity(ref buffer, startoffset, max); // check +escape capacity
-
-                offset += StringEncoding.UTF8.GetBytes(value, from, i - from, buffer, offset);
+				offset += StringEncoding.UTF8.GetBytes(value, from, i - from, buffer, offset);
                 from = i + 1;
-                buffer[offset++] = (byte)'\\';
-                buffer[offset++] = escapeChar;
-            }
+
+				if (escapeChar == default)
+					ToUnicode(value[i], ref offset, buffer);
+				else
+				{
+					buffer[offset++] = (byte)'\\';
+					buffer[offset++] = escapeChar;
+				}
+			}
 
             if (from != value.Length)
             {
@@ -521,5 +470,15 @@ namespace Elasticsearch.Net
 
             buffer[offset++] = (byte)'\"';
         }
-    }
+
+		private static void ToUnicode(char c, ref int offset, byte[] buffer)
+		{
+			buffer[offset++] = (byte)'\\';
+			buffer[offset++] = (byte)'u';
+			buffer[offset++] = (byte)CharUtils.HexDigit((c >> 12) & '\x000f');
+			buffer[offset++] = (byte)CharUtils.HexDigit((c >> 8) & '\x000f');
+			buffer[offset++] = (byte)CharUtils.HexDigit((c >> 4) & '\x000f');
+			buffer[offset++] = (byte)CharUtils.HexDigit(c & '\x000f');
+		}
+	}
 }

--- a/src/Tests/Tests.Reproduce/GithubIssue3743.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue3743.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Tests.Core.Serialization;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3743
+	{
+		[U]
+		public void SerializesUnicodeEscapeSequences()
+		{
+			var doc = new { value = new string(Enumerable.Range(0, 9727).Select(i => (char)i).ToArray()) };
+
+			var internalJson = SerializationTester.Default.Client.SourceSerializer.SerializeToString(doc, formatting: SerializationFormatting.None);
+			var jsonNet = JsonConvert.SerializeObject(doc, Formatting.None);
+
+			// json.net lowercases unicode escape sequences, utf8json uppercases them (faster op). Both are valid and accepted
+			internalJson.Should().BeEquivalentTo(jsonNet);
+		}
+	}
+}


### PR DESCRIPTION
This commit corrects serialization of Unicode special characters.
All characters before U+0020 (' ' space character) must be encoded
in bytes as Unicode escape sequences

Fixes #3743