### PR TITLE
Fix Query DSL usage tests

### DIFF
--- a/src/CodeGeneration/DocGenerator/StringExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/StringExtensions.cs
@@ -62,7 +62,7 @@ namespace DocGenerator
 			{ "Script.Map", "\"if (doc['state'].value == \\\"Stable\\\") { params._agg.commits.add(doc['numberOfCommits'].value) }\"" },
 			{ "Script.Combine", "\"def sum = 0.0; for (c in params._agg.commits) { sum += c } return sum\"" },
 			{ "Script.Reduce", "\"def sum = 0.0; for (a in params._aggs) { sum += a } return sum\"" },
-			{ "EnvelopeCoordinates", @"new [] { new [] { 45.0, -45.0 }, new [] { -45.0, 45.0 }}" },
+			{ "EnvelopeCoordinates", @"new [] { new [] { -45.0, 45.0 }, new [] { 45.0, -45.0 }}" },
 			{ "CircleCoordinates", @"new [] { 45.0, -45.0 }" },
 			{ "MultiPointCoordinates", @"new [] { new [] {38.897676, -77.03653}, new [] {38.889939, -77.009051} }" },
 			{

--- a/src/Nest/Mapping/Visitor/PropertyWalker.cs
+++ b/src/Nest/Mapping/Visitor/PropertyWalker.cs
@@ -163,6 +163,9 @@ namespace Nest
 			if (type == typeof(QueryContainer))
 				return new PercolatorProperty();
 
+			if (type == typeof(IGeoShape))
+				return new GeoShapeProperty();
+
 			return new ObjectProperty();
 		}
 

--- a/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using Elasticsearch.Net.Extensions;
 using Elasticsearch.Net.Utf8Json;
