### PR TITLE
User SecureString for Basic and Proxy passwords

### DIFF
--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Net.Security;
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
@@ -97,7 +98,7 @@ namespace Elasticsearch.Net
 		TimeSpan? KeepAliveTime { get; }
 
 		/// <summary>
-		/// The maximum ammount of time a node is allowed to marked dead
+		/// The maximum amount of time a node is allowed to marked dead
 		/// </summary>
 		TimeSpan? MaxDeadTimeout { get; }
 
@@ -158,7 +159,7 @@ namespace Elasticsearch.Net
 		/// <summary>
 		/// The password for the proxy, when configured
 		/// </summary>
-		string ProxyPassword { get; }
+		SecureString ProxyPassword { get; }
 
 		/// <summary>
 		/// The username for the proxy, when configured

--- a/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
@@ -257,6 +258,15 @@ namespace Elasticsearch.Net
 		}
 
 		public RequestConfigurationDescriptor BasicAuthentication(string userName, string password)
+		{
+			if (Self.BasicAuthenticationCredentials == null)
+				Self.BasicAuthenticationCredentials = new BasicAuthenticationCredentials();
+			Self.BasicAuthenticationCredentials.Username = userName;
+			Self.BasicAuthenticationCredentials.Password = password.CreateSecureString();
+			return this;
+		}
+
+		public RequestConfigurationDescriptor BasicAuthentication(string userName, SecureString password)
 		{
 			if (Self.BasicAuthenticationCredentials == null)
 				Self.BasicAuthenticationCredentials = new BasicAuthenticationCredentials();

--- a/src/Elasticsearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
+++ b/src/Elasticsearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
@@ -1,10 +1,36 @@
-﻿namespace Elasticsearch.Net
+﻿using System.Security;
+
+namespace Elasticsearch.Net
 {
+	/// <summary>
+	/// Credentials for Basic Authentication
+	/// </summary>
 	public class BasicAuthenticationCredentials
 	{
-		public string Password { get; set; }
-		public string Username { get; set; }
+		public BasicAuthenticationCredentials()
+		{
+		}
 
-		public override string ToString() => $"{Username}:{Password}";
+		public BasicAuthenticationCredentials(string username, string password)
+		{
+			Username = username;
+			Password = password.CreateSecureString();
+		}
+
+		public BasicAuthenticationCredentials(string username, SecureString password)
+		{
+			Username = username;
+			Password = password;
+		}
+
+		/// <summary>
+		/// The password with which to authenticate
+		/// </summary>
+		public SecureString Password { get; set; }
+
+		/// <summary>
+		/// The username with which to authenticate
+		/// </summary>
+		public string Username { get; set; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -253,7 +253,7 @@ namespace Elasticsearch.Net
 			if (!requestData.Uri.UserInfo.IsNullOrEmpty())
 				userInfo = Uri.UnescapeDataString(requestData.Uri.UserInfo);
 			else if (requestData.BasicAuthorizationCredentials != null)
-				userInfo = requestData.BasicAuthorizationCredentials.ToString();
+				userInfo = $"{requestData.BasicAuthorizationCredentials.Username}:{requestData.BasicAuthorizationCredentials.Password.CreateString()}";
 			if (!userInfo.IsNullOrEmpty())
 			{
 				var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes(userInfo));

--- a/src/Elasticsearch.Net/Connection/SecureStrings.cs
+++ b/src/Elasticsearch.Net/Connection/SecureStrings.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// Methods for working with <see cref="SecureString"/>
+	/// </summary>
+	public static class SecureStrings
+	{
+		/// <summary>
+		/// Creates a string from a secure string
+		/// </summary>
+		public static string CreateString(this SecureString secureString)
+		{
+			var num = IntPtr.Zero;
+			if (secureString != null && secureString.Length != 0)
+			{
+				try
+				{
+					num = Marshal.SecureStringToBSTR(secureString);
+					return Marshal.PtrToStringBSTR(num);
+				}
+				finally
+				{
+					if (num != IntPtr.Zero)
+						Marshal.ZeroFreeBSTR(num);
+				}
+			}
+
+			return string.Empty;
+		}
+
+		/// <summary>
+		/// Creates a secure string from a string
+		/// </summary>
+		public static SecureString CreateSecureString(this string plainString)
+		{
+			var secureString = new SecureString();
+
+			if (plainString == null)
+				return secureString;
+
+			foreach (var ch in plainString)
+				secureString.AppendChar(ch);
+
+			return secureString;
+		}
+	}
+}

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Elasticsearch.Net.Extensions;
 
@@ -105,7 +106,7 @@ namespace Elasticsearch.Net
 		public bool Pipelined { get; }
 		public PostData PostData { get; }
 		public string ProxyAddress { get; }
-		public string ProxyPassword { get; }
+		public SecureString ProxyPassword { get; }
 		public string ProxyUsername { get; }
 		public string RequestMimeType { get; }
 		public TimeSpan RequestTimeout { get; }

--- a/src/Tests/Tests/Cat/CatIndices/CatIndicesApiTests.cs
+++ b/src/Tests/Tests/Cat/CatIndices/CatIndicesApiTests.cs
@@ -48,11 +48,9 @@ namespace Tests.Cat.CatIndices
 		{
 			RequestConfiguration = new RequestConfiguration
 			{
-				BasicAuthenticationCredentials = new BasicAuthenticationCredentials
-				{
-					Username = ClusterAuthentication.User.Username,
-					Password = ClusterAuthentication.User.Password,
-				}
+				BasicAuthenticationCredentials = new BasicAuthenticationCredentials(
+					ClusterAuthentication.User.Username,
+					ClusterAuthentication.User.Password)
 			}
 		};
 

--- a/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -70,7 +70,7 @@ namespace Tests.ClientConcepts.Connection
 				.EnableHttpCompression(httpCompression);
 
 			if (proxyAddress != null)
-				connectionSettings.Proxy(proxyAddress, null, null);
+				connectionSettings.Proxy(proxyAddress, null, (string)null);
 
 			var requestData = new RequestData(HttpMethod.GET, "/", null, connectionSettings, new PingRequestParameters(),
 				new MemoryStreamFactory())

--- a/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
+++ b/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
@@ -163,11 +163,7 @@ namespace Tests.XPack.Security.ApiKey
 							},
 							RequestConfiguration = new RequestConfiguration
 							{
-								BasicAuthenticationCredentials = new BasicAuthenticationCredentials
-								{
-									Username = $"user-{v}",
-									Password = "password"
-								}
+								BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}", "password")
 							}
 						},
 						(v, d) => d
