### PR TITLE
Add pretty names (and other properties) to the cluster stats response. #3766

### DIFF
--- a/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
+++ b/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
@@ -9,6 +9,9 @@ namespace Nest
 		[DataMember(Name ="count")]
 		public ClusterNodeCount Count { get; internal set; }
 
+		[DataMember(Name ="discovery_types")]
+		public IReadOnlyDictionary<string, int> DiscoveryTypes { get; internal set; }
+
 		[DataMember(Name ="fs")]
 		public ClusterFileSystem FileSystem { get; internal set; }
 
@@ -44,20 +47,11 @@ namespace Nest
 	[DataContract]
 	public class ClusterFileSystem
 	{
-		[DataMember(Name ="available")]
-		public string Available { get; internal set; }
-
 		[DataMember(Name ="available_in_bytes")]
 		public long AvailableInBytes { get; internal set; }
 
-		[DataMember(Name ="free")]
-		public string Free { get; internal set; }
-
 		[DataMember(Name ="free_in_bytes")]
 		public long FreeInBytes { get; internal set; }
-
-		[DataMember(Name ="total")]
-		public string Total { get; internal set; }
 
 		[DataMember(Name ="total_in_bytes")]
 		public long TotalInBytes { get; internal set; }
@@ -66,9 +60,6 @@ namespace Nest
 	[DataContract]
 	public class ClusterJvm
 	{
-		[DataMember(Name ="max_uptime")]
-		public string MaxUptime { get; internal set; }
-
 		[DataMember(Name ="max_uptime_in_millis")]
 		public long MaxUptimeInMilliseconds { get; internal set; }
 
@@ -85,6 +76,12 @@ namespace Nest
 	[DataContract]
 	public class ClusterJvmVersion
 	{
+		[DataMember(Name ="bundled_jdk")]
+		public bool BundledJdk { get; internal set; }
+
+		[DataMember(Name ="using_bundled_jdk")]
+		public bool? UsingBundledJdk { get; internal set; }
+
 		[DataMember(Name ="count")]
 		public int Count { get; internal set; }
 
@@ -104,14 +101,8 @@ namespace Nest
 	[DataContract]
 	public class ClusterJvmMemory
 	{
-		[DataMember(Name ="heap_max")]
-		public string HeapMax { get; internal set; }
-
 		[DataMember(Name ="heap_max_in_bytes")]
 		public long HeapMaxInBytes { get; internal set; }
-
-		[DataMember(Name ="heap_used")]
-		public string HeapUsed { get; set; }
 
 		[DataMember(Name ="heap_used_in_bytes")]
 		public long HeapUsedInBytes { get; internal set; }

--- a/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
+++ b/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
@@ -15,6 +15,9 @@ namespace Nest
 		[DataMember(Name ="jvm")]
 		public ClusterJvm Jvm { get; internal set; }
 
+		[DataMember(Name ="network_types")]
+		public ClusterNetworkTypes NetworkTypes { get; internal set; }
+
 		[DataMember(Name ="os")]
 		public ClusterOperatingSystemStats OperatingSystem { get; internal set; }
 
@@ -26,6 +29,16 @@ namespace Nest
 
 		[DataMember(Name ="versions")]
 		public IReadOnlyCollection<string> Versions { get; internal set; }
+	}
+
+	[DataContract]
+	public class ClusterNetworkTypes
+	{
+		[DataMember(Name ="http_types")]
+		public IReadOnlyDictionary<string, int> HttpTypes { get; internal set; }
+
+		[DataMember(Name ="transport_types")]
+		public IReadOnlyDictionary<string, int> TransportTypes { get; internal set; }
 	}
 
 	[DataContract]
@@ -143,8 +156,33 @@ namespace Nest
 		[DataMember(Name ="available_processors")]
 		public int AvailableProcessors { get; internal set; }
 
+		[DataMember(Name ="mem")]
+		public OperatingSystemMemoryInfo Memory { get; internal set; }
+
 		[DataMember(Name ="names")]
 		public IReadOnlyCollection<ClusterOperatingSystemName> Names { get; internal set; }
+
+		[DataMember(Name ="pretty_names")]
+		public IReadOnlyCollection<ClusterOperatingSystemPrettyNane> PrettyNames { get; internal set; }
+	}
+
+	[DataContract]
+	public class OperatingSystemMemoryInfo
+	{
+		[DataMember(Name ="free_in_bytes")]
+		public long FreeBytes { get; internal set; }
+
+		[DataMember(Name ="free_percent")]
+		public int FreePercent { get; internal set; }
+
+		[DataMember(Name ="total_in_bytes")]
+		public long TotalBytes { get; internal set; }
+
+		[DataMember(Name ="used_in_bytes")]
+		public long UsedBytes { get; internal set; }
+
+		[DataMember(Name ="used_percent")]
+		public int UsedPercent { get; internal set; }
 	}
 
 	[DataContract]

--- a/src/Nest/Cluster/ClusterStats/ClusterStatsResponse.cs
+++ b/src/Nest/Cluster/ClusterStats/ClusterStatsResponse.cs
@@ -6,7 +6,7 @@ namespace Nest
 	{
 		[DataMember(Name ="cluster_name")]
 		public string ClusterName { get; internal set; }
-		
+
 		[DataMember(Name ="cluster_uuid")]
 		public string ClusterUUID { get; internal set; }
 

--- a/src/Nest/Cluster/ClusterStats/ClusterStatsResponse.cs
+++ b/src/Nest/Cluster/ClusterStats/ClusterStatsResponse.cs
@@ -6,6 +6,9 @@ namespace Nest
 	{
 		[DataMember(Name ="cluster_name")]
 		public string ClusterName { get; internal set; }
+		
+		[DataMember(Name ="cluster_uuid")]
+		public string ClusterUUID { get; internal set; }
 
 		[DataMember(Name ="indices")]
 		public ClusterIndicesStats Indices { get; internal set; }

--- a/src/Nest/Cluster/NodesInfo/NodeInfo.cs
+++ b/src/Nest/Cluster/NodesInfo/NodeInfo.cs
@@ -80,6 +80,9 @@ namespace Nest
 		[DataMember(Name = "name")]
 		public string Name { get; internal set; }
 
+		[DataMember(Name = "pretty_name")]
+		public string PrettyName { get; internal set; }
+
 		[DataMember(Name = "refresh_interval_in_millis")]
 		public int RefreshInterval { get; internal set; }
 
@@ -88,6 +91,16 @@ namespace Nest
 
 		[DataMember(Name = "version")]
 		public string Version { get; internal set; }
+	}
+
+	[DataContract]
+	public class ClusterOperatingSystemPrettyNane
+	{
+		[DataMember(Name = "count")]
+		public int Count { get; internal set; }
+
+		[DataMember(Name = "pretty_name")]
+		public string PrettyName { get; internal set; }
 	}
 
 	[DataContract]

--- a/src/Nest/CommonOptions/Stats/CompletionStats.cs
+++ b/src/Nest/CommonOptions/Stats/CompletionStats.cs
@@ -5,9 +5,6 @@ namespace Nest
 	[DataContract]
 	public class CompletionStats
 	{
-		[DataMember(Name ="size")]
-		public string Size { get; set; }
-
 		[DataMember(Name ="size_in_bytes")]
 		public long SizeInBytes { get; set; }
 	}

--- a/src/Nest/CommonOptions/Stats/FieldDataStats.cs
+++ b/src/Nest/CommonOptions/Stats/FieldDataStats.cs
@@ -8,9 +8,6 @@ namespace Nest
 		[DataMember(Name ="evictions")]
 		public long Evictions { get; set; }
 
-		[DataMember(Name ="memory_size")]
-		public string MemorySize { get; set; }
-
 		[DataMember(Name ="memory_size_in_bytes")]
 		public long MemorySizeInBytes { get; set; }
 	}

--- a/src/Nest/CommonOptions/Stats/PluginStats.cs
+++ b/src/Nest/CommonOptions/Stats/PluginStats.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Nest
 {
@@ -14,17 +15,11 @@ namespace Nest
 		[DataMember(Name ="elasticsearch_version")]
 		public string ElasticsearchVersion { get; set; }
 
-		[DataMember(Name ="isolated")]
-		public bool Isolated { get; set; }
-
-		[DataMember(Name ="jvm")]
-		public bool Jvm { get; set; }
+		[DataMember(Name ="extended_plugins")]
+		public IReadOnlyCollection<string> ExtendedPlugins { get; set; }
 
 		[DataMember(Name ="name")]
 		public string Name { get; set; }
-
-		[DataMember(Name ="site")]
-		public bool Site { get; set; }
 
 		[DataMember(Name = "has_native_controller")]
 		public bool? HasNativeController { get; set; }

--- a/src/Nest/CommonOptions/Stats/PluginStats.cs
+++ b/src/Nest/CommonOptions/Stats/PluginStats.cs
@@ -11,6 +11,9 @@ namespace Nest
 		[DataMember(Name ="description")]
 		public string Description { get; set; }
 
+		[DataMember(Name ="elasticsearch_version")]
+		public string ElasticsearchVersion { get; set; }
+
 		[DataMember(Name ="isolated")]
 		public bool Isolated { get; set; }
 
@@ -22,6 +25,12 @@ namespace Nest
 
 		[DataMember(Name ="site")]
 		public bool Site { get; set; }
+
+		[DataMember(Name = "has_native_controller")]
+		public bool? HasNativeController { get; set; }
+
+		[DataMember(Name ="java_version")]
+		public string JavaVersion { get; set; }
 
 		[DataMember(Name ="version")]
 		public string Version { get; set; }

--- a/src/Nest/CommonOptions/Stats/QueryCacheStats.cs
+++ b/src/Nest/CommonOptions/Stats/QueryCacheStats.cs
@@ -17,9 +17,6 @@ namespace Nest
 		[DataMember(Name ="hit_count")]
 		public long HitCount { get; set; }
 
-		[DataMember(Name ="memory_size")]
-		public string MemorySize { get; set; }
-
 		[DataMember(Name ="memory_size_in_bytes")]
 		public long MemorySizeInBytes { get; set; }
 

--- a/src/Nest/CommonOptions/Stats/SegmentsStats.cs
+++ b/src/Nest/CommonOptions/Stats/SegmentsStats.cs
@@ -8,68 +8,38 @@ namespace Nest
 		[DataMember(Name ="count")]
 		public long Count { get; set; }
 
-		[DataMember(Name ="doc_values_memory")]
-		public string DocValuesMemory { get; set; }
-
 		[DataMember(Name ="doc_values_memory_in_bytes")]
 		public long DocValuesMemoryInBytes { get; set; }
-
-		[DataMember(Name ="fixed_bit_set_memory")]
-		public string FixedBitSetMemory { get; set; }
 
 		[DataMember(Name ="fixed_bit_set_memory_in_bytes")]
 		public long FixedBitSetMemoryInBytes { get; set; }
 
-		[DataMember(Name ="index_writer_max_memory")]
-		public string IndexWriterMaxMemory { get; set; }
-
 		[DataMember(Name ="index_writer_max_memory_in_bytes")]
 		public long IndexWriterMaxMemoryInBytes { get; set; }
-
-		[DataMember(Name ="index_writer_memory")]
-		public string IndexWriterMemory { get; set; }
 
 		[DataMember(Name ="index_writer_memory_in_bytes")]
 		public long IndexWriterMemoryInBytes { get; set; }
 
-		[DataMember(Name ="memory")]
-		public string Memory { get; set; }
+		[DataMember(Name ="max_unsafe_auto_id_timestamp")]
+		public string MaximumUnsafeAutoIdTimestamp { get; set; }
 
 		[DataMember(Name ="memory_in_bytes")]
 		public long MemoryInBytes { get; set; }
 
-		[DataMember(Name ="norms_memory")]
-		public string NormsMemory { get; set; }
-
 		[DataMember(Name ="norms_memory_in_bytes")]
 		public long NormsMemoryInBytes { get; set; }
-
-		[DataMember(Name ="points_memory")]
-		public string PointsMemory { get; set; }
 
 		[DataMember(Name ="points_memory_in_bytes")]
 		public long PointsMemoryInBytes { get; set; }
 
-		[DataMember(Name ="stored_fields_memory")]
-		public string StoredFieldsMemory { get; set; }
-
 		[DataMember(Name ="stored_fields_memory_in_bytes")]
 		public long StoredFieldsMemoryInBytes { get; set; }
-
-		[DataMember(Name ="terms_memory")]
-		public string TermsMemory { get; set; }
 
 		[DataMember(Name ="terms_memory_in_bytes")]
 		public long TermsMemoryInBytes { get; set; }
 
-		[DataMember(Name ="term_vectors_memory")]
-		public string TermVectorsMemory { get; set; }
-
 		[DataMember(Name ="term_vectors_memory_in_bytes")]
 		public long TermVectorsMemoryInBytes { get; set; }
-
-		[DataMember(Name ="version_map_memory")]
-		public string VersionMapMemory { get; set; }
 
 		[DataMember(Name ="version_map_memory_in_bytes")]
 		public long VersionMapMemoryInBytes { get; set; }

--- a/src/Nest/CommonOptions/Stats/SegmentsStats.cs
+++ b/src/Nest/CommonOptions/Stats/SegmentsStats.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Nest
 {
@@ -21,7 +22,7 @@ namespace Nest
 		public long IndexWriterMemoryInBytes { get; set; }
 
 		[DataMember(Name ="max_unsafe_auto_id_timestamp")]
-		public string MaximumUnsafeAutoIdTimestamp { get; set; }
+		public long MaximumUnsafeAutoIdTimestamp { get; set; }
 
 		[DataMember(Name ="memory_in_bytes")]
 		public long MemoryInBytes { get; set; }
@@ -43,5 +44,8 @@ namespace Nest
 
 		[DataMember(Name ="version_map_memory_in_bytes")]
 		public long VersionMapMemoryInBytes { get; set; }
+		
+		[DataMember(Name ="file_sizes")]
+		public IReadOnlyDictionary<string, ShardFileSizeInfo> FileSizes { get; internal set; } = EmptyReadOnly<string, ShardFileSizeInfo>.Dictionary;
 	}
 }

--- a/src/Nest/CommonOptions/Stats/SegmentsStats.cs
+++ b/src/Nest/CommonOptions/Stats/SegmentsStats.cs
@@ -44,8 +44,8 @@ namespace Nest
 
 		[DataMember(Name ="version_map_memory_in_bytes")]
 		public long VersionMapMemoryInBytes { get; set; }
-		
+
 		[DataMember(Name ="file_sizes")]
-		public IReadOnlyDictionary<string, ShardFileSizeInfo> FileSizes { get; internal set; } = EmptyReadOnly<string, ShardFileSizeInfo>.Dictionary;
+		public IReadOnlyDictionary<string, ShardFileSizeInfo> FileSizes { get; internal set; }
 	}
 }