+using Elasticsearch.Net.Utf8Json.Internal;
 
 namespace Nest
 {
@@ -52,16 +54,21 @@ namespace Nest
 	internal class GeoShapeFormatter<TShape> : IJsonFormatter<TShape>
 		where TShape : IGeoShape
 	{
-		public void Serialize(ref JsonWriter writer, TShape value, IJsonFormatterResolver formatterResolver) =>
-			GeoShapeFormatter.Instance.Serialize(ref writer, value, formatterResolver);
-
 		public TShape Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver) =>
 			(TShape)GeoShapeFormatter.Instance.Deserialize(ref reader, formatterResolver);
+
+		public void Serialize(ref JsonWriter writer, TShape value, IJsonFormatterResolver formatterResolver) =>
+			GeoShapeFormatter.Instance.Serialize(ref writer, value, formatterResolver);
 	}
 
 	internal class GeoShapeFormatter : IJsonFormatter<IGeoShape>
 	{
+		private static readonly AutomataDictionary CircleFields = new AutomataDictionary { { "coordinates", 0 }, { "radius", 1 } };
+		private static readonly byte[] CoordinatesField = JsonWriter.GetEncodedPropertyNameWithoutQuotation("coordinates");
+		private static readonly byte[] GeometriesField = JsonWriter.GetEncodedPropertyNameWithoutQuotation("geometries");
 		internal static readonly GeoShapeFormatter Instance = new GeoShapeFormatter();
+
+		private static readonly byte[] TypeField = JsonWriter.GetEncodedPropertyNameWithoutQuotation("type");
 
 		public IGeoShape Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
@@ -179,12 +186,14 @@ namespace Nest
 
 			while (segmentReader.ReadIsInObject(ref count))
 			{
-				var propertyName = segmentReader.ReadPropertyName();
-				if (propertyName == "type")
+				var propertyName = segmentReader.ReadPropertyNameSegmentRaw();
+				if (propertyName.EqualsBytes(TypeField))
 				{
 					typeName = segmentReader.ReadString().ToUpperInvariant();
 					break;
 				}
+
+				segmentReader.ReadNextBlock();
 			}
 
 			segmentReader = new JsonReader(segment.Array, segment.Offset);
@@ -217,18 +226,21 @@ namespace Nest
 		private static GeometryCollection ParseGeometryCollection(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
 			var count = 0;
-			var geoShapes = Enumerable.Empty<IGeoShape>();
+			var geometries = Enumerable.Empty<IGeoShape>();
 			while (reader.ReadIsInObject(ref count))
 			{
-				var propertyName = reader.ReadPropertyName();
-				if (propertyName == "geometries")
-					geoShapes = formatterResolver.GetFormatter<IEnumerable<IGeoShape>>()
+				var propertyName = reader.ReadPropertyNameSegmentRaw();
+				if (propertyName.EqualsBytes(GeometriesField))
+				{
+					geometries = formatterResolver.GetFormatter<IEnumerable<IGeoShape>>()
 						.Deserialize(ref reader, formatterResolver);
-				else
-					reader.ReadNextBlock();
+					break;
+				}
+
+				reader.ReadNextBlock();
 			}
 
-			return new GeometryCollection { Geometries = geoShapes };
+			return new GeometryCollection { Geometries = geometries };
 		}
 
 		private static MultiPolygonGeoShape ParseMultiPolygonGeoShape(ref JsonReader reader, IJsonFormatterResolver formatterResolver) =>
@@ -247,10 +259,7 @@ namespace Nest
 			new PointGeoShape { Coordinates = GetCoordinates<GeoCoordinate>(ref reader, formatterResolver) };
 
 		private static MultiLineStringGeoShape ParseMultiLineStringGeoShape(ref JsonReader reader, IJsonFormatterResolver formatterResolver) =>
-			new MultiLineStringGeoShape
-			{
-				Coordinates = GetCoordinates<IEnumerable<IEnumerable<GeoCoordinate>>>(ref reader, formatterResolver)
-			};
+			new MultiLineStringGeoShape { Coordinates = GetCoordinates<IEnumerable<IEnumerable<GeoCoordinate>>>(ref reader, formatterResolver) };
 
 		private static LineStringGeoShape ParseLineStringGeoShape(ref JsonReader reader, IJsonFormatterResolver formatterResolver) =>
 			new LineStringGeoShape { Coordinates = GetCoordinates<IEnumerable<GeoCoordinate>>(ref reader, formatterResolver) };
@@ -265,27 +274,26 @@ namespace Nest
 			GeoCoordinate coordinate = null;
 			while (reader.ReadIsInObject(ref count))
 			{
-				var propertyName = reader.ReadPropertyName();
-				switch (propertyName)
+				var propertyName = reader.ReadPropertyNameSegmentRaw();
+
+				if (CircleFields.TryGetValue(propertyName, out var value))
 				{
-					case "coordinates":
-						coordinate = formatterResolver.GetFormatter<GeoCoordinate>()
-							.Deserialize(ref reader, formatterResolver);
-						break;
-					case "radius":
-						radius = reader.ReadString();
-						break;
-					default:
-						reader.ReadNextBlock();
-						break;
+					switch (value)
+					{
+						case 0:
+							coordinate = formatterResolver.GetFormatter<GeoCoordinate>()
+								.Deserialize(ref reader, formatterResolver);
+							break;
+						case 1:
+							radius = reader.ReadString();
+							break;
+					}
 				}
+				else
+					reader.ReadNextBlock();
 			}
 
-			return new CircleGeoShape
-			{
-				Coordinates = coordinate,
-				Radius = radius
-			};
+			return new CircleGeoShape { Coordinates = coordinate, Radius = radius };
 		}
 
 		private static T GetCoordinates<T>(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
@@ -294,14 +302,15 @@ namespace Nest
 			var coordinates = default(T);
 			while (reader.ReadIsInObject(ref count))
 			{
-				var propertyName = reader.ReadPropertyName();
-				if (propertyName == "coordinates")
+				var propertyName = reader.ReadPropertyNameSegmentRaw();
+				if (propertyName.EqualsBytes(CoordinatesField))
 				{
 					var formatter = formatterResolver.GetFormatter<T>();
 					coordinates = formatter.Deserialize(ref reader, formatterResolver);
+					break;
 				}
-				else
-					reader.ReadNextBlock();
+
+				reader.ReadNextBlock();
 			}
 
 			return coordinates;

--- a/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
@@ -41,8 +41,6 @@ namespace Nest
 	/// </summary>
 	public abstract class GeoShapeBase : IGeoShape
 	{
-		internal static readonly GeoShapeFormatter ShapeFormatter = new GeoShapeFormatter();
-		
 		protected GeoShapeBase(string type) => Type = type;
 
 		/// <inheritdoc />
@@ -55,14 +53,16 @@ namespace Nest
 		where TShape : IGeoShape
 	{
 		public void Serialize(ref JsonWriter writer, TShape value, IJsonFormatterResolver formatterResolver) =>
-			GeoShapeBase.ShapeFormatter.Serialize(ref writer, value, formatterResolver);
+			GeoShapeFormatter.Instance.Serialize(ref writer, value, formatterResolver);
 
 		public TShape Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver) =>
-			(TShape)GeoShapeBase.ShapeFormatter.Deserialize(ref reader, formatterResolver);
+			(TShape)GeoShapeFormatter.Instance.Deserialize(ref reader, formatterResolver);
 	}
 
 	internal class GeoShapeFormatter : IJsonFormatter<IGeoShape>
 	{
+		internal static readonly GeoShapeFormatter Instance = new GeoShapeFormatter();
+
 		public IGeoShape Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
 			var token = reader.GetCurrentJsonToken();

--- a/src/Nest/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
+++ b/src/Nest/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
@@ -62,7 +62,6 @@ namespace Nest
 
 		public LikeDocument(TDocument document)
 		{
-			Id = Id.From(document);
 			Document = document;
 			Index = typeof(TDocument);
 		}
@@ -98,11 +97,7 @@ namespace Nest
 
 		public LikeDocumentDescriptor<TDocument> Fields(Fields fields) => Assign(fields, (a, v) => a.Fields = v);
 
-		public LikeDocumentDescriptor<TDocument> Document(TDocument document) => Assign(document,  (a, v) =>
-		{
-			a.Id = Infer.Id(v);
-			a.Document = v;
-		});
+		public LikeDocumentDescriptor<TDocument> Document(TDocument document) => Assign(document,  (a, v) => a.Document = v);
 
 		public LikeDocumentDescriptor<TDocument> PerFieldAnalyzer(
 			Func<PerFieldAnalyzerDescriptor<TDocument>, IPromise<IPerFieldAnalyzer>> analyzerSelector

--- a/src/Tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
@@ -329,7 +329,10 @@ namespace Tests.Core.ManagedElasticsearch.NodeSeeders
 				.Properties(DeveloperProperties)
 			)
 			.GeoPoint(g => g
-				.Name(p => p.Location)
+				.Name(p => p.LocationPoint)
+			)
+			.GeoShape(g => g
+				.Name(p => p.LocationShape)
 			)
 			.Completion(cm => cm
 				.Name(p => p.Suggest)

--- a/src/Tests/Tests.Domain/Project.cs
+++ b/src/Tests/Tests.Domain/Project.cs
@@ -26,7 +26,8 @@ namespace Tests.Domain
 		public JoinField Join => JoinField.Root<Project>();
 		public DateTime LastActivity { get; set; }
 		public Developer LeadDeveloper { get; set; }
-		public SimpleGeoPoint Location { get; set; }
+		public SimpleGeoPoint LocationPoint { get; set; }
+		public IGeoShape LocationShape { get; set; }
 		public Dictionary<string, Metadata> Metadata { get; set; }
 		public string Name { get; set; }
 		public int? NumberOfCommits { get; set; }
@@ -59,7 +60,8 @@ namespace Tests.Domain
 				.RuleFor(p => p.LeadDeveloper, p => Developer.Developers[Gimme.Random.Number(0, Developer.Developers.Count - 1)])
 				.RuleFor(p => p.Tags, f => Tag.Generator.Generate(Gimme.Random.Number(2, 50)))
 				.RuleFor(p => p.CuratedTags, f => Tag.Generator.Generate(Gimme.Random.Number(1, 5)))
-				.RuleFor(p => p.Location, f => SimpleGeoPoint.Generator.Generate())
+				.RuleFor(p => p.LocationPoint, f => SimpleGeoPoint.Generator.Generate())
+				.RuleFor(p => p.LocationShape, f => new PointGeoShape(new GeoCoordinate(f.Address.Latitude(), f.Address.Latitude())))
 				.RuleFor(p => p.NumberOfCommits, f => Gimme.Random.Number(1, 1000))
 				.RuleFor(p => p.NumberOfContributors, f => Gimme.Random.Number(1, 200))
 				.RuleFor(p => p.Ranges, f => Ranges.Generator.Generate())
@@ -86,7 +88,7 @@ namespace Tests.Domain
 			LeadDeveloper = new Developer() { FirstName = "Martijn", LastName = "Laarman" },
 			StartedOn = new DateTime(2015, 1, 1),
 			DateString = new DateTime(2015, 1, 1).ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"),
-			Location = new SimpleGeoPoint { Lat = 42.1523, Lon = -80.321 },
+			LocationPoint = new SimpleGeoPoint { Lat = 42.1523, Lon = -80.321 },
 			SourceOnly = TestConfiguration.Instance.Random.SourceSerializer ? new SourceOnlyObject() : null
 		};
 
@@ -102,7 +104,7 @@ namespace Tests.Domain
 			numberOfContributors = 0,
 			dateString = new DateTime(2015, 1, 1).ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"),
 			leadDeveloper = new { gender = "Male", id = 0, firstName = "Martijn", lastName = "Laarman" },
-			location = new { lat = Instance.Location.Lat, lon = Instance.Location.Lon }
+			locationPoint = new { lat = Instance.LocationPoint.Lat, lon = Instance.LocationPoint.Lon }
 		};
 
 		private static readonly object InstanceAnonymousSourceSerializer = new
@@ -117,7 +119,7 @@ namespace Tests.Domain
 			numberOfContributors = 0,
 			dateString = new DateTime(2015, 1, 1).ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"),
 			leadDeveloper = new { gender = "Male", id = 0, firstName = "Martijn", lastName = "Laarman" },
-			location = new { lat = Instance.Location.Lat, lon = Instance.Location.Lon },
+			locationPoint = new { lat = Instance.LocationPoint.Lat, lon = Instance.LocationPoint.Lon },
 			sourceOnly = new { notWrittenByDefaultSerializer = "written" }
 		};
 

