### PR TITLE
Routing must be specified when doc used

### DIFF
--- a/src/Nest/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
+++ b/src/Nest/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
@@ -52,9 +52,6 @@ namespace Nest
 	/// <inheritdoc />
 	public abstract class LikeDocumentBase : ILikeDocument
 	{
-		[IgnoreDataMember]
-		private Routing _routing;
-
 		/// <inheritdoc />
 		public object Document { get; set; }
 
@@ -71,11 +68,7 @@ namespace Nest
 		public IPerFieldAnalyzer PerFieldAnalyzer { get; set; }
 
 		/// <inheritdoc />
-		public Routing Routing
-		{
-			get => _routing ?? (Document == null ? null : new Routing(Document));
-			set => _routing = value;
-		}
+		public Routing Routing { get; set; }
 	}
 
 	/// <inheritdoc cref="ILikeDocument" />
@@ -103,39 +96,33 @@ namespace Nest
 	{
 		public LikeDocumentDescriptor() => Self.Index = typeof(TDocument);
 
-		private Routing _routing;
-
 		object ILikeDocument.Document { get; set; }
 		Fields ILikeDocument.Fields { get; set; }
 		Id ILikeDocument.Id { get; set; }
 		IndexName ILikeDocument.Index { get; set; }
 		IPerFieldAnalyzer ILikeDocument.PerFieldAnalyzer { get; set; }
-		Routing ILikeDocument.Routing
-		{
-			get => _routing ?? (Self.Document == null ? null : new Routing(Self.Document));
-			set => _routing = value;
-		}
+		Routing ILikeDocument.Routing { get; set; }
 
-		/// <inheritdoc cref="ILikeDocument.Index"/>
+		/// <inheritdoc cref="ILikeDocument.Index" />
 		public LikeDocumentDescriptor<TDocument> Index(IndexName index) => Assign(index, (a, v) => a.Index = v);
 
-		/// <inheritdoc cref="ILikeDocument.Id"/>
+		/// <inheritdoc cref="ILikeDocument.Id" />
 		public LikeDocumentDescriptor<TDocument> Id(Id id) => Assign(id, (a, v) => a.Id = v);
 
-		/// <inheritdoc cref="ILikeDocument.Routing"/>
+		/// <inheritdoc cref="ILikeDocument.Routing" />
 		public LikeDocumentDescriptor<TDocument> Routing(Routing routing) => Assign(routing, (a, v) => a.Routing = v);
 
-		/// <inheritdoc cref="ILikeDocument.Fields"/>
+		/// <inheritdoc cref="ILikeDocument.Fields" />
 		public LikeDocumentDescriptor<TDocument> Fields(Func<FieldsDescriptor<TDocument>, IPromise<Fields>> fields) =>
 			Assign(fields, (a, v) => a.Fields = v?.Invoke(new FieldsDescriptor<TDocument>())?.Value);
 
-		/// <inheritdoc cref="ILikeDocument.Fields"/>
+		/// <inheritdoc cref="ILikeDocument.Fields" />
 		public LikeDocumentDescriptor<TDocument> Fields(Fields fields) => Assign(fields, (a, v) => a.Fields = v);
 
-		/// <inheritdoc cref="ILikeDocument.Document"/>
+		/// <inheritdoc cref="ILikeDocument.Document" />
 		public LikeDocumentDescriptor<TDocument> Document(TDocument document) => Assign(document, (a, v) => a.Document = v);
 
-		/// <inheritdoc cref="ILikeDocument.PerFieldAnalyzer"/> />
+		/// <inheritdoc cref="ILikeDocument.PerFieldAnalyzer" />
 		public LikeDocumentDescriptor<TDocument> PerFieldAnalyzer(
 			Func<PerFieldAnalyzerDescriptor<TDocument>, IPromise<IPerFieldAnalyzer>> analyzerSelector
 		) =>

--- a/src/Nest/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
+++ b/src/Nest/QueryDsl/Specialized/MoreLikeThis/Like/LikeDocument.cs
@@ -4,44 +4,73 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// An indexed or artificial document with which to find likeness
+	/// </summary>
 	[InterfaceDataContract]
 	[ReadAs(typeof(LikeDocument<object>))]
 	public interface ILikeDocument
 	{
+		/// <summary>
+		/// A document to find other documents like
+		/// </summary>
 		[DataMember(Name = "doc")]
 		[JsonFormatter(typeof(SourceFormatter<object>))]
 		object Document { get; set; }
 
+		/// <summary>
+		/// The fields to use for likeness
+		/// </summary>
 		[DataMember(Name = "fields")]
 		Fields Fields { get; set; }
 
+		/// <summary>
+		/// The id of an indexed document to find other documents like
+		/// </summary>
 		[DataMember(Name = "_id")]
 		Id Id { get; set; }
 
+		/// <summary>
+		/// The index of an indexed document to find other documents like
+		/// </summary>
 		[DataMember(Name = "_index")]
 		IndexName Index { get; set; }
 
+		/// <summary>
+		/// A different analyzer than the one defined for the target fields
+		/// </summary>
 		[DataMember(Name = "per_field_analyzer")]
 		IPerFieldAnalyzer PerFieldAnalyzer { get; set; }
 
+		/// <summary>
+		/// The routing value of an indexed document to find other documents like
+		/// </summary>
 		[DataMember(Name = "routing")]
 		Routing Routing { get; set; }
 	}
 
+	/// <inheritdoc />
 	public abstract class LikeDocumentBase : ILikeDocument
 	{
 		[IgnoreDataMember]
 		private Routing _routing;
 
+		/// <inheritdoc />
 		public object Document { get; set; }
 
+		/// <inheritdoc />
 		public Fields Fields { get; set; }
 
+		/// <inheritdoc />
 		public Id Id { get; set; }
+
+		/// <inheritdoc />
 		public IndexName Index { get; set; }
 
+		/// <inheritdoc />
 		public IPerFieldAnalyzer PerFieldAnalyzer { get; set; }
 
+		/// <inheritdoc />
 		public Routing Routing
 		{
 			get => _routing ?? (Document == null ? null : new Routing(Document));
@@ -49,6 +78,7 @@ namespace Nest
 		}
 	}
 
+	/// <inheritdoc cref="ILikeDocument" />
 	public class LikeDocument<TDocument> : LikeDocumentBase
 		where TDocument : class
 	{
@@ -67,38 +97,45 @@ namespace Nest
 		}
 	}
 
