### PR TITLE
Invert document generation so it is not run by default.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 build_script:
-    - cmd: build.bat canary skipdocs
+    - cmd: build.bat canary
 
 nuget:
     disable_publish_on_pr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-  - script: ./build.sh test-one skipdocs
+  - script: ./build.sh test-one
     displayName: 'build and unit test'
   - task: PublishTestResults@2
     inputs:
@@ -15,7 +15,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - script: build.bat canary skipdocs
+  - script: build.bat canary
     displayName: 'build and unit test'
   - task: PublishTestResults@2
     inputs:
@@ -37,7 +37,7 @@ jobs:
       latest7:
         esVersion: 'latest-7'
   steps:
-      - script: 'build.bat integrate-one $(esVersion) "readonly,writable,bool,xpack" skipdocs'
+      - script: 'build.bat integrate-one $(esVersion) "readonly,writable,bool,xpack"'
         displayName: '$(esVersion) windows integration tests'
       - task: PublishTestResults@2
         condition: succeededOrFailed()
@@ -56,7 +56,7 @@ jobs:
           latest7:
               esVersion: 'latest-7'
   steps:
-      - script: './build.sh integrate-one $(esVersion) "readonly,writable" skipdocs'
+      - script: './build.sh integrate-one $(esVersion) "readonly,writable"'
         displayName: '$(esVersion) linux integration tests'
       - task: PublishTestResults@2
         condition: succeededOrFailed()

--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -41,7 +41,7 @@ NOTE: both the `test` and `integrate` targets can be suffixed with `-all` to for
 
 Execution hints can be provided anywhere on the command line
 - skiptests : skip running tests as part of the target chain
-- skipdocs : skip generating documentation
+- gendocs : generate documentation
 - non-interactive : make targets that run in interactive mode by default to run unassisted.
 - docs:<B> : the branch name B to use when generating documentation
 - seed:<N> : provide a seed to run the tests with.
@@ -91,7 +91,7 @@ Execution hints can be provided anywhere on the command line
     type PassedArguments = {
         NonInteractive: bool;
         SkipTests: bool;
-        SkipDocs: bool;
+        GenDocs: bool;
         Seed: string;
         RandomArguments: string list;
         DocsBranch: string;
@@ -119,7 +119,7 @@ Execution hints can be provided anywhere on the command line
             args
             |> List.filter(fun x -> 
                x <> "skiptests" && 
-               x <> "skipdocs" && 
+               x <> "gendocs" && 
                x <> "non-interactive" && 
                not (x.StartsWith("seed:")) && 
                not (x.StartsWith("random:")) && 
@@ -133,7 +133,7 @@ Execution hints can be provided anywhere on the command line
         let parsed = {
             NonInteractive = args |> List.exists (fun x -> x = "non-interactive")
             SkipTests = skipTests
-            SkipDocs = args |> List.exists (fun x -> x = "skipdocs") || isMono
+            GenDocs = args |> List.exists (fun x -> x = "gendocs") && isMono = false
             Seed = 
                 match args |> List.tryFind (fun x -> x.StartsWith("seed:")) with
                 | Some t -> t.Replace("seed:", "")

--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -133,7 +133,7 @@ Execution hints can be provided anywhere on the command line
         let parsed = {
             NonInteractive = args |> List.exists (fun x -> x = "non-interactive")
             SkipTests = skipTests
-            GenDocs = args |> List.exists (fun x -> x = "gendocs") && isMono = false
+            GenDocs = (args |> List.exists (fun x -> x = "gendocs") || target = "build") && not isMono 
             Seed = 
                 match args |> List.tryFind (fun x -> x.StartsWith("seed:")) with
                 | Some t -> t.Replace("seed:", "")

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -55,7 +55,7 @@ module Main =
 
         conditional (not isMono) "internalize-dependencies" <| fun _ -> ShadowDependencies.ShadowDependencies artifactsVersion 
 
-        conditional (not parsed.SkipDocs) "documentation" <| fun _ -> Documentation.Generate parsed
+        conditional (parsed.GenDocs) "documentation" <| fun _ -> Documentation.Generate parsed
 
         conditional (not parsed.SkipTests) "test" <| fun _ -> Tests.RunUnitTests parsed |> ignore
         


### PR DESCRIPTION
To generate documentation include the "gendocs" argument in the build command line, e.g.

`build.bat gendocs`

Fixes #3674