### PR TITLE
Add overloads of SerializeToString and SerializeToBytes

### DIFF
--- a/src/Elasticsearch.Net/Serialization/ElasticsearchSerializerExtensions.cs
+++ b/src/Elasticsearch.Net/Serialization/ElasticsearchSerializerExtensions.cs
@@ -8,7 +8,13 @@ namespace Elasticsearch.Net
 		public static byte[] SerializeToBytes<T>(
 			this IElasticsearchSerializer serializer,
 			T data,
-			IMemoryStreamFactory memoryStreamFactory = null,
+			SerializationFormatting formatting = SerializationFormatting.Indented) =>
+			SerializeToBytes(serializer, data, RecyclableMemoryStreamFactory.Default, formatting);
+
+		public static byte[] SerializeToBytes<T>(
+			this IElasticsearchSerializer serializer,
+			T data,
+			IMemoryStreamFactory memoryStreamFactory,
 			SerializationFormatting formatting = SerializationFormatting.Indented
 		)
 		{
@@ -23,7 +29,13 @@ namespace Elasticsearch.Net
 		public static string SerializeToString<T>(
 			this IElasticsearchSerializer serializer,
 			T data,
-			IMemoryStreamFactory memoryStreamFactory = null,
+			SerializationFormatting formatting = SerializationFormatting.Indented) =>
+			SerializeToString(serializer, data, RecyclableMemoryStreamFactory.Default, formatting);
+
+		public static string SerializeToString<T>(
+			this IElasticsearchSerializer serializer,
+			T data,
+			IMemoryStreamFactory memoryStreamFactory,
 			SerializationFormatting formatting = SerializationFormatting.Indented
 		)
 		{
@@ -34,7 +46,5 @@ namespace Elasticsearch.Net
 				return ms.Utf8String();
 			}
 		}
-
-
 	}
 }


### PR DESCRIPTION
This commit adds method overloads of SerializeToString and SerializeToBytes
that accept an IMemoryStreamFactory as a non-optional parameter, and reinstates
methods that do not take an IMemoryStreamFactory. This will make upgrading from
6.x to 7.x easier for those that make use of SerializeToString.

Closes #3771