### PR TITLE
Convert rollover lifecycle action to accept max size as a string and not long?

### DIFF
--- a/src/Nest/XPack/Ilm/Actions/RolloverAction.cs
+++ b/src/Nest/XPack/Ilm/Actions/RolloverAction.cs
@@ -1,3 +1,4 @@
+using System;
 using Newtonsoft.Json;
 
 namespace Nest
@@ -26,7 +27,14 @@ namespace Nest
 		/// Max primary shard index storage size using byte notation (e.g. 40gb or 40000000000b).
 		/// </summary>
 		[JsonProperty("max_size")]
-		string MaximumSize { get; set; }
+		string MaximumSizeAsString { get; set; }
+
+		/// <summary>
+		/// Max primary shard index storage size in bytes.
+		/// </summary>
+		[JsonIgnore]
+		[Obsolete("Use MaximumSizeAsString property instead")]
+		long? MaximumSize { get; set; }
 	}
 
 	public class RolloverLifecycleAction : IRolloverLifecycleAction
@@ -38,23 +46,91 @@ namespace Nest
 		public long? MaximumDocuments { get; set; }
 
 		/// <inheritdoc />
-		public string MaximumSize { get; set; }
+		public string MaximumSizeAsString { get; set; }
+
+		/// <inheritdoc />
+		[Obsolete("Use MaximumSizeAsString property instead")]
+		public long? MaximumSize
+		{
+			get => BytesValueConverter.ToBytes(MaximumSizeAsString);
+			set
+			{
+				if (value == null)
+				{
+					MaximumSizeAsString = null;
+					return;
+				}
+				MaximumSizeAsString = value + "b";
+			}
+		}
+	}
+
+	public static class BytesValueConverter
+	{
+		public static long? ToBytes(string value)
+		{
+			if (string.IsNullOrEmpty(value))
+			{
+				return null;
+			}
+
+			if (value.EndsWith("pb")) return Convert.ToInt64(value.Substring(0, value.Length - 2)) * 1_125_899_906_842_624;
+			if (value.EndsWith("tb")) return Convert.ToInt64(value.Substring(0, value.Length - 2)) * 1_099_511_627_776;
+			if (value.EndsWith("gb")) return Convert.ToInt64(value.Substring(0, value.Length - 2)) * 1_073_741_824;
+			if (value.EndsWith("mb")) return Convert.ToInt64(value.Substring(0, value.Length - 2)) * 1_048_576;
+			if (value.EndsWith("kb")) return Convert.ToInt64(value.Substring(0, value.Length - 2)) * 1_024;
+
+			if (value.EndsWith("p")) return Convert.ToInt64(value.Substring(0, value.Length - 1)) * 1_125_899_906_842_624;
+			if (value.EndsWith("t")) return Convert.ToInt64(value.Substring(0, value.Length - 1)) * 1_099_511_627_776;
+			if (value.EndsWith("g")) return Convert.ToInt64(value.Substring(0, value.Length - 1)) * 1_073_741_824;
+			if (value.EndsWith("m")) return Convert.ToInt64(value.Substring(0, value.Length - 1)) * 1_048_576;
+			if (value.EndsWith("k")) return Convert.ToInt64(value.Substring(0, value.Length - 1)) * 1_024;
+
+			if (value.EndsWith("b")) return Convert.ToInt64(value.Substring(0, value.Length - 1));
+
+			// Assume bytes
+			return Convert.ToInt64(value);
+		}
 	}
 
 	public class RolloverLifecycleActionDescriptor
 		: DescriptorBase<RolloverLifecycleActionDescriptor, IRolloverLifecycleAction>, IRolloverLifecycleAction
 	{
+		private string _maximumSizeAsString;
+
 		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumAge" />
 		Time IRolloverLifecycleAction.MaximumAge { get; set; }
 
 		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumDocuments" />
 		long? IRolloverLifecycleAction.MaximumDocuments { get; set; }
 
-		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumSize" />
-		string IRolloverLifecycleAction.MaximumSize { get; set; }
+		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumSizeAsString" />
+		string IRolloverLifecycleAction.MaximumSizeAsString { get => _maximumSizeAsString; set => _maximumSizeAsString = value; }
 
 		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumSize" />
-		public RolloverLifecycleActionDescriptor MaximumSize(string maximumSize) => Assign(maximumSize, (a, v) => a.MaximumSize = maximumSize);
+		[Obsolete("Use MaximumSizeAsString property instead")]
+		long? IRolloverLifecycleAction.MaximumSize
+		{
+			get => BytesValueConverter.ToBytes(_maximumSizeAsString);
+			set
+			{
+				if (value == null)
+				{
+					_maximumSizeAsString = null;
+					return;
+				}
+				_maximumSizeAsString = value + "b";
+			}
+		}
+
+		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumSizeAsString" />
+		public RolloverLifecycleActionDescriptor MaximumSizeAsString(string maximumSizeAsString) => Assign(maximumSizeAsString, (a, v) => a.MaximumSizeAsString = maximumSizeAsString);
+
+		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumSize" />
+		[Obsolete("Use MaximumSizeAsString property instead")]
+#pragma warning disable 618
+		public RolloverLifecycleActionDescriptor MaximumSize(long? maximumSize) => Assign(maximumSize, (a, v) => a.MaximumSize = maximumSize);
+#pragma warning restore 618
 
 		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumAge" />
 		public RolloverLifecycleActionDescriptor MaximumAge(Time maximumAge) => Assign(maximumAge, (a, v) => a.MaximumAge = maximumAge);

--- a/src/Nest/XPack/Ilm/Actions/RolloverAction.cs
+++ b/src/Nest/XPack/Ilm/Actions/RolloverAction.cs
@@ -23,10 +23,10 @@ namespace Nest
 		long? MaximumDocuments { get; set; }
 
 		/// <summary>
-		/// Max primary shard index storage size in bytes.
+		/// Max primary shard index storage size using byte notation (e.g. 40gb or 40000000000b).
 		/// </summary>
 		[JsonProperty("max_size")]
-		long? MaximumSize { get; set; }
+		string MaximumSize { get; set; }
 	}
 
 	public class RolloverLifecycleAction : IRolloverLifecycleAction
