### PR TITLE
Some event do not carry timings information but DebugInformation stil…

### DIFF
--- a/src/Elasticsearch.Net/Responses/ResponseStatics.cs
+++ b/src/Elasticsearch.Net/Responses/ResponseStatics.cs
@@ -42,7 +42,7 @@ namespace Elasticsearch.Net
 				sb.AppendLine($"# Audit exception in step {a.i + 1} {a.audit.Event.GetStringValue()}:\r\n{a.audit.Exception}");
 		}
 
-		public static void DebugAuditTrail(List<Audit> auditTrail, System.Text.StringBuilder sb)
+		public static void DebugAuditTrail(List<Audit> auditTrail, StringBuilder sb)
 		{
 			if (auditTrail == null) return;
 
@@ -54,7 +54,9 @@ namespace Elasticsearch.Net
 				AuditNodeUrl(sb, audit);
 
 				if (audit.Exception != null) sb.Append($" Exception: {audit.Exception.GetType().Name}");
-				sb.AppendLine($" Took: {(audit.Ended - audit.Started).ToString()}");
+				if (audit.Ended == default)
+					sb.AppendLine();
+				else sb.AppendLine($" Took: {(audit.Ended - audit.Started).ToString()}");
 			}
 		}
 


### PR DESCRIPTION
…l tries to display timings information

```
# Audit trail of this API call:
 - [1] PingFailure: Node: http://localhost:9200/ Exception: PipelineException Took: 00:00:00.1001219
 - [2] PingFailure: Node: http://localhost:9201/ Exception: PipelineException Took: 00:00:00.0012111
 - [3] PingFailure: Node: http://localhost:9202/ Exception: PipelineException Took: 00:00:00.0007504
 - [4] PingFailure: Node: http://localhost:9203/ Exception: PipelineException Took: 00:00:00.0007236
 - [5] PingFailure: Node: http://localhost:9204/ Exception: PipelineException Took: 00:00:00.0007315
 - [6] PingFailure: Node: http://localhost:9205/ Exception: PipelineException Took: 00:00:00.0037279
 - [7] PingFailure: Node: http://localhost:9206/ Exception: PipelineException Took: 00:00:00.0008012
 - [8] PingFailure: Node: http://localhost:9207/ Exception: PipelineException Took: 00:00:00.0009753
 - [9] PingFailure: Node: http://localhost:9208/ Exception: PipelineException Took: 00:00:00.0008170
 - [10] PingFailure: Node: http://localhost:9209/ Exception: PipelineException Took: 00:00:00.0008090
 - [11] MaxRetriesReached:
 - [12] FailedOverAllNodes:
```

This fixes `DebugInformation` showing a negative took for the last two events.