### PR TITLE
Use a custom convertor for GeoOrientation to tolerate alternative options in Elasticsearch #3776

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/NestFormatterResolver.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/NestFormatterResolver.cs
@@ -43,6 +43,8 @@ namespace Nest
 					new TimeSpanToStringFormatter(),
 					new NullableTimeSpanToStringFormatter(),
 					new JsonNetCompatibleUriFormatter(),
+					new GeoOrientationFormatter(),
+					new NullableGeoOrientationFormatter(),
 				}, new IJsonFormatterResolver[0]),
 				BuiltinResolver.Instance, // Builtin primitives
 				ElasticsearchNetEnumResolver.Instance, // Specialized Enum handling

--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.Serialization;
-using Elasticsearch.Net;
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {
@@ -27,11 +26,11 @@ namespace Nest
 		public GeoOrientation Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
 			var enumString = reader.ReadString();
-			switch (enumString.ToLowerInvariant())
+			switch (enumString)
 			{
-				case "left":
-				case "cw":
-				case "clockwise":
+				case "LEFT":
+				case "CW":
+				case "CLOCKWISE":
 					return GeoOrientation.ClockWise;
 			}
 			// Default, complies with the OGC standard
@@ -69,15 +68,15 @@ namespace Nest
 				return null;
 			}
 
-			switch (enumString.ToLowerInvariant())
+			switch (enumString)
 			{
-				case "left":
-				case "cw":
-				case "clockwise":
+				case "LEFT":
+				case "CW":
+				case "CLOCKWISE":
 					return GeoOrientation.ClockWise;
-				case "right":
-				case "ccw":
-				case "counterclockwise":
+				case "RIGHT":
+				case "CCW":
+				case "COUNTERCLOCKWISE":
 					return GeoOrientation.CounterClockWise;
 			}
 

--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -26,7 +26,7 @@ namespace Nest
 		public GeoOrientation Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
 			var enumString = reader.ReadString();
-			switch (enumString)
+			switch (enumString.ToUpperInvariant())
 			{
 				case "LEFT":
 				case "CW":
@@ -68,7 +68,7 @@ namespace Nest
 				return null;
 			}
 
-			switch (enumString)
+			switch (enumString.ToUpperInvariant())
 			{
 				case "LEFT":
 				case "CW":

--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -1,15 +1,15 @@
-﻿using Elasticsearch.Net;
+﻿using System.Runtime.Serialization;
+using Elasticsearch.Net;
 
 namespace Nest
 {
-	[JsonFormatter(typeof(GeoOrientationConverter))]
 	public enum GeoOrientation
 	{
 		ClockWise,
 		CounterClockWise
 	}
 
-	internal class GeoOrientationConverter : IJsonFormatter<GeoOrientation>
+	internal class GeoOrientationFormatter : IJsonFormatter<GeoOrientation>
 	{
 		public void Serialize(ref JsonWriter writer, GeoOrientation value, IJsonFormatterResolver formatterResolver)
 		{
@@ -36,6 +36,52 @@ namespace Nest
 			}
 			// Default, complies with the OGC standard
 			return GeoOrientation.CounterClockWise;
+		}
+	}
+
+	internal class NullableGeoOrientationFormatter : IJsonFormatter<GeoOrientation?>
+	{
+		public void Serialize(ref JsonWriter writer, GeoOrientation? value, IJsonFormatterResolver formatterResolver)
+		{
+			if (!value.HasValue)
+			{
+				writer.WriteNull();
+				return;
+			}
+
+			switch (value)
+			{
+				case GeoOrientation.ClockWise:
+					writer.WriteString("cw");
+					break;
+				case GeoOrientation.CounterClockWise:
+					writer.WriteString("ccw");
+					break;
+			}
+		}
+
+		public GeoOrientation? Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
+		{
+			var enumString = reader.ReadString();
+
+			if (string.IsNullOrEmpty(enumString))
+			{
+				return null;
+			}
+
+			switch (enumString.ToLowerInvariant())
+			{
+				case "left":
+				case "cw":
+				case "clockwise":
+					return GeoOrientation.ClockWise;
+				case "right":
+				case "ccw":
+				case "counterclockwise":
+					return GeoOrientation.CounterClockWise;
+			}
+
+			return null;
 		}
 	}
 }

--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -25,6 +25,12 @@ namespace Nest
 
 		public GeoOrientation Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
+			if (reader.ReadIsNull())
+			{
+				// Default, complies with the OGC standard
+				return GeoOrientation.CounterClockWise;
+			}
+
 			var enumString = reader.ReadString();
 			switch (enumString.ToUpperInvariant())
 			{
@@ -33,6 +39,7 @@ namespace Nest
 				case "CLOCKWISE":
 					return GeoOrientation.ClockWise;
 			}
+
 			// Default, complies with the OGC standard
 			return GeoOrientation.CounterClockWise;
 		}
@@ -61,12 +68,12 @@ namespace Nest
 
 		public GeoOrientation? Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
-			var enumString = reader.ReadString();
-
-			if (string.IsNullOrEmpty(enumString))
+			if (reader.ReadIsNull())
 			{
 				return null;
 			}
+
+			var enumString = reader.ReadString();
 
 			switch (enumString.ToUpperInvariant())
 			{
@@ -78,9 +85,9 @@ namespace Nest
 				case "CCW":
 				case "COUNTERCLOCKWISE":
 					return GeoOrientation.CounterClockWise;
+				default:
+					return null;
 			}
