### PR TITLE
Serialize DateMath with minimum 3 decimal places

### DIFF
--- a/src/Nest/CommonOptions/DateMath/DateMath.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMath.cs
@@ -92,7 +92,7 @@ namespace Nest
 
 			var sb = new StringBuilder();
 			var anchor = Self.Anchor.Match(
-				d => d.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFF") + separator,
+				d => ToMinThreeDecimalPlaces(d) + separator,
 				s => s == "now" || s.EndsWith("||", StringComparison.Ordinal) ? s : s + separator
 			);
 			sb.Append(anchor);
@@ -106,6 +106,24 @@ namespace Nest
 				sb.Append("/" + Self.Round.Value.GetStringValue());
 
 			return sb.ToString();
+		}
+
+		/// <summary>
+		/// Formats a <see cref="DateTime"/> to have a minimum of 3 decimal places if there
+		/// are sub second values
+		/// </summary>
+		/// Fixes bug in Elasticsearch: https://github.com/elastic/elasticsearch/pull/41871
+		private static string ToMinThreeDecimalPlaces(DateTime dateTime)
+		{
+			var format = dateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFF");
+
+			if (format.Length > 20 && format.Length < 23)
+			{
+				var diff = 23 - format.Length;
+				return $"{format}{new string('0', diff)}";
+			}
+
+			return format;
 		}
 	}
 

--- a/src/Tests/Tests.Reproduce/GitHubIssue3719.cs
+++ b/src/Tests/Tests.Reproduce/GitHubIssue3719.cs
@@ -1,0 +1,30 @@
+using System;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue3719
+	{
+		[U]
+		public void SerializeDateMathWithMinimumThreeDecimalPlacesWhenTens()
+		{
+			DateMath dateMath = new DateTime(2019, 5, 7, 12, 0, 0, 20);
+
+			var json = TestClient.Default.RequestResponseSerializer.SerializeToString(dateMath, RecyclableMemoryStreamFactory.Default);
+			json.Should().Be("\"2019-05-07T12:00:00.020\"");
+		}
+
+		[U]
+		public void SerializeDateMathWithMinimumThreeDecimalPlacesThenHundreds()
+		{
+			DateMath dateMath = new DateTime(2019, 5, 7, 12, 0, 0, 200);
+
+			var json = TestClient.Default.RequestResponseSerializer.SerializeToString(dateMath, RecyclableMemoryStreamFactory.Default);
+			json.Should().Be("\"2019-05-07T12:00:00.200\"");
+		}
+	}
+}

--- a/src/Tests/Tests.Reproduce/GitHubIssue3719.cs
+++ b/src/Tests/Tests.Reproduce/GitHubIssue3719.cs
@@ -19,7 +19,7 @@ namespace Tests.Reproduce
 		}
 
 		[U]
-		public void SerializeDateMathWithMinimumThreeDecimalPlacesThenHundreds()
+		public void SerializeDateMathWithMinimumThreeDecimalPlacesWhenHundreds()
 		{
 			DateMath dateMath = new DateTime(2019, 5, 7, 12, 0, 0, 200);
 


### PR DESCRIPTION
This commit ensures that DateMath containing DateTime are always serialized with a minimum of 3 decimal places.

https://github.com/elastic/elasticsearch/pull/41871 introduced a bug in Elasticsearch 7.x < 7.1.0 whereby date strings
with less than 3 decimal places throw a parser exception.

Fixes #3719