### PR TITLE
Set CompositeKey on BucketAggregate

### DIFF
--- a/src/Nest/Aggregations/AggregateDictionary.cs
+++ b/src/Nest/Aggregations/AggregateDictionary.cs
@@ -192,7 +192,6 @@ namespace Nest
 			};
 		}
 
-
 		public CompositeBucketAggregate Composite(string key)
 		{
 			var bucket = TryGet<BucketAggregate>(key);
@@ -202,7 +201,7 @@ namespace Nest
 			{
 				Buckets = bucket.Items.OfType<CompositeBucket>().ToList(),
 				Meta = bucket.Meta,
-				AfterKey = new CompositeKey(bucket.AfterKey)
+				AfterKey = bucket.CompositeAfterKey
 			};
 		}
 
@@ -211,11 +210,8 @@ namespace Nest
 		public ValueAggregate MedianAbsoluteDeviation(string key) => TryGet<ValueAggregate>(key);
 
 		private TAggregate TryGet<TAggregate>(string key)
-			where TAggregate : class, IAggregate
-		{
-			IAggregate agg;
-			return BackingDictionary.TryGetValue(key, out agg) ? agg as TAggregate : null;
-		}
+			where TAggregate : class, IAggregate =>
+			BackingDictionary.TryGetValue(key, out var agg) ? agg as TAggregate : null;
 
 		private MultiBucketAggregate<TBucket> GetMultiBucketAggregate<TBucket>(string key)
 			where TBucket : IBucket

--- a/src/Nest/Aggregations/AggregateJsonConverter.cs
+++ b/src/Nest/Aggregations/AggregateJsonConverter.cs
@@ -88,7 +88,10 @@ namespace Nest
 					var bucketAggregate = reader.Value.ToString() == Parser.Buckets
 						? GetMultiBucketAggregate(reader, serializer) as BucketAggregate ?? new BucketAggregate()
 						: new BucketAggregate();
+#pragma warning disable 618
 					bucketAggregate.AfterKey = afterKeys;
+#pragma warning restore 618
+					bucketAggregate.CompositeAfterKey = new CompositeKey(afterKeys);
 					aggregate = bucketAggregate;
 					break;
 				case Parser.Buckets:

--- a/src/Nest/Aggregations/Bucket/BucketAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/BucketAggregate.cs
@@ -63,6 +63,8 @@ namespace Nest
 	// Intermediate object used for deserialization
 	public class BucketAggregate : IAggregate
 	{
+		public CompositeKey CompositeAfterKey { get; set; }
+		[Obsolete("Use " + nameof(CompositeAfterKey))]
 		public IReadOnlyDictionary<string, object> AfterKey { get; set; } = EmptyReadOnly<string, object>.Dictionary;
 		public long BgCount { get; set; }
 		public long DocCount { get; set; }


### PR DESCRIPTION
Discourage the use of AfterKey on BucketAggregate by marking it as obsolete. Passing it directly into After will not honour null values for keys returned - it must be passed as a CompositeKey.

Fixes #3694