### PR TITLE
Add buckets to AutoDateHistogramAggregation.

### DIFF
--- a/src/Nest/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregation.cs
@@ -12,6 +12,9 @@ namespace Nest
 		[JsonProperty("field")]
 		Field Field { get; set; }
 
+		[JsonProperty("buckets")]
+		int? Buckets { get; set; }
+
 		[JsonProperty("format")]
 		string Format { get; set; }
 
@@ -40,6 +43,8 @@ namespace Nest
 		public AutoDateHistogramAggregation(string name) : base(name) { }
 
 		public Field Field { get; set; }
+
+		public int? Buckets { get; set; }
 
 		//see: https://github.com/elastic/elasticsearch/issues/9725
 		public string Format
@@ -70,6 +75,8 @@ namespace Nest
 
 		Field IAutoDateHistogramAggregation.Field { get; set; }
 
+		int? IAutoDateHistogramAggregation.Buckets { get; set; }
+
 		//see: https://github.com/elastic/elasticsearch/issues/9725
 		string IAutoDateHistogramAggregation.Format
 		{
@@ -94,6 +101,8 @@ namespace Nest
 		public AutoDateHistogramAggregationDescriptor<T> Field(Field field) => Assign(field, (a, v) => a.Field = v);
 
 		public AutoDateHistogramAggregationDescriptor<T> Field(Expression<Func<T, object>> field) => Assign(field, (a, v) => a.Field = v);
+
+		public AutoDateHistogramAggregationDescriptor<T> Buckets(int? buckets) => Assign(buckets, (a, v) => a.Buckets = v);
 
 		public AutoDateHistogramAggregationDescriptor<T> Script(string script) => Assign((InlineScript)script, (a, v) => a.Script = v);
 

--- a/src/Tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs
@@ -36,6 +36,7 @@ namespace Tests.Aggregations.Bucket.AutoDateHistogram
 				auto_date_histogram = new
 				{
 					field = "startedOn",
+					buckets = 10,
 					format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", //<1> Note the inclusion of `date_optional_time` to `format`
 					missing = FixedDate
 				},
@@ -62,6 +63,7 @@ namespace Tests.Aggregations.Bucket.AutoDateHistogram
 		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
 			.AutoDateHistogram("projects_started_per_month", date => date
 				.Field(p => p.StartedOn)
+				.Buckets(10)
 				.Format("yyyy-MM-dd'T'HH:mm:ss")
 				.Missing(FixedDate)
 				.Aggregations(childAggs => childAggs
@@ -78,6 +80,7 @@ namespace Tests.Aggregations.Bucket.AutoDateHistogram
 			new AutoDateHistogramAggregation("projects_started_per_month")
 			{
 				Field = Field<Project>(p => p.StartedOn),
+				Buckets = 10,
 				Format = "yyyy-MM-dd'T'HH:mm:ss",
 				Missing = FixedDate,
 				Aggregations = new NestedAggregation("project_tags")


### PR DESCRIPTION
Fixes #3754.

Sets test values to 10 (which is the default).