### PR TITLE
Remove default TypeNames and TypeName from IClrTypeMapping

### DIFF
--- a/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ClrTypeDefaults.cs
@@ -26,11 +26,6 @@ namespace Nest
 		/// </summary>
 		string RelationName { get; set; }
 
-		/// <summary>
-		/// The default Elasticsearch type name for the given <see cref="ClrType" />
-		/// </summary>
-		string TypeName { get; set; }
-
 		/// <summary>Disables Id inference for the given <see cref="ClrType"/>.
 		/// By default, the _id value for a document is inferred from a property named Id,
 		/// or from the property named by <see cref="IdPropertyName"/>, if set.
@@ -72,9 +67,6 @@ namespace Nest
 		public string RelationName { get; set; }
 
 		/// <inheritdoc />
-		public string TypeName { get; set; }
-
-		/// <inheritdoc />
 		public bool DisableIdInference { get; set; }
 	}
 
@@ -106,14 +98,10 @@ namespace Nest
 		string IClrTypeMapping.IdPropertyName { get; set; }
 		string IClrTypeMapping.IndexName { get; set; }
 		string IClrTypeMapping.RelationName { get; set; }
-		string IClrTypeMapping.TypeName { get; set; }
 		bool IClrTypeMapping.DisableIdInference { get; set; }
 
 		/// <inheritdoc cref="IClrTypeMapping.IndexName"/>
 		public ClrTypeMappingDescriptor IndexName(string indexName) => Assign(indexName, (a, v) => a.IndexName = v);
-
-		/// <inheritdoc cref="IClrTypeMapping.TypeName"/>
-		public ClrTypeMappingDescriptor TypeName(string typeName) => Assign(typeName, (a, v) => a.TypeName = v);
 
 		/// <inheritdoc cref="IClrTypeMapping.RelationName"/>
 		public ClrTypeMappingDescriptor RelationName(string relationName) => Assign(relationName, (a, v) => a.RelationName = v);
@@ -136,18 +124,12 @@ namespace Nest
 		IList<IClrPropertyMapping<TDocument>> IClrTypeMapping<TDocument>.Properties { get; set; } = new List<IClrPropertyMapping<TDocument>>();
 		string IClrTypeMapping.RelationName { get; set; }
 		Expression<Func<TDocument, object>> IClrTypeMapping<TDocument>.RoutingProperty { get; set; }
-		string IClrTypeMapping.TypeName { get; set; }
 		bool IClrTypeMapping.DisableIdInference { get; set; }
 
 		/// <summary>
 		/// The default Elasticsearch index name for <typeparamref name="TDocument" />
 		/// </summary>
 		public ClrTypeMappingDescriptor<TDocument> IndexName(string indexName) => Assign(indexName, (a, v) => a.IndexName = v);
-
-		/// <summary>
-		/// The default Elasticsearch type name for <typeparamref name="TDocument" />
-		/// </summary>
-		public ClrTypeMappingDescriptor<TDocument> TypeName(string typeName) => Assign(typeName, (a, v) => a.TypeName = v);
 
 		/// <summary>
 		/// The relation name for <typeparamref name="TDocument" /> to resolve to.

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -56,8 +56,6 @@ namespace Nest
 
 		private readonly FluentDictionary<Type, string> _defaultRelationNames;
 
-		private readonly FluentDictionary<Type, string> _defaultTypeNames;
-
 		private readonly FluentDictionary<Type, string> _idProperties = new FluentDictionary<Type, string>();
 
 		private readonly Inferrer _inferrer;
@@ -94,7 +92,6 @@ namespace Nest
 
 			_defaultFieldNameInferrer = p => p.ToCamelCase();
 			_defaultIndices = new FluentDictionary<Type, string>();
-			_defaultTypeNames = new FluentDictionary<Type, string>();
 			_defaultRelationNames = new FluentDictionary<Type, string>();
 			_inferrer = new Inferrer(this);
 		}
@@ -216,9 +213,6 @@ namespace Nest
 			if (!inferMapping.IndexName.IsNullOrEmpty())
 				_defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
 
-			if (!inferMapping.TypeName.IsNullOrEmpty())
-				_defaultTypeNames.Add(inferMapping.ClrType, inferMapping.TypeName);
-
 			if (!inferMapping.RelationName.IsNullOrEmpty())
 				_defaultRelationNames.Add(inferMapping.ClrType, inferMapping.RelationName);
 
@@ -250,9 +244,6 @@ namespace Nest
 			if (!inferMapping.IndexName.IsNullOrEmpty())
 				_defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
 
-			if (!inferMapping.TypeName.IsNullOrEmpty())
-				_defaultTypeNames.Add(inferMapping.ClrType, inferMapping.TypeName);
-
 			if (!inferMapping.RelationName.IsNullOrEmpty())
 				_defaultRelationNames.Add(inferMapping.ClrType, inferMapping.RelationName);
 