@@ -38,7 +38,7 @@ namespace Nest
 		public long? MaximumDocuments { get; set; }
 
 		/// <inheritdoc />
-		public long? MaximumSize { get; set; }
+		public string MaximumSize { get; set; }
 	}
 
 	public class RolloverLifecycleActionDescriptor
@@ -51,10 +51,10 @@ namespace Nest
 		long? IRolloverLifecycleAction.MaximumDocuments { get; set; }
 
 		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumSize" />
-		long? IRolloverLifecycleAction.MaximumSize { get; set; }
+		string IRolloverLifecycleAction.MaximumSize { get; set; }
 
 		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumSize" />
-		public RolloverLifecycleActionDescriptor MaximumSize(long? maximumSize) => Assign(maximumSize, (a, v) => a.MaximumSize = maximumSize);
+		public RolloverLifecycleActionDescriptor MaximumSize(string maximumSize) => Assign(maximumSize, (a, v) => a.MaximumSize = maximumSize);
 
 		/// <inheritdoc cref="IRolloverLifecycleAction.MaximumAge" />
 		public RolloverLifecycleActionDescriptor MaximumAge(Time maximumAge) => Assign(maximumAge, (a, v) => a.MaximumAge = maximumAge);

--- a/src/Tests/Tests/XPack/Ilm/BytesValueConverterTests.cs
+++ b/src/Tests/Tests/XPack/Ilm/BytesValueConverterTests.cs
@@ -1,0 +1,66 @@
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.XPack.Ilm
+{
+	public class BytesValueConverterTests
+	{
+		[U] public void Test()
+		{
+			BytesValueConverter.ToBytes("1").Should().Be(1L);
+			BytesValueConverter.ToBytes("1b").Should().Be(1L);
+
+			BytesValueConverter.ToBytes("1kb").Should().Be(1024);
+			BytesValueConverter.ToBytes("1k").Should().Be(1024);
+
+			BytesValueConverter.ToBytes("1mb").Should().Be(1024 * 1024);
+			BytesValueConverter.ToBytes("1m").Should().Be(1024 * 1024);
+
+			BytesValueConverter.ToBytes("1gb").Should().Be(1024 * 1024 * 1024);
+			BytesValueConverter.ToBytes("1g").Should().Be(1024 * 1024 * 1024);
+
+			BytesValueConverter.ToBytes("1tb").Should().Be(1024L * 1024 * 1024 * 1024);
+			BytesValueConverter.ToBytes("1t").Should().Be(1024L * 1024 * 1024 * 1024);
+
+			BytesValueConverter.ToBytes("1pb").Should().Be(1024L * 1024 * 1024 * 1024 * 1024);
+			BytesValueConverter.ToBytes("1p").Should().Be(1024L * 1024 * 1024 * 1024 * 1024);
+		}
+
+		[U] public void RolloverLifecycleActionTest()
+		{
+#pragma warning disable 618
+			var rolloverLifecycleAction = new RolloverLifecycleAction();
+
+			rolloverLifecycleAction.MaximumSize = 1;
+			rolloverLifecycleAction.MaximumSizeAsString.Should().Be("1b");
+			rolloverLifecycleAction.MaximumSize.Should().Be(1);
+
+			rolloverLifecycleAction = new RolloverLifecycleAction();
+			rolloverLifecycleAction.MaximumSize = 1024;
+			rolloverLifecycleAction.MaximumSizeAsString.Should().Be("1024b");
+			rolloverLifecycleAction.MaximumSize.Should().Be(1024);
+
+			rolloverLifecycleAction = new RolloverLifecycleAction();
+			rolloverLifecycleAction.MaximumSizeAsString = "1gb";
+			rolloverLifecycleAction.MaximumSize.Should().Be(1024 * 1024 * 1024);
+#pragma warning restore 618
+		}
+
+		[U] public void RolloverLifecycleActionDescriptorTest()
+		{
+#pragma warning disable 618
+			var rolloverLifecycleActionDescriptor = new RolloverLifecycleActionDescriptor();
+			rolloverLifecycleActionDescriptor.MaximumSize(1);
+			((IRolloverLifecycleAction)rolloverLifecycleActionDescriptor).MaximumSize.Should().Be(1);
+			((IRolloverLifecycleAction)rolloverLifecycleActionDescriptor).MaximumSizeAsString.Should().Be("1b");
+
+			rolloverLifecycleActionDescriptor = new RolloverLifecycleActionDescriptor();
+			rolloverLifecycleActionDescriptor.MaximumSizeAsString("1gb");
+			((IRolloverLifecycleAction)rolloverLifecycleActionDescriptor).MaximumSize.Should().Be(1024 * 1024 * 1024);
+			((IRolloverLifecycleAction)rolloverLifecycleActionDescriptor).MaximumSizeAsString.Should().Be("1gb");
+#pragma warning restore 618
+		}
+	}
+
+}