@@ -192,11 +188,7 @@ namespace Tests.XPack.Security.ApiKey
 							Expiration = "1d",
 							RequestConfiguration = new RequestConfiguration
 							{
-								BasicAuthenticationCredentials = new BasicAuthenticationCredentials
-								{
-									Username = $"user-{v}",
-									Password = "password"
-								}
+								BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}", "password")
 							}
 						},
 						(v, d) => d
@@ -218,11 +210,7 @@ namespace Tests.XPack.Security.ApiKey
 							Name = v,
 							RequestConfiguration = new RequestConfiguration
 							{
-								BasicAuthenticationCredentials = new BasicAuthenticationCredentials
-								{
-									Username = $"user-{v}",
-									Password = "password"
-								}
+								BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}", "password")
 							}
 						},
 						(v, d) => d
@@ -243,11 +231,7 @@ namespace Tests.XPack.Security.ApiKey
 							Name = v,
 							RequestConfiguration = new RequestConfiguration
 							{
-								BasicAuthenticationCredentials = new BasicAuthenticationCredentials
-								{
-									Username = $"user-{v}",
-									Password = "password"
-								}
+								BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}","password")
 							}
 						},
 						(v, d) => d

--- a/src/Tests/Tests/XPack/Security/Authenticate/AuthenticateApiTests.cs
+++ b/src/Tests/Tests/XPack/Security/Authenticate/AuthenticateApiTests.cs
@@ -51,11 +51,9 @@ namespace Tests.XPack.Security.Authenticate
 		{
 			RequestConfiguration = new RequestConfiguration
 			{
-				BasicAuthenticationCredentials = new BasicAuthenticationCredentials
-				{
-					Username = ClusterAuthentication.User.Username,
-					Password = ClusterAuthentication.User.Password
-				}
+				BasicAuthenticationCredentials = new BasicAuthenticationCredentials(
+					ClusterAuthentication.User.Username,
+					ClusterAuthentication.User.Password)
 			}
 		};
 

--- a/src/Tests/Tests/XPack/Security/Privileges/ApplicationPrivilegesApiTests.cs
+++ b/src/Tests/Tests/XPack/Security/Privileges/ApplicationPrivilegesApiTests.cs
@@ -93,10 +93,7 @@ namespace Tests.XPack.Security.Privileges
 					{
 						RequestConfiguration = new RequestConfiguration
 						{
-							BasicAuthenticationCredentials = new BasicAuthenticationCredentials
-							{
-								Username = $"user-{v}", Password = $"pass-{v}"
-							}
+							BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}", $"pass-{v}")
 						},
 						Application = new[]
 						{
@@ -130,10 +127,7 @@ namespace Tests.XPack.Security.Privileges
 					{
 						RequestConfiguration = new RequestConfiguration
 						{
-							BasicAuthenticationCredentials = new BasicAuthenticationCredentials
-							{
-								Username = $"user-{v}", Password = $"pass-{v}"
-							}
+							BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}", $"pass-{v}")
 						}
 					},
 					(v, d) => d.RequestConfiguration(r=>r.BasicAuthentication($"user-{v}", $"pass-{v}")),


### PR DESCRIPTION
This commit changes the BasicAuthenticationCredentials and ProxyPassword types
to use SecureString for holding the passwords in memory, as opposed to as a plain text string.

A plain text string is retrieved from SecureString only at the point at which it is required.
This prevents plain text passwords from being automatically emitted in cases where properties
may be enumerated and captured e.g. logging frameworks.

Closes #2505