### PR TITLE
Use a custom convertor for GeoOrientation to tolerate alternative options in Elasticsearch

### DIFF
--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -1,16 +1,45 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Nest
 {
-	[JsonConverter(typeof(StringEnumConverter))]
+	[JsonConverter(typeof(GeoOrientationConverter))]
 	public enum GeoOrientation
 	{
-		[EnumMember(Value = "cw")]
 		ClockWise,
-
-		[EnumMember(Value = "ccw")]
 		CounterClockWise
+	}
+
+	public class GeoOrientationConverter : JsonConverter
+	{
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var geoOrientation = (GeoOrientation)value;
+			switch (geoOrientation)
+			{
+				case GeoOrientation.ClockWise:
+					writer.WriteValue("cw");
+					break;
+				case GeoOrientation.CounterClockWise:
+					writer.WriteValue("ccw");
+					break;
+			}
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var enumString = (string)reader.Value;
+			switch (enumString.ToLower())
+			{
+				case "left":
+				case "cw":
+				case "clockwise":
+					return GeoOrientation.ClockWise;
+			}
+			// Default, complies with the OGC standard
+			return GeoOrientation.CounterClockWise;
+		}
+
+		public override bool CanConvert(Type objectType) => true;
 	}
 }

--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -10,7 +10,7 @@ namespace Nest
 		CounterClockWise
 	}
 
-	public class GeoOrientationConverter : JsonConverter
+	internal class GeoOrientationConverter : JsonConverter
 	{
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{

--- a/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Linq;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework;
+using Tests.Framework.Integration;
+
+namespace Tests.Mapping.Types.Core.GeoShape
+{
+	public class GeoShapeClusterMetadataApiTests : ApiIntegrationTestBase<WritableCluster, IPutMappingResponse, IPutMappingRequest, PutMappingDescriptor<Project>,
+		PutMappingRequest<Project>>
+	{
+		public GeoShapeClusterMetadataApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var index in values.Values) client.CreateIndex(index, CreateIndexSettings).ShouldBeValid();
+			var indices = Infer.Indices(values.Values.Select(i => (IndexName)i));
+			client.ClusterHealth(f => f.WaitForStatus(WaitForStatus.Yellow).Index(indices))
+				.ShouldBeValid();
+		}
+
+		protected virtual ICreateIndexRequest CreateIndexSettings(CreateIndexDescriptor create) => create;
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<PutMappingDescriptor<Project>, IPutMappingRequest> Fluent => f => f
+			.Index(CallIsolatedValue)
+			.Properties(FluentProperties);
+
+		private static Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.GeoShape(s => s
+				.Name(p => p.Location)
+				.Tree(GeoTree.Quadtree)
+				.Orientation(GeoOrientation.ClockWise)
+				.Strategy(GeoStrategy.Recursive)
+				.TreeLevels(3)
+				.PointsOnly()
+				.DistanceErrorPercentage(1.0)
+				.Coerce()
+			);
+
+		private static IProperties InitializerProperties => new Properties
+		{
+			{
+				"location", new GeoShapeProperty
+				{
+					Tree = GeoTree.Quadtree,
+					Orientation = GeoOrientation.ClockWise,
+					Strategy = GeoStrategy.Recursive,
+					TreeLevels = 3,
+					PointsOnly = true,
+					DistanceErrorPercentage = 1.0,
+					Coerce = true
+				}
+			}
+		};
+
+		protected override HttpMethod HttpMethod => HttpMethod.PUT;
+
+		protected override PutMappingRequest<Project> Initializer => new PutMappingRequest<Project>(CallIsolatedValue, typeof(Project))
+		{
+			Properties = InitializerProperties
+		};
+
+		protected override string UrlPath => $"/{CallIsolatedValue}/doc/_mapping";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.Map(f),
+			(client, f) => client.MapAsync(f),
+			(client, r) => client.Map(r),
+			(client, r) => client.MapAsync(r)
+		);
+
+		protected override void ExpectResponse(IPutMappingResponse response)
+		{
+			// Ensure metadata can be deserialised
+			var metadata = Client.ClusterState(r => r.Metric(ClusterStateMetric.Metadata));
+			metadata.IsValid.Should().BeTrue();
+		}
+	}
+}


### PR DESCRIPTION
The documentation (https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html) states that there are multiple values possible; 1. Right-hand rule: `right`, `ccw`, `counterclockwise`, 2. Left-hand rule: `left`, `cw`, `clockwise`.

It looks like NEST only supported `cw` and `ccw`.

Cluster metadata exposed `cw` as `LEFT` in the responses.