+	/// <inheritdoc cref="ILikeDocument" />
 	public class LikeDocumentDescriptor<TDocument> : DescriptorBase<LikeDocumentDescriptor<TDocument>, ILikeDocument>, ILikeDocument
 		where TDocument : class
 	{
-		private Routing _routing;
-
 		public LikeDocumentDescriptor() => Self.Index = typeof(TDocument);
+
+		private Routing _routing;
 
 		object ILikeDocument.Document { get; set; }
 		Fields ILikeDocument.Fields { get; set; }
 		Id ILikeDocument.Id { get; set; }
 		IndexName ILikeDocument.Index { get; set; }
 		IPerFieldAnalyzer ILikeDocument.PerFieldAnalyzer { get; set; }
-
 		Routing ILikeDocument.Routing
 		{
 			get => _routing ?? (Self.Document == null ? null : new Routing(Self.Document));
 			set => _routing = value;
 		}
 
+		/// <inheritdoc cref="ILikeDocument.Index"/>
 		public LikeDocumentDescriptor<TDocument> Index(IndexName index) => Assign(index, (a, v) => a.Index = v);
 
+		/// <inheritdoc cref="ILikeDocument.Id"/>
 		public LikeDocumentDescriptor<TDocument> Id(Id id) => Assign(id, (a, v) => a.Id = v);
 
+		/// <inheritdoc cref="ILikeDocument.Routing"/>
 		public LikeDocumentDescriptor<TDocument> Routing(Routing routing) => Assign(routing, (a, v) => a.Routing = v);
 
+		/// <inheritdoc cref="ILikeDocument.Fields"/>
 		public LikeDocumentDescriptor<TDocument> Fields(Func<FieldsDescriptor<TDocument>, IPromise<Fields>> fields) =>
 			Assign(fields, (a, v) => a.Fields = v?.Invoke(new FieldsDescriptor<TDocument>())?.Value);
 
+		/// <inheritdoc cref="ILikeDocument.Fields"/>
 		public LikeDocumentDescriptor<TDocument> Fields(Fields fields) => Assign(fields, (a, v) => a.Fields = v);
 
-		public LikeDocumentDescriptor<TDocument> Document(TDocument document) => Assign(document,  (a, v) => a.Document = v);
+		/// <inheritdoc cref="ILikeDocument.Document"/>
+		public LikeDocumentDescriptor<TDocument> Document(TDocument document) => Assign(document, (a, v) => a.Document = v);
 
+		/// <inheritdoc cref="ILikeDocument.PerFieldAnalyzer"/> />
 		public LikeDocumentDescriptor<TDocument> PerFieldAnalyzer(
 			Func<PerFieldAnalyzerDescriptor<TDocument>, IPromise<IPerFieldAnalyzer>> analyzerSelector
 		) =>

--- a/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs
@@ -28,7 +28,8 @@ namespace Tests.QueryDsl.Specialized.MoreLikeThis
 					new
 					{
 						_index = "project",
-						doc = Project.InstanceAnonymous
+						doc = Project.InstanceAnonymous,
+						routing = Project.Instance.Name
 					},
 					"some long text"
 				}

--- a/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs
@@ -14,7 +14,7 @@ namespace Tests.QueryDsl.Specialized.MoreLikeThis
 		{
 			Like = new List<Like>
 			{
-				new LikeDocument<Project>(Project.Instance),
+				new LikeDocument<Project>(Project.Instance) { Routing = Project.Instance.Name },
 				"some long text"
 			}
 		};
@@ -39,7 +39,10 @@ namespace Tests.QueryDsl.Specialized.MoreLikeThis
 		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
 			.MoreLikeThis(sn => sn
 				.Like(l => l
-					.Document(d => d.Document(Project.Instance))
+					.Document(d => d
+						.Document(Project.Instance)
+						.Routing(Project.Instance.Name)
+					)
 					.Text("some long text")
 				)
 			);


### PR DESCRIPTION
This commit updates the unit test for more like this query to ensure that routing
is set when an artificial document is specified.