@@ -271,9 +262,6 @@ namespace Nest
 			{
 				if (!inferMapping.IndexName.IsNullOrEmpty())
 					_defaultIndices.Add(inferMapping.ClrType, inferMapping.IndexName);
-
-				if (!inferMapping.TypeName.IsNullOrEmpty())
-					_defaultTypeNames.Add(inferMapping.ClrType, inferMapping.TypeName);
 
 				if (!inferMapping.RelationName.IsNullOrEmpty())
 					_defaultRelationNames.Add(inferMapping.ClrType, inferMapping.RelationName);

--- a/src/Tests/Tests.Domain/Extensions/ConnectionSettingsExtensions.cs
+++ b/src/Tests/Tests.Domain/Extensions/ConnectionSettingsExtensions.cs
@@ -11,12 +11,10 @@ namespace Tests.Domain.Extensions
 				.IndexName(TestValueHelper.ProjectsIndex)
 				.IdProperty(p => p.Name)
 				.RelationName("project")
-				.TypeName("doc")
 			)
 			.DefaultMappingFor<CommitActivity>(map => map
 				.IndexName(TestValueHelper.ProjectsIndex)
 				.RelationName("commits")
-				.TypeName("doc")
 			)
 			.DefaultMappingFor<Developer>(map => map
 				.IndexName("devs")
@@ -25,14 +23,12 @@ namespace Tests.Domain.Extensions
 			)
 			.DefaultMappingFor<ProjectPercolation>(map => map
 				.IndexName("queries")
-				.TypeName(TestValueHelper.PercolatorType)
 			)
 			.DefaultMappingFor<Metric>(map => map
 				.IndexName("server-metrics")
 			)
 			.DefaultMappingFor<Shape>(map => map
 				.IndexName("shapes")
-				.TypeName("doc")
 			);
 	}
 }

--- a/src/Tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
@@ -49,7 +49,6 @@ namespace Tests.ClientConcepts.Connection
 			var connectionSettings = new ConnectionSettings()
 				.DefaultMappingFor<Project>(i => i
 					.IndexName("my-projects")
-					.TypeName("project")
 				)
 				.EnableDebugMode()
 				.PrettyJson()

--- a/src/Tests/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs
@@ -39,12 +39,10 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			var settings = new ConnectionSettings()
 				.DefaultMappingFor<CommitActivity>(m => m
 					.IndexName("projects-and-commits")
-					.TypeName("doc")
 					.RelationName("commits")
 				)
 				.DefaultMappingFor<Project>(m => m
 					.IndexName("projects-and-commits")
-					.TypeName("doc")
 					.RelationName("projects")
 				);
 
@@ -67,7 +65,6 @@ namespace Tests.ClientConcepts.HighLevel.Inference
 			var settings = new ConnectionSettings()
 				.DefaultMappingFor<Project>(m => m
 					.IndexName("projects-and-commits")
-					.TypeName("doc")
 				);
 
 			var resolver = new RelationNameResolver(settings);

--- a/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs
@@ -161,7 +161,6 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 			var connectionSettings = new ConnectionSettings(new InMemoryConnection()) // <1> we're using an _in memory_ connection for this example. In your production application though, you'll want to use an `IConnection` that actually sends a request.
 				.DisableDirectStreaming() // <2> we disable direct streaming here to capture the request and response bytes. In your production application however, you'll likely not want to do this, since it causes the request and response bytes to be buffered in memory.
 				.DefaultMappingFor<ParentWithStringId>(m => m
-					.TypeName("parent")
 					.Ignore(p => p.Description)
 					.Ignore(p => p.IgnoreMe)
 				);

--- a/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
@@ -77,9 +77,9 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 		{
 			var connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 			var connectionSettings = new ConnectionSettings(connectionPool, new InMemoryConnection()) // <1> for the purposes of this example, an in memory connection is used which doesn't actually send a request. In your application, you'd use the default connection or your own implementation that actually sends a request.
-				.DefaultMappingFor<MyDocument>(m => m.IndexName("index").TypeName("doc"))
-				.DefaultMappingFor<MyChild>(m => m.IndexName("index").TypeName("doc"))
-				.DefaultMappingFor<MyParent>(m => m.IndexName("index").TypeName("doc").RelationName("parent"));
+				.DefaultMappingFor<MyDocument>(m => m.IndexName("index"))
+				.DefaultMappingFor<MyChild>(m => m.IndexName("index"))
+				.DefaultMappingFor<MyParent>(m => m.IndexName("index").RelationName("parent"));
 
 			var client = new ElasticClient(connectionSettings);
 


### PR DESCRIPTION
This commit removes the defaultTypeNames mappings on ConnectionSettings as they
are no longer used.

The TypeName on IClrTypeMapping is also removed as it too is no longer used.