--- a/src/Tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
+++ b/src/Tests/Tests/Cluster/ClusterStats/ClusterStatsApiTests.cs
@@ -28,6 +28,10 @@ namespace Tests.Cluster.ClusterStats
 		protected override void ExpectResponse(ClusterStatsResponse response)
 		{
 			response.ClusterName.Should().NotBeNullOrWhiteSpace();
+
+			if (base.Cluster.ClusterConfiguration.Version >= "6.8.0")
+				response.ClusterUUID.Should().NotBeNullOrWhiteSpace();
+
 			response.NodeStatistics.Should().NotBeNull();
 			response.Status.Should().NotBe(ClusterStatus.Red);
 			response.Timestamp.Should().BeGreaterThan(0);
@@ -66,6 +70,12 @@ namespace Tests.Cluster.ClusterStats
 			nodes.OperatingSystem.AllocatedProcessors.Should().BeGreaterThan(0);
 
 			nodes.OperatingSystem.Names.Should().NotBeEmpty();
+
+			if (base.Cluster.ClusterConfiguration.Version >= "6.8.0")
+			{
+				nodes.OperatingSystem.Memory.Should().NotBeNull();
+				nodes.OperatingSystem.PrettyNames.Should().NotBeNull();
+			}
 
 			var plugins = nodes.Plugins;
 			plugins.Should().NotBeEmpty();


### PR DESCRIPTION
Removes some of the redundant properties.