### PR TITLE
Use CompositeKey on BucketAggregate

### DIFF
--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -116,14 +116,14 @@ namespace Nest
 						aggregate = GetValueAggregate(ref reader, formatterResolver);
 						break;
 					case 2:
-						var dictionaryFormatter = formatterResolver.GetFormatter<Dictionary<string, object>>();
-						var afterKeys = dictionaryFormatter.Deserialize(ref reader, formatterResolver);
+						var compositeKeyFormatter = formatterResolver.GetFormatter<CompositeKey>();
+						var afterKey = compositeKeyFormatter.Deserialize(ref reader, formatterResolver);
 						reader.ReadNext(); // ,
 						propertyName = reader.ReadPropertyNameSegmentRaw();
 						var bucketAggregate = propertyName.EqualsBytes(BucketsField)
 							? GetMultiBucketAggregate(ref reader, formatterResolver, ref propertyName) as BucketAggregate ?? new BucketAggregate()
 							: new BucketAggregate();
-						bucketAggregate.AfterKey = afterKeys;
+						bucketAggregate.AfterKey = afterKey;
 						aggregate = bucketAggregate;
 						break;
 					case 3:

--- a/src/Nest/Aggregations/Bucket/BucketAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/BucketAggregate.cs
@@ -53,7 +53,7 @@ namespace Nest
 	// Intermediate object used for deserialization
 	public class BucketAggregate : IAggregate
 	{
-		public IReadOnlyDictionary<string, object> AfterKey { get; set; } = EmptyReadOnly<string, object>.Dictionary;
+		public CompositeKey AfterKey { get; set; }
 		public long BgCount { get; set; }
 		public long DocCount { get; set; }
 		public long? DocCountErrorUpperBound { get; set; }

--- a/src/Nest/Aggregations/Bucket/Composite/CompositeAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/CompositeAggregation.cs
@@ -17,7 +17,7 @@ namespace Nest
 		/// last composite buckets returned in a previous round
 		/// </summary>
 		[DataMember(Name ="after")]
-		object After { get; set; }
+		CompositeKey After { get; set; }
 
 		/// <summary>
 		/// Defines how many composite buckets should be returned.
@@ -43,7 +43,7 @@ namespace Nest
 		public CompositeAggregation(string name) : base(name) { }
 
 		/// <inheritdoc />
-		public object After { get; set; }
+		public CompositeKey After { get; set; }
 
 		/// <inheritdoc />
 		public int? Size { get; set; }
@@ -60,7 +60,7 @@ namespace Nest
 			, ICompositeAggregation
 		where T : class
 	{
-		object ICompositeAggregation.After { get; set; }
+		CompositeKey ICompositeAggregation.After { get; set; }
 		int? ICompositeAggregation.Size { get; set; }
 		IEnumerable<ICompositeAggregationSource> ICompositeAggregation.Sources { get; set; }
 
@@ -74,6 +74,6 @@ namespace Nest
 		public CompositeAggregationDescriptor<T> Size(int? size) => Assign(size, (a, v) => a.Size = v);
 
 		/// <inheritdoc cref="ICompositeAggregation.After" />
-		public CompositeAggregationDescriptor<T> After(object after) => Assign(after, (a, v) => a.After = v);
+		public CompositeAggregationDescriptor<T> After(CompositeKey after) => Assign(after, (a, v) => a.After = v);
 	}
 }

--- a/src/Nest/Aggregations/Bucket/Composite/CompositeBucket.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/CompositeBucket.cs
@@ -119,6 +119,13 @@ namespace Nest
 		public void Serialize(ref JsonWriter writer, CompositeKey value, IJsonFormatterResolver formatterResolver) =>
 			DictionaryFormatter.Serialize(ref writer, value, formatterResolver);
 
-		public CompositeKey Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver) => throw new NotSupportedException();
+		public CompositeKey Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
+		{
+			if (reader.ReadIsNull())
+				return null;
+
+			var dictionary = DictionaryFormatter.Deserialize(ref reader, formatterResolver);
+			return new CompositeKey(dictionary);
+		}
 	}
 }


### PR DESCRIPTION
This commit sets AfterKey as a CompositeKey on BucketAggregate, such that null values are respected
when passing into subsequent composite aggregation calls.

Fixes #3694