### PR TITLE
Include stored_scripts response in cluster metadata response.

### DIFF
--- a/src/Nest/Cluster/ClusterState/MetadataState.cs
+++ b/src/Nest/Cluster/ClusterState/MetadataState.cs
@@ -15,5 +15,9 @@ namespace Nest
 		[JsonProperty("templates")]
 		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, TemplateMapping>))]
 		public IReadOnlyDictionary<string, TemplateMapping> Templates { get; internal set; }
+
+		[JsonProperty("stored_scripts")]
+		[JsonConverter(typeof(VerbatimDictionaryKeysJsonConverter<string, StoredScriptMapping>))]
+		public IReadOnlyDictionary<string, StoredScriptMapping> StoredScripts { get; internal set; }
 	}
 }

--- a/src/Nest/Cluster/ClusterState/StoredScriptMapping.cs
+++ b/src/Nest/Cluster/ClusterState/StoredScriptMapping.cs
@@ -6,7 +6,7 @@ namespace Nest
 	public class StoredScriptMapping
 	{
 		[JsonProperty("lang")]
-		public string Lang { get; internal set; }
+		public string Language { get; internal set; }
 
 		[JsonProperty("source")]
 		public string Source { get; internal set; }

--- a/src/Nest/Cluster/ClusterState/StoredScriptMapping.cs
+++ b/src/Nest/Cluster/ClusterState/StoredScriptMapping.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nest
+{
+	public class StoredScriptMapping
+	{
+		[JsonProperty("lang")]
+		public string Lang { get; internal set; }
+
+		[JsonProperty("source")]
+		public string Source { get; internal set; }
+
+		[JsonProperty("options")]
+		public IReadOnlyDictionary<string, string> Options { get; internal set; } = EmptyReadOnly<string, string>.Dictionary;
+	}
+}

--- a/src/Tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
@@ -119,7 +119,7 @@ namespace Tests.Cluster.ClusterState
 		protected override bool ExpectIsValid => true;
 		protected override int ExpectStatusCode => 200;
 		protected override HttpMethod HttpMethod => HttpMethod.GET;
-		protected override string UrlPath => "/_cluster/state";
+		protected override string UrlPath => "/_cluster/state/metadata";
 
 		protected override LazyResponses ClientUsage() => Calls(
 			(client, f) => client.ClusterState(s => s.Metric(ClusterStateMetric.Metadata)),

--- a/src/Tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
@@ -100,6 +101,46 @@ namespace Tests.Cluster.ClusterState
 			node.Index.Should().NotBeNullOrWhiteSpace();
 			node.Node.Should().NotBeNullOrWhiteSpace();
 			node.State.Should().NotBeNullOrWhiteSpace();
+		}
+	}
+
+	[SkipVersion("<6.5.0", "Validated against 6.5.0")]
+	public class ClusterStateStoredScriptApiTests
+		: ApiIntegrationTestBase<WritableCluster, IClusterStateResponse, IClusterStateRequest, ClusterStateDescriptor, ClusterStateRequest>
+	{
+		public ClusterStateStoredScriptApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			client.PutScript("my-script-id", s => s.Painless("return 0"));
+			client.PutScript("my-other-script-id", s => s.Painless("return 1"));
+		}
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+		protected override HttpMethod HttpMethod => HttpMethod.GET;
+		protected override string UrlPath => "/_cluster/state";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.ClusterState(s => s.Metric(ClusterStateMetric.Metadata)),
+			(client, f) => client.ClusterStateAsync(s => s.Metric(ClusterStateMetric.Metadata)),
+			(client, r) => client.ClusterState(new ClusterStateRequest(ClusterStateMetric.Metadata)),
+			(client, r) => client.ClusterStateAsync(new ClusterStateRequest(ClusterStateMetric.Metadata))
+		);
+
+		protected override void ExpectResponse(IClusterStateResponse response)
+		{
+			response.Metadata.Should().NotBeNull();
+			response.Metadata.StoredScripts.Should().NotBeNull();
+			response.Metadata.StoredScripts.Count.Should().Be(2);
+
+			response.Metadata.StoredScripts["my-script-id"].Lang.Should().Be("painless");
+			response.Metadata.StoredScripts["my-script-id"].Source.Should().Be("return 0");
+			response.Metadata.StoredScripts["my-script-id"].Options.Should().BeEmpty();
+
+			response.Metadata.StoredScripts["my-other-script-id"].Lang.Should().Be("painless");
+			response.Metadata.StoredScripts["my-other-script-id"].Source.Should().Be("return 1");
+			response.Metadata.StoredScripts["my-other-script-id"].Options.Should().BeEmpty();
 		}
 	}
 }

--- a/src/Tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterState/ClusterStateApiTests.cs
@@ -134,11 +134,11 @@ namespace Tests.Cluster.ClusterState
 			response.Metadata.StoredScripts.Should().NotBeNull();
 			response.Metadata.StoredScripts.Count.Should().Be(2);
 
-			response.Metadata.StoredScripts["my-script-id"].Lang.Should().Be("painless");
+			response.Metadata.StoredScripts["my-script-id"].Language.Should().Be("painless");
 			response.Metadata.StoredScripts["my-script-id"].Source.Should().Be("return 0");
 			response.Metadata.StoredScripts["my-script-id"].Options.Should().BeEmpty();
 
-			response.Metadata.StoredScripts["my-other-script-id"].Lang.Should().Be("painless");
+			response.Metadata.StoredScripts["my-other-script-id"].Language.Should().Be("painless");
 			response.Metadata.StoredScripts["my-other-script-id"].Source.Should().Be("return 1");
 			response.Metadata.StoredScripts["my-other-script-id"].Options.Should().BeEmpty();
 		}


### PR DESCRIPTION
Fixes #3746.

Backport to `7.x` and `master` after approval and merge.