### PR TITLE
Attribute SuggestBucket for serialization

### DIFF
--- a/src/Nest/Search/Suggesters/SuggestBucket.cs
+++ b/src/Nest/Search/Suggesters/SuggestBucket.cs
@@ -27,15 +27,22 @@ namespace Nest
 
 	public class SuggestBucket : ISuggestBucket
 	{
+		[JsonProperty("completion")]
 		public ICompletionSuggester Completion { get; set; }
 
+		[JsonProperty("phrase")]
 		public IPhraseSuggester Phrase { get; set; }
 
+		[JsonProperty("prefix")]
 		public string Prefix { get; set; }
 
+		[JsonProperty("regex")]
 		public string Regex { get; set; }
 
+		[JsonProperty("term")]
 		public ITermSuggester Term { get; set; }
+
+		[JsonProperty("text")]
 		public string Text { get; set; }
 	}
 }

--- a/src/Tests/Tests.Reproduce/Discuss179634.cs
+++ b/src/Tests/Tests.Reproduce/Discuss179634.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Globalization;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using FluentAssertions.Common;
+using Nest;
+using Newtonsoft.Json.Linq;
+using Tests.Core.Client;
+using Tests.Core.Extensions;
+using Tests.Core.Serialization;
+using Tests.Domain;
+
+namespace Tests.Reproduce
+{
+	public class Discuss179634
+	{
+		[U]
+		public void SerializeCompletionSuggesterFieldsCorrectlyWhenDefaultFieldNameInferrerUsed()
+		{
+			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var settings = new ConnectionSettings(connectionPool, new InMemoryConnection())
+				.DefaultFieldNameInferrer(p => p.ToUpper(CultureInfo.CurrentCulture))
+				.DisableDirectStreaming();
+
+			var tester = new SerializationTester(new ElasticClient(settings));
+
+			var suggest = new SearchDescriptor<Project>()
+				.Suggest(ss => ss
+					.Completion("title", cs => cs
+						.Field(f => f.Suggest)
+						.Prefix("keyword")
+						.Fuzzy(f => f
+							.Fuzziness(Fuzziness.Auto)
+						)
+						.Size(5)
+					)
+				);
+
+			var expected = @"{
+  ""suggest"": {
+    ""title"": {
+      ""completion"": {
+        ""field"": ""SUGGEST"",
+        ""size"": 5,
+        ""fuzzy"": {
+          ""fuzziness"": ""AUTO""
+        }
+      },
+      ""prefix"": ""keyword""
+    }
+  }
+}";
+
+			var result = tester.Serializes(suggest, expected);
+			result.Success.Should().Be(true, result.DiffFromExpected);
+		}
+	}
+}


### PR DESCRIPTION
This commit adds JsonProperty attributes to SuggestBucket to ensure
that properties are correctly serialized when a DefaultFieldNameInferrer delegate is passed.

These are required because the concrete SuggestBucket is not passed and serialized as the
ISuggestBucket interface in the VerbatimDictionaryKeysJsonConverter WriteJson method.

Fixes issue found by https://discuss.elastic.co/t/nest-suggester-errors/179634/5