--- a/src/Tests/Tests/Aggregations/Bucket/GeoDistance/GeoDistanceAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/GeoDistance/GeoDistanceAggregationUsageTests.cs
@@ -21,7 +21,7 @@ namespace Tests.Aggregations.Bucket.GeoDistance
 			{
 				geo_distance = new
 				{
-					field = "location",
+					field = "locationPoint",
 					origin = new
 					{
 						lat = 52.376,
@@ -39,7 +39,7 @@ namespace Tests.Aggregations.Bucket.GeoDistance
 
 		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
 			.GeoDistance("rings_around_amsterdam", g => g
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 				.Origin(52.376, 4.894)
 				.Ranges(
 					r => r.To(100),
@@ -51,7 +51,7 @@ namespace Tests.Aggregations.Bucket.GeoDistance
 		protected override AggregationDictionary InitializerAggs =>
 			new GeoDistanceAggregation("rings_around_amsterdam")
 			{
-				Field = Field((Project p) => p.Location),
+				Field = Field((Project p) => p.LocationPoint),
 				Origin = "52.376, 4.894",
 				Ranges = new List<AggregationRange>
 				{

--- a/src/Tests/Tests/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregationUsageTests.cs
@@ -19,7 +19,7 @@ namespace Tests.Aggregations.Bucket.GeoHashGrid
 			{
 				geohash_grid = new
 				{
-					field = "location",
+					field = "locationPoint",
 					precision = 3,
 					size = 1000,
 					shard_size = 100
@@ -29,7 +29,7 @@ namespace Tests.Aggregations.Bucket.GeoHashGrid
 
 		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
 			.GeoHash("my_geohash_grid", g => g
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 				.GeoHashPrecision(GeoHashPrecision.Precision3)
 				.Size(1000)
 				.ShardSize(100)
@@ -38,7 +38,7 @@ namespace Tests.Aggregations.Bucket.GeoHashGrid
 		protected override AggregationDictionary InitializerAggs =>
 			new GeoHashGridAggregation("my_geohash_grid")
 			{
-				Field = Field<Project>(p => p.Location),
+				Field = Field<Project>(p => p.LocationPoint),
 				Precision = GeoHashPrecision.Precision3,
 				Size = 1000,
 				ShardSize = 100

--- a/src/Tests/Tests/Aggregations/Metric/GeoBounds/GeoBoundsAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Metric/GeoBounds/GeoBoundsAggregationUsageTests.cs
@@ -19,7 +19,7 @@ namespace Tests.Aggregations.Metric.GeoBounds
 			{
 				geo_bounds = new
 				{
-					field = "location",
+					field = "locationPoint",
 					wrap_longitude = true
 				}
 			}
@@ -27,12 +27,12 @@ namespace Tests.Aggregations.Metric.GeoBounds
 
 		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
 			.GeoBounds("viewport", gb => gb
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 				.WrapLongitude()
 			);
 
 		protected override AggregationDictionary InitializerAggs =>
-			new GeoBoundsAggregation("viewport", Field<Project>(p => p.Location))
+			new GeoBoundsAggregation("viewport", Field<Project>(p => p.LocationPoint))
 			{
 				WrapLongitude = true
 			};

--- a/src/Tests/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs
@@ -25,18 +25,18 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 			{
 				geo_centroid = new
 				{
-					field = "location"
+					field = "locationPoint"
 				}
 			}
 		};
 
 		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
 			.GeoCentroid("centroid", gb => gb
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 			);
 
 		protected override AggregationDictionary InitializerAggs =>
-			new GeoCentroidAggregation("centroid", Infer.Field<Project>(p => p.Location));
+			new GeoCentroidAggregation("centroid", Infer.Field<Project>(p => p.LocationPoint));
 
 		protected override void ExpectResponse(SearchResponse<Project> response)
 		{
@@ -76,7 +76,7 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 					{
 						geo_centroid = new
 						{
-							field = "location"
+							field = "locationPoint"
 						}
 					}
 				}
@@ -88,7 +88,7 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 				.Field(p => p.Name)
 				.Aggregations(sa => sa
 					.GeoCentroid("centroid", gb => gb
-						.Field(p => p.Location)
+						.Field(p => p.LocationPoint)
 					)
 				)
 			);
@@ -97,7 +97,7 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 			new TermsAggregation("projects")
 			{
 				Field = Infer.Field<Project>(p => p.Name),
-				Aggregations = new GeoCentroidAggregation("centroid", Infer.Field<Project>(p => p.Location))
+				Aggregations = new GeoCentroidAggregation("centroid", Infer.Field<Project>(p => p.LocationPoint))
 			};
 
 		protected override void ExpectResponse(SearchResponse<Project> response)
@@ -128,17 +128,17 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 		{
 			centroid = new
 			{
-				geo_centroid = new { field = "location" }
+				geo_centroid = new { field = "locationPoint" }
 			}
 		};
 
 		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
 			.GeoCentroid("centroid", gb => gb
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 			);
 
 		protected override AggregationDictionary InitializerAggs =>
-			new GeoCentroidAggregation("centroid", Infer.Field<Project>(p => p.Location));
+			new GeoCentroidAggregation("centroid", Infer.Field<Project>(p => p.LocationPoint));
 
 		protected override QueryContainer QueryScope => new TermQuery { Field = Infer.Field<Project>(p => p.Name), Value = "noresult" };
 		protected override object QueryScopeJson { get; } = new { term = new { name = new { value = "noresult" } } };

--- a/src/Tests/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldsEqualityTests.cs
+++ b/src/Tests/Tests/ClientConcepts/HighLevel/Inference/Equality/FieldsEqualityTests.cs
@@ -61,7 +61,7 @@ namespace Tests.ClientConcepts.HighLevel.Inference.Equality
 			t1.Should().NotBeEquivalentTo(t2);
 
 			t1 = Infer.Field<Project>(p => p.Name, 1.0);
-			t2 = Infer.Field<Project>(p => p.Location, 1.0);
+			t2 = Infer.Field<Project>(p => p.LocationPoint, 1.0);
 			(t1 != t2).ShouldBeTrue(t2);
 			t1.Should().NotBeEquivalentTo(t2);
 		}

--- a/src/Tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
+++ b/src/Tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
@@ -68,7 +68,7 @@ namespace Tests.Indices.MappingManagement.PutMapping
 					},
 					type = "object"
 				},
-				location = new
+				locationPoint = new
 				{
 					properties = new
 					{
@@ -76,6 +76,10 @@ namespace Tests.Indices.MappingManagement.PutMapping
 						lon = new { type = "double" }
 					},
 					type = "object"
+				},
+				locationShape = new
+				{
+					type = "geo_shape"
 				},
 				metadata = new { type = "object" },
 				name = new
@@ -235,7 +239,7 @@ namespace Tests.Indices.MappingManagement.PutMapping
 					}
 				},
 				{
-					p => p.Location, new ObjectProperty
+					p => p.LocationPoint, new ObjectProperty
 					{
 						Properties = new Properties<SimpleGeoPoint>
 						{
@@ -244,6 +248,7 @@ namespace Tests.Indices.MappingManagement.PutMapping
 						}
 					}
 				},
+				{ p => p.LocationShape, new GeoShapeProperty() },
 				{ p => p.Metadata, new ObjectProperty() },
 				{ p => p.Name, new TextProperty { Index = false } },
 				{ p => p.NumberOfCommits, new NumberProperty(NumberType.Integer) },

--- a/src/Tests/Tests/Mapping/Types/Geo/GeoPoint/GeoPointPropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Geo/GeoPoint/GeoPointPropertyTests.cs
@@ -14,7 +14,7 @@ namespace Tests.Mapping.Types.Geo.GeoPoint
 		{
 			properties = new
 			{
-				location = new
+				locationPoint = new
 				{
 					type = "geo_point",
 					ignore_malformed = true
@@ -25,7 +25,7 @@ namespace Tests.Mapping.Types.Geo.GeoPoint
 
 		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
 			.GeoPoint(s => s
-				.Name(p => p.Location)
+				.Name(p => p.LocationPoint)
 				.IgnoreMalformed()
 			);
 
@@ -33,7 +33,7 @@ namespace Tests.Mapping.Types.Geo.GeoPoint
 		protected override IProperties InitializerProperties => new Properties
 		{
 			{
-				"location", new GeoPointProperty
+				"locationPoint", new GeoPointProperty
 				{
 					IgnoreMalformed = true
 				}

--- a/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapePropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Geo/GeoShape/GeoShapePropertyTests.cs
@@ -14,7 +14,7 @@ namespace Tests.Mapping.Types.Geo.GeoShape
 		{
 			properties = new
 			{
-				location = new
+				locationShape = new
 				{
 					type = "geo_shape",
 					orientation = "cw",
@@ -26,7 +26,7 @@ namespace Tests.Mapping.Types.Geo.GeoShape
 
 		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
 			.GeoShape(s => s
-				.Name(p => p.Location)
+				.Name(p => p.LocationShape)
 				.Orientation(GeoOrientation.ClockWise)
 				.Strategy(GeoStrategy.Recursive)
 				.Coerce()
@@ -36,7 +36,7 @@ namespace Tests.Mapping.Types.Geo.GeoShape
 		protected override IProperties InitializerProperties => new Properties
 		{
 			{
-				"location", new GeoShapeProperty
+				"locationShape", new GeoShapeProperty
 				{
 					Orientation = GeoOrientation.ClockWise,
 					Strategy = GeoStrategy.Recursive,

--- a/src/Tests/Tests/QueryDsl/Compound/FunctionScore/FunctionScoreQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Compound/FunctionScore/FunctionScoreQueryUsageTests.cs
@@ -42,7 +42,7 @@ namespace Tests.QueryDsl.Compound.FunctionScore
 					{ Origin = DateMath.Now, Field = Field<Project>(p => p.LastActivity), Decay = 0.5, Scale = TimeSpan.FromDays(1) },
 				new LinearGeoDecayFunction
 				{
-					Origin = new GeoLocation(70, -70), Field = Field<Project>(p => p.Location), Scale = Distance.Miles(1),
+					Origin = new GeoLocation(70, -70), Field = Field<Project>(p => p.LocationPoint), Scale = Distance.Miles(1),
 					MultiValueMode = MultiValueMode.Average
 				},
 				new FieldValueFactorFunction
@@ -94,7 +94,7 @@ namespace Tests.QueryDsl.Compound.FunctionScore
 					{
 						linear = new
 						{
-							location = new
+							locationPoint = new
 							{
 								origin = new
 								{
@@ -153,7 +153,7 @@ namespace Tests.QueryDsl.Compound.FunctionScore
 					.Exponential(b => b.Field(p => p.NumberOfCommits).Decay(0.5).Origin(1.0).Scale(0.1).Weight(2.1))
 					.GaussDate(b => b.Field(p => p.LastActivity).Origin(DateMath.Now).Decay(0.5).Scale("1d"))
 					.LinearGeoLocation(b =>
-						b.Field(p => p.Location).Origin(new GeoLocation(70, -70)).Scale(Distance.Miles(1)).MultiValueMode(MultiValueMode.Average))
+						b.Field(p => p.LocationPoint).Origin(new GeoLocation(70, -70)).Scale(Distance.Miles(1)).MultiValueMode(MultiValueMode.Average))
 					.FieldValueFactor(b => b.Field(p => p.NumberOfContributors).Factor(1.1).Missing(0.1).Modifier(FieldValueFactorModifier.Square))
 					.RandomScore(r => r.Seed(1337).Field("_seq_no"))
 					.RandomScore(r => r.Seed("randomstring").Field("_seq_no"))

--- a/src/Tests/Tests/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryUsageTests.cs
@@ -20,7 +20,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 		{
 			Boost = 1.1,
 			Name = "named_query",
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationPoint),
 			BoundingBox = new Nest.BoundingBox
 			{
 				TopLeft = new GeoLocation(34, -34),
@@ -38,7 +38,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 				validation_method = "strict",
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationPoint = new
 				{
 					top_left = new
 					{
@@ -58,7 +58,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 			.GeoBoundingBox(g => g
 				.Boost(1.1)
 				.Name("named_query")
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 				.BoundingBox(b => b
 					.TopLeft(34, -34)
 					.BottomRight(-34, 34)
@@ -83,7 +83,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 		{
 			Boost = 1.1,
 			Name = "named_query",
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationPoint),
 			BoundingBox = new Nest.BoundingBox
 			{
 				WellKnownText = "BBOX (34, -34, -34, 34)"
@@ -100,7 +100,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 				validation_method = "strict",
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationPoint = new
 				{
 					wkt = "BBOX (34, -34, -34, 34)"
 				}
@@ -111,7 +111,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 			.GeoBoundingBox(g => g
 				.Boost(1.1)
 				.Name("named_query")
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 				.BoundingBox(b => b
 					.WellKnownText("BBOX (34, -34, -34, 34)")
 				)

--- a/src/Tests/Tests/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryUsageTests.cs
@@ -86,7 +86,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 			Field = Infer.Field<Project>(p => p.LocationPoint),
 			BoundingBox = new Nest.BoundingBox
 			{
-				WellKnownText = "BBOX (34, -34, -34, 34)"
+				WellKnownText = "BBOX (-34, 34, 34, -34)"
 			},
 			Type = GeoExecution.Indexed,
 			ValidationMethod = GeoValidationMethod.Strict
@@ -102,7 +102,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 				boost = 1.1,
 				locationPoint = new
 				{
-					wkt = "BBOX (34, -34, -34, 34)"
+					wkt = "BBOX (-34, 34, 34, -34)"
 				}
 			}
 		};
@@ -113,7 +113,7 @@ namespace Tests.QueryDsl.Geo.BoundingBox
 				.Name("named_query")
 				.Field(p => p.LocationPoint)
 				.BoundingBox(b => b
-					.WellKnownText("BBOX (34, -34, -34, 34)")
+					.WellKnownText("BBOX (-34, 34, 34, -34)")
 				)
 				.ValidationMethod(GeoValidationMethod.Strict)
 				.Type(GeoExecution.Indexed)

--- a/src/Tests/Tests/QueryDsl/Geo/Distance/GeoDistanceQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/Distance/GeoDistanceQueryUsageTests.cs
@@ -20,7 +20,7 @@ namespace Tests.QueryDsl.Geo.Distance
 		{
 			Boost = 1.1,
 			Name = "named_query",
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationPoint),
 			DistanceType = GeoDistanceType.Arc,
 			Location = new GeoLocation(34, -34),
 			Distance = "200m",
@@ -36,7 +36,7 @@ namespace Tests.QueryDsl.Geo.Distance
 				distance = "200m",
 				distance_type = "arc",
 				validation_method = "ignore_malformed",
-				location = new
+				locationPoint = new
 				{
 					lat = 34.0,
 					lon = -34.0
@@ -48,7 +48,7 @@ namespace Tests.QueryDsl.Geo.Distance
 			.GeoDistance(g => g
 				.Boost(1.1)
 				.Name("named_query")
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 				.DistanceType(GeoDistanceType.Arc)
 				.Location(34, -34)
 				.Distance("200m")

--- a/src/Tests/Tests/QueryDsl/Geo/Polygon/GeoPolygonQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/Polygon/GeoPolygonQueryUsageTests.cs
@@ -22,7 +22,7 @@ namespace Tests.QueryDsl.Geo.Polygon
 			Boost = 1.1,
 			Name = "named_query",
 			ValidationMethod = GeoValidationMethod.Strict,
-			Points = new[] { new GeoLocation(45, -45), new GeoLocation(-34, 34), },
+			Points = new[] { new GeoLocation(45, -45), new GeoLocation(-34, 34), new GeoLocation(70, -70) },
 			Field = Infer.Field<Project>(p => p.LocationPoint)
 		};
 
@@ -38,7 +38,8 @@ namespace Tests.QueryDsl.Geo.Polygon
 					points = new[]
 					{
 						new { lat = 45.0, lon = -45.0 },
-						new { lat = -34.0, lon = 34.0 }
+						new { lat = -34.0, lon = 34.0 },
+						new { lat = 70.0, lon = -70.0 },
 					}
 				}
 			}
@@ -50,7 +51,7 @@ namespace Tests.QueryDsl.Geo.Polygon
 				.Boost(1.1)
 				.Field(p => p.LocationPoint)
 				.ValidationMethod(GeoValidationMethod.Strict)
-				.Points(new GeoLocation(45, -45), new GeoLocation(-34, 34))
+				.Points(new GeoLocation(45, -45), new GeoLocation(-34, 34), new GeoLocation(70, -70))
 			);
 	}
 }

--- a/src/Tests/Tests/QueryDsl/Geo/Polygon/GeoPolygonQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/Polygon/GeoPolygonQueryUsageTests.cs
@@ -23,7 +23,7 @@ namespace Tests.QueryDsl.Geo.Polygon
 			Name = "named_query",
 			ValidationMethod = GeoValidationMethod.Strict,
 			Points = new[] { new GeoLocation(45, -45), new GeoLocation(-34, 34), },
-			Field = Infer.Field<Project>(p => p.Location)
+			Field = Infer.Field<Project>(p => p.LocationPoint)
 		};
 
 		protected override object QueryJson => new
@@ -33,7 +33,7 @@ namespace Tests.QueryDsl.Geo.Polygon
 				_name = "named_query",
 				boost = 1.1,
 				validation_method = "strict",
-				location = new
+				locationPoint = new
 				{
 					points = new[]
 					{
@@ -48,7 +48,7 @@ namespace Tests.QueryDsl.Geo.Polygon
 			.GeoPolygon(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationPoint)
 				.ValidationMethod(GeoValidationMethod.Strict)
 				.Points(new GeoLocation(45, -45), new GeoLocation(-34, 34))
 			);

--- a/src/Tests/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Elastic.Xunit.XunitPlumbing;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
@@ -63,7 +64,7 @@ namespace Tests.QueryDsl.Geo.Shape
 					new[] { 18.2, 8.2 },
 					new[] { -18.8, 8.2 },
 					new[] { -10.8, -8.8 },
-					new[] { 18.2, 8.8 }
+					new[] { 18.2, 8.2 }
 				}
 			},
 			new[]
@@ -90,7 +91,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			},
 			new GeoCoordinate[]
 			{
-				new[] { 18.2, 8.2 }, new[] { -18.8, 8.2 }, new[] { -10.8, -8.8 }, new[] { 18.2, 8.8 }
+				new[] { 18.2, 8.2 }, new[] { -18.8, 8.2 }, new[] { -10.8, -8.8 }, new[] { 18.2, 8.2 }
 			}
 		};
 
@@ -160,6 +161,7 @@ namespace Tests.QueryDsl.Geo.Shape
 	 * == Querying with MultiPoint
 	 *
 	 */
+	[SkipVersion(">7.0.0", "multipoint queries are not supported")]
 	public class GeoShapeMultiPointQueryUsageTests : GeoShapeQueryUsageTestsBase
 	{
 		public GeoShapeMultiPointQueryUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }

--- a/src/Tests/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTests.cs
@@ -23,8 +23,8 @@ namespace Tests.QueryDsl.Geo.Shape
 
 		protected static readonly IEnumerable<GeoCoordinate> EnvelopeCoordinates = new GeoCoordinate[]
 		{
-			new[] { -45.0, 45.0 },
-			new[] { 45.0, -45.0 }
+			new[] { 45.0, -45.0, },
+			new[] { -45.0, 45.0 }
 		};
 
 		protected static readonly IEnumerable<GeoCoordinate> LineStringCoordinates = new GeoCoordinate[]
@@ -161,7 +161,7 @@ namespace Tests.QueryDsl.Geo.Shape
 	 * == Querying with MultiPoint
 	 *
 	 */
-	[SkipVersion(">7.0.0", "multipoint queries are not supported")]
+	[SkipVersion(">=7.0.0", "multipoint queries are not supported")]
 	public class GeoShapeMultiPointQueryUsageTests : GeoShapeQueryUsageTestsBase
 	{
 		public GeoShapeMultiPointQueryUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
@@ -604,6 +604,7 @@ namespace Tests.QueryDsl.Geo.Shape
 	 * == Querying with Circle
 	 *
 	 */
+	[SkipVersion(">=7.0.0", "CIRCLE geometry is not supported")]
 	public class GeoShapeCircleQueryUsageTests : GeoShapeQueryUsageTestsBase
 	{
 		public GeoShapeCircleQueryUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }

--- a/src/Tests/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTests.cs
@@ -119,7 +119,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new PointGeoShape(PointCoordinates),
 			Relation = GeoShapeRelation.Intersects,
 		};
@@ -130,7 +130,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -146,7 +146,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.Point(PointCoordinates)
 				)
@@ -175,7 +175,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new MultiPointGeoShape(MultiPointCoordinates),
 			Relation = GeoShapeRelation.Intersects,
 		};
@@ -186,7 +186,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -202,7 +202,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.MultiPoint(MultiPointCoordinates)
 				)
@@ -231,7 +231,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new LineStringGeoShape(LineStringCoordinates),
 			Relation = GeoShapeRelation.Intersects,
 		};
@@ -242,7 +242,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -258,7 +258,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.LineString(LineStringCoordinates)
 				)
@@ -287,7 +287,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new MultiLineStringGeoShape(MultiLineStringCoordinates),
 			Relation = GeoShapeRelation.Intersects,
 		};
@@ -298,7 +298,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -314,7 +314,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.MultiLineString(MultiLineStringCoordinates)
 				)
@@ -343,7 +343,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new PolygonGeoShape(PolygonCoordinates),
 			IgnoreUnmapped = true,
 			Relation = GeoShapeRelation.Intersects,
@@ -356,7 +356,7 @@ namespace Tests.QueryDsl.Geo.Shape
 				_name = "named_query",
 				boost = 1.1,
 				ignore_unmapped = true,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -372,7 +372,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.Polygon(PolygonCoordinates)
 				)
@@ -402,7 +402,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new MultiPolygonGeoShape(MultiPolygonCoordinates),
 			Relation = GeoShapeRelation.Intersects,
 		};
@@ -413,7 +413,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -429,7 +429,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.MultiPolygon(MultiPolygonCoordinates)
 				)
@@ -458,7 +458,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new GeometryCollection(new IGeoShape[]
 			{
 				new PointGeoShape(PointCoordinates),
@@ -477,7 +477,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -525,7 +525,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.GeometryCollection(
 						new PointGeoShape(PointCoordinates),
@@ -561,7 +561,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new EnvelopeGeoShape(EnvelopeCoordinates),
 			Relation = GeoShapeRelation.Intersects,
 		};
@@ -572,7 +572,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -588,7 +588,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.Envelope(EnvelopeCoordinates)
 				)
@@ -617,7 +617,7 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			Shape = new CircleGeoShape(CircleCoordinates, "100m"),
 			Relation = GeoShapeRelation.Intersects,
 		};
@@ -628,7 +628,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					relation = "intersects",
 					shape = new
@@ -645,7 +645,7 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.Shape(s => s
 					.Circle(CircleCoordinates, "100m")
 				)
@@ -681,12 +681,12 @@ namespace Tests.QueryDsl.Geo.Shape
 		{
 			Name = "named_query",
 			Boost = 1.1,
-			Field = Infer.Field<Project>(p => p.Location),
+			Field = Infer.Field<Project>(p => p.LocationShape),
 			IndexedShape = new FieldLookup
 			{
 				Id = Project.Instance.Name,
 				Index = Infer.Index<Project>(),
-				Path = Infer.Field<Project>(p => p.Location),
+				Path = Infer.Field<Project>(p => p.LocationShape),
 				Routing = Project.Instance.Name
 			},
 			Relation = GeoShapeRelation.Intersects
@@ -698,13 +698,13 @@ namespace Tests.QueryDsl.Geo.Shape
 			{
 				_name = "named_query",
 				boost = 1.1,
-				location = new
+				locationShape = new
 				{
 					indexed_shape = new
 					{
 						id = Project.Instance.Name,
 						index = "project",
-						path = "location",
+						path = "locationShape",
 						routing = Project.Instance.Name
 					},
 					relation = "intersects"
@@ -716,10 +716,10 @@ namespace Tests.QueryDsl.Geo.Shape
 			.GeoShape(c => c
 				.Name("named_query")
 				.Boost(1.1)
-				.Field(p => p.Location)
+				.Field(p => p.LocationShape)
 				.IndexedShape(p => p
 					.Id(Project.Instance.Name)
-					.Path(pp => pp.Location)
+					.Path(pp => pp.LocationShape)
 					.Routing(Project.Instance.Name)
 				)
 				.Relation(GeoShapeRelation.Intersects)

--- a/src/Tests/Tests/QueryDsl/QueryDslUsageTestsBase.cs
+++ b/src/Tests/Tests/QueryDsl/QueryDslUsageTestsBase.cs
@@ -5,6 +5,7 @@ using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Core.Client;
+using Tests.Core.Extensions;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
@@ -106,10 +107,7 @@ namespace Tests.QueryDsl
 
 		[I] protected async Task AssertQueryResponse() => await AssertOnAllResponses(r =>
 		{
-			var validOrNotParseExceptionOrKnownParseException = r.IsValid || r.ServerError?.Error.Type != "parsing_exception" || KnownParseException;
-			validOrNotParseExceptionOrKnownParseException.Should().BeTrue("query should be valid or when not valid not a parsing_exception.");
-
-			//TODO only assert IsValid == true and remove corner cases we don't have time to fix now.
+			r.ShouldBeValid();
 		});
 	}
 }

--- a/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs
@@ -28,8 +28,6 @@ namespace Tests.QueryDsl.Specialized.MoreLikeThis
 					new
 					{
 						_index = "project",
-						_id = Project.Instance.Name,
-						routing = Project.Instance.Name,
 						doc = Project.InstanceAnonymous
 					},
 					"some long text"

--- a/src/Tests/Tests/Search/Request/SortUsageTests.cs
+++ b/src/Tests/Tests/Search/Request/SortUsageTests.cs
@@ -59,7 +59,7 @@ namespace Tests.Search.Request
 					{
 						_geo_distance = new
 						{
-							location = new[]
+							locationPoint = new[]
 							{
 								new
 								{
@@ -120,7 +120,7 @@ namespace Tests.Search.Request
 					.Missing(-1)
 				)
 				.GeoDistance(g => g
-					.Field(p => p.Location)
+					.Field(p => p.LocationPoint)
 					.DistanceType(GeoDistanceType.Arc)
 					.Order(SortOrder.Ascending)
 					.Unit(DistanceUnit.Centimeters)
@@ -168,7 +168,7 @@ namespace Tests.Search.Request
 					},
 					new GeoDistanceSort
 					{
-						Field = "location",
+						Field = "locationPoint",
 						Order = SortOrder.Ascending,
 						DistanceType = GeoDistanceType.Arc,
 						Unit = DistanceUnit.Centimeters,
@@ -285,7 +285,7 @@ namespace Tests.Search.Request
 					{
 						_geo_distance = new
 						{
-							location = new[]
+							locationPoint = new[]
 							{
 								new { lat = 70.0, lon = -70.0 },
 								new { lat = -12.0, lon = 12.0 }
@@ -303,7 +303,7 @@ namespace Tests.Search.Request
 		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
 			.Sort(ss => ss
 				.GeoDistance(g => g
-					.Field(p => p.Location)
+					.Field(p => p.LocationPoint)
 					.IgnoreUnmapped()
 					.DistanceType(GeoDistanceType.Arc)
 					.Order(SortOrder.Ascending)
@@ -320,7 +320,7 @@ namespace Tests.Search.Request
 				{
 					new GeoDistanceSort
 					{
-						Field = "location",
+						Field = "locationPoint",
 						IgnoreUnmapped = true,
 						Order = SortOrder.Ascending,
 						DistanceType = GeoDistanceType.Arc,


### PR DESCRIPTION
This PR removes the lenient assertion within QueryDslUsagesTestsBase that allowed parsing exceptions in Elasticsearch to pass. This was a temporary solution whilst upgrading the client to work with Elasticsearch 7.x that must be removed before releasing to GA.

The remaining commits fix the remaining query usage tests that exhibited parsing tests. These were 

1. geo shape query tests, which are now run against a new `geo_shape` field mapping on `Project`. Automapping will now also map an `IGeoShape` property on a POCO as a `GeoShapeProperty` automatically.

2. more like this queries where the `_id` field was also being set when a document is provided for the `like` input.