--- a/src/Tests/Tests/XPack/Ilm/IlmApiTests.cs
+++ b/src/Tests/Tests/XPack/Ilm/IlmApiTests.cs
@@ -86,7 +86,7 @@ namespace Tests.XPack.Ilm
 										new RolloverLifecycleAction
 										{
 											MaximumDocuments = 1_000_000,
-											MaximumSize = "40000000000b"
+											MaximumSizeAsString = "40gb"
 										}
 									}
 								},
@@ -106,7 +106,9 @@ namespace Tests.XPack.Ilm
 																.Actions(ac => ac.ForceMerge(f => f.MaximumNumberOfSegments(1))))
 													.Hot(h => h.MinimumAge("1d")
 															    .Actions(ac => ac.Rollover(r => r.MaximumDocuments(1_000_000)
-																								.MaximumSize("40000000000b"))))
+#pragma warning disable 612, 618
+																								.MaximumSize(40_000_000_000))))
+#pragma warning restore 612, 618
 													.Delete(w => w.MinimumAge("30d")
 		       													  .Actions(ac => ac.Delete(f => f)))))
 					,

--- a/src/Tests/Tests/XPack/Ilm/IlmApiTests.cs
+++ b/src/Tests/Tests/XPack/Ilm/IlmApiTests.cs
@@ -78,6 +78,18 @@ namespace Tests.XPack.Ilm
 										}
 									}
 								},
+								Hot = new Phase
+								{
+									MinimumAge = "1d",
+									Actions	= new LifecycleActions
+									{
+										new RolloverLifecycleAction
+										{
+											MaximumDocuments = 1_000_000,
+											MaximumSize = "40000000000b"
+										}
+									}
+								},
 								Delete = new Phase
 								{
 									MinimumAge = "30d",
@@ -92,6 +104,9 @@ namespace Tests.XPack.Ilm
 					(v, d) => d
 						.Policy(p => p.Phases(a => a.Warm(w => w.MinimumAge("10d")
 																.Actions(ac => ac.ForceMerge(f => f.MaximumNumberOfSegments(1))))
+													.Hot(h => h.MinimumAge("1d")
+															    .Actions(ac => ac.Rollover(r => r.MaximumDocuments(1_000_000)
+																								.MaximumSize("40000000000b"))))
 													.Delete(w => w.MinimumAge("30d")
 		       													  .Actions(ac => ac.Delete(f => f)))))
 					,


### PR DESCRIPTION
Convert rollover lifecycle action to accept max size as a `string` instead of `long?`

Breaking change from `6.7` to `6.8`

Fixes #3768