### PR TITLE
Add doc’s sequence number + primary term to get responses

### DIFF
--- a/src/Nest/Document/Multiple/MultiGet/Response/MultiGetHit.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Response/MultiGetHit.cs
@@ -23,6 +23,10 @@ namespace Nest
 		string Type { get; }
 
 		long Version { get; }
+
+		long PrimaryTerm { get; }
+
+		long SequenceNumber { get; }
 	}
 
 	[JsonObject]
@@ -58,5 +62,11 @@ namespace Nest
 
 		[JsonProperty("_version")]
 		public long Version { get; internal set; }
+
+		[JsonProperty("_primary_term")]
+		public long PrimaryTerm { get; internal set; }
+
+		[JsonProperty("_seq_no")]
+		public long SequenceNumber { get; internal set; }
 	}
 }

--- a/src/Nest/Document/Single/Get/GetResponse.cs
+++ b/src/Nest/Document/Single/Get/GetResponse.cs
@@ -33,6 +33,12 @@ namespace Nest
 
 		[JsonProperty("_version")]
 		long Version { get; }
+
+		[JsonProperty("_primary_term")]
+		long PrimaryTerm { get; }
+
+		[JsonProperty("_seq_no")]
+		long SequenceNumber { get; }
 	}
 
 	[JsonObject(MemberSerialization.OptIn)]
@@ -47,5 +53,7 @@ namespace Nest
 		public TDocument Source { get; internal set; }
 		public string Type { get; internal set; }
 		public long Version { get; internal set; }
+		public long PrimaryTerm { get; internal set; }
+		public long SequenceNumber { get; internal set; }
 	}
 }

--- a/src/Nest/Document/Single/Get/GetResponse.cs
+++ b/src/Nest/Document/Single/Get/GetResponse.cs
@@ -35,10 +35,10 @@ namespace Nest
 		long Version { get; }
 
 		[JsonProperty("_primary_term")]
-		long PrimaryTerm { get; }
+		long? PrimaryTerm { get; }
 
 		[JsonProperty("_seq_no")]
-		long SequenceNumber { get; }
+		long? SequenceNumber { get; }
 	}
 
 	[JsonObject(MemberSerialization.OptIn)]
@@ -53,7 +53,7 @@ namespace Nest
 		public TDocument Source { get; internal set; }
 		public string Type { get; internal set; }
 		public long Version { get; internal set; }
-		public long PrimaryTerm { get; internal set; }
-		public long SequenceNumber { get; internal set; }
+		public long? PrimaryTerm { get; internal set; }
+		public long? SequenceNumber { get; internal set; }
 	}
 }

--- a/src/Tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
@@ -170,8 +170,11 @@ namespace Tests.Document.Multiple.MultiGet
 				hit.Id.Should().NotBeNullOrWhiteSpace();
 				hit.Found.Should().BeTrue();
 				hit.Version.Should().Be(1);
-				hit.PrimaryTerm.Should().BeGreaterOrEqualTo(1);
-				hit.SequenceNumber.Should().BeGreaterOrEqualTo(0);
+				if (base.Cluster.ClusterConfiguration.Version >= "6.8.0")
+				{
+				    hit.PrimaryTerm.Should().BeGreaterOrEqualTo(1);
+				    hit.SequenceNumber.Should().BeGreaterOrEqualTo(0);
+				}
 				hit.Source.ShouldAdhereToSourceSerializerWhenSet();
 			}
 		}

--- a/src/Tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/MultiGet/MultiGetApiTests.cs
@@ -170,6 +170,8 @@ namespace Tests.Document.Multiple.MultiGet
 				hit.Id.Should().NotBeNullOrWhiteSpace();
 				hit.Found.Should().BeTrue();
 				hit.Version.Should().Be(1);
+				hit.PrimaryTerm.Should().BeGreaterOrEqualTo(1);
+				hit.SequenceNumber.Should().BeGreaterOrEqualTo(0);
 				hit.Source.ShouldAdhereToSourceSerializerWhenSet();
 			}
 		}

--- a/src/Tests/Tests/Document/Single/DocumentCrudTests.cs
+++ b/src/Tests/Tests/Document/Single/DocumentCrudTests.cs
@@ -78,8 +78,11 @@ namespace Tests.Document.Single
 		{
 			r.Source.Should().NotBeNull();
 			r.Version.Should().BeGreaterThan(1);
-			r.SequenceNumber.Should().BeGreaterOrEqualTo(1);
-			r.PrimaryTerm.Should().BeGreaterThan(0);
+			if (base.Cluster.ClusterConfiguration.Version >= "6.8.0")
+			{
+				r.SequenceNumber.Should().BeGreaterOrEqualTo(1);
+				r.PrimaryTerm.Should().BeGreaterThan(0);
+			}
 			r.Source.Description.Should().EndWith("updated");
 		});
 

--- a/src/Tests/Tests/Document/Single/DocumentCrudTests.cs
+++ b/src/Tests/Tests/Document/Single/DocumentCrudTests.cs
@@ -78,6 +78,8 @@ namespace Tests.Document.Single
 		{
 			r.Source.Should().NotBeNull();
 			r.Version.Should().BeGreaterThan(1);
+			r.SequenceNumber.Should().BeGreaterOrEqualTo(1);
+			r.PrimaryTerm.Should().BeGreaterThan(0);
 			r.Source.Description.Should().EndWith("updated");
 		});
 

--- a/src/Tests/Tests/Document/Single/Get/GetApiTests.cs
+++ b/src/Tests/Tests/Document/Single/Get/GetApiTests.cs
@@ -45,8 +45,12 @@ namespace Tests.Document.Single.Get
 			response.Source.Should().NotBeNull();
 			response.Source.Name.Should().Be(ProjectId);
 			response.Source.ShouldAdhereToSourceSerializerWhenSet();
-			response.SequenceNumber.Should().BeGreaterOrEqualTo(0);
-			response.PrimaryTerm.Should().BeGreaterOrEqualTo(1);
+
+			if (base.Cluster.ClusterConfiguration.Version >= "6.8.0")
+			{
+				response.SequenceNumber.Should().BeGreaterOrEqualTo(0);
+				response.PrimaryTerm.Should().BeGreaterOrEqualTo(1);
+			}
 		}
 	}
 

--- a/src/Tests/Tests/Document/Single/Get/GetApiTests.cs
+++ b/src/Tests/Tests/Document/Single/Get/GetApiTests.cs
@@ -45,6 +45,8 @@ namespace Tests.Document.Single.Get
 			response.Source.Should().NotBeNull();
 			response.Source.Name.Should().Be(ProjectId);
 			response.Source.ShouldAdhereToSourceSerializerWhenSet();
+			response.SequenceNumber.Should().BeGreaterOrEqualTo(0);
+			response.PrimaryTerm.Should().BeGreaterOrEqualTo(1);
 		}
 	}
 


### PR DESCRIPTION
Addresses: https://github.com/elastic/elasticsearch/pull/36680

Backport to `master` and `7.x` requires care due to naming conventions,