-
-			return null;
 		}
 	}
 }

--- a/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
+++ b/src/Nest/Mapping/Types/Geo/GeoShape/GeoOrientation.cs
@@ -1,16 +1,41 @@
-﻿using System.Runtime.Serialization;
-using Elasticsearch.Net;
-
+﻿using Elasticsearch.Net;
 
 namespace Nest
 {
-	[StringEnum]
+	[JsonFormatter(typeof(GeoOrientationConverter))]
 	public enum GeoOrientation
 	{
-		[EnumMember(Value = "cw")]
 		ClockWise,
-
-		[EnumMember(Value = "ccw")]
 		CounterClockWise
+	}
+
+	internal class GeoOrientationConverter : IJsonFormatter<GeoOrientation>
+	{
+		public void Serialize(ref JsonWriter writer, GeoOrientation value, IJsonFormatterResolver formatterResolver)
+		{
+			switch (value)
+			{
+				case GeoOrientation.ClockWise:
+					writer.WriteString("cw");
+					break;
+				case GeoOrientation.CounterClockWise:
+					writer.WriteString("ccw");
+					break;
+			}
+		}
+
+		public GeoOrientation Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
+		{
+			var enumString = reader.ReadString();
+			switch (enumString.ToLowerInvariant())
+			{
+				case "left":
+				case "cw":
+				case "clockwise":
+					return GeoOrientation.ClockWise;
+			}
+			// Default, complies with the OGC standard
+			return GeoOrientation.CounterClockWise;
+		}
 	}
 }

--- a/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
@@ -68,7 +68,7 @@ namespace Tests.Mapping.Types.Core.GeoShape
 			Properties = InitializerProperties
 		};
 
-		protected override string UrlPath => $"/{CallIsolatedValue}/doc/_mapping";
+		protected override string UrlPath => $"/{CallIsolatedValue}/_mapping";
 
 		protected override LazyResponses ClientUsage() => Calls(
 			(client, f) => client.Map(f),

--- a/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
@@ -80,7 +80,7 @@ namespace Tests.Mapping.Types.Core.GeoShape
 		protected override void ExpectResponse(PutMappingResponse response)
 		{
 			// Ensure metadata can be deserialised
-			var metadata = Client.Cluster.State(null, r => r.Metric(ClusterStateMetric.Metadata));
+			var metadata = Client.Cluster.State(CallIsolatedValue, r => r.Metric(ClusterStateMetric.Metadata));
 			metadata.IsValid.Should().BeTrue();
 		}
 	}

--- a/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapeClusterMetadataApiTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Linq;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework;
+using Tests.Framework.Integration;
+
+namespace Tests.Mapping.Types.Core.GeoShape
+{
+	public class GeoShapeClusterMetadataApiTests : ApiIntegrationTestBase<WritableCluster, PutMappingResponse, IPutMappingRequest, PutMappingDescriptor<Project>,
+		PutMappingRequest<Project>>
+	{
+		public GeoShapeClusterMetadataApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var index in values.Values) client.Indices.Create(index, CreateIndexSettings).ShouldBeValid();
+			var indices = Infer.Indices(values.Values.Select(i => (IndexName)i));
+			client.Cluster.Health(null, f => f.WaitForStatus(WaitForStatus.Yellow).Index(indices))
+				.ShouldBeValid();
+		}
+
+		protected virtual ICreateIndexRequest CreateIndexSettings(CreateIndexDescriptor create) => create;
+
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<PutMappingDescriptor<Project>, IPutMappingRequest> Fluent => f => f
+			.Index(CallIsolatedValue)
+			.Properties(FluentProperties);
+
+		private static Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.GeoShape(s => s
+				.Name(p => p.Location)
+				.Tree(GeoTree.Quadtree)
+				.Orientation(GeoOrientation.ClockWise)
+				.Strategy(GeoStrategy.Recursive)
+				.TreeLevels(3)
+				.PointsOnly()
+				.DistanceErrorPercentage(1.0)
+				.Coerce()
+			);
+
+		private static IProperties InitializerProperties => new Properties
+		{
+			{
+				"location", new GeoShapeProperty
+				{
+					Tree = GeoTree.Quadtree,
+					Orientation = GeoOrientation.ClockWise,
+					Strategy = GeoStrategy.Recursive,
+					TreeLevels = 3,
+					PointsOnly = true,
+					DistanceErrorPercentage = 1.0,
+					Coerce = true
+				}
+			}
+		};
+
+		protected override HttpMethod HttpMethod => HttpMethod.PUT;
+
+		protected override PutMappingRequest<Project> Initializer => new PutMappingRequest<Project>(CallIsolatedValue)
+		{
+			Properties = InitializerProperties
+		};
+
+		protected override string UrlPath => $"/{CallIsolatedValue}/doc/_mapping";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.Map(f),
+			(client, f) => client.MapAsync(f),
+			(client, r) => client.Map(r),
+			(client, r) => client.MapAsync(r)
+		);
+
+		protected override void ExpectResponse(PutMappingResponse response)
+		{
+			// Ensure metadata can be deserialised
+			var metadata = Client.Cluster.State(null, r => r.Metric(ClusterStateMetric.Metadata));
+			metadata.IsValid.Should().BeTrue();
+		}
+	}
+}


### PR DESCRIPTION
Opening to start a conversation on how to implement a `JsonFormatter` for an `enum`.

OOTB it looks like UTF8JSON doesnt support placing the attribute on enum values.

Any idea where to go with this? @russcam 