### PR TITLE
Add pretty names (and other properties) to the cluster stats response.

### DIFF
--- a/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
+++ b/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
@@ -15,6 +15,9 @@ namespace Nest
 		[JsonProperty("jvm")]
 		public ClusterJvm Jvm { get; internal set; }
 
+		[JsonProperty("network_types")]
+		public ClusterNetworkTypes NetworkTypes { get; internal set; }
+
 		[JsonProperty("os")]
 		public ClusterOperatingSystemStats OperatingSystem { get; internal set; }
 
@@ -26,6 +29,16 @@ namespace Nest
 
 		[JsonProperty("versions")]
 		public IReadOnlyCollection<string> Versions { get; internal set; }
+	}
+
+	[JsonObject]
+	public class ClusterNetworkTypes
+	{
+		[JsonProperty("http_types")]
+		public IReadOnlyDictionary<string, int> HttpTypes { get; internal set; }
+
+		[JsonProperty("transport_types")]
+		public IReadOnlyDictionary<string, int> TransportTypes { get; internal set; }
 	}
 
 	[JsonObject]
@@ -143,8 +156,33 @@ namespace Nest
 		[JsonProperty("available_processors")]
 		public int AvailableProcessors { get; internal set; }
 
+		[JsonProperty("mem")]
+		public OperatingSystemMemoryInfo Memory { get; internal set; }
+
 		[JsonProperty("names")]
 		public IReadOnlyCollection<ClusterOperatingSystemName> Names { get; internal set; }
+
+		[JsonProperty("pretty_names")]
+		public IReadOnlyCollection<ClusterOperatingSystemPrettyNane> PrettyNames { get; internal set; }
+	}
+
+	[JsonObject]
+	public class OperatingSystemMemoryInfo
+	{
+		[JsonProperty("free_in_bytes")]
+		public long FreeBytes { get; internal set; }
+
+		[JsonProperty("free_percent")]
+		public int FreePercent { get; internal set; }
+
+		[JsonProperty("total_in_bytes")]
+		public long TotalBytes { get; internal set; }
+
+		[JsonProperty("used_in_bytes")]
+		public long UsedBytes { get; internal set; }
+
+		[JsonProperty("used_percent")]
+		public int UsedPercent { get; internal set; }
 	}
 
 	[JsonObject]

--- a/src/Nest/Cluster/ClusterStats/ClusterStatsResponse.cs
+++ b/src/Nest/Cluster/ClusterStats/ClusterStatsResponse.cs
@@ -7,6 +7,9 @@ namespace Nest
 		[JsonProperty("cluster_name")]
 		string ClusterName { get; }
 
+		[JsonProperty("cluster_uuid")]
+		string ClusterUUID { get; }
+
 		[JsonProperty("indices")]
 		ClusterIndicesStats Indices { get; }
 
@@ -23,6 +26,8 @@ namespace Nest
 	public class ClusterStatsResponse : NodesResponseBase, IClusterStatsResponse
 	{
 		public string ClusterName { get; internal set; }
+
+		public string ClusterUUID { get; internal set; }
 
 		public ClusterIndicesStats Indices { get; internal set; }
 

--- a/src/Nest/Cluster/NodesInfo/NodeInfo.cs
+++ b/src/Nest/Cluster/NodesInfo/NodeInfo.cs
@@ -92,6 +92,16 @@ namespace Nest
 	}
 
 	[JsonObject]
+	public class ClusterOperatingSystemPrettyNane
+	{
+		[JsonProperty("pretty_name")]
+		public string PrettyName { get; internal set; }
+
+		[JsonProperty("count")]
+		public int Count { get; internal set; }
+	}
+
+	[JsonObject]
 	public class NodeInfoOSCPU
 	{
 		[JsonProperty("cache_size")]

--- a/src/Nest/Cluster/NodesInfo/NodeInfo.cs
+++ b/src/Nest/Cluster/NodesInfo/NodeInfo.cs
@@ -81,6 +81,9 @@ namespace Nest
 		[JsonProperty("name")]
 		public string Name { get; internal set; }
 
+		[JsonProperty("pretty_name")]
+		public string PrettyName { get; internal set; }
+
 		[JsonProperty("refresh_interval_in_millis")]
 		public int RefreshInterval { get; internal set; }
 

--- a/src/Nest/CommonOptions/Stats/PluginStats.cs
+++ b/src/Nest/CommonOptions/Stats/PluginStats.cs
@@ -11,6 +11,9 @@ namespace Nest
 		[JsonProperty("description")]
 		public string Description { get; set; }
 
+		[JsonProperty("elasticsearch_version")]
+		public string ElasticsearchVersion { get; set; }
+
 		[JsonProperty("isolated")]
 		public bool Isolated { get; set; }
 
@@ -22,6 +25,12 @@ namespace Nest
 
 		[JsonProperty("site")]
 		public bool Site { get; set; }
+
+		[JsonProperty("java_version")]
+		public string JavaVersion { get; set; }
+
+		[JsonProperty("has_native_controller")]
+		public bool HasNativeController { get; set; }
 
 		[JsonProperty("version")]
 		public string Version { get; set; }

--- a/src/Nest/CommonOptions/Stats/PluginStats.cs
+++ b/src/Nest/CommonOptions/Stats/PluginStats.cs
@@ -30,7 +30,7 @@ namespace Nest
 		public string JavaVersion { get; set; }
 
 		[JsonProperty("has_native_controller")]
-		public bool HasNativeController { get; set; }
+		public bool? HasNativeController { get; set; }
 
 		[JsonProperty("version")]
 		public string Version { get; set; }

--- a/src/Nest/CommonOptions/Stats/SegmentsStats.cs
+++ b/src/Nest/CommonOptions/Stats/SegmentsStats.cs
@@ -32,6 +32,9 @@ namespace Nest
 		[JsonProperty("index_writer_memory_in_bytes")]
 		public long IndexWriterMemoryInBytes { get; set; }
 
+		[JsonProperty("max_unsafe_auto_id_timestamp")]
+		public string MaximumUnsafeAutoIdTimestamp { get; set; }
+
 		[JsonProperty("memory")]
 		public string Memory { get; set; }
 

--- a/src/Tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
@@ -28,7 +28,10 @@ namespace Tests.Cluster.ClusterStats
 		protected override void ExpectResponse(IClusterStatsResponse response)
 		{
 			response.ClusterName.Should().NotBeNullOrWhiteSpace();
-			response.ClusterUUID.Should().NotBeNullOrWhiteSpace();
+
+			if (base.Cluster.ClusterConfiguration.Version >= "6.8.0")
+				response.ClusterUUID.Should().NotBeNullOrWhiteSpace();
+
 			response.NodeStatistics.Should().NotBeNull();
 			response.Status.Should().NotBe(ClusterStatus.Red);
 			response.Timestamp.Should().BeGreaterThan(0);
@@ -67,8 +70,12 @@ namespace Tests.Cluster.ClusterStats
 			nodes.OperatingSystem.AllocatedProcessors.Should().BeGreaterThan(0);
 
 			nodes.OperatingSystem.Names.Should().NotBeEmpty();
-			nodes.OperatingSystem.Memory.Should().NotBeNull();
-			nodes.OperatingSystem.PrettyNames.Should().NotBeNull();
+
+			if (base.Cluster.ClusterConfiguration.Version >= "6.8.0")
+			{
+				nodes.OperatingSystem.Memory.Should().NotBeNull();
+				nodes.OperatingSystem.PrettyNames.Should().NotBeNull();
+			}
 
 			var plugins = nodes.Plugins;
 			plugins.Should().NotBeEmpty();

--- a/src/Tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
@@ -28,6 +28,7 @@ namespace Tests.Cluster.ClusterStats
 		protected override void ExpectResponse(IClusterStatsResponse response)
 		{
 			response.ClusterName.Should().NotBeNullOrWhiteSpace();
+			response.ClusterUUID.Should().NotBeNullOrWhiteSpace();
 			response.NodeStatistics.Should().NotBeNull();
 			response.Status.Should().NotBe(ClusterStatus.Red);
 			response.Timestamp.Should().BeGreaterThan(0);
@@ -66,6 +67,8 @@ namespace Tests.Cluster.ClusterStats
 			nodes.OperatingSystem.AllocatedProcessors.Should().BeGreaterThan(0);
 
 			nodes.OperatingSystem.Names.Should().NotBeEmpty();
+			nodes.OperatingSystem.Memory.Should().NotBeNull();
+			nodes.OperatingSystem.PrettyNames.Should().NotBeNull();
 
 			var plugins = nodes.Plugins;
 			plugins.Should().NotBeEmpty();


### PR DESCRIPTION
Do not port to `master` or `7.x` as responses need to be cleaned up in those branches as per: https://github.com/elastic/elasticsearch-net/issues/3765