### PR TITLE
Refine generated documentation comments

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
@@ -18,7 +18,7 @@ namespace ApiGenerator.Configuration.Overrides
 
 		public override IDictionary<string, string> ObsoleteQueryStringParams { get; set; } = new Dictionary<string, string>
 		{
-			{ "parent", "the parent parameter has been deprecated from elasticsearch, please use routing instead directly." },
+			{ "parent", "the parent parameter has been deprecated from Elasticsearch, please use routing instead directly." },
 			{ "copy_settings", "Elasticsearch 6.4 will throw an exception if this is turned off see elastic/elasticsearch#30404" }
 		};
 

--- a/src/CodeGeneration/ApiGenerator/Extensions.cs
+++ b/src/CodeGeneration/ApiGenerator/Extensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using CsQuery.ExtensionMethods.Internal;
 
@@ -38,5 +39,8 @@ namespace ApiGenerator
 
 			return pascal[0].ToLower() + pascal.Substring(1);
 		}
+
+		public static string SplitPascalCase(this string s) =>
+			Regex.Replace(s, "([a-z](?=[A-Z]|[0-9])|[A-Z](?=[A-Z][a-z]|[0-9])|[0-9](?=[^0-9]))", "$1 ");
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Extensions.cs
+++ b/src/CodeGeneration/ApiGenerator/Extensions.cs
@@ -41,6 +41,6 @@ namespace ApiGenerator
 		}
 
 		public static string SplitPascalCase(this string s) =>
-			Regex.Replace(s, "([a-z](?=[A-Z]|[0-9])|[A-Z](?=[A-Z][a-z]|[0-9])|[0-9](?=[^0-9]))", "$1 ");
+			Regex.Replace(s, "([A-Z]+[a-z]*)", " $1").Trim();
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.Namespace.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.Namespace.cshtml
@@ -1,5 +1,6 @@
 @using RazorLight
 @using System.Linq
+@using ApiGenerator
 @using ApiGenerator.Domain
 @using System
 @using System.Collections.Generic
@@ -24,8 +25,8 @@ using Elasticsearch.Net.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamesp
 namespace Nest.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamespaceSuffix)
 {
 	///<summary>
-	/// Logically groups all <c>@ns</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref="IElasticClient.@ns"/> property
+	/// @(ns.SplitPascalCase()) APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref="IElasticClient.@ns"/> property
 	/// on <see cref="IElasticClient"/>.
 	///</para>
 	///</summary>

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.cshtml
@@ -26,14 +26,14 @@ using Nest;
 namespace Nest
 {
 	///<summary>
-	///Raw operations with elasticsearch
+	///Elasticsearch high level client
 	///</summary>
 	public partial class ElasticClient : IElasticClient
 	{
 </text>
 	foreach (var ns in namespaces)
 	{
-<text>		///<summary> This property logically groups all <c>@ns</c> API's together.</summary>
+<text>		///<summary>@(ns.SplitPascalCase()) APIs</summary>
 			public @CsharpNames.HighLevelClientNamespacePrefix@(ns)@CsharpNames.ClientNamespaceSuffix @ns { get; private set; }
 </text>
 	}

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Interface/IElasticClient.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Interface/IElasticClient.cshtml
@@ -1,5 +1,6 @@
 @using RazorLight
 @using System.Linq
+@using ApiGenerator
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
@@ -16,7 +17,7 @@ using Nest;
 namespace Nest
 {
 	///<summary>
-	///Raw operations with elasticsearch
+	///Elasticsearch high level client 
 	///</summary>
 	public partial interface IElasticClient 
 	{
@@ -24,7 +25,7 @@ namespace Nest
 		{
 		if (kv.Key != CsharpNames.RootNamespace)
 		{
-<text>		///<summary> This property logically groups all <c>@kv.Key</c> API's together.</summary>
+<text>		///<summary>@(kv.Key.SplitPascalCase()) APIs</summary>
 			@CsharpNames.HighLevelClientNamespacePrefix@(kv.Key)@CsharpNames.ClientNamespaceSuffix @kv.Key { get; }
 </text>
 			continue;

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/MethodXmlDocs.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/MethodXmlDocs.cshtml
@@ -8,6 +8,6 @@
 }
 /// <summary>
 /// @Raw(syntax.XmlDocSummary)
-/// @Raw("<para> </para>")
+/// @Raw("<para></para>")
 /// <a href="@syntax.DocumentationLink">@syntax.DocumentationLink</a>
 /// </summary>

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
@@ -15,7 +15,7 @@
 	var baseInterface = names.GenericOrNonGenericInterfacePreference;
 	var apiLookup = $"ApiUrlsLookups.{d.CsharpNames.Namespace}{d.CsharpNames.MethodName}";
 }
-	///<summary>descriptor for @names.MethodName <pre>@d.OfficialDocumentationLink</pre></summary>
+	///<summary>descriptor for @names.MethodName <para>@d.OfficialDocumentationLink</para></summary>
 	public partial class @Raw(type) @(Raw(string.Format(" : RequestDescriptorBase<{0},{1}, {2}>, {2}", type,names.ParametersName, concreteInterface)))
 	{ 
 		internal override ApiUrls ApiUrls => @apiLookup;

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
@@ -12,7 +12,7 @@
 	CsharpNames names = r.CsharpNames;
 	var apiLookup = $"ApiUrlsLookups.{r.CsharpNames.Namespace}{r.CsharpNames.MethodName}";
 }
-	///<summary>Request for @names.MethodName <pre>@r.OfficialDocumentationLink</pre></summary>
+	///<summary>Request for @names.MethodName <para>@r.OfficialDocumentationLink</para></summary>
 	public partial class @Raw(r.Name) @Raw(string.Format(": PlainRequestBase<{0}>, {1}", names.ParametersName, r.InterfaceName))
 	{
 		protected @(Raw(r.InterfaceName)) Self => this;

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.Namespace.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.Namespace.cshtml
@@ -35,8 +35,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamespaceSuffix)
 {
 	///<summary>
-	/// Logically groups all @ns API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref="IElasticLowLevelClient.@ns"/> property
+	/// @(ns.SplitPascalCase()) APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref="IElasticLowLevelClient.@ns"/> property
 	/// on <see cref="IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.cshtml
@@ -31,7 +31,7 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net
 {
 	///<summary>
-	///Raw operations with elasticsearch
+	///Elasticsearch low level client
 	///</summary>
 	public partial class ElasticLowLevelClient : IElasticLowLevelClient
 	{

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Interface/IElasticLowLevelClient.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Interface/IElasticLowLevelClient.cshtml
@@ -1,5 +1,6 @@
 @using RazorLight
 @using System.Linq
+@using ApiGenerator
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
@@ -18,7 +19,7 @@ using Elasticsearch.Net;
 namespace Elasticsearch.Net
 {
 	///<summary>
-	///Raw operations with elasticsearch
+	///Elasticsearch low level client
 	///</summary>
 	public partial interface IElasticLowLevelClient 
 	{
@@ -26,7 +27,9 @@ namespace Elasticsearch.Net
 		{
 		if (kv.Key != CsharpNames.RootNamespace)
 		{
-<text>		@CsharpNames.LowLevelClientNamespacePrefix@(kv.Key)@CsharpNames.ClientNamespaceSuffix @kv.Key { get; }
+<text>
+			///<summary>@(kv.Key.SplitPascalCase()) APIs</summary>
+		    @CsharpNames.LowLevelClientNamespacePrefix@(kv.Key)@CsharpNames.ClientNamespaceSuffix @kv.Key { get; }
 </text>
 			continue;
 		}

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
@@ -28,7 +28,7 @@ namespace Elasticsearch.Net@(ns)
 		var r = endpoint.RequestParameterImplementation;
 		var names = r.CsharpNames;
 <text>
-	///<summary>Request options for @names.MethodName<pre>@r.OfficialDocumentationLink</pre></summary>
+	///<summary>Request options for @names.MethodName <para>@r.OfficialDocumentationLink</para></summary>
 	public class @names.ParametersName : RequestParameters<@names.ParametersName> 
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.@r.HttpMethod;

--- a/src/Elasticsearch.Net/Api/RequestParameters/IRequestParameters.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/IRequestParameters.cs
@@ -35,7 +35,7 @@ namespace Elasticsearch.Net
 		TOut GetQueryStringValue<TOut>(string name);
 
 		/// <summary>
-		/// Gets the stringified representation of a query string value as it would be sent to elasticsearch.
+		/// Gets the stringified representation of a query string value as it would be sent to Elasticsearch.
 		/// </summary>
 		string GetResolvedQueryStringValue(string n, IConnectionConfigurationValues s);
 	}

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.CatApi
 {
-	///<summary>Request options for Aliases<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</pre></summary>
+	///<summary>Request options for Aliases <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</para></summary>
 	public class CatAliasesRequestParameters : RequestParameters<CatAliasesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -78,7 +78,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Allocation<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</pre></summary>
+	///<summary>Request options for Allocation <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</para></summary>
 	public class CatAllocationRequestParameters : RequestParameters<CatAllocationRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -139,7 +139,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Count<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</pre></summary>
+	///<summary>Request options for Count <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</para></summary>
 	public class CatCountRequestParameters : RequestParameters<CatCountRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -193,7 +193,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Fielddata<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</pre></summary>
+	///<summary>Request options for Fielddata <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para></summary>
 	public class CatFielddataRequestParameters : RequestParameters<CatFielddataRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -261,7 +261,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Health<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</pre></summary>
+	///<summary>Request options for Health <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</para></summary>
 	public class CatHealthRequestParameters : RequestParameters<CatHealthRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -322,7 +322,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Help<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</pre></summary>
+	///<summary>Request options for Help <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</para></summary>
 	public class CatHelpRequestParameters : RequestParameters<CatHelpRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -341,7 +341,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Indices<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</pre></summary>
+	///<summary>Request options for Indices <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</para></summary>
 	public class CatIndicesRequestParameters : RequestParameters<CatIndicesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -416,7 +416,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Master<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</pre></summary>
+	///<summary>Request options for Master <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</para></summary>
 	public class CatMasterRequestParameters : RequestParameters<CatMasterRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -470,7 +470,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for NodeAttributes<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</pre></summary>
+	///<summary>Request options for NodeAttributes <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</para></summary>
 	public class CatNodeAttributesRequestParameters : RequestParameters<CatNodeAttributesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -524,7 +524,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Nodes<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</pre></summary>
+	///<summary>Request options for Nodes <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</para></summary>
 	public class CatNodesRequestParameters : RequestParameters<CatNodesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -585,7 +585,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for PendingTasks<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</pre></summary>
+	///<summary>Request options for PendingTasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</para></summary>
 	public class CatPendingTasksRequestParameters : RequestParameters<CatPendingTasksRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -639,7 +639,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Plugins<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</pre></summary>
+	///<summary>Request options for Plugins <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para></summary>
 	public class CatPluginsRequestParameters : RequestParameters<CatPluginsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -693,7 +693,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Recovery<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</pre></summary>
+	///<summary>Request options for Recovery <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</para></summary>
 	public class CatRecoveryRequestParameters : RequestParameters<CatRecoveryRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -747,7 +747,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Repositories<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</pre></summary>
+	///<summary>Request options for Repositories <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</para></summary>
 	public class CatRepositoriesRequestParameters : RequestParameters<CatRepositoriesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -801,7 +801,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Segments<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</pre></summary>
+	///<summary>Request options for Segments <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para></summary>
 	public class CatSegmentsRequestParameters : RequestParameters<CatSegmentsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -848,7 +848,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Shards<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</pre></summary>
+	///<summary>Request options for Shards <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</para></summary>
 	public class CatShardsRequestParameters : RequestParameters<CatShardsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -909,7 +909,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Snapshots<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</pre></summary>
+	///<summary>Request options for Snapshots <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</para></summary>
 	public class CatSnapshotsRequestParameters : RequestParameters<CatSnapshotsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -963,7 +963,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Tasks<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>Request options for Tasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public class CatTasksRequestParameters : RequestParameters<CatTasksRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -1034,7 +1034,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for Templates<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</pre></summary>
+	///<summary>Request options for Templates <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</para></summary>
 	public class CatTemplatesRequestParameters : RequestParameters<CatTemplatesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -1088,7 +1088,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 		}
 	}
 
-	///<summary>Request options for ThreadPool<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</pre></summary>
+	///<summary>Request options for ThreadPool <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para></summary>
 	public class CatThreadPoolRequestParameters : RequestParameters<CatThreadPoolRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.ClusterApi
 {
-	///<summary>Request options for AllocationExplain<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</pre></summary>
+	///<summary>Request options for AllocationExplain <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</para></summary>
 	public class ClusterAllocationExplainRequestParameters : RequestParameters<ClusterAllocationExplainRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -43,7 +43,7 @@ namespace Elasticsearch.Net.Specification.ClusterApi
 		}
 	}
 
-	///<summary>Request options for GetSettings<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</pre></summary>
+	///<summary>Request options for GetSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</para></summary>
 	public class ClusterGetSettingsRequestParameters : RequestParameters<ClusterGetSettingsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -76,7 +76,7 @@ namespace Elasticsearch.Net.Specification.ClusterApi
 		}
 	}
 
-	///<summary>Request options for Health<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</pre></summary>
+	///<summary>Request options for Health <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</para></summary>
 	public class ClusterHealthRequestParameters : RequestParameters<ClusterHealthRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -151,7 +151,7 @@ namespace Elasticsearch.Net.Specification.ClusterApi
 		}
 	}
 
-	///<summary>Request options for PendingTasks<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</pre></summary>
+	///<summary>Request options for PendingTasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</para></summary>
 	public class ClusterPendingTasksRequestParameters : RequestParameters<ClusterPendingTasksRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -170,7 +170,7 @@ namespace Elasticsearch.Net.Specification.ClusterApi
 		}
 	}
 
-	///<summary>Request options for PutSettings<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</pre></summary>
+	///<summary>Request options for PutSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</para></summary>
 	public class ClusterPutSettingsRequestParameters : RequestParameters<ClusterPutSettingsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -196,13 +196,13 @@ namespace Elasticsearch.Net.Specification.ClusterApi
 		}
 	}
 
-	///<summary>Request options for RemoteInfo<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</pre></summary>
+	///<summary>Request options for RemoteInfo <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</para></summary>
 	public class RemoteInfoRequestParameters : RequestParameters<RemoteInfoRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for Reroute<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</pre></summary>
+	///<summary>Request options for Reroute <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</para></summary>
 	public class ClusterRerouteRequestParameters : RequestParameters<ClusterRerouteRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -249,7 +249,7 @@ namespace Elasticsearch.Net.Specification.ClusterApi
 		}
 	}
 
-	///<summary>Request options for State<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</pre></summary>
+	///<summary>Request options for State <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</para></summary>
 	public class ClusterStateRequestParameters : RequestParameters<ClusterStateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -313,7 +313,7 @@ namespace Elasticsearch.Net.Specification.ClusterApi
 		}
 	}
 
-	///<summary>Request options for Stats<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</pre></summary>
+	///<summary>Request options for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</para></summary>
 	public class ClusterStatsRequestParameters : RequestParameters<ClusterStatsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.CrossClusterReplication.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.CrossClusterReplication.cs
@@ -24,13 +24,13 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.CrossClusterReplicationApi
 {
-	///<summary>Request options for DeleteAutoFollowPattern<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</pre></summary>
+	///<summary>Request options for DeleteAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</para></summary>
 	public class DeleteAutoFollowPatternRequestParameters : RequestParameters<DeleteAutoFollowPatternRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for CreateFollowIndex<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</pre></summary>
+	///<summary>Request options for CreateFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</para></summary>
 	public class CreateFollowIndexRequestParameters : RequestParameters<CreateFollowIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -45,43 +45,43 @@ namespace Elasticsearch.Net.Specification.CrossClusterReplicationApi
 		}
 	}
 
-	///<summary>Request options for FollowIndexStats<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</pre></summary>
+	///<summary>Request options for FollowIndexStats <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</para></summary>
 	public class FollowIndexStatsRequestParameters : RequestParameters<FollowIndexStatsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetAutoFollowPattern<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</pre></summary>
+	///<summary>Request options for GetAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</para></summary>
 	public class GetAutoFollowPatternRequestParameters : RequestParameters<GetAutoFollowPatternRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for PauseFollowIndex<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</pre></summary>
+	///<summary>Request options for PauseFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</para></summary>
 	public class PauseFollowIndexRequestParameters : RequestParameters<PauseFollowIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for CreateAutoFollowPattern<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</pre></summary>
+	///<summary>Request options for CreateAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</para></summary>
 	public class CreateAutoFollowPatternRequestParameters : RequestParameters<CreateAutoFollowPatternRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for ResumeFollowIndex<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</pre></summary>
+	///<summary>Request options for ResumeFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</para></summary>
 	public class ResumeFollowIndexRequestParameters : RequestParameters<ResumeFollowIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for Stats<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</pre></summary>
+	///<summary>Request options for Stats <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</para></summary>
 	public class CcrStatsRequestParameters : RequestParameters<CcrStatsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for UnfollowIndex<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current</pre></summary>
+	///<summary>Request options for UnfollowIndex <para>http://www.elastic.co/guide/en/elasticsearch/reference/current</para></summary>
 	public class UnfollowIndexRequestParameters : RequestParameters<UnfollowIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Graph.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Graph.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.GraphApi
 {
-	///<summary>Request options for Explore<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</pre></summary>
+	///<summary>Request options for Explore <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</para></summary>
 	public class GraphExploreRequestParameters : RequestParameters<GraphExploreRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.IndexLifecycleManagement.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.IndexLifecycleManagement.cs
@@ -24,61 +24,61 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.IndexLifecycleManagementApi
 {
-	///<summary>Request options for DeleteLifecycle<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</pre></summary>
+	///<summary>Request options for DeleteLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</para></summary>
 	public class DeleteLifecycleRequestParameters : RequestParameters<DeleteLifecycleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for ExplainLifecycle<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</pre></summary>
+	///<summary>Request options for ExplainLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</para></summary>
 	public class ExplainLifecycleRequestParameters : RequestParameters<ExplainLifecycleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetLifecycle<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</pre></summary>
+	///<summary>Request options for GetLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</para></summary>
 	public class GetLifecycleRequestParameters : RequestParameters<GetLifecycleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetStatus<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</pre></summary>
+	///<summary>Request options for GetStatus <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</para></summary>
 	public class GetIlmStatusRequestParameters : RequestParameters<GetIlmStatusRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for MoveToStep<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</pre></summary>
+	///<summary>Request options for MoveToStep <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</para></summary>
 	public class MoveToStepRequestParameters : RequestParameters<MoveToStepRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for PutLifecycle<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</pre></summary>
+	///<summary>Request options for PutLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</para></summary>
 	public class PutLifecycleRequestParameters : RequestParameters<PutLifecycleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for RemovePolicy<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</pre></summary>
+	///<summary>Request options for RemovePolicy <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</para></summary>
 	public class RemovePolicyRequestParameters : RequestParameters<RemovePolicyRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for Retry<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</pre></summary>
+	///<summary>Request options for Retry <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</para></summary>
 	public class RetryIlmRequestParameters : RequestParameters<RetryIlmRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for Start<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</pre></summary>
+	///<summary>Request options for Start <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</para></summary>
 	public class StartIlmRequestParameters : RequestParameters<StartIlmRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for Stop<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</pre></summary>
+	///<summary>Request options for Stop <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</para></summary>
 	public class StopIlmRequestParameters : RequestParameters<StopIlmRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.IndicesApi
 {
-	///<summary>Request options for Analyze<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</pre></summary>
+	///<summary>Request options for Analyze <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</para></summary>
 	public class AnalyzeRequestParameters : RequestParameters<AnalyzeRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -36,7 +36,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for ClearCache<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</pre></summary>
+	///<summary>Request options for ClearCache <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</para></summary>
 	public class ClearCacheRequestParameters : RequestParameters<ClearCacheRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -100,7 +100,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Close<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</pre></summary>
+	///<summary>Request options for Close <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 	public class CloseIndexRequestParameters : RequestParameters<CloseIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -143,7 +143,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Create<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</pre></summary>
+	///<summary>Request options for Create <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</para></summary>
 	public class CreateIndexRequestParameters : RequestParameters<CreateIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -176,7 +176,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Delete<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</pre></summary>
+	///<summary>Request options for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</para></summary>
 	public class DeleteIndexRequestParameters : RequestParameters<DeleteIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -216,7 +216,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for DeleteAlias<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request options for DeleteAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public class DeleteAliasRequestParameters : RequestParameters<DeleteAliasRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -235,7 +235,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for DeleteTemplate<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>Request options for DeleteTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public class DeleteIndexTemplateRequestParameters : RequestParameters<DeleteIndexTemplateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -254,7 +254,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Exists<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</pre></summary>
+	///<summary>Request options for Exists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</para></summary>
 	public class IndexExistsRequestParameters : RequestParameters<IndexExistsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
@@ -301,7 +301,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for AliasExists<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request options for AliasExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public class AliasExistsRequestParameters : RequestParameters<AliasExistsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
@@ -337,7 +337,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for TemplateExists<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>Request options for TemplateExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public class IndexTemplateExistsRequestParameters : RequestParameters<IndexTemplateExistsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
@@ -363,7 +363,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for TypeExists<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</pre></summary>
+	///<summary>Request options for TypeExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</para></summary>
 	public class TypeExistsRequestParameters : RequestParameters<TypeExistsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
@@ -399,7 +399,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Flush<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</pre></summary>
+	///<summary>Request options for Flush <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para></summary>
 	public class FlushRequestParameters : RequestParameters<FlushRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -448,7 +448,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for SyncedFlush<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</pre></summary>
+	///<summary>Request options for SyncedFlush <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para></summary>
 	public class SyncedFlushRequestParameters : RequestParameters<SyncedFlushRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -477,7 +477,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for ForceMerge<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</pre></summary>
+	///<summary>Request options for ForceMerge <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</para></summary>
 	public class ForceMergeRequestParameters : RequestParameters<ForceMergeRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -527,7 +527,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Get<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</pre></summary>
+	///<summary>Request options for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</para></summary>
 	public class GetIndexRequestParameters : RequestParameters<GetIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -588,7 +588,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for GetAlias<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request options for GetAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public class GetAliasRequestParameters : RequestParameters<GetAliasRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -624,7 +624,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for GetFieldMapping<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</pre></summary>
+	///<summary>Request options for GetFieldMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</para></summary>
 	public class GetFieldMappingRequestParameters : RequestParameters<GetFieldMappingRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -674,7 +674,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for GetMapping<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</pre></summary>
+	///<summary>Request options for GetMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</para></summary>
 	public class GetMappingRequestParameters : RequestParameters<GetMappingRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -724,7 +724,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for GetSettings<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</pre></summary>
+	///<summary>Request options for GetSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</para></summary>
 	public class GetIndexSettingsRequestParameters : RequestParameters<GetIndexSettingsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -781,7 +781,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for GetTemplate<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>Request options for GetTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public class GetIndexTemplateRequestParameters : RequestParameters<GetIndexTemplateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -814,7 +814,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for UpgradeStatus<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</pre></summary>
+	///<summary>Request options for UpgradeStatus <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para></summary>
 	public class UpgradeStatusRequestParameters : RequestParameters<UpgradeStatusRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -843,7 +843,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Open<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</pre></summary>
+	///<summary>Request options for Open <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 	public class OpenIndexRequestParameters : RequestParameters<OpenIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -893,7 +893,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for PutAlias<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request options for PutAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public class PutAliasRequestParameters : RequestParameters<PutAliasRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -912,7 +912,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for PutMapping<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</pre></summary>
+	///<summary>Request options for PutMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</para></summary>
 	public class PutMappingRequestParameters : RequestParameters<PutMappingRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -962,7 +962,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for UpdateSettings<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</pre></summary>
+	///<summary>Request options for UpdateSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</para></summary>
 	public class UpdateIndexSettingsRequestParameters : RequestParameters<UpdateIndexSettingsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -1019,7 +1019,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for PutTemplate<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>Request options for PutTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public class PutIndexTemplateRequestParameters : RequestParameters<PutIndexTemplateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -1059,7 +1059,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for RecoveryStatus<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</pre></summary>
+	///<summary>Request options for RecoveryStatus <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para></summary>
 	public class RecoveryStatusRequestParameters : RequestParameters<RecoveryStatusRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -1078,7 +1078,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Refresh<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</pre></summary>
+	///<summary>Request options for Refresh <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</para></summary>
 	public class RefreshRequestParameters : RequestParameters<RefreshRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1107,7 +1107,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Rollover<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</pre></summary>
+	///<summary>Request options for Rollover <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</para></summary>
 	public class RolloverIndexRequestParameters : RequestParameters<RolloverIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1147,7 +1147,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Segments<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</pre></summary>
+	///<summary>Request options for Segments <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</para></summary>
 	public class SegmentsRequestParameters : RequestParameters<SegmentsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -1183,7 +1183,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for ShardStores<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</pre></summary>
+	///<summary>Request options for ShardStores <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</para></summary>
 	public class IndicesShardStoresRequestParameters : RequestParameters<IndicesShardStoresRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -1219,7 +1219,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Shrink<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</pre></summary>
+	///<summary>Request options for Shrink <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</para></summary>
 	public class ShrinkIndexRequestParameters : RequestParameters<ShrinkIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -1245,7 +1245,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Split<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</pre></summary>
+	///<summary>Request options for Split <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</para></summary>
 	public class SplitIndexRequestParameters : RequestParameters<SplitIndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -1271,7 +1271,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Stats<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</pre></summary>
+	///<summary>Request options for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</para></summary>
 	public class IndicesStatsRequestParameters : RequestParameters<IndicesStatsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -1318,7 +1318,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for BulkAlias<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request options for BulkAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public class BulkAliasRequestParameters : RequestParameters<BulkAliasRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1337,7 +1337,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for Upgrade<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</pre></summary>
+	///<summary>Request options for Upgrade <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para></summary>
 	public class UpgradeRequestParameters : RequestParameters<UpgradeRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1380,7 +1380,7 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
-	///<summary>Request options for ValidateQuery<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</pre></summary>
+	///<summary>Request options for ValidateQuery <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</para></summary>
 	public class ValidateQueryRequestParameters : RequestParameters<ValidateQueryRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Ingest.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Ingest.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.IngestApi
 {
-	///<summary>Request options for DeletePipeline<pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request options for DeletePipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public class DeletePipelineRequestParameters : RequestParameters<DeletePipelineRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -43,7 +43,7 @@ namespace Elasticsearch.Net.Specification.IngestApi
 		}
 	}
 
-	///<summary>Request options for GetPipeline<pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request options for GetPipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public class GetPipelineRequestParameters : RequestParameters<GetPipelineRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -55,13 +55,13 @@ namespace Elasticsearch.Net.Specification.IngestApi
 		}
 	}
 
-	///<summary>Request options for GrokProcessorPatterns<pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request options for GrokProcessorPatterns <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public class GrokProcessorPatternsRequestParameters : RequestParameters<GrokProcessorPatternsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for PutPipeline<pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request options for PutPipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public class PutPipelineRequestParameters : RequestParameters<PutPipelineRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -80,7 +80,7 @@ namespace Elasticsearch.Net.Specification.IngestApi
 		}
 	}
 
-	///<summary>Request options for SimulatePipeline<pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request options for SimulatePipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public class SimulatePipelineRequestParameters : RequestParameters<SimulatePipelineRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.License.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.License.cs
@@ -24,13 +24,13 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.LicenseApi
 {
-	///<summary>Request options for Delete<pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request options for Delete <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public class DeleteLicenseRequestParameters : RequestParameters<DeleteLicenseRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for Get<pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request options for Get <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public class GetLicenseRequestParameters : RequestParameters<GetLicenseRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -42,19 +42,19 @@ namespace Elasticsearch.Net.Specification.LicenseApi
 		}
 	}
 
-	///<summary>Request options for GetBasicStatus<pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request options for GetBasicStatus <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public class GetBasicLicenseStatusRequestParameters : RequestParameters<GetBasicLicenseStatusRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetTrialStatus<pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request options for GetTrialStatus <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public class GetTrialLicenseStatusRequestParameters : RequestParameters<GetTrialLicenseStatusRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for Post<pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request options for Post <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public class PostLicenseRequestParameters : RequestParameters<PostLicenseRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -66,7 +66,7 @@ namespace Elasticsearch.Net.Specification.LicenseApi
 		}
 	}
 
-	///<summary>Request options for StartBasic<pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request options for StartBasic <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public class StartBasicLicenseRequestParameters : RequestParameters<StartBasicLicenseRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -78,7 +78,7 @@ namespace Elasticsearch.Net.Specification.LicenseApi
 		}
 	}
 
-	///<summary>Request options for StartTrial<pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request options for StartTrial <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public class StartTrialLicenseRequestParameters : RequestParameters<StartTrialLicenseRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.MachineLearning.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.MachineLearning.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.MachineLearningApi
 {
-	///<summary>Request options for CloseJob<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</pre></summary>
+	///<summary>Request options for CloseJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</para></summary>
 	public class CloseJobRequestParameters : RequestParameters<CloseJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -50,25 +50,25 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for DeleteCalendar<pre></pre></summary>
+	///<summary>Request options for DeleteCalendar <para></para></summary>
 	public class DeleteCalendarRequestParameters : RequestParameters<DeleteCalendarRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for DeleteCalendarEvent<pre></pre></summary>
+	///<summary>Request options for DeleteCalendarEvent <para></para></summary>
 	public class DeleteCalendarEventRequestParameters : RequestParameters<DeleteCalendarEventRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for DeleteCalendarJob<pre></pre></summary>
+	///<summary>Request options for DeleteCalendarJob <para></para></summary>
 	public class DeleteCalendarJobRequestParameters : RequestParameters<DeleteCalendarJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for DeleteDatafeed<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</pre></summary>
+	///<summary>Request options for DeleteDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</para></summary>
 	public class DeleteDatafeedRequestParameters : RequestParameters<DeleteDatafeedRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -80,19 +80,19 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for DeleteExpiredData<pre></pre></summary>
+	///<summary>Request options for DeleteExpiredData <para></para></summary>
 	public class DeleteExpiredDataRequestParameters : RequestParameters<DeleteExpiredDataRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for DeleteFilter<pre></pre></summary>
+	///<summary>Request options for DeleteFilter <para></para></summary>
 	public class DeleteFilterRequestParameters : RequestParameters<DeleteFilterRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for DeleteForecast<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</pre></summary>
+	///<summary>Request options for DeleteForecast <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</para></summary>
 	public class DeleteForecastRequestParameters : RequestParameters<DeleteForecastRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -111,7 +111,7 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for DeleteJob<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</pre></summary>
+	///<summary>Request options for DeleteJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</para></summary>
 	public class DeleteJobRequestParameters : RequestParameters<DeleteJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -130,13 +130,13 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for DeleteModelSnapshot<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</pre></summary>
+	///<summary>Request options for DeleteModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</para></summary>
 	public class DeleteModelSnapshotRequestParameters : RequestParameters<DeleteModelSnapshotRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for FlushJob<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</pre></summary>
+	///<summary>Request options for FlushJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</para></summary>
 	public class FlushJobRequestParameters : RequestParameters<FlushJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -148,19 +148,19 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for ForecastJob<pre></pre></summary>
+	///<summary>Request options for ForecastJob <para></para></summary>
 	public class ForecastJobRequestParameters : RequestParameters<ForecastJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for GetBuckets<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</pre></summary>
+	///<summary>Request options for GetBuckets <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</para></summary>
 	public class GetBucketsRequestParameters : RequestParameters<GetBucketsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for GetCalendarEvents<pre></pre></summary>
+	///<summary>Request options for GetCalendarEvents <para></para></summary>
 	public class GetCalendarEventsRequestParameters : RequestParameters<GetCalendarEventsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -186,19 +186,19 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for GetCalendars<pre></pre></summary>
+	///<summary>Request options for GetCalendars <para></para></summary>
 	public class GetCalendarsRequestParameters : RequestParameters<GetCalendarsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for GetCategories<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</pre></summary>
+	///<summary>Request options for GetCategories <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</para></summary>
 	public class GetCategoriesRequestParameters : RequestParameters<GetCategoriesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for GetDatafeedStats<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</pre></summary>
+	///<summary>Request options for GetDatafeedStats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</para></summary>
 	public class GetDatafeedStatsRequestParameters : RequestParameters<GetDatafeedStatsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -210,7 +210,7 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for GetDatafeeds<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</pre></summary>
+	///<summary>Request options for GetDatafeeds <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</para></summary>
 	public class GetDatafeedsRequestParameters : RequestParameters<GetDatafeedsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -222,7 +222,7 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for GetFilters<pre></pre></summary>
+	///<summary>Request options for GetFilters <para></para></summary>
 	public class GetFiltersRequestParameters : RequestParameters<GetFiltersRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -241,13 +241,13 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for GetInfluencers<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</pre></summary>
+	///<summary>Request options for GetInfluencers <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</para></summary>
 	public class GetInfluencersRequestParameters : RequestParameters<GetInfluencersRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for GetJobStats<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</pre></summary>
+	///<summary>Request options for GetJobStats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</para></summary>
 	public class GetJobStatsRequestParameters : RequestParameters<GetJobStatsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -259,7 +259,7 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for GetJobs<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</pre></summary>
+	///<summary>Request options for GetJobs <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</para></summary>
 	public class GetJobsRequestParameters : RequestParameters<GetJobsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -271,43 +271,43 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for GetModelSnapshots<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</pre></summary>
+	///<summary>Request options for GetModelSnapshots <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</para></summary>
 	public class GetModelSnapshotsRequestParameters : RequestParameters<GetModelSnapshotsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for GetOverallBuckets<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</pre></summary>
+	///<summary>Request options for GetOverallBuckets <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</para></summary>
 	public class GetOverallBucketsRequestParameters : RequestParameters<GetOverallBucketsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for GetAnomalyRecords<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</pre></summary>
+	///<summary>Request options for GetAnomalyRecords <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</para></summary>
 	public class GetAnomalyRecordsRequestParameters : RequestParameters<GetAnomalyRecordsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for Info<pre></pre></summary>
+	///<summary>Request options for Info <para></para></summary>
 	public class MachineLearningInfoRequestParameters : RequestParameters<MachineLearningInfoRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for OpenJob<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</pre></summary>
+	///<summary>Request options for OpenJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</para></summary>
 	public class OpenJobRequestParameters : RequestParameters<OpenJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for PostCalendarEvents<pre></pre></summary>
+	///<summary>Request options for PostCalendarEvents <para></para></summary>
 	public class PostCalendarEventsRequestParameters : RequestParameters<PostCalendarEventsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for PostJobData<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</pre></summary>
+	///<summary>Request options for PostJobData <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</para></summary>
 	public class PostJobDataRequestParameters : RequestParameters<PostJobDataRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -326,55 +326,55 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for PreviewDatafeed<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</pre></summary>
+	///<summary>Request options for PreviewDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
 	public class PreviewDatafeedRequestParameters : RequestParameters<PreviewDatafeedRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for PutCalendar<pre></pre></summary>
+	///<summary>Request options for PutCalendar <para></para></summary>
 	public class PutCalendarRequestParameters : RequestParameters<PutCalendarRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for PutCalendarJob<pre></pre></summary>
+	///<summary>Request options for PutCalendarJob <para></para></summary>
 	public class PutCalendarJobRequestParameters : RequestParameters<PutCalendarJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for PutDatafeed<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</pre></summary>
+	///<summary>Request options for PutDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</para></summary>
 	public class PutDatafeedRequestParameters : RequestParameters<PutDatafeedRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for PutFilter<pre></pre></summary>
+	///<summary>Request options for PutFilter <para></para></summary>
 	public class PutFilterRequestParameters : RequestParameters<PutFilterRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for PutJob<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</pre></summary>
+	///<summary>Request options for PutJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</para></summary>
 	public class PutJobRequestParameters : RequestParameters<PutJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for RevertModelSnapshot<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</pre></summary>
+	///<summary>Request options for RevertModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</para></summary>
 	public class RevertModelSnapshotRequestParameters : RequestParameters<RevertModelSnapshotRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for StartDatafeed<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</pre></summary>
+	///<summary>Request options for StartDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</para></summary>
 	public class StartDatafeedRequestParameters : RequestParameters<StartDatafeedRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for StopDatafeed<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</pre></summary>
+	///<summary>Request options for StopDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</para></summary>
 	public class StopDatafeedRequestParameters : RequestParameters<StopDatafeedRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -386,37 +386,37 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		}
 	}
 
-	///<summary>Request options for UpdateDatafeed<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</pre></summary>
+	///<summary>Request options for UpdateDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</para></summary>
 	public class UpdateDatafeedRequestParameters : RequestParameters<UpdateDatafeedRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for UpdateFilter<pre></pre></summary>
+	///<summary>Request options for UpdateFilter <para></para></summary>
 	public class UpdateFilterRequestParameters : RequestParameters<UpdateFilterRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for UpdateJob<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</pre></summary>
+	///<summary>Request options for UpdateJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</para></summary>
 	public class UpdateJobRequestParameters : RequestParameters<UpdateJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for UpdateModelSnapshot<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</pre></summary>
+	///<summary>Request options for UpdateModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</para></summary>
 	public class UpdateModelSnapshotRequestParameters : RequestParameters<UpdateModelSnapshotRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for ValidateJob<pre></pre></summary>
+	///<summary>Request options for ValidateJob <para></para></summary>
 	public class ValidateJobRequestParameters : RequestParameters<ValidateJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for ValidateDetector<pre></pre></summary>
+	///<summary>Request options for ValidateDetector <para></para></summary>
 	public class ValidateDetectorRequestParameters : RequestParameters<ValidateDetectorRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Migration.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Migration.cs
@@ -24,13 +24,13 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.MigrationApi
 {
-	///<summary>Request options for DeprecationInfo<pre>http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</pre></summary>
+	///<summary>Request options for DeprecationInfo <para>http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</para></summary>
 	public class DeprecationInfoRequestParameters : RequestParameters<DeprecationInfoRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for Assistance<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</pre></summary>
+	///<summary>Request options for Assistance <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</para></summary>
 	public class MigrationAssistanceRequestParameters : RequestParameters<MigrationAssistanceRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -59,7 +59,7 @@ namespace Elasticsearch.Net.Specification.MigrationApi
 		}
 	}
 
-	///<summary>Request options for Upgrade<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</pre></summary>
+	///<summary>Request options for Upgrade <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</para></summary>
 	public class MigrationUpgradeRequestParameters : RequestParameters<MigrationUpgradeRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net
 {
-	///<summary>Request options for Bulk<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</pre></summary>
+	///<summary>Request options for Bulk <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</para></summary>
 	public class BulkRequestParameters : RequestParameters<BulkRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -99,13 +99,13 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for ClearScroll<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</pre></summary>
+	///<summary>Request options for ClearScroll <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</para></summary>
 	public class ClearScrollRequestParameters : RequestParameters<ClearScrollRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for Count<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</pre></summary>
+	///<summary>Request options for Count <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</para></summary>
 	public class CountRequestParameters : RequestParameters<CountRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -211,7 +211,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Create<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</pre></summary>
+	///<summary>Request options for Create <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 	public class CreateRequestParameters : RequestParameters<CreateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -272,7 +272,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Delete<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</pre></summary>
+	///<summary>Request options for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</para></summary>
 	public class DeleteRequestParameters : RequestParameters<DeleteRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -340,7 +340,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for DeleteByQuery<pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</pre></summary>
+	///<summary>Request options for DeleteByQuery <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</para></summary>
 	public class DeleteByQueryRequestParameters : RequestParameters<DeleteByQueryRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -576,7 +576,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for DeleteByQueryRethrottle<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</pre></summary>
+	///<summary>Request options for DeleteByQueryRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</para></summary>
 	public class DeleteByQueryRethrottleRequestParameters : RequestParameters<DeleteByQueryRethrottleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -588,7 +588,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for DeleteScript<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>Request options for DeleteScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public class DeleteScriptRequestParameters : RequestParameters<DeleteScriptRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -607,7 +607,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for DocumentExists<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>Request options for DocumentExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public class DocumentExistsRequestParameters : RequestParameters<DocumentExistsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
@@ -682,7 +682,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for SourceExists<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>Request options for SourceExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public class SourceExistsRequestParameters : RequestParameters<SourceExistsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
@@ -750,7 +750,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Explain<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</pre></summary>
+	///<summary>Request options for Explain <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</para></summary>
 	public class ExplainRequestParameters : RequestParameters<ExplainRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -839,7 +839,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for FieldCapabilities<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</pre></summary>
+	///<summary>Request options for FieldCapabilities <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</para></summary>
 	public class FieldCapabilitiesRequestParameters : RequestParameters<FieldCapabilitiesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -875,7 +875,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Get<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>Request options for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public class GetRequestParameters : RequestParameters<GetRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -950,7 +950,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for GetScript<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>Request options for GetScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public class GetScriptRequestParameters : RequestParameters<GetScriptRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -962,7 +962,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Source<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>Request options for Source <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public class SourceRequestParameters : RequestParameters<SourceRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -1030,7 +1030,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Index<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</pre></summary>
+	///<summary>Request options for Index <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 	public class IndexRequestParameters : RequestParameters<IndexRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1112,13 +1112,13 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for RootNodeInfo<pre>http://www.elastic.co/guide/</pre></summary>
+	///<summary>Request options for RootNodeInfo <para>http://www.elastic.co/guide/</para></summary>
 	public class RootNodeInfoRequestParameters : RequestParameters<RootNodeInfoRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for MultiGet<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</pre></summary>
+	///<summary>Request options for MultiGet <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</para></summary>
 	public class MultiGetRequestParameters : RequestParameters<MultiGetRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1179,7 +1179,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for MultiSearch<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</pre></summary>
+	///<summary>Request options for MultiSearch <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</para></summary>
 	public class MultiSearchRequestParameters : RequestParameters<MultiSearchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1241,7 +1241,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for MultiSearchTemplate<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</pre></summary>
+	///<summary>Request options for MultiSearchTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</para></summary>
 	public class MultiSearchTemplateRequestParameters : RequestParameters<MultiSearchTemplateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1281,7 +1281,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for MultiTermVectors<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</pre></summary>
+	///<summary>Request options for MultiTermVectors <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</para></summary>
 	public class MultiTermVectorsRequestParameters : RequestParameters<MultiTermVectorsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1372,13 +1372,13 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Ping<pre>http://www.elastic.co/guide/</pre></summary>
+	///<summary>Request options for Ping <para>http://www.elastic.co/guide/</para></summary>
 	public class PingRequestParameters : RequestParameters<PingRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.HEAD;
 	}
 
-	///<summary>Request options for PutScript<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>Request options for PutScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public class PutScriptRequestParameters : RequestParameters<PutScriptRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -1404,7 +1404,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for ReindexOnServer<pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</pre></summary>
+	///<summary>Request options for ReindexOnServer <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</para></summary>
 	public class ReindexOnServerRequestParameters : RequestParameters<ReindexOnServerRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1462,7 +1462,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for ReindexRethrottle<pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</pre></summary>
+	///<summary>Request options for ReindexRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</para></summary>
 	public class ReindexRethrottleRequestParameters : RequestParameters<ReindexRethrottleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1474,19 +1474,19 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for RenderSearchTemplate<pre>http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</pre></summary>
+	///<summary>Request options for RenderSearchTemplate <para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para></summary>
 	public class RenderSearchTemplateRequestParameters : RequestParameters<RenderSearchTemplateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for ExecutePainlessScript<pre>https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</pre></summary>
+	///<summary>Request options for ExecutePainlessScript <para>https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</para></summary>
 	public class ExecutePainlessScriptRequestParameters : RequestParameters<ExecutePainlessScriptRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for Scroll<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</pre></summary>
+	///<summary>Request options for Scroll <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</para></summary>
 	public class ScrollRequestParameters : RequestParameters<ScrollRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1498,7 +1498,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Search<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</pre></summary>
+	///<summary>Request options for Search <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</para></summary>
 	public class SearchRequestParameters : RequestParameters<SearchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1727,7 +1727,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for SearchShards<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</pre></summary>
+	///<summary>Request options for SearchShards <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para></summary>
 	public class SearchShardsRequestParameters : RequestParameters<SearchShardsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1777,7 +1777,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for SearchTemplate<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</pre></summary>
+	///<summary>Request options for SearchTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para></summary>
 	public class SearchTemplateRequestParameters : RequestParameters<SearchTemplateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1876,7 +1876,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for TermVectors<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</pre></summary>
+	///<summary>Request options for TermVectors <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</para></summary>
 	public class TermVectorsRequestParameters : RequestParameters<TermVectorsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -1958,7 +1958,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for Update<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</pre></summary>
+	///<summary>Request options for Update <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</para></summary>
 	public class UpdateRequestParameters : RequestParameters<UpdateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -2033,7 +2033,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for UpdateByQuery<pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</pre></summary>
+	///<summary>Request options for UpdateByQuery <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</para></summary>
 	public class UpdateByQueryRequestParameters : RequestParameters<UpdateByQueryRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -2283,7 +2283,7 @@ namespace Elasticsearch.Net
 		}
 	}
 
-	///<summary>Request options for UpdateByQueryRethrottle<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</pre></summary>
+	///<summary>Request options for UpdateByQueryRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</para></summary>
 	public class UpdateByQueryRethrottleRequestParameters : RequestParameters<UpdateByQueryRethrottleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Nodes.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Nodes.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.NodesApi
 {
-	///<summary>Request options for HotThreads<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</pre></summary>
+	///<summary>Request options for HotThreads <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</para></summary>
 	public class NodesHotThreadsRequestParameters : RequestParameters<NodesHotThreadsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -71,7 +71,7 @@ namespace Elasticsearch.Net.Specification.NodesApi
 		}
 	}
 
-	///<summary>Request options for Info<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</pre></summary>
+	///<summary>Request options for Info <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</para></summary>
 	public class NodesInfoRequestParameters : RequestParameters<NodesInfoRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -90,7 +90,7 @@ namespace Elasticsearch.Net.Specification.NodesApi
 		}
 	}
 
-	///<summary>Request options for ReloadSecureSettings<pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</pre></summary>
+	///<summary>Request options for ReloadSecureSettings <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</para></summary>
 	public class ReloadSecureSettingsRequestParameters : RequestParameters<ReloadSecureSettingsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -102,7 +102,7 @@ namespace Elasticsearch.Net.Specification.NodesApi
 		}
 	}
 
-	///<summary>Request options for Stats<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</pre></summary>
+	///<summary>Request options for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</para></summary>
 	public class NodesStatsRequestParameters : RequestParameters<NodesStatsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -163,7 +163,7 @@ namespace Elasticsearch.Net.Specification.NodesApi
 		}
 	}
 
-	///<summary>Request options for Usage<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</pre></summary>
+	///<summary>Request options for Usage <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</para></summary>
 	public class NodesUsageRequestParameters : RequestParameters<NodesUsageRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Rollup.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Rollup.cs
@@ -24,37 +24,37 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.RollupApi
 {
-	///<summary>Request options for DeleteJob<pre></pre></summary>
+	///<summary>Request options for DeleteJob <para></para></summary>
 	public class DeleteRollupJobRequestParameters : RequestParameters<DeleteRollupJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for GetJob<pre></pre></summary>
+	///<summary>Request options for GetJob <para></para></summary>
 	public class GetRollupJobRequestParameters : RequestParameters<GetRollupJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetCapabilities<pre></pre></summary>
+	///<summary>Request options for GetCapabilities <para></para></summary>
 	public class GetRollupCapabilitiesRequestParameters : RequestParameters<GetRollupCapabilitiesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetIndexCapabilities<pre></pre></summary>
+	///<summary>Request options for GetIndexCapabilities <para></para></summary>
 	public class GetRollupIndexCapabilitiesRequestParameters : RequestParameters<GetRollupIndexCapabilitiesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for CreateJob<pre></pre></summary>
+	///<summary>Request options for CreateJob <para></para></summary>
 	public class CreateRollupJobRequestParameters : RequestParameters<CreateRollupJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for Search<pre></pre></summary>
+	///<summary>Request options for Search <para></para></summary>
 	public class RollupSearchRequestParameters : RequestParameters<RollupSearchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -73,13 +73,13 @@ namespace Elasticsearch.Net.Specification.RollupApi
 		}
 	}
 
-	///<summary>Request options for StartJob<pre></pre></summary>
+	///<summary>Request options for StartJob <para></para></summary>
 	public class StartRollupJobRequestParameters : RequestParameters<StartRollupJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for StopJob<pre></pre></summary>
+	///<summary>Request options for StopJob <para></para></summary>
 	public class StopRollupJobRequestParameters : RequestParameters<StopRollupJobRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Security.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Security.cs
@@ -24,13 +24,13 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.SecurityApi
 {
-	///<summary>Request options for Authenticate<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</pre></summary>
+	///<summary>Request options for Authenticate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</para></summary>
 	public class AuthenticateRequestParameters : RequestParameters<AuthenticateRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for ChangePassword<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</pre></summary>
+	///<summary>Request options for ChangePassword <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</para></summary>
 	public class ChangePasswordRequestParameters : RequestParameters<ChangePasswordRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -45,7 +45,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for ClearCachedRealms<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</pre></summary>
+	///<summary>Request options for ClearCachedRealms <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</para></summary>
 	public class ClearCachedRealmsRequestParameters : RequestParameters<ClearCachedRealmsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -57,13 +57,13 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for ClearCachedRoles<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</pre></summary>
+	///<summary>Request options for ClearCachedRoles <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</para></summary>
 	public class ClearCachedRolesRequestParameters : RequestParameters<ClearCachedRolesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for CreateApiKey<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</pre></summary>
+	///<summary>Request options for CreateApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</para></summary>
 	public class CreateApiKeyRequestParameters : RequestParameters<CreateApiKeyRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -78,7 +78,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for DeletePrivileges<pre>TODO</pre></summary>
+	///<summary>Request options for DeletePrivileges <para>TODO</para></summary>
 	public class DeletePrivilegesRequestParameters : RequestParameters<DeletePrivilegesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -93,7 +93,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for DeleteRole<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</pre></summary>
+	///<summary>Request options for DeleteRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</para></summary>
 	public class DeleteRoleRequestParameters : RequestParameters<DeleteRoleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -108,7 +108,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for DeleteRoleMapping<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</pre></summary>
+	///<summary>Request options for DeleteRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</para></summary>
 	public class DeleteRoleMappingRequestParameters : RequestParameters<DeleteRoleMappingRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -123,7 +123,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for DeleteUser<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</pre></summary>
+	///<summary>Request options for DeleteUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</para></summary>
 	public class DeleteUserRequestParameters : RequestParameters<DeleteUserRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -138,7 +138,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for DisableUser<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</pre></summary>
+	///<summary>Request options for DisableUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</para></summary>
 	public class DisableUserRequestParameters : RequestParameters<DisableUserRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -153,7 +153,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for EnableUser<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</pre></summary>
+	///<summary>Request options for EnableUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</para></summary>
 	public class EnableUserRequestParameters : RequestParameters<EnableUserRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -168,7 +168,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for GetApiKey<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</pre></summary>
+	///<summary>Request options for GetApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</para></summary>
 	public class GetApiKeyRequestParameters : RequestParameters<GetApiKeyRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -201,61 +201,61 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for GetPrivileges<pre>TODO</pre></summary>
+	///<summary>Request options for GetPrivileges <para>TODO</para></summary>
 	public class GetPrivilegesRequestParameters : RequestParameters<GetPrivilegesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetRole<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</pre></summary>
+	///<summary>Request options for GetRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</para></summary>
 	public class GetRoleRequestParameters : RequestParameters<GetRoleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetRoleMapping<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</pre></summary>
+	///<summary>Request options for GetRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</para></summary>
 	public class GetRoleMappingRequestParameters : RequestParameters<GetRoleMappingRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetUserAccessToken<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</pre></summary>
+	///<summary>Request options for GetUserAccessToken <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</para></summary>
 	public class GetUserAccessTokenRequestParameters : RequestParameters<GetUserAccessTokenRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for GetUser<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</pre></summary>
+	///<summary>Request options for GetUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</para></summary>
 	public class GetUserRequestParameters : RequestParameters<GetUserRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for GetUserPrivileges<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</pre></summary>
+	///<summary>Request options for GetUserPrivileges <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</para></summary>
 	public class GetUserPrivilegesRequestParameters : RequestParameters<GetUserPrivilegesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for HasPrivileges<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</pre></summary>
+	///<summary>Request options for HasPrivileges <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</para></summary>
 	public class HasPrivilegesRequestParameters : RequestParameters<HasPrivilegesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for InvalidateApiKey<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</pre></summary>
+	///<summary>Request options for InvalidateApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</para></summary>
 	public class InvalidateApiKeyRequestParameters : RequestParameters<InvalidateApiKeyRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for InvalidateUserAccessToken<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</pre></summary>
+	///<summary>Request options for InvalidateUserAccessToken <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</para></summary>
 	public class InvalidateUserAccessTokenRequestParameters : RequestParameters<InvalidateUserAccessTokenRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for PutPrivileges<pre>TODO</pre></summary>
+	///<summary>Request options for PutPrivileges <para>TODO</para></summary>
 	public class PutPrivilegesRequestParameters : RequestParameters<PutPrivilegesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -270,7 +270,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for PutRole<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</pre></summary>
+	///<summary>Request options for PutRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</para></summary>
 	public class PutRoleRequestParameters : RequestParameters<PutRoleRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -285,7 +285,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for PutRoleMapping<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</pre></summary>
+	///<summary>Request options for PutRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</para></summary>
 	public class PutRoleMappingRequestParameters : RequestParameters<PutRoleMappingRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -300,7 +300,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for PutUser<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</pre></summary>
+	///<summary>Request options for PutUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</para></summary>
 	public class PutUserRequestParameters : RequestParameters<PutUserRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -315,7 +315,7 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		}
 	}
 
-	///<summary>Request options for GetCertificates<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</pre></summary>
+	///<summary>Request options for GetCertificates <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</para></summary>
 	public class GetCertificatesRequestParameters : RequestParameters<GetCertificatesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Snapshot.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Snapshot.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.SnapshotApi
 {
-	///<summary>Request options for Snapshot<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for Snapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class SnapshotRequestParameters : RequestParameters<SnapshotRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -43,7 +43,7 @@ namespace Elasticsearch.Net.Specification.SnapshotApi
 		}
 	}
 
-	///<summary>Request options for CreateRepository<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for CreateRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class CreateRepositoryRequestParameters : RequestParameters<CreateRepositoryRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -69,7 +69,7 @@ namespace Elasticsearch.Net.Specification.SnapshotApi
 		}
 	}
 
-	///<summary>Request options for Delete<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class DeleteSnapshotRequestParameters : RequestParameters<DeleteSnapshotRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -81,7 +81,7 @@ namespace Elasticsearch.Net.Specification.SnapshotApi
 		}
 	}
 
-	///<summary>Request options for DeleteRepository<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for DeleteRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class DeleteRepositoryRequestParameters : RequestParameters<DeleteRepositoryRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
@@ -100,7 +100,7 @@ namespace Elasticsearch.Net.Specification.SnapshotApi
 		}
 	}
 
-	///<summary>Request options for Get<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class GetSnapshotRequestParameters : RequestParameters<GetSnapshotRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -126,7 +126,7 @@ namespace Elasticsearch.Net.Specification.SnapshotApi
 		}
 	}
 
-	///<summary>Request options for GetRepository<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for GetRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class GetRepositoryRequestParameters : RequestParameters<GetRepositoryRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -145,7 +145,7 @@ namespace Elasticsearch.Net.Specification.SnapshotApi
 		}
 	}
 
-	///<summary>Request options for Restore<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for Restore <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class RestoreRequestParameters : RequestParameters<RestoreRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -164,7 +164,7 @@ namespace Elasticsearch.Net.Specification.SnapshotApi
 		}
 	}
 
-	///<summary>Request options for Status<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for Status <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class SnapshotStatusRequestParameters : RequestParameters<SnapshotStatusRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -183,7 +183,7 @@ namespace Elasticsearch.Net.Specification.SnapshotApi
 		}
 	}
 
-	///<summary>Request options for VerifyRepository<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request options for VerifyRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public class VerifyRepositoryRequestParameters : RequestParameters<VerifyRepositoryRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Sql.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Sql.cs
@@ -24,13 +24,13 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.SqlApi
 {
-	///<summary>Request options for ClearCursor<pre>Clear SQL cursor</pre></summary>
+	///<summary>Request options for ClearCursor <para>Clear SQL cursor</para></summary>
 	public class ClearSqlCursorRequestParameters : RequestParameters<ClearSqlCursorRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for Query<pre>Execute SQL</pre></summary>
+	///<summary>Request options for Query <para>Execute SQL</para></summary>
 	public class QuerySqlRequestParameters : RequestParameters<QuerySqlRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -42,7 +42,7 @@ namespace Elasticsearch.Net.Specification.SqlApi
 		}
 	}
 
-	///<summary>Request options for Translate<pre>Translate SQL into Elasticsearch queries</pre></summary>
+	///<summary>Request options for Translate <para>Translate SQL into Elasticsearch queries</para></summary>
 	public class TranslateSqlRequestParameters : RequestParameters<TranslateSqlRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Tasks.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Tasks.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.TasksApi
 {
-	///<summary>Request options for Cancel<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>Request options for Cancel <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public class CancelTasksRequestParameters : RequestParameters<CancelTasksRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
@@ -53,7 +53,7 @@ namespace Elasticsearch.Net.Specification.TasksApi
 		}
 	}
 
-	///<summary>Request options for GetTask<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>Request options for GetTask <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public class GetTaskRequestParameters : RequestParameters<GetTaskRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -72,7 +72,7 @@ namespace Elasticsearch.Net.Specification.TasksApi
 		}
 	}
 
-	///<summary>Request options for List<pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>Request options for List <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public class ListTasksRequestParameters : RequestParameters<ListTasksRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Watcher.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Watcher.cs
@@ -24,31 +24,31 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.WatcherApi
 {
-	///<summary>Request options for Acknowledge<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</pre></summary>
+	///<summary>Request options for Acknowledge <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</para></summary>
 	public class AcknowledgeWatchRequestParameters : RequestParameters<AcknowledgeWatchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for Activate<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</pre></summary>
+	///<summary>Request options for Activate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</para></summary>
 	public class ActivateWatchRequestParameters : RequestParameters<ActivateWatchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for Deactivate<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</pre></summary>
+	///<summary>Request options for Deactivate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</para></summary>
 	public class DeactivateWatchRequestParameters : RequestParameters<DeactivateWatchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 	}
 
-	///<summary>Request options for Delete<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</pre></summary>
+	///<summary>Request options for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</para></summary>
 	public class DeleteWatchRequestParameters : RequestParameters<DeleteWatchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 	}
 
-	///<summary>Request options for Execute<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</pre></summary>
+	///<summary>Request options for Execute <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</para></summary>
 	public class ExecuteWatchRequestParameters : RequestParameters<ExecuteWatchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -60,13 +60,13 @@ namespace Elasticsearch.Net.Specification.WatcherApi
 		}
 	}
 
-	///<summary>Request options for Get<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</pre></summary>
+	///<summary>Request options for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</para></summary>
 	public class GetWatchRequestParameters : RequestParameters<GetWatchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 	}
 
-	///<summary>Request options for Put<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</pre></summary>
+	///<summary>Request options for Put <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</para></summary>
 	public class PutWatchRequestParameters : RequestParameters<PutWatchRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
@@ -99,13 +99,13 @@ namespace Elasticsearch.Net.Specification.WatcherApi
 		}
 	}
 
-	///<summary>Request options for Start<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</pre></summary>
+	///<summary>Request options for Start <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</para></summary>
 	public class StartWatcherRequestParameters : RequestParameters<StartWatcherRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
-	///<summary>Request options for Stats<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</pre></summary>
+	///<summary>Request options for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</para></summary>
 	public class WatcherStatsRequestParameters : RequestParameters<WatcherStatsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -117,7 +117,7 @@ namespace Elasticsearch.Net.Specification.WatcherApi
 		}
 	}
 
-	///<summary>Request options for Stop<pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</pre></summary>
+	///<summary>Request options for Stop <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</para></summary>
 	public class StopWatcherRequestParameters : RequestParameters<StopWatcherRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.XPack.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.XPack.cs
@@ -24,7 +24,7 @@ using System.Linq.Expressions;
 // ReSharper disable once CheckNamespace
 namespace Elasticsearch.Net.Specification.XPackApi
 {
-	///<summary>Request options for Info<pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</pre></summary>
+	///<summary>Request options for Info <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</para></summary>
 	public class XPackInfoRequestParameters : RequestParameters<XPackInfoRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -36,7 +36,7 @@ namespace Elasticsearch.Net.Specification.XPackApi
 		}
 	}
 
-	///<summary>Request options for Usage<pre>Retrieve information about xpack features usage</pre></summary>
+	///<summary>Request options for Usage <para>Retrieve information about xpack features usage</para></summary>
 	public class XPackUsageRequestParameters : RequestParameters<XPackUsageRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -494,7 +494,7 @@ namespace Elasticsearch.Net
 			Assign(new X509Certificate2Collection { new X509Certificate(certificatePath) }, (a, v) => a._clientCertificates = v);
 
 		/// <summary>
-		/// Configure the client to skip deserialization of certain status codes e.g: you run elasticsearch behind a proxy that returns a HTML for 401,
+		/// Configure the client to skip deserialization of certain status codes e.g: you run Elasticsearch behind a proxy that returns a HTML for 401,
 		/// 500
 		/// </summary>
 		public T SkipDeserializationForStatusCodes(params int[] statusCodes) =>

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -58,7 +58,7 @@ namespace Elasticsearch.Net
 
 		/// <summary>
 		/// When set to true will disable (de)serializing directly to the request and response stream and return a byte[]
-		/// copy of the raw request and response on elasticsearch calls. Defaults to  false
+		/// copy of the raw request and response on Elasticsearch calls. Defaults to  false
 		/// </summary>
 		bool DisableDirectStreaming { get; }
 
@@ -69,7 +69,7 @@ namespace Elasticsearch.Net
 		bool DisablePings { get; }
 
 		/// <summary>
-		/// Enable gzip compressed requests and responses, do note that you need to configure elasticsearch to set this
+		/// Enable gzip compressed requests and responses, do note that you need to configure Elasticsearch to set this
 		/// <para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html</para>
 		/// </summary>
 		bool EnableHttpCompression { get; }
@@ -80,7 +80,7 @@ namespace Elasticsearch.Net
 		NameValueCollection Headers { get; }
 
 		/// <summary>
-		/// By default the client enables http pipelining as elasticsearch 2.0 defaults to true as well
+		/// Whether HTTP pipelining is enabled. The default is <c>true</c>
 		/// </summary>
 		bool HttpPipeliningEnabled { get; }
 
@@ -104,7 +104,7 @@ namespace Elasticsearch.Net
 
 		/// <summary>
 		/// When a retryable exception occurs or status code is returned this controls the maximum
-		/// amount of times we should retry the call to elasticsearch
+		/// amount of times we should retry the call to Elasticsearch
 		/// </summary>
 		int? MaxRetries { get; }
 
@@ -146,7 +146,7 @@ namespace Elasticsearch.Net
 		TimeSpan? PingTimeout { get; }
 
 		/// <summary>
-		/// Forces all requests to have ?pretty=true, causing elasticsearch to return formatted json.
+		/// Forces all requests to have ?pretty=true, causing Elasticsearch to return formatted json.
 		/// Also forces the client to send out formatted json. Defaults to false
 		/// </summary>
 		bool PrettyJson { get; }
@@ -185,7 +185,7 @@ namespace Elasticsearch.Net
 		Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> ServerCertificateValidationCallback { get; }
 
 		/// <summary>
-		/// Configure the client to skip deserialization of certain status codes e.g: you run elasticsearch behind a proxy that returns an unexpected
+		/// Configure the client to skip deserialization of certain status codes e.g: you run Elasticsearch behind a proxy that returns an unexpected
 		/// json format
 		/// </summary>
 		IReadOnlyCollection<int> SkipDeserializationForStatusCodes { get; }

--- a/src/Elasticsearch.Net/ConnectionPool/Node.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/Node.cs
@@ -11,7 +11,7 @@ namespace Elasticsearch.Net
 
 		public Node(Uri uri)
 		{
-			//this makes sure that elasticsearch paths stay relative to the path passed in
+			//this makes sure that Elasticsearch paths stay relative to the path passed in
 			//http://my-saas-provider.com/instance
 			if (!uri.OriginalString.EndsWith("/", StringComparison.Ordinal))
 				uri = new Uri(uri.OriginalString + "/");

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Cat.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Cat.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.CatApi
 {
 	///<summary>
-	/// Logically groups all Cat API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Cat"/> property
+	/// Cat APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Cat"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Cluster.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Cluster.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.ClusterApi
 {
 	///<summary>
-	/// Logically groups all Cluster API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Cluster"/> property
+	/// Cluster APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Cluster"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.CrossClusterReplication.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.CrossClusterReplication.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.CrossClusterReplicationApi
 {
 	///<summary>
-	/// Logically groups all CrossClusterReplication API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.CrossClusterReplication"/> property
+	/// Cross Cluster Replication APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.CrossClusterReplication"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Graph.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Graph.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.GraphApi
 {
 	///<summary>
-	/// Logically groups all Graph API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Graph"/> property
+	/// Graph APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Graph"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.IndexLifecycleManagement.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.IndexLifecycleManagement.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.IndexLifecycleManagementApi
 {
 	///<summary>
-	/// Logically groups all IndexLifecycleManagement API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.IndexLifecycleManagement"/> property
+	/// Index Lifecycle Management APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.IndexLifecycleManagement"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Indices.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Indices.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.IndicesApi
 {
 	///<summary>
-	/// Logically groups all Indices API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Indices"/> property
+	/// Indices APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Indices"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Ingest.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Ingest.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.IngestApi
 {
 	///<summary>
-	/// Logically groups all Ingest API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Ingest"/> property
+	/// Ingest APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Ingest"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.License.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.License.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.LicenseApi
 {
 	///<summary>
-	/// Logically groups all License API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.License"/> property
+	/// License APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.License"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.MachineLearning.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.MachineLearning.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.MachineLearningApi
 {
 	///<summary>
-	/// Logically groups all MachineLearning API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.MachineLearning"/> property
+	/// Machine Learning APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.MachineLearning"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Migration.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Migration.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.MigrationApi
 {
 	///<summary>
-	/// Logically groups all Migration API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Migration"/> property
+	/// Migration APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Migration"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.NoNamespace.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.NoNamespace.cs
@@ -48,7 +48,7 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net
 {
 	///<summary>
-	///Raw operations with elasticsearch
+	///Elasticsearch low level client
 	///</summary>
 	public partial class ElasticLowLevelClient : IElasticLowLevelClient
 	{

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Nodes.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Nodes.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.NodesApi
 {
 	///<summary>
-	/// Logically groups all Nodes API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Nodes"/> property
+	/// Nodes APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Nodes"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Rollup.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Rollup.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.RollupApi
 {
 	///<summary>
-	/// Logically groups all Rollup API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Rollup"/> property
+	/// Rollup APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Rollup"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Security.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Security.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.SecurityApi
 {
 	///<summary>
-	/// Logically groups all Security API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Security"/> property
+	/// Security APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Security"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Snapshot.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Snapshot.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.SnapshotApi
 {
 	///<summary>
-	/// Logically groups all Snapshot API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Snapshot"/> property
+	/// Snapshot APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Snapshot"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Sql.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Sql.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.SqlApi
 {
 	///<summary>
-	/// Logically groups all Sql API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Sql"/> property
+	/// Sql APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Sql"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Tasks.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Tasks.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.TasksApi
 {
 	///<summary>
-	/// Logically groups all Tasks API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Tasks"/> property
+	/// Tasks APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Tasks"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Watcher.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Watcher.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.WatcherApi
 {
 	///<summary>
-	/// Logically groups all Watcher API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.Watcher"/> property
+	/// Watcher APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.Watcher"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.XPack.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.XPack.cs
@@ -32,7 +32,7 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.XPackApi
 {
 	///<summary>
-	/// X Pack APIs.
+	/// XPack APIs.
 	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.XPack"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.XPack.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.XPack.cs
@@ -32,8 +32,8 @@ using static Elasticsearch.Net.HttpMethod;
 namespace Elasticsearch.Net.Specification.XPackApi
 {
 	///<summary>
-	/// Logically groups all XPack API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticLowLevelClient.XPack"/> property
+	/// X Pack APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticLowLevelClient.XPack"/> property
 	/// on <see cref = "IElasticLowLevelClient"/>.
 	///</para>
 	///</summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.cs
@@ -7,21 +7,21 @@ using Elasticsearch.Net.Extensions;
 namespace Elasticsearch.Net
 {
 	/// <summary>
-	/// Low level client that exposes all of elasticsearch API endpoints but leaves you in charge of building request and handling the response
+	/// Low level client that exposes all of Elasticsearch API endpoints but leaves you in charge of building request and handling the response
 	/// </summary>
 	public partial class ElasticLowLevelClient : IElasticLowLevelClient
 	{
-		/// <summary>Instantiate a new low level elasticsearch client to http://localhost:9200</summary>
+		/// <summary>Instantiate a new low level Elasticsearch client to http://localhost:9200</summary>
 		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
 		public ElasticLowLevelClient() : this(new Transport<IConnectionConfigurationValues>(new ConnectionConfiguration())) { }
 
-		/// <summary>Instantiate a new low level elasticsearch client using the specified settings</summary>
+		/// <summary>Instantiate a new low level Elasticsearch client using the specified settings</summary>
 		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
 		public ElasticLowLevelClient(IConnectionConfigurationValues settings) : this(
 			new Transport<IConnectionConfigurationValues>(settings ?? new ConnectionConfiguration())) { }
 
 		/// <summary>
-		/// Instantiate a new low level elasticsearch client explicitly specifying a custom transport setup
+		/// Instantiate a new low level Elasticsearch client explicitly specifying a custom transport setup
 		/// </summary>
 		public ElasticLowLevelClient(ITransport<IConnectionConfigurationValues> transport)
 		{
@@ -41,7 +41,7 @@ namespace Elasticsearch.Net
 		public IConnectionConfigurationValues Settings => Transport.Settings;
 
 		protected ITransport<IConnectionConfigurationValues> Transport { get; set; }
-		
+
 		private ElasticsearchUrlFormatter UrlFormatter { get; }
 
 		public TResponse DoRequest<TResponse>(HttpMethod method, string path, PostData data = null, IRequestParameters requestParameters = null)

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
@@ -45,60 +45,71 @@ using Elasticsearch.Net.Specification.XPackApi;
 namespace Elasticsearch.Net
 {
 	///<summary>
-	///Raw operations with elasticsearch
+	///Elasticsearch low level client
 	///</summary>
 	public partial interface IElasticLowLevelClient
 	{
+		///<summary>Cat APIs</summary>
 		LowLevelCatNamespace Cat
 		{
 			get;
 		}
 
+		///<summary>Cluster APIs</summary>
 		LowLevelClusterNamespace Cluster
 		{
 			get;
 		}
 
+		///<summary>Cross Cluster Replication APIs</summary>
 		LowLevelCrossClusterReplicationNamespace CrossClusterReplication
 		{
 			get;
 		}
 
+		///<summary>Graph APIs</summary>
 		LowLevelGraphNamespace Graph
 		{
 			get;
 		}
 
+		///<summary>Index Lifecycle Management APIs</summary>
 		LowLevelIndexLifecycleManagementNamespace IndexLifecycleManagement
 		{
 			get;
 		}
 
+		///<summary>Indices APIs</summary>
 		LowLevelIndicesNamespace Indices
 		{
 			get;
 		}
 
+		///<summary>Ingest APIs</summary>
 		LowLevelIngestNamespace Ingest
 		{
 			get;
 		}
 
+		///<summary>License APIs</summary>
 		LowLevelLicenseNamespace License
 		{
 			get;
 		}
 
+		///<summary>Machine Learning APIs</summary>
 		LowLevelMachineLearningNamespace MachineLearning
 		{
 			get;
 		}
 
+		///<summary>Migration APIs</summary>
 		LowLevelMigrationNamespace Migration
 		{
 			get;
 		}
 
+		///<summary>Nodes APIs</summary>
 		LowLevelNodesNamespace Nodes
 		{
 			get;
@@ -648,36 +659,43 @@ namespace Elasticsearch.Net
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		Task<TResponse> UpdateByQueryRethrottleAsync<TResponse>(string taskId, UpdateByQueryRethrottleRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new();
+		///<summary>Rollup APIs</summary>
 		LowLevelRollupNamespace Rollup
 		{
 			get;
 		}
 
+		///<summary>Security APIs</summary>
 		LowLevelSecurityNamespace Security
 		{
 			get;
 		}
 
+		///<summary>Snapshot APIs</summary>
 		LowLevelSnapshotNamespace Snapshot
 		{
 			get;
 		}
 
+		///<summary>Sql APIs</summary>
 		LowLevelSqlNamespace Sql
 		{
 			get;
 		}
 
+		///<summary>Tasks APIs</summary>
 		LowLevelTasksNamespace Tasks
 		{
 			get;
 		}
 
+		///<summary>Watcher APIs</summary>
 		LowLevelWatcherNamespace Watcher
 		{
 			get;
 		}
 
+		///<summary>X Pack APIs</summary>
 		LowLevelXPackNamespace XPack
 		{
 			get;

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
@@ -695,7 +695,7 @@ namespace Elasticsearch.Net
 			get;
 		}
 
-		///<summary>X Pack APIs</summary>
+		///<summary>XPack APIs</summary>
 		LowLevelXPackNamespace XPack
 		{
 			get;

--- a/src/Nest/Aggregations/AggregateDictionary.cs
+++ b/src/Nest/Aggregations/AggregateDictionary.cs
@@ -6,8 +6,8 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	/// <summary>
-	/// Contains aggregates that are returned by Elasticsearch. In NEST `Aggregation` always refers to an aggregation
-	/// going to elasticsearch and an `Aggregate` describes an aggregation going out.
+	/// Contains aggregates that are returned by Elasticsearch. In NEST, Aggregation always refers to an aggregation
+	/// request to Elasticsearch and an Aggregate describes an aggregation response.
 	/// </summary>
 	[JsonFormatter(typeof(AggregateDictionaryFormatter))]
 	public class AggregateDictionary : IsAReadOnlyDictionaryBase<string, IAggregate>

--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -73,7 +73,7 @@ namespace Nest
 			UsingReservedAggNameFormat =
 				"'{0}' is one of the reserved aggregation keywords"
 				+ " we use a heuristics based response parser and using these reserved keywords"
-				+ " could throw its heuristics off course. We are working on a solution in elasticsearch itself to make"
+				+ " could throw its heuristics off course. We are working on a solution in Elasticsearch itself to make"
 				+ " the response parseable. For now these are all the reserved keywords: "
 				+ allKeys;
 		}

--- a/src/Nest/CommonAbstractions/Fields/FieldValues.cs
+++ b/src/Nest/CommonAbstractions/Fields/FieldValues.cs
@@ -70,7 +70,7 @@ namespace Nest
 			if (BackingDictionary == null || !BackingDictionary.TryGetValue(field, out var o))
 				return null;
 
-			//numerics are always returned as doubles by elasticsearch.
+			//numerics are always returned as doubles by Elasticsearch.
 			if (!IsNumeric(typeof(TValue)))
 				return o.As<TValue[]>();
 

--- a/src/Nest/CommonAbstractions/Response/ResponseBase.cs
+++ b/src/Nest/CommonAbstractions/Response/ResponseBase.cs
@@ -6,24 +6,23 @@ using Elasticsearch.Net;
 namespace Nest
 {
 	/// <summary>
-	/// Shared interface by all elasticsearch responses
+	/// A response from Elasticsearch
 	/// </summary>
 	public interface IResponse : IElasticsearchResponse
 	{
 		/// <summary>
-		/// A lazy human readable string representation of what happened during this request for both successful and
-		/// failed requests, very useful while developing or to log when <see cref="IsValid" /> is false on responses.
+		/// A lazily computed, human readable string representation of what happened during a request for both successful and
+		/// failed requests. Useful whilst developing or to log when <see cref="IsValid" /> is false on responses.
 		/// </summary>
 		[IgnoreDataMember]
 		string DebugInformation { get; }
 
 		/// <summary>
-		/// This property can be used to check if a response is functionally valid or not.
-		/// This is a NEST abstraction to have a single point to check whether something wrong happened with the request.
+		/// Checks if a response is functionally valid or not.
+		/// This is a NEST abstraction to have a single property to check whether there was something wrong with a request.
 		/// <para>
-		/// For instance an elasticsearch bulk response always returns 200 and individual bulk items may fail,
-		/// <see cref="IsValid" /> will be
-		/// false in that case
+		/// For instance, an Elasticsearch bulk response always returns 200 and individual bulk items may fail,
+		/// <see cref="IsValid" /> will be false in that case.
 		/// </para>
 		/// <para>
 		/// You can also configure the client to always throw an <see cref="ElasticsearchClientException" /> using
@@ -49,7 +48,7 @@ namespace Nest
 		Exception OriginalException { get; }
 
 		/// <summary>
-		/// If the response results in an error on elasticsearch's side an <pre>error</pre> element will be returned, this is
+		/// If the response results in an error on Elasticsearch's side an <pre>error</pre> element will be returned, this is
 		/// mapped to
 		/// <see cref="ServerError" /> in NEST.
 		/// <para>Possibly set when <see cref="IsValid" /> is false, depending on the cause of the error</para>
@@ -93,6 +92,7 @@ namespace Nest
 		/// <inheritdoc />
 		public Exception OriginalException => ApiCall?.OriginalException;
 
+		/// <inheritdoc />
 		public ServerError ServerError
 		{
 			get

--- a/src/Nest/Descriptors.Cat.cs
+++ b/src/Nest/Descriptors.Cat.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.CatApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Aliases <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</pre></summary>
+	///<summary>descriptor for Aliases <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</para></summary>
 	public partial class CatAliasesDescriptor : RequestDescriptorBase<CatAliasesDescriptor, CatAliasesRequestParameters, ICatAliasesRequest>, ICatAliasesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatAliases;
@@ -66,7 +66,7 @@ namespace Nest
 		public CatAliasesDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Allocation <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</pre></summary>
+	///<summary>descriptor for Allocation <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</para></summary>
 	public partial class CatAllocationDescriptor : RequestDescriptorBase<CatAllocationDescriptor, CatAllocationRequestParameters, ICatAllocationRequest>, ICatAllocationRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatAllocation;
@@ -104,7 +104,7 @@ namespace Nest
 		public CatAllocationDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Count <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</pre></summary>
+	///<summary>descriptor for Count <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</para></summary>
 	public partial class CatCountDescriptor : RequestDescriptorBase<CatCountDescriptor, CatCountRequestParameters, ICatCountRequest>, ICatCountRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatCount;
@@ -145,7 +145,7 @@ namespace Nest
 		public CatCountDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Fielddata <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</pre></summary>
+	///<summary>descriptor for Fielddata <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para></summary>
 	public partial class CatFielddataDescriptor : RequestDescriptorBase<CatFielddataDescriptor, CatFielddataRequestParameters, ICatFielddataRequest>, ICatFielddataRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatFielddata;
@@ -185,7 +185,7 @@ namespace Nest
 		public CatFielddataDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Health <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</pre></summary>
+	///<summary>descriptor for Health <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</para></summary>
 	public partial class CatHealthDescriptor : RequestDescriptorBase<CatHealthDescriptor, CatHealthRequestParameters, ICatHealthRequest>, ICatHealthRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatHealth;
@@ -209,7 +209,7 @@ namespace Nest
 		public CatHealthDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Help <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</pre></summary>
+	///<summary>descriptor for Help <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</para></summary>
 	public partial class CatHelpDescriptor : RequestDescriptorBase<CatHelpDescriptor, CatHelpRequestParameters, ICatHelpRequest>, ICatHelpRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatHelp;
@@ -221,7 +221,7 @@ namespace Nest
 		public CatHelpDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 	}
 
-	///<summary>descriptor for Indices <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</pre></summary>
+	///<summary>descriptor for Indices <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</para></summary>
 	public partial class CatIndicesDescriptor : RequestDescriptorBase<CatIndicesDescriptor, CatIndicesRequestParameters, ICatIndicesRequest>, ICatIndicesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatIndices;
@@ -268,7 +268,7 @@ namespace Nest
 		public CatIndicesDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Master <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</pre></summary>
+	///<summary>descriptor for Master <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</para></summary>
 	public partial class CatMasterDescriptor : RequestDescriptorBase<CatMasterDescriptor, CatMasterRequestParameters, ICatMasterRequest>, ICatMasterRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatMaster;
@@ -290,7 +290,7 @@ namespace Nest
 		public CatMasterDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for NodeAttributes <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</pre></summary>
+	///<summary>descriptor for NodeAttributes <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</para></summary>
 	public partial class CatNodeAttributesDescriptor : RequestDescriptorBase<CatNodeAttributesDescriptor, CatNodeAttributesRequestParameters, ICatNodeAttributesRequest>, ICatNodeAttributesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatNodeAttributes;
@@ -312,7 +312,7 @@ namespace Nest
 		public CatNodeAttributesDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Nodes <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</pre></summary>
+	///<summary>descriptor for Nodes <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</para></summary>
 	public partial class CatNodesDescriptor : RequestDescriptorBase<CatNodesDescriptor, CatNodesRequestParameters, ICatNodesRequest>, ICatNodesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatNodes;
@@ -336,7 +336,7 @@ namespace Nest
 		public CatNodesDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for PendingTasks <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</pre></summary>
+	///<summary>descriptor for PendingTasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</para></summary>
 	public partial class CatPendingTasksDescriptor : RequestDescriptorBase<CatPendingTasksDescriptor, CatPendingTasksRequestParameters, ICatPendingTasksRequest>, ICatPendingTasksRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatPendingTasks;
@@ -358,7 +358,7 @@ namespace Nest
 		public CatPendingTasksDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Plugins <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</pre></summary>
+	///<summary>descriptor for Plugins <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para></summary>
 	public partial class CatPluginsDescriptor : RequestDescriptorBase<CatPluginsDescriptor, CatPluginsRequestParameters, ICatPluginsRequest>, ICatPluginsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatPlugins;
@@ -380,7 +380,7 @@ namespace Nest
 		public CatPluginsDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Recovery <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</pre></summary>
+	///<summary>descriptor for Recovery <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</para></summary>
 	public partial class CatRecoveryDescriptor : RequestDescriptorBase<CatRecoveryDescriptor, CatRecoveryRequestParameters, ICatRecoveryRequest>, ICatRecoveryRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatRecovery;
@@ -421,7 +421,7 @@ namespace Nest
 		public CatRecoveryDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Repositories <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</pre></summary>
+	///<summary>descriptor for Repositories <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</para></summary>
 	public partial class CatRepositoriesDescriptor : RequestDescriptorBase<CatRepositoriesDescriptor, CatRepositoriesRequestParameters, ICatRepositoriesRequest>, ICatRepositoriesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatRepositories;
@@ -443,7 +443,7 @@ namespace Nest
 		public CatRepositoriesDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Segments <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</pre></summary>
+	///<summary>descriptor for Segments <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para></summary>
 	public partial class CatSegmentsDescriptor : RequestDescriptorBase<CatSegmentsDescriptor, CatSegmentsRequestParameters, ICatSegmentsRequest>, ICatSegmentsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatSegments;
@@ -482,7 +482,7 @@ namespace Nest
 		public CatSegmentsDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Shards <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</pre></summary>
+	///<summary>descriptor for Shards <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</para></summary>
 	public partial class CatShardsDescriptor : RequestDescriptorBase<CatShardsDescriptor, CatShardsRequestParameters, ICatShardsRequest>, ICatShardsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatShards;
@@ -525,7 +525,7 @@ namespace Nest
 		public CatShardsDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Snapshots <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</pre></summary>
+	///<summary>descriptor for Snapshots <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</para></summary>
 	public partial class CatSnapshotsDescriptor : RequestDescriptorBase<CatSnapshotsDescriptor, CatSnapshotsRequestParameters, ICatSnapshotsRequest>, ICatSnapshotsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatSnapshots;
@@ -561,7 +561,7 @@ namespace Nest
 		public CatSnapshotsDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Tasks <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>descriptor for Tasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public partial class CatTasksDescriptor : RequestDescriptorBase<CatTasksDescriptor, CatTasksRequestParameters, ICatTasksRequest>, ICatTasksRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatTasks;
@@ -587,7 +587,7 @@ namespace Nest
 		public CatTasksDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for Templates <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</pre></summary>
+	///<summary>descriptor for Templates <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</para></summary>
 	public partial class CatTemplatesDescriptor : RequestDescriptorBase<CatTemplatesDescriptor, CatTemplatesRequestParameters, ICatTemplatesRequest>, ICatTemplatesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatTemplates;
@@ -623,7 +623,7 @@ namespace Nest
 		public CatTemplatesDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	///<summary>descriptor for ThreadPool <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</pre></summary>
+	///<summary>descriptor for ThreadPool <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para></summary>
 	public partial class CatThreadPoolDescriptor : RequestDescriptorBase<CatThreadPoolDescriptor, CatThreadPoolRequestParameters, ICatThreadPoolRequest>, ICatThreadPoolRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatThreadPool;

--- a/src/Nest/Descriptors.Cluster.cs
+++ b/src/Nest/Descriptors.Cluster.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.ClusterApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for AllocationExplain <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</pre></summary>
+	///<summary>descriptor for AllocationExplain <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</para></summary>
 	public partial class ClusterAllocationExplainDescriptor : RequestDescriptorBase<ClusterAllocationExplainDescriptor, ClusterAllocationExplainRequestParameters, IClusterAllocationExplainRequest>, IClusterAllocationExplainRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterAllocationExplain;
@@ -42,7 +42,7 @@ namespace Nest
 		public ClusterAllocationExplainDescriptor IncludeYesDecisions(bool? includeyesdecisions = true) => Qs("include_yes_decisions", includeyesdecisions);
 	}
 
-	///<summary>descriptor for GetSettings <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</pre></summary>
+	///<summary>descriptor for GetSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</para></summary>
 	public partial class ClusterGetSettingsDescriptor : RequestDescriptorBase<ClusterGetSettingsDescriptor, ClusterGetSettingsRequestParameters, IClusterGetSettingsRequest>, IClusterGetSettingsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterGetSettings;
@@ -58,7 +58,7 @@ namespace Nest
 		public ClusterGetSettingsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for Health <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</pre></summary>
+	///<summary>descriptor for Health <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</para></summary>
 	public partial class ClusterHealthDescriptor : RequestDescriptorBase<ClusterHealthDescriptor, ClusterHealthRequestParameters, IClusterHealthRequest>, IClusterHealthRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterHealth;
@@ -105,7 +105,7 @@ namespace Nest
 		public ClusterHealthDescriptor WaitForStatus(WaitForStatus? waitforstatus) => Qs("wait_for_status", waitforstatus);
 	}
 
-	///<summary>descriptor for PendingTasks <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</pre></summary>
+	///<summary>descriptor for PendingTasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</para></summary>
 	public partial class ClusterPendingTasksDescriptor : RequestDescriptorBase<ClusterPendingTasksDescriptor, ClusterPendingTasksRequestParameters, IClusterPendingTasksRequest>, IClusterPendingTasksRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterPendingTasks;
@@ -117,7 +117,7 @@ namespace Nest
 		public ClusterPendingTasksDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for PutSettings <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</pre></summary>
+	///<summary>descriptor for PutSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</para></summary>
 	public partial class ClusterPutSettingsDescriptor : RequestDescriptorBase<ClusterPutSettingsDescriptor, ClusterPutSettingsRequestParameters, IClusterPutSettingsRequest>, IClusterPutSettingsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterPutSettings;
@@ -131,7 +131,7 @@ namespace Nest
 		public ClusterPutSettingsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for RemoteInfo <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</pre></summary>
+	///<summary>descriptor for RemoteInfo <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</para></summary>
 	public partial class RemoteInfoDescriptor : RequestDescriptorBase<RemoteInfoDescriptor, RemoteInfoRequestParameters, IRemoteInfoRequest>, IRemoteInfoRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterRemoteInfo;
@@ -139,7 +139,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Reroute <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</pre></summary>
+	///<summary>descriptor for Reroute <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</para></summary>
 	public partial class ClusterRerouteDescriptor : RequestDescriptorBase<ClusterRerouteDescriptor, ClusterRerouteRequestParameters, IClusterRerouteRequest>, IClusterRerouteRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterReroute;
@@ -159,7 +159,7 @@ namespace Nest
 		public ClusterRerouteDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for State <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</pre></summary>
+	///<summary>descriptor for State <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</para></summary>
 	public partial class ClusterStateDescriptor : RequestDescriptorBase<ClusterStateDescriptor, ClusterStateRequestParameters, IClusterStateRequest>, IClusterStateRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterState;
@@ -212,7 +212,7 @@ namespace Nest
 		public ClusterStateDescriptor WaitForTimeout(Time waitfortimeout) => Qs("wait_for_timeout", waitfortimeout);
 	}
 
-	///<summary>descriptor for Stats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</pre></summary>
+	///<summary>descriptor for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</para></summary>
 	public partial class ClusterStatsDescriptor : RequestDescriptorBase<ClusterStatsDescriptor, ClusterStatsRequestParameters, IClusterStatsRequest>, IClusterStatsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterStats;

--- a/src/Nest/Descriptors.CrossClusterReplication.cs
+++ b/src/Nest/Descriptors.CrossClusterReplication.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.CrossClusterReplicationApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for DeleteAutoFollowPattern <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</pre></summary>
+	///<summary>descriptor for DeleteAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</para></summary>
 	public partial class DeleteAutoFollowPatternDescriptor : RequestDescriptorBase<DeleteAutoFollowPatternDescriptor, DeleteAutoFollowPatternRequestParameters, IDeleteAutoFollowPatternRequest>, IDeleteAutoFollowPatternRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationDeleteAutoFollowPattern;
@@ -51,7 +51,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for CreateFollowIndex <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</pre></summary>
+	///<summary>descriptor for CreateFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</para></summary>
 	public partial class CreateFollowIndexDescriptor : RequestDescriptorBase<CreateFollowIndexDescriptor, CreateFollowIndexRequestParameters, ICreateFollowIndexRequest>, ICreateFollowIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationCreateFollowIndex;
@@ -79,7 +79,7 @@ namespace Nest
 		public CreateFollowIndexDescriptor WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for FollowIndexStats <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</pre></summary>
+	///<summary>descriptor for FollowIndexStats <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</para></summary>
 	public partial class FollowIndexStatsDescriptor : RequestDescriptorBase<FollowIndexStatsDescriptor, FollowIndexStatsRequestParameters, IFollowIndexStatsRequest>, IFollowIndexStatsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationFollowIndexStats;
@@ -107,7 +107,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetAutoFollowPattern <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</pre></summary>
+	///<summary>descriptor for GetAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</para></summary>
 	public partial class GetAutoFollowPatternDescriptor : RequestDescriptorBase<GetAutoFollowPatternDescriptor, GetAutoFollowPatternRequestParameters, IGetAutoFollowPatternRequest>, IGetAutoFollowPatternRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationGetAutoFollowPattern;
@@ -129,7 +129,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PauseFollowIndex <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</pre></summary>
+	///<summary>descriptor for PauseFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</para></summary>
 	public partial class PauseFollowIndexDescriptor : RequestDescriptorBase<PauseFollowIndexDescriptor, PauseFollowIndexRequestParameters, IPauseFollowIndexRequest>, IPauseFollowIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationPauseFollowIndex;
@@ -155,7 +155,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for CreateAutoFollowPattern <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</pre></summary>
+	///<summary>descriptor for CreateAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</para></summary>
 	public partial class CreateAutoFollowPatternDescriptor : RequestDescriptorBase<CreateAutoFollowPatternDescriptor, CreateAutoFollowPatternRequestParameters, ICreateAutoFollowPatternRequest>, ICreateAutoFollowPatternRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationCreateAutoFollowPattern;
@@ -176,7 +176,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for ResumeFollowIndex <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</pre></summary>
+	///<summary>descriptor for ResumeFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</para></summary>
 	public partial class ResumeFollowIndexDescriptor : RequestDescriptorBase<ResumeFollowIndexDescriptor, ResumeFollowIndexRequestParameters, IResumeFollowIndexRequest>, IResumeFollowIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationResumeFollowIndex;
@@ -202,7 +202,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Stats <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</pre></summary>
+	///<summary>descriptor for Stats <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</para></summary>
 	public partial class CcrStatsDescriptor : RequestDescriptorBase<CcrStatsDescriptor, CcrStatsRequestParameters, ICcrStatsRequest>, ICcrStatsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationStats;
@@ -210,7 +210,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for UnfollowIndex <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current</pre></summary>
+	///<summary>descriptor for UnfollowIndex <para>http://www.elastic.co/guide/en/elasticsearch/reference/current</para></summary>
 	public partial class UnfollowIndexDescriptor : RequestDescriptorBase<UnfollowIndexDescriptor, UnfollowIndexRequestParameters, IUnfollowIndexRequest>, IUnfollowIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CrossClusterReplicationUnfollowIndex;

--- a/src/Nest/Descriptors.Graph.cs
+++ b/src/Nest/Descriptors.Graph.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.GraphApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Explore <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</pre></summary>
+	///<summary>descriptor for Explore <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</para></summary>
 	public partial class GraphExploreDescriptor<TDocument> : RequestDescriptorBase<GraphExploreDescriptor<TDocument>, GraphExploreRequestParameters, IGraphExploreRequest<TDocument>>, IGraphExploreRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.GraphExplore;

--- a/src/Nest/Descriptors.IndexLifecycleManagement.cs
+++ b/src/Nest/Descriptors.IndexLifecycleManagement.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.IndexLifecycleManagementApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for DeleteLifecycle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</pre></summary>
+	///<summary>descriptor for DeleteLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</para></summary>
 	public partial class DeleteLifecycleDescriptor : RequestDescriptorBase<DeleteLifecycleDescriptor, DeleteLifecycleRequestParameters, IDeleteLifecycleRequest>, IDeleteLifecycleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementDeleteLifecycle;
@@ -51,7 +51,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for ExplainLifecycle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</pre></summary>
+	///<summary>descriptor for ExplainLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</para></summary>
 	public partial class ExplainLifecycleDescriptor : RequestDescriptorBase<ExplainLifecycleDescriptor, ExplainLifecycleRequestParameters, IExplainLifecycleRequest>, IExplainLifecycleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementExplainLifecycle;
@@ -77,7 +77,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetLifecycle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</pre></summary>
+	///<summary>descriptor for GetLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</para></summary>
 	public partial class GetLifecycleDescriptor : RequestDescriptorBase<GetLifecycleDescriptor, GetLifecycleRequestParameters, IGetLifecycleRequest>, IGetLifecycleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementGetLifecycle;
@@ -99,7 +99,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetStatus <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</pre></summary>
+	///<summary>descriptor for GetStatus <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</para></summary>
 	public partial class GetIlmStatusDescriptor : RequestDescriptorBase<GetIlmStatusDescriptor, GetIlmStatusRequestParameters, IGetIlmStatusRequest>, IGetIlmStatusRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementGetStatus;
@@ -107,7 +107,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for MoveToStep <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</pre></summary>
+	///<summary>descriptor for MoveToStep <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</para></summary>
 	public partial class MoveToStepDescriptor : RequestDescriptorBase<MoveToStepDescriptor, MoveToStepRequestParameters, IMoveToStepRequest>, IMoveToStepRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementMoveToStep;
@@ -134,7 +134,7 @@ namespace Nest
 	//TODO THIS METHOD IS UNMAPPED!
 	}
 
-	///<summary>descriptor for PutLifecycle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</pre></summary>
+	///<summary>descriptor for PutLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</para></summary>
 	public partial class PutLifecycleDescriptor : RequestDescriptorBase<PutLifecycleDescriptor, PutLifecycleRequestParameters, IPutLifecycleRequest>, IPutLifecycleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementPutLifecycle;
@@ -155,7 +155,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for RemovePolicy <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</pre></summary>
+	///<summary>descriptor for RemovePolicy <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</para></summary>
 	public partial class RemovePolicyDescriptor : RequestDescriptorBase<RemovePolicyDescriptor, RemovePolicyRequestParameters, IRemovePolicyRequest>, IRemovePolicyRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementRemovePolicy;
@@ -181,7 +181,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Retry <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</pre></summary>
+	///<summary>descriptor for Retry <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</para></summary>
 	public partial class RetryIlmDescriptor : RequestDescriptorBase<RetryIlmDescriptor, RetryIlmRequestParameters, IRetryIlmRequest>, IRetryIlmRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementRetry;
@@ -207,7 +207,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Start <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</pre></summary>
+	///<summary>descriptor for Start <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</para></summary>
 	public partial class StartIlmDescriptor : RequestDescriptorBase<StartIlmDescriptor, StartIlmRequestParameters, IStartIlmRequest>, IStartIlmRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementStart;
@@ -215,7 +215,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Stop <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</pre></summary>
+	///<summary>descriptor for Stop <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</para></summary>
 	public partial class StopIlmDescriptor : RequestDescriptorBase<StopIlmDescriptor, StopIlmRequestParameters, IStopIlmRequest>, IStopIlmRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexLifecycleManagementStop;

--- a/src/Nest/Descriptors.Indices.cs
+++ b/src/Nest/Descriptors.Indices.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.IndicesApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Analyze <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</pre></summary>
+	///<summary>descriptor for Analyze <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</para></summary>
 	public partial class AnalyzeDescriptor : RequestDescriptorBase<AnalyzeDescriptor, AnalyzeRequestParameters, IAnalyzeRequest>, IAnalyzeRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesAnalyze;
@@ -55,7 +55,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for ClearCache <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</pre></summary>
+	///<summary>descriptor for ClearCache <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</para></summary>
 	public partial class ClearCacheDescriptor : RequestDescriptorBase<ClearCacheDescriptor, ClearCacheRequestParameters, IClearCacheRequest>, IClearCacheRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesClearCache;
@@ -99,7 +99,7 @@ namespace Nest
 		public ClearCacheDescriptor Request(bool? request = true) => Qs("request", request);
 	}
 
-	///<summary>descriptor for Close <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</pre></summary>
+	///<summary>descriptor for Close <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 	public partial class CloseIndexDescriptor : RequestDescriptorBase<CloseIndexDescriptor, CloseIndexRequestParameters, ICloseIndexRequest>, ICloseIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesClose;
@@ -137,7 +137,7 @@ namespace Nest
 		public CloseIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for Create <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</pre></summary>
+	///<summary>descriptor for Create <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</para></summary>
 	public partial class CreateIndexDescriptor : RequestDescriptorBase<CreateIndexDescriptor, CreateIndexRequestParameters, ICreateIndexRequest>, ICreateIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesCreate;
@@ -171,7 +171,7 @@ namespace Nest
 		public CreateIndexDescriptor WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for Delete <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</pre></summary>
+	///<summary>descriptor for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</para></summary>
 	public partial class DeleteIndexDescriptor : RequestDescriptorBase<DeleteIndexDescriptor, DeleteIndexRequestParameters, IDeleteIndexRequest>, IDeleteIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesDelete;
@@ -209,7 +209,7 @@ namespace Nest
 		public DeleteIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for DeleteAlias <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>descriptor for DeleteAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class DeleteAliasDescriptor : RequestDescriptorBase<DeleteAliasDescriptor, DeleteAliasRequestParameters, IDeleteAliasRequest>, IDeleteAliasRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesDeleteAlias;
@@ -243,7 +243,7 @@ namespace Nest
 		public DeleteAliasDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for DeleteTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>descriptor for DeleteTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public partial class DeleteIndexTemplateDescriptor : RequestDescriptorBase<DeleteIndexTemplateDescriptor, DeleteIndexTemplateRequestParameters, IDeleteIndexTemplateRequest>, IDeleteIndexTemplateRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesDeleteTemplate;
@@ -268,7 +268,7 @@ namespace Nest
 		public DeleteIndexTemplateDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for Exists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</pre></summary>
+	///<summary>descriptor for Exists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</para></summary>
 	public partial class IndexExistsDescriptor : RequestDescriptorBase<IndexExistsDescriptor, IndexExistsRequestParameters, IIndexExistsRequest>, IIndexExistsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesExists;
@@ -308,7 +308,7 @@ namespace Nest
 		public IndexExistsDescriptor Local(bool? local = true) => Qs("local", local);
 	}
 
-	///<summary>descriptor for AliasExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>descriptor for AliasExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class AliasExistsDescriptor : RequestDescriptorBase<AliasExistsDescriptor, AliasExistsRequestParameters, IAliasExistsRequest>, IAliasExistsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesAliasExists;
@@ -352,7 +352,7 @@ namespace Nest
 		public AliasExistsDescriptor Local(bool? local = true) => Qs("local", local);
 	}
 
-	///<summary>descriptor for TemplateExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>descriptor for TemplateExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public partial class IndexTemplateExistsDescriptor : RequestDescriptorBase<IndexTemplateExistsDescriptor, IndexTemplateExistsRequestParameters, IIndexTemplateExistsRequest>, IIndexTemplateExistsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesTemplateExists;
@@ -379,7 +379,7 @@ namespace Nest
 		public IndexTemplateExistsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for TypeExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</pre></summary>
+	///<summary>descriptor for TypeExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</para></summary>
 	public partial class TypeExistsDescriptor : RequestDescriptorBase<TypeExistsDescriptor, TypeExistsRequestParameters, ITypeExistsRequest>, ITypeExistsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesTypeExists;
@@ -417,7 +417,7 @@ namespace Nest
 		public TypeExistsDescriptor Local(bool? local = true) => Qs("local", local);
 	}
 
-	///<summary>descriptor for Flush <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</pre></summary>
+	///<summary>descriptor for Flush <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para></summary>
 	public partial class FlushDescriptor : RequestDescriptorBase<FlushDescriptor, FlushRequestParameters, IFlushRequest>, IFlushRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesFlush;
@@ -454,7 +454,7 @@ namespace Nest
 		public FlushDescriptor WaitIfOngoing(bool? waitifongoing = true) => Qs("wait_if_ongoing", waitifongoing);
 	}
 
-	///<summary>descriptor for SyncedFlush <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</pre></summary>
+	///<summary>descriptor for SyncedFlush <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para></summary>
 	public partial class SyncedFlushDescriptor : RequestDescriptorBase<SyncedFlushDescriptor, SyncedFlushRequestParameters, ISyncedFlushRequest>, ISyncedFlushRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesSyncedFlush;
@@ -487,7 +487,7 @@ namespace Nest
 		public SyncedFlushDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 	}
 
-	///<summary>descriptor for ForceMerge <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</pre></summary>
+	///<summary>descriptor for ForceMerge <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</para></summary>
 	public partial class ForceMergeDescriptor : RequestDescriptorBase<ForceMergeDescriptor, ForceMergeRequestParameters, IForceMergeRequest>, IForceMergeRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesForceMerge;
@@ -526,7 +526,7 @@ namespace Nest
 		public ForceMergeDescriptor OnlyExpungeDeletes(bool? onlyexpungedeletes = true) => Qs("only_expunge_deletes", onlyexpungedeletes);
 	}
 
-	///<summary>descriptor for Get <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</pre></summary>
+	///<summary>descriptor for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</para></summary>
 	public partial class GetIndexDescriptor : RequestDescriptorBase<GetIndexDescriptor, GetIndexRequestParameters, IGetIndexRequest>, IGetIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesGet;
@@ -570,7 +570,7 @@ namespace Nest
 		public GetIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for GetAlias <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>descriptor for GetAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class GetAliasDescriptor : RequestDescriptorBase<GetAliasDescriptor, GetAliasRequestParameters, IGetAliasRequest>, IGetAliasRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesGetAlias;
@@ -621,7 +621,7 @@ namespace Nest
 		public GetAliasDescriptor Local(bool? local = true) => Qs("local", local);
 	}
 
-	///<summary>descriptor for GetFieldMapping <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</pre></summary>
+	///<summary>descriptor for GetFieldMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</para></summary>
 	public partial class GetFieldMappingDescriptor<TDocument> : RequestDescriptorBase<GetFieldMappingDescriptor<TDocument>, GetFieldMappingRequestParameters, IGetFieldMappingRequest>, IGetFieldMappingRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesGetFieldMapping;
@@ -669,7 +669,7 @@ namespace Nest
 		public GetFieldMappingDescriptor<TDocument> Local(bool? local = true) => Qs("local", local);
 	}
 
-	///<summary>descriptor for GetMapping <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</pre></summary>
+	///<summary>descriptor for GetMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</para></summary>
 	public partial class GetMappingDescriptor<TDocument> : RequestDescriptorBase<GetMappingDescriptor<TDocument>, GetMappingRequestParameters, IGetMappingRequest>, IGetMappingRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesGetMapping;
@@ -708,7 +708,7 @@ namespace Nest
 		public GetMappingDescriptor<TDocument> MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for GetSettings <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</pre></summary>
+	///<summary>descriptor for GetSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</para></summary>
 	public partial class GetIndexSettingsDescriptor : RequestDescriptorBase<GetIndexSettingsDescriptor, GetIndexSettingsRequestParameters, IGetIndexSettingsRequest>, IGetIndexSettingsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesGetSettings;
@@ -765,7 +765,7 @@ namespace Nest
 		public GetIndexSettingsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for GetTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>descriptor for GetTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public partial class GetIndexTemplateDescriptor : RequestDescriptorBase<GetIndexTemplateDescriptor, GetIndexTemplateRequestParameters, IGetIndexTemplateRequest>, IGetIndexTemplateRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesGetTemplate;
@@ -795,7 +795,7 @@ namespace Nest
 		public GetIndexTemplateDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for UpgradeStatus <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</pre></summary>
+	///<summary>descriptor for UpgradeStatus <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para></summary>
 	public partial class UpgradeStatusDescriptor : RequestDescriptorBase<UpgradeStatusDescriptor, UpgradeStatusRequestParameters, IUpgradeStatusRequest>, IUpgradeStatusRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesUpgradeStatus;
@@ -828,7 +828,7 @@ namespace Nest
 		public UpgradeStatusDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 	}
 
-	///<summary>descriptor for Open <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</pre></summary>
+	///<summary>descriptor for Open <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 	public partial class OpenIndexDescriptor : RequestDescriptorBase<OpenIndexDescriptor, OpenIndexRequestParameters, IOpenIndexRequest>, IOpenIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesOpen;
@@ -868,7 +868,7 @@ namespace Nest
 		public OpenIndexDescriptor WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for PutAlias <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>descriptor for PutAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class PutAliasDescriptor : RequestDescriptorBase<PutAliasDescriptor, PutAliasRequestParameters, IPutAliasRequest>, IPutAliasRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesPutAlias;
@@ -902,7 +902,7 @@ namespace Nest
 		public PutAliasDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for PutMapping <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</pre></summary>
+	///<summary>descriptor for PutMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</para></summary>
 	public partial class PutMappingDescriptor<TDocument> : RequestDescriptorBase<PutMappingDescriptor<TDocument>, PutMappingRequestParameters, IPutMappingRequest<TDocument>>, IPutMappingRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesPutMapping;
@@ -941,7 +941,7 @@ namespace Nest
 		public PutMappingDescriptor<TDocument> Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for UpdateSettings <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</pre></summary>
+	///<summary>descriptor for UpdateSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</para></summary>
 	public partial class UpdateIndexSettingsDescriptor : RequestDescriptorBase<UpdateIndexSettingsDescriptor, UpdateIndexSettingsRequestParameters, IUpdateIndexSettingsRequest>, IUpdateIndexSettingsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesUpdateSettings;
@@ -982,7 +982,7 @@ namespace Nest
 		public UpdateIndexSettingsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for PutTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>descriptor for PutTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public partial class PutIndexTemplateDescriptor : RequestDescriptorBase<PutIndexTemplateDescriptor, PutIndexTemplateRequestParameters, IPutIndexTemplateRequest>, IPutIndexTemplateRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesPutTemplate;
@@ -1013,7 +1013,7 @@ namespace Nest
 		public PutIndexTemplateDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for RecoveryStatus <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</pre></summary>
+	///<summary>descriptor for RecoveryStatus <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para></summary>
 	public partial class RecoveryStatusDescriptor : RequestDescriptorBase<RecoveryStatusDescriptor, RecoveryStatusRequestParameters, IRecoveryStatusRequest>, IRecoveryStatusRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesRecoveryStatus;
@@ -1044,7 +1044,7 @@ namespace Nest
 		public RecoveryStatusDescriptor Detailed(bool? detailed = true) => Qs("detailed", detailed);
 	}
 
-	///<summary>descriptor for Refresh <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</pre></summary>
+	///<summary>descriptor for Refresh <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</para></summary>
 	public partial class RefreshDescriptor : RequestDescriptorBase<RefreshDescriptor, RefreshRequestParameters, IRefreshRequest>, IRefreshRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesRefresh;
@@ -1077,7 +1077,7 @@ namespace Nest
 		public RefreshDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 	}
 
-	///<summary>descriptor for Rollover <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</pre></summary>
+	///<summary>descriptor for Rollover <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</para></summary>
 	public partial class RolloverIndexDescriptor : RequestDescriptorBase<RolloverIndexDescriptor, RolloverIndexRequestParameters, IRolloverIndexRequest>, IRolloverIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesRollover;
@@ -1118,7 +1118,7 @@ namespace Nest
 		public RolloverIndexDescriptor WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for Segments <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</pre></summary>
+	///<summary>descriptor for Segments <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</para></summary>
 	public partial class SegmentsDescriptor : RequestDescriptorBase<SegmentsDescriptor, SegmentsRequestParameters, ISegmentsRequest>, ISegmentsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesSegments;
@@ -1153,7 +1153,7 @@ namespace Nest
 		public SegmentsDescriptor Verbose(bool? verbose = true) => Qs("verbose", verbose);
 	}
 
-	///<summary>descriptor for ShardStores <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</pre></summary>
+	///<summary>descriptor for ShardStores <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</para></summary>
 	public partial class IndicesShardStoresDescriptor : RequestDescriptorBase<IndicesShardStoresDescriptor, IndicesShardStoresRequestParameters, IIndicesShardStoresRequest>, IIndicesShardStoresRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesShardStores;
@@ -1188,7 +1188,7 @@ namespace Nest
 		public IndicesShardStoresDescriptor Status(params string[] status) => Qs("status", status);
 	}
 
-	///<summary>descriptor for Shrink <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</pre></summary>
+	///<summary>descriptor for Shrink <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</para></summary>
 	public partial class ShrinkIndexDescriptor : RequestDescriptorBase<ShrinkIndexDescriptor, ShrinkIndexRequestParameters, IShrinkIndexRequest>, IShrinkIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesShrink;
@@ -1222,7 +1222,7 @@ namespace Nest
 		public ShrinkIndexDescriptor WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for Split <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</pre></summary>
+	///<summary>descriptor for Split <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</para></summary>
 	public partial class SplitIndexDescriptor : RequestDescriptorBase<SplitIndexDescriptor, SplitIndexRequestParameters, ISplitIndexRequest>, ISplitIndexRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesSplit;
@@ -1256,7 +1256,7 @@ namespace Nest
 		public SplitIndexDescriptor WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for Stats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</pre></summary>
+	///<summary>descriptor for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</para></summary>
 	public partial class IndicesStatsDescriptor : RequestDescriptorBase<IndicesStatsDescriptor, IndicesStatsRequestParameters, IIndicesStatsRequest>, IIndicesStatsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesStats;
@@ -1320,7 +1320,7 @@ namespace Nest
 		public IndicesStatsDescriptor Level(Level? level) => Qs("level", level);
 	}
 
-	///<summary>descriptor for BulkAlias <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>descriptor for BulkAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class BulkAliasDescriptor : RequestDescriptorBase<BulkAliasDescriptor, BulkAliasRequestParameters, IBulkAliasRequest>, IBulkAliasRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesBulkAlias;
@@ -1332,7 +1332,7 @@ namespace Nest
 		public BulkAliasDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for Upgrade <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</pre></summary>
+	///<summary>descriptor for Upgrade <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para></summary>
 	public partial class UpgradeDescriptor : RequestDescriptorBase<UpgradeDescriptor, UpgradeRequestParameters, IUpgradeRequest>, IUpgradeRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesUpgrade;
@@ -1369,7 +1369,7 @@ namespace Nest
 		public UpgradeDescriptor WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
 
-	///<summary>descriptor for ValidateQuery <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</pre></summary>
+	///<summary>descriptor for ValidateQuery <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</para></summary>
 	public partial class ValidateQueryDescriptor<TDocument> : RequestDescriptorBase<ValidateQueryDescriptor<TDocument>, ValidateQueryRequestParameters, IValidateQueryRequest<TDocument>>, IValidateQueryRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesValidateQuery;

--- a/src/Nest/Descriptors.Ingest.cs
+++ b/src/Nest/Descriptors.Ingest.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.IngestApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for DeletePipeline <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>descriptor for DeletePipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class DeletePipelineDescriptor : RequestDescriptorBase<DeletePipelineDescriptor, DeletePipelineRequestParameters, IDeletePipelineRequest>, IDeletePipelineRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestDeletePipeline;
@@ -55,7 +55,7 @@ namespace Nest
 		public DeletePipelineDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for GetPipeline <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>descriptor for GetPipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class GetPipelineDescriptor : RequestDescriptorBase<GetPipelineDescriptor, GetPipelineRequestParameters, IGetPipelineRequest>, IGetPipelineRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestGetPipeline;
@@ -79,7 +79,7 @@ namespace Nest
 		public GetPipelineDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for GrokProcessorPatterns <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>descriptor for GrokProcessorPatterns <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class GrokProcessorPatternsDescriptor : RequestDescriptorBase<GrokProcessorPatternsDescriptor, GrokProcessorPatternsRequestParameters, IGrokProcessorPatternsRequest>, IGrokProcessorPatternsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestGrokProcessorPatterns;
@@ -87,7 +87,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PutPipeline <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>descriptor for PutPipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class PutPipelineDescriptor : RequestDescriptorBase<PutPipelineDescriptor, PutPipelineRequestParameters, IPutPipelineRequest>, IPutPipelineRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestPutPipeline;
@@ -112,7 +112,7 @@ namespace Nest
 		public PutPipelineDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for SimulatePipeline <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>descriptor for SimulatePipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class SimulatePipelineDescriptor : RequestDescriptorBase<SimulatePipelineDescriptor, SimulatePipelineRequestParameters, ISimulatePipelineRequest>, ISimulatePipelineRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IngestSimulatePipeline;

--- a/src/Nest/Descriptors.License.cs
+++ b/src/Nest/Descriptors.License.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.LicenseApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Delete <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>descriptor for Delete <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class DeleteLicenseDescriptor : RequestDescriptorBase<DeleteLicenseDescriptor, DeleteLicenseRequestParameters, IDeleteLicenseRequest>, IDeleteLicenseRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.LicenseDelete;
@@ -38,7 +38,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Get <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>descriptor for Get <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class GetLicenseDescriptor : RequestDescriptorBase<GetLicenseDescriptor, GetLicenseRequestParameters, IGetLicenseRequest>, IGetLicenseRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.LicenseGet;
@@ -48,7 +48,7 @@ namespace Nest
 		public GetLicenseDescriptor Local(bool? local = true) => Qs("local", local);
 	}
 
-	///<summary>descriptor for GetBasicStatus <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>descriptor for GetBasicStatus <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class GetBasicLicenseStatusDescriptor : RequestDescriptorBase<GetBasicLicenseStatusDescriptor, GetBasicLicenseStatusRequestParameters, IGetBasicLicenseStatusRequest>, IGetBasicLicenseStatusRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.LicenseGetBasicStatus;
@@ -56,7 +56,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetTrialStatus <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>descriptor for GetTrialStatus <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class GetTrialLicenseStatusDescriptor : RequestDescriptorBase<GetTrialLicenseStatusDescriptor, GetTrialLicenseStatusRequestParameters, IGetTrialLicenseStatusRequest>, IGetTrialLicenseStatusRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.LicenseGetTrialStatus;
@@ -64,7 +64,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Post <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>descriptor for Post <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class PostLicenseDescriptor : RequestDescriptorBase<PostLicenseDescriptor, PostLicenseRequestParameters, IPostLicenseRequest>, IPostLicenseRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.LicensePost;
@@ -74,7 +74,7 @@ namespace Nest
 		public PostLicenseDescriptor Acknowledge(bool? acknowledge = true) => Qs("acknowledge", acknowledge);
 	}
 
-	///<summary>descriptor for StartBasic <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>descriptor for StartBasic <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class StartBasicLicenseDescriptor : RequestDescriptorBase<StartBasicLicenseDescriptor, StartBasicLicenseRequestParameters, IStartBasicLicenseRequest>, IStartBasicLicenseRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.LicenseStartBasic;
@@ -84,7 +84,7 @@ namespace Nest
 		public StartBasicLicenseDescriptor Acknowledge(bool? acknowledge = true) => Qs("acknowledge", acknowledge);
 	}
 
-	///<summary>descriptor for StartTrial <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>descriptor for StartTrial <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class StartTrialLicenseDescriptor : RequestDescriptorBase<StartTrialLicenseDescriptor, StartTrialLicenseRequestParameters, IStartTrialLicenseRequest>, IStartTrialLicenseRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.LicenseStartTrial;

--- a/src/Nest/Descriptors.MachineLearning.cs
+++ b/src/Nest/Descriptors.MachineLearning.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.MachineLearningApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for CloseJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</pre></summary>
+	///<summary>descriptor for CloseJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</para></summary>
 	public partial class CloseJobDescriptor : RequestDescriptorBase<CloseJobDescriptor, CloseJobRequestParameters, ICloseJobRequest>, ICloseJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningCloseJob;
@@ -57,7 +57,7 @@ namespace Nest
 		public CloseJobDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for DeleteCalendar <pre></pre></summary>
+	///<summary>descriptor for DeleteCalendar <para></para></summary>
 	public partial class DeleteCalendarDescriptor : RequestDescriptorBase<DeleteCalendarDescriptor, DeleteCalendarRequestParameters, IDeleteCalendarRequest>, IDeleteCalendarRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteCalendar;
@@ -78,7 +78,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for DeleteCalendarEvent <pre></pre></summary>
+	///<summary>descriptor for DeleteCalendarEvent <para></para></summary>
 	public partial class DeleteCalendarEventDescriptor : RequestDescriptorBase<DeleteCalendarEventDescriptor, DeleteCalendarEventRequestParameters, IDeleteCalendarEventRequest>, IDeleteCalendarEventRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteCalendarEvent;
@@ -101,7 +101,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for DeleteCalendarJob <pre></pre></summary>
+	///<summary>descriptor for DeleteCalendarJob <para></para></summary>
 	public partial class DeleteCalendarJobDescriptor : RequestDescriptorBase<DeleteCalendarJobDescriptor, DeleteCalendarJobRequestParameters, IDeleteCalendarJobRequest>, IDeleteCalendarJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteCalendarJob;
@@ -124,7 +124,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for DeleteDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</pre></summary>
+	///<summary>descriptor for DeleteDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</para></summary>
 	public partial class DeleteDatafeedDescriptor : RequestDescriptorBase<DeleteDatafeedDescriptor, DeleteDatafeedRequestParameters, IDeleteDatafeedRequest>, IDeleteDatafeedRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteDatafeed;
@@ -147,7 +147,7 @@ namespace Nest
 		public DeleteDatafeedDescriptor Force(bool? force = true) => Qs("force", force);
 	}
 
-	///<summary>descriptor for DeleteExpiredData <pre></pre></summary>
+	///<summary>descriptor for DeleteExpiredData <para></para></summary>
 	public partial class DeleteExpiredDataDescriptor : RequestDescriptorBase<DeleteExpiredDataDescriptor, DeleteExpiredDataRequestParameters, IDeleteExpiredDataRequest>, IDeleteExpiredDataRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteExpiredData;
@@ -155,7 +155,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for DeleteFilter <pre></pre></summary>
+	///<summary>descriptor for DeleteFilter <para></para></summary>
 	public partial class DeleteFilterDescriptor : RequestDescriptorBase<DeleteFilterDescriptor, DeleteFilterRequestParameters, IDeleteFilterRequest>, IDeleteFilterRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteFilter;
@@ -176,7 +176,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for DeleteForecast <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</pre></summary>
+	///<summary>descriptor for DeleteForecast <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</para></summary>
 	public partial class DeleteForecastDescriptor : RequestDescriptorBase<DeleteForecastDescriptor, DeleteForecastRequestParameters, IDeleteForecastRequest>, IDeleteForecastRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteForecast;
@@ -203,7 +203,7 @@ namespace Nest
 		public DeleteForecastDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for DeleteJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</pre></summary>
+	///<summary>descriptor for DeleteJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</para></summary>
 	public partial class DeleteJobDescriptor : RequestDescriptorBase<DeleteJobDescriptor, DeleteJobRequestParameters, IDeleteJobRequest>, IDeleteJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteJob;
@@ -228,7 +228,7 @@ namespace Nest
 		public DeleteJobDescriptor WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
 
-	///<summary>descriptor for DeleteModelSnapshot <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</pre></summary>
+	///<summary>descriptor for DeleteModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</para></summary>
 	public partial class DeleteModelSnapshotDescriptor : RequestDescriptorBase<DeleteModelSnapshotDescriptor, DeleteModelSnapshotRequestParameters, IDeleteModelSnapshotRequest>, IDeleteModelSnapshotRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningDeleteModelSnapshot;
@@ -251,7 +251,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for FlushJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</pre></summary>
+	///<summary>descriptor for FlushJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</para></summary>
 	public partial class FlushJobDescriptor : RequestDescriptorBase<FlushJobDescriptor, FlushJobRequestParameters, IFlushJobRequest>, IFlushJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningFlushJob;
@@ -274,7 +274,7 @@ namespace Nest
 		public FlushJobDescriptor SkipTime(string skiptime) => Qs("skip_time", skiptime);
 	}
 
-	///<summary>descriptor for ForecastJob <pre></pre></summary>
+	///<summary>descriptor for ForecastJob <para></para></summary>
 	public partial class ForecastJobDescriptor : RequestDescriptorBase<ForecastJobDescriptor, ForecastJobRequestParameters, IForecastJobRequest>, IForecastJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningForecastJob;
@@ -295,7 +295,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetBuckets <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</pre></summary>
+	///<summary>descriptor for GetBuckets <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</para></summary>
 	public partial class GetBucketsDescriptor : RequestDescriptorBase<GetBucketsDescriptor, GetBucketsRequestParameters, IGetBucketsRequest>, IGetBucketsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetBuckets;
@@ -326,7 +326,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetCalendarEvents <pre></pre></summary>
+	///<summary>descriptor for GetCalendarEvents <para></para></summary>
 	public partial class GetCalendarEventsDescriptor : RequestDescriptorBase<GetCalendarEventsDescriptor, GetCalendarEventsRequestParameters, IGetCalendarEventsRequest>, IGetCalendarEventsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetCalendarEvents;
@@ -353,7 +353,7 @@ namespace Nest
 		public GetCalendarEventsDescriptor Start(string start) => Qs("start", start);
 	}
 
-	///<summary>descriptor for GetCalendars <pre></pre></summary>
+	///<summary>descriptor for GetCalendars <para></para></summary>
 	public partial class GetCalendarsDescriptor : RequestDescriptorBase<GetCalendarsDescriptor, GetCalendarsRequestParameters, IGetCalendarsRequest>, IGetCalendarsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetCalendars;
@@ -375,7 +375,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetCategories <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</pre></summary>
+	///<summary>descriptor for GetCategories <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</para></summary>
 	public partial class GetCategoriesDescriptor : RequestDescriptorBase<GetCategoriesDescriptor, GetCategoriesRequestParameters, IGetCategoriesRequest>, IGetCategoriesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetCategories;
@@ -406,7 +406,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetDatafeedStats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</pre></summary>
+	///<summary>descriptor for GetDatafeedStats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</para></summary>
 	public partial class GetDatafeedStatsDescriptor : RequestDescriptorBase<GetDatafeedStatsDescriptor, GetDatafeedStatsRequestParameters, IGetDatafeedStatsRequest>, IGetDatafeedStatsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetDatafeedStats;
@@ -430,7 +430,7 @@ namespace Nest
 		public GetDatafeedStatsDescriptor AllowNoDatafeeds(bool? allownodatafeeds = true) => Qs("allow_no_datafeeds", allownodatafeeds);
 	}
 
-	///<summary>descriptor for GetDatafeeds <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</pre></summary>
+	///<summary>descriptor for GetDatafeeds <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</para></summary>
 	public partial class GetDatafeedsDescriptor : RequestDescriptorBase<GetDatafeedsDescriptor, GetDatafeedsRequestParameters, IGetDatafeedsRequest>, IGetDatafeedsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetDatafeeds;
@@ -454,7 +454,7 @@ namespace Nest
 		public GetDatafeedsDescriptor AllowNoDatafeeds(bool? allownodatafeeds = true) => Qs("allow_no_datafeeds", allownodatafeeds);
 	}
 
-	///<summary>descriptor for GetFilters <pre></pre></summary>
+	///<summary>descriptor for GetFilters <para></para></summary>
 	public partial class GetFiltersDescriptor : RequestDescriptorBase<GetFiltersDescriptor, GetFiltersRequestParameters, IGetFiltersRequest>, IGetFiltersRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetFilters;
@@ -480,7 +480,7 @@ namespace Nest
 		public GetFiltersDescriptor Size(int? size) => Qs("size", size);
 	}
 
-	///<summary>descriptor for GetInfluencers <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</pre></summary>
+	///<summary>descriptor for GetInfluencers <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</para></summary>
 	public partial class GetInfluencersDescriptor : RequestDescriptorBase<GetInfluencersDescriptor, GetInfluencersRequestParameters, IGetInfluencersRequest>, IGetInfluencersRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetInfluencers;
@@ -501,7 +501,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetJobStats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</pre></summary>
+	///<summary>descriptor for GetJobStats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</para></summary>
 	public partial class GetJobStatsDescriptor : RequestDescriptorBase<GetJobStatsDescriptor, GetJobStatsRequestParameters, IGetJobStatsRequest>, IGetJobStatsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetJobStats;
@@ -525,7 +525,7 @@ namespace Nest
 		public GetJobStatsDescriptor AllowNoJobs(bool? allownojobs = true) => Qs("allow_no_jobs", allownojobs);
 	}
 
-	///<summary>descriptor for GetJobs <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</pre></summary>
+	///<summary>descriptor for GetJobs <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</para></summary>
 	public partial class GetJobsDescriptor : RequestDescriptorBase<GetJobsDescriptor, GetJobsRequestParameters, IGetJobsRequest>, IGetJobsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetJobs;
@@ -549,7 +549,7 @@ namespace Nest
 		public GetJobsDescriptor AllowNoJobs(bool? allownojobs = true) => Qs("allow_no_jobs", allownojobs);
 	}
 
-	///<summary>descriptor for GetModelSnapshots <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</pre></summary>
+	///<summary>descriptor for GetModelSnapshots <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</para></summary>
 	public partial class GetModelSnapshotsDescriptor : RequestDescriptorBase<GetModelSnapshotsDescriptor, GetModelSnapshotsRequestParameters, IGetModelSnapshotsRequest>, IGetModelSnapshotsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetModelSnapshots;
@@ -580,7 +580,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetOverallBuckets <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</pre></summary>
+	///<summary>descriptor for GetOverallBuckets <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</para></summary>
 	public partial class GetOverallBucketsDescriptor : RequestDescriptorBase<GetOverallBucketsDescriptor, GetOverallBucketsRequestParameters, IGetOverallBucketsRequest>, IGetOverallBucketsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetOverallBuckets;
@@ -601,7 +601,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetAnomalyRecords <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</pre></summary>
+	///<summary>descriptor for GetAnomalyRecords <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</para></summary>
 	public partial class GetAnomalyRecordsDescriptor : RequestDescriptorBase<GetAnomalyRecordsDescriptor, GetAnomalyRecordsRequestParameters, IGetAnomalyRecordsRequest>, IGetAnomalyRecordsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningGetAnomalyRecords;
@@ -622,7 +622,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Info <pre></pre></summary>
+	///<summary>descriptor for Info <para></para></summary>
 	public partial class MachineLearningInfoDescriptor : RequestDescriptorBase<MachineLearningInfoDescriptor, MachineLearningInfoRequestParameters, IMachineLearningInfoRequest>, IMachineLearningInfoRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningInfo;
@@ -630,7 +630,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for OpenJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</pre></summary>
+	///<summary>descriptor for OpenJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</para></summary>
 	public partial class OpenJobDescriptor : RequestDescriptorBase<OpenJobDescriptor, OpenJobRequestParameters, IOpenJobRequest>, IOpenJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningOpenJob;
@@ -651,7 +651,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PostCalendarEvents <pre></pre></summary>
+	///<summary>descriptor for PostCalendarEvents <para></para></summary>
 	public partial class PostCalendarEventsDescriptor : RequestDescriptorBase<PostCalendarEventsDescriptor, PostCalendarEventsRequestParameters, IPostCalendarEventsRequest>, IPostCalendarEventsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningPostCalendarEvents;
@@ -672,7 +672,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PostJobData <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</pre></summary>
+	///<summary>descriptor for PostJobData <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</para></summary>
 	public partial class PostJobDataDescriptor : RequestDescriptorBase<PostJobDataDescriptor, PostJobDataRequestParameters, IPostJobDataRequest>, IPostJobDataRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningPostJobData;
@@ -697,7 +697,7 @@ namespace Nest
 		public PostJobDataDescriptor ResetStart(DateTimeOffset? resetstart) => Qs("reset_start", resetstart);
 	}
 
-	///<summary>descriptor for PreviewDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</pre></summary>
+	///<summary>descriptor for PreviewDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
 	public partial class PreviewDatafeedDescriptor : RequestDescriptorBase<PreviewDatafeedDescriptor, PreviewDatafeedRequestParameters, IPreviewDatafeedRequest>, IPreviewDatafeedRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningPreviewDatafeed;
@@ -718,7 +718,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PutCalendar <pre></pre></summary>
+	///<summary>descriptor for PutCalendar <para></para></summary>
 	public partial class PutCalendarDescriptor : RequestDescriptorBase<PutCalendarDescriptor, PutCalendarRequestParameters, IPutCalendarRequest>, IPutCalendarRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningPutCalendar;
@@ -739,7 +739,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PutCalendarJob <pre></pre></summary>
+	///<summary>descriptor for PutCalendarJob <para></para></summary>
 	public partial class PutCalendarJobDescriptor : RequestDescriptorBase<PutCalendarJobDescriptor, PutCalendarJobRequestParameters, IPutCalendarJobRequest>, IPutCalendarJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningPutCalendarJob;
@@ -762,7 +762,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PutDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</pre></summary>
+	///<summary>descriptor for PutDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</para></summary>
 	public partial class PutDatafeedDescriptor<TDocument> : RequestDescriptorBase<PutDatafeedDescriptor<TDocument>, PutDatafeedRequestParameters, IPutDatafeedRequest>, IPutDatafeedRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningPutDatafeed;
@@ -783,7 +783,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PutFilter <pre></pre></summary>
+	///<summary>descriptor for PutFilter <para></para></summary>
 	public partial class PutFilterDescriptor : RequestDescriptorBase<PutFilterDescriptor, PutFilterRequestParameters, IPutFilterRequest>, IPutFilterRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningPutFilter;
@@ -804,7 +804,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PutJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</pre></summary>
+	///<summary>descriptor for PutJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</para></summary>
 	public partial class PutJobDescriptor<TDocument> : RequestDescriptorBase<PutJobDescriptor<TDocument>, PutJobRequestParameters, IPutJobRequest>, IPutJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningPutJob;
@@ -825,7 +825,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for RevertModelSnapshot <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</pre></summary>
+	///<summary>descriptor for RevertModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</para></summary>
 	public partial class RevertModelSnapshotDescriptor : RequestDescriptorBase<RevertModelSnapshotDescriptor, RevertModelSnapshotRequestParameters, IRevertModelSnapshotRequest>, IRevertModelSnapshotRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningRevertModelSnapshot;
@@ -848,7 +848,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for StartDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</pre></summary>
+	///<summary>descriptor for StartDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</para></summary>
 	public partial class StartDatafeedDescriptor : RequestDescriptorBase<StartDatafeedDescriptor, StartDatafeedRequestParameters, IStartDatafeedRequest>, IStartDatafeedRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningStartDatafeed;
@@ -869,7 +869,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for StopDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</pre></summary>
+	///<summary>descriptor for StopDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</para></summary>
 	public partial class StopDatafeedDescriptor : RequestDescriptorBase<StopDatafeedDescriptor, StopDatafeedRequestParameters, IStopDatafeedRequest>, IStopDatafeedRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningStopDatafeed;
@@ -892,7 +892,7 @@ namespace Nest
 		public StopDatafeedDescriptor AllowNoDatafeeds(bool? allownodatafeeds = true) => Qs("allow_no_datafeeds", allownodatafeeds);
 	}
 
-	///<summary>descriptor for UpdateDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</pre></summary>
+	///<summary>descriptor for UpdateDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</para></summary>
 	public partial class UpdateDatafeedDescriptor<TDocument> : RequestDescriptorBase<UpdateDatafeedDescriptor<TDocument>, UpdateDatafeedRequestParameters, IUpdateDatafeedRequest>, IUpdateDatafeedRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningUpdateDatafeed;
@@ -913,7 +913,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for UpdateFilter <pre></pre></summary>
+	///<summary>descriptor for UpdateFilter <para></para></summary>
 	public partial class UpdateFilterDescriptor : RequestDescriptorBase<UpdateFilterDescriptor, UpdateFilterRequestParameters, IUpdateFilterRequest>, IUpdateFilterRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningUpdateFilter;
@@ -934,7 +934,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for UpdateJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</pre></summary>
+	///<summary>descriptor for UpdateJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</para></summary>
 	public partial class UpdateJobDescriptor<TDocument> : RequestDescriptorBase<UpdateJobDescriptor<TDocument>, UpdateJobRequestParameters, IUpdateJobRequest>, IUpdateJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningUpdateJob;
@@ -955,7 +955,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for UpdateModelSnapshot <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</pre></summary>
+	///<summary>descriptor for UpdateModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</para></summary>
 	public partial class UpdateModelSnapshotDescriptor : RequestDescriptorBase<UpdateModelSnapshotDescriptor, UpdateModelSnapshotRequestParameters, IUpdateModelSnapshotRequest>, IUpdateModelSnapshotRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningUpdateModelSnapshot;
@@ -978,7 +978,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for ValidateJob <pre></pre></summary>
+	///<summary>descriptor for ValidateJob <para></para></summary>
 	public partial class ValidateJobDescriptor<TDocument> : RequestDescriptorBase<ValidateJobDescriptor<TDocument>, ValidateJobRequestParameters, IValidateJobRequest>, IValidateJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningValidateJob;
@@ -986,7 +986,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for ValidateDetector <pre></pre></summary>
+	///<summary>descriptor for ValidateDetector <para></para></summary>
 	public partial class ValidateDetectorDescriptor<TDocument> : RequestDescriptorBase<ValidateDetectorDescriptor<TDocument>, ValidateDetectorRequestParameters, IValidateDetectorRequest>, IValidateDetectorRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MachineLearningValidateDetector;

--- a/src/Nest/Descriptors.Migration.cs
+++ b/src/Nest/Descriptors.Migration.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.MigrationApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for DeprecationInfo <pre>http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</pre></summary>
+	///<summary>descriptor for DeprecationInfo <para>http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</para></summary>
 	public partial class DeprecationInfoDescriptor : RequestDescriptorBase<DeprecationInfoDescriptor, DeprecationInfoRequestParameters, IDeprecationInfoRequest>, IDeprecationInfoRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MigrationDeprecationInfo;
@@ -55,7 +55,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Assistance <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</pre></summary>
+	///<summary>descriptor for Assistance <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</para></summary>
 	public partial class MigrationAssistanceDescriptor : RequestDescriptorBase<MigrationAssistanceDescriptor, MigrationAssistanceRequestParameters, IMigrationAssistanceRequest>, IMigrationAssistanceRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MigrationAssistance;
@@ -88,7 +88,7 @@ namespace Nest
 		public MigrationAssistanceDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 	}
 
-	///<summary>descriptor for Upgrade <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</pre></summary>
+	///<summary>descriptor for Upgrade <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</para></summary>
 	public partial class MigrationUpgradeDescriptor : RequestDescriptorBase<MigrationUpgradeDescriptor, MigrationUpgradeRequestParameters, IMigrationUpgradeRequest>, IMigrationUpgradeRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.MigrationUpgrade;

--- a/src/Nest/Descriptors.NoNamespace.cs
+++ b/src/Nest/Descriptors.NoNamespace.cs
@@ -29,7 +29,7 @@ using Elasticsearch.Net.Utf8Json;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Bulk <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</pre></summary>
+	///<summary>descriptor for Bulk <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</para></summary>
 	public partial class BulkDescriptor : RequestDescriptorBase<BulkDescriptor, BulkRequestParameters, IBulkRequest>, IBulkRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceBulk;
@@ -84,7 +84,7 @@ namespace Nest
 		public BulkDescriptor WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for ClearScroll <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</pre></summary>
+	///<summary>descriptor for ClearScroll <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</para></summary>
 	public partial class ClearScrollDescriptor : RequestDescriptorBase<ClearScrollDescriptor, ClearScrollRequestParameters, IClearScrollRequest>, IClearScrollRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceClearScroll;
@@ -92,7 +92,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Count <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</pre></summary>
+	///<summary>descriptor for Count <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</para></summary>
 	public partial class CountDescriptor<TDocument> : RequestDescriptorBase<CountDescriptor<TDocument>, CountRequestParameters, ICountRequest<TDocument>>, ICountRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceCount;
@@ -153,7 +153,7 @@ namespace Nest
 		public CountDescriptor<TDocument> TerminateAfter(long? terminateafter) => Qs("terminate_after", terminateafter);
 	}
 
-	///<summary>descriptor for Create <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</pre></summary>
+	///<summary>descriptor for Create <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 	public partial class CreateDescriptor<TDocument> : RequestDescriptorBase<CreateDescriptor<TDocument>, CreateRequestParameters, ICreateRequest<TDocument>>, ICreateRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceCreate;
@@ -211,7 +211,7 @@ namespace Nest
 		public CreateDescriptor<TDocument> WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for Delete <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</pre></summary>
+	///<summary>descriptor for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</para></summary>
 	public partial class DeleteDescriptor<TDocument> : RequestDescriptorBase<DeleteDescriptor<TDocument>, DeleteRequestParameters, IDeleteRequest<TDocument>>, IDeleteRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceDelete;
@@ -271,7 +271,7 @@ namespace Nest
 		public DeleteDescriptor<TDocument> WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for DeleteByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</pre></summary>
+	///<summary>descriptor for DeleteByQuery <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</para></summary>
 	public partial class DeleteByQueryDescriptor<TDocument> : RequestDescriptorBase<DeleteByQueryDescriptor<TDocument>, DeleteByQueryRequestParameters, IDeleteByQueryRequest<TDocument>>, IDeleteByQueryRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceDeleteByQuery;
@@ -372,7 +372,7 @@ namespace Nest
 		public DeleteByQueryDescriptor<TDocument> WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
 
-	///<summary>descriptor for DeleteByQueryRethrottle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</pre></summary>
+	///<summary>descriptor for DeleteByQueryRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</para></summary>
 	public partial class DeleteByQueryRethrottleDescriptor : RequestDescriptorBase<DeleteByQueryRethrottleDescriptor, DeleteByQueryRethrottleRequestParameters, IDeleteByQueryRethrottleRequest>, IDeleteByQueryRethrottleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceDeleteByQueryRethrottle;
@@ -395,7 +395,7 @@ namespace Nest
 		public DeleteByQueryRethrottleDescriptor RequestsPerSecond(long? requestspersecond) => Qs("requests_per_second", requestspersecond);
 	}
 
-	///<summary>descriptor for DeleteScript <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>descriptor for DeleteScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public partial class DeleteScriptDescriptor : RequestDescriptorBase<DeleteScriptDescriptor, DeleteScriptRequestParameters, IDeleteScriptRequest>, IDeleteScriptRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceDeleteScript;
@@ -420,7 +420,7 @@ namespace Nest
 		public DeleteScriptDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for DocumentExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>descriptor for DocumentExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public partial class DocumentExistsDescriptor<TDocument> : RequestDescriptorBase<DocumentExistsDescriptor<TDocument>, DocumentExistsRequestParameters, IDocumentExistsRequest<TDocument>>, IDocumentExistsRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceDocumentExists;
@@ -490,7 +490,7 @@ namespace Nest
 		public DocumentExistsDescriptor<TDocument> VersionType(VersionType? versiontype) => Qs("version_type", versiontype);
 	}
 
-	///<summary>descriptor for SourceExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>descriptor for SourceExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public partial class SourceExistsDescriptor<TDocument> : RequestDescriptorBase<SourceExistsDescriptor<TDocument>, SourceExistsRequestParameters, ISourceExistsRequest<TDocument>>, ISourceExistsRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceSourceExists;
@@ -556,7 +556,7 @@ namespace Nest
 		public SourceExistsDescriptor<TDocument> VersionType(VersionType? versiontype) => Qs("version_type", versiontype);
 	}
 
-	///<summary>descriptor for Explain <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</pre></summary>
+	///<summary>descriptor for Explain <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</para></summary>
 	public partial class ExplainDescriptor<TDocument> : RequestDescriptorBase<ExplainDescriptor<TDocument>, ExplainRequestParameters, IExplainRequest<TDocument>>, IExplainRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceExplain;
@@ -626,7 +626,7 @@ namespace Nest
 		public ExplainDescriptor<TDocument> SourceIncludes(params Expression<Func<TDocument, object>>[] fields) => Qs("_source_includes", fields?.Select(e => (Field)e));
 	}
 
-	///<summary>descriptor for FieldCapabilities <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</pre></summary>
+	///<summary>descriptor for FieldCapabilities <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</para></summary>
 	public partial class FieldCapabilitiesDescriptor : RequestDescriptorBase<FieldCapabilitiesDescriptor, FieldCapabilitiesRequestParameters, IFieldCapabilitiesRequest>, IFieldCapabilitiesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceFieldCapabilities;
@@ -664,7 +664,7 @@ namespace Nest
 		public FieldCapabilitiesDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 	}
 
-	///<summary>descriptor for Get <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>descriptor for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public partial class GetDescriptor<TDocument> : RequestDescriptorBase<GetDescriptor<TDocument>, GetRequestParameters, IGetRequest<TDocument>>, IGetRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceGet;
@@ -734,7 +734,7 @@ namespace Nest
 		public GetDescriptor<TDocument> VersionType(VersionType? versiontype) => Qs("version_type", versiontype);
 	}
 
-	///<summary>descriptor for GetScript <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>descriptor for GetScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public partial class GetScriptDescriptor : RequestDescriptorBase<GetScriptDescriptor, GetScriptRequestParameters, IGetScriptRequest>, IGetScriptRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceGetScript;
@@ -757,7 +757,7 @@ namespace Nest
 		public GetScriptDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for Source <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>descriptor for Source <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public partial class SourceDescriptor<TDocument> : RequestDescriptorBase<SourceDescriptor<TDocument>, SourceRequestParameters, ISourceRequest<TDocument>>, ISourceRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceSource;
@@ -823,7 +823,7 @@ namespace Nest
 		public SourceDescriptor<TDocument> VersionType(VersionType? versiontype) => Qs("version_type", versiontype);
 	}
 
-	///<summary>descriptor for Index <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</pre></summary>
+	///<summary>descriptor for Index <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 	public partial class IndexDescriptor<TDocument> : RequestDescriptorBase<IndexDescriptor<TDocument>, IndexRequestParameters, IIndexRequest<TDocument>>, IIndexRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceIndex;
@@ -894,7 +894,7 @@ namespace Nest
 		public IndexDescriptor<TDocument> WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for RootNodeInfo <pre>http://www.elastic.co/guide/</pre></summary>
+	///<summary>descriptor for RootNodeInfo <para>http://www.elastic.co/guide/</para></summary>
 	public partial class RootNodeInfoDescriptor : RequestDescriptorBase<RootNodeInfoDescriptor, RootNodeInfoRequestParameters, IRootNodeInfoRequest>, IRootNodeInfoRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceRootNodeInfo;
@@ -902,7 +902,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for MultiGet <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</pre></summary>
+	///<summary>descriptor for MultiGet <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</para></summary>
 	public partial class MultiGetDescriptor : RequestDescriptorBase<MultiGetDescriptor, MultiGetRequestParameters, IMultiGetRequest>, IMultiGetRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceMultiGet;
@@ -953,7 +953,7 @@ namespace Nest
 			where T : class => Qs("_source_includes", fields?.Select(e => (Field)e));
 	}
 
-	///<summary>descriptor for MultiSearch <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</pre></summary>
+	///<summary>descriptor for MultiSearch <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</para></summary>
 	public partial class MultiSearchDescriptor : RequestDescriptorBase<MultiSearchDescriptor, MultiSearchRequestParameters, IMultiSearchRequest>, IMultiSearchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceMultiSearch;
@@ -994,7 +994,7 @@ namespace Nest
 		public MultiSearchDescriptor TypedKeys(bool? typedkeys = true) => Qs("typed_keys", typedkeys);
 	}
 
-	///<summary>descriptor for MultiSearchTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</pre></summary>
+	///<summary>descriptor for MultiSearchTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</para></summary>
 	public partial class MultiSearchTemplateDescriptor : RequestDescriptorBase<MultiSearchTemplateDescriptor, MultiSearchTemplateRequestParameters, IMultiSearchTemplateRequest>, IMultiSearchTemplateRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceMultiSearchTemplate;
@@ -1031,7 +1031,7 @@ namespace Nest
 		public MultiSearchTemplateDescriptor TypedKeys(bool? typedkeys = true) => Qs("typed_keys", typedkeys);
 	}
 
-	///<summary>descriptor for MultiTermVectors <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</pre></summary>
+	///<summary>descriptor for MultiTermVectors <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</para></summary>
 	public partial class MultiTermVectorsDescriptor : RequestDescriptorBase<MultiTermVectorsDescriptor, MultiTermVectorsRequestParameters, IMultiTermVectorsRequest>, IMultiTermVectorsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceMultiTermVectors;
@@ -1087,7 +1087,7 @@ namespace Nest
 		public MultiTermVectorsDescriptor VersionType(VersionType? versiontype) => Qs("version_type", versiontype);
 	}
 
-	///<summary>descriptor for Ping <pre>http://www.elastic.co/guide/</pre></summary>
+	///<summary>descriptor for Ping <para>http://www.elastic.co/guide/</para></summary>
 	public partial class PingDescriptor : RequestDescriptorBase<PingDescriptor, PingRequestParameters, IPingRequest>, IPingRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespacePing;
@@ -1095,7 +1095,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PutScript <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>descriptor for PutScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public partial class PutScriptDescriptor : RequestDescriptorBase<PutScriptDescriptor, PutScriptRequestParameters, IPutScriptRequest>, IPutScriptRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespacePutScript;
@@ -1130,7 +1130,7 @@ namespace Nest
 		public PutScriptDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for ReindexOnServer <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</pre></summary>
+	///<summary>descriptor for ReindexOnServer <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</para></summary>
 	public partial class ReindexOnServerDescriptor : RequestDescriptorBase<ReindexOnServerDescriptor, ReindexOnServerRequestParameters, IReindexOnServerRequest>, IReindexOnServerRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceReindexOnServer;
@@ -1152,7 +1152,7 @@ namespace Nest
 		public ReindexOnServerDescriptor WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
 
-	///<summary>descriptor for ReindexRethrottle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</pre></summary>
+	///<summary>descriptor for ReindexRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</para></summary>
 	public partial class ReindexRethrottleDescriptor : RequestDescriptorBase<ReindexRethrottleDescriptor, ReindexRethrottleRequestParameters, IReindexRethrottleRequest>, IReindexRethrottleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceReindexRethrottle;
@@ -1175,7 +1175,7 @@ namespace Nest
 		public ReindexRethrottleDescriptor RequestsPerSecond(long? requestspersecond) => Qs("requests_per_second", requestspersecond);
 	}
 
-	///<summary>descriptor for RenderSearchTemplate <pre>http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</pre></summary>
+	///<summary>descriptor for RenderSearchTemplate <para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para></summary>
 	public partial class RenderSearchTemplateDescriptor : RequestDescriptorBase<RenderSearchTemplateDescriptor, RenderSearchTemplateRequestParameters, IRenderSearchTemplateRequest>, IRenderSearchTemplateRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceRenderSearchTemplate;
@@ -1197,7 +1197,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for ExecutePainlessScript <pre>https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</pre></summary>
+	///<summary>descriptor for ExecutePainlessScript <para>https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</para></summary>
 	public partial class ExecutePainlessScriptDescriptor : RequestDescriptorBase<ExecutePainlessScriptDescriptor, ExecutePainlessScriptRequestParameters, IExecutePainlessScriptRequest>, IExecutePainlessScriptRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceExecutePainlessScript;
@@ -1205,7 +1205,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Scroll <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</pre></summary>
+	///<summary>descriptor for Scroll <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</para></summary>
 	public partial class ScrollDescriptor<TInferDocument> : RequestDescriptorBase<ScrollDescriptor<TInferDocument>, ScrollRequestParameters, IScrollRequest>, IScrollRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceScroll;
@@ -1215,7 +1215,7 @@ namespace Nest
 		public ScrollDescriptor<TInferDocument> TotalHitsAsInteger(bool? totalhitsasinteger = true) => Qs("rest_total_hits_as_int", totalhitsasinteger);
 	}
 
-	///<summary>descriptor for Search <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</pre></summary>
+	///<summary>descriptor for Search <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</para></summary>
 	public partial class SearchDescriptor<TInferDocument> : RequestDescriptorBase<SearchDescriptor<TInferDocument>, SearchRequestParameters, ISearchRequest<TInferDocument>>, ISearchRequest<TInferDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceSearch;
@@ -1306,7 +1306,7 @@ namespace Nest
 		public SearchDescriptor<TInferDocument> TypedKeys(bool? typedkeys = true) => Qs("typed_keys", typedkeys);
 	}
 
-	///<summary>descriptor for SearchShards <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</pre></summary>
+	///<summary>descriptor for SearchShards <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para></summary>
 	public partial class SearchShardsDescriptor<TDocument> : RequestDescriptorBase<SearchShardsDescriptor<TDocument>, SearchShardsRequestParameters, ISearchShardsRequest<TDocument>>, ISearchShardsRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceSearchShards;
@@ -1351,7 +1351,7 @@ namespace Nest
 		public SearchShardsDescriptor<TDocument> Routing(Routing routing) => Qs("routing", routing);
 	}
 
-	///<summary>descriptor for SearchTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</pre></summary>
+	///<summary>descriptor for SearchTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para></summary>
 	public partial class SearchTemplateDescriptor<TDocument> : RequestDescriptorBase<SearchTemplateDescriptor<TDocument>, SearchTemplateRequestParameters, ISearchTemplateRequest>, ISearchTemplateRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceSearchTemplate;
@@ -1410,7 +1410,7 @@ namespace Nest
 		public SearchTemplateDescriptor<TDocument> TypedKeys(bool? typedkeys = true) => Qs("typed_keys", typedkeys);
 	}
 
-	///<summary>descriptor for TermVectors <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</pre></summary>
+	///<summary>descriptor for TermVectors <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</para></summary>
 	public partial class TermVectorsDescriptor<TDocument> : RequestDescriptorBase<TermVectorsDescriptor<TDocument>, TermVectorsRequestParameters, ITermVectorsRequest<TDocument>>, ITermVectorsRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceTermVectors;
@@ -1485,7 +1485,7 @@ namespace Nest
 		public TermVectorsDescriptor<TDocument> VersionType(VersionType? versiontype) => Qs("version_type", versiontype);
 	}
 
-	///<summary>descriptor for Update <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</pre></summary>
+	///<summary>descriptor for Update <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</para></summary>
 	public partial class UpdateDescriptor<TDocument, TPartialDocument> : RequestDescriptorBase<UpdateDescriptor<TDocument, TPartialDocument>, UpdateRequestParameters, IUpdateRequest<TDocument, TPartialDocument>>, IUpdateRequest<TDocument, TPartialDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceUpdate;
@@ -1547,7 +1547,7 @@ namespace Nest
 		public UpdateDescriptor<TDocument, TPartialDocument> WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
 	}
 
-	///<summary>descriptor for UpdateByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</pre></summary>
+	///<summary>descriptor for UpdateByQuery <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</para></summary>
 	public partial class UpdateByQueryDescriptor<TDocument> : RequestDescriptorBase<UpdateByQueryDescriptor<TDocument>, UpdateByQueryRequestParameters, IUpdateByQueryRequest<TDocument>>, IUpdateByQueryRequest<TDocument>
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceUpdateByQuery;
@@ -1652,7 +1652,7 @@ namespace Nest
 		public UpdateByQueryDescriptor<TDocument> WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
 
-	///<summary>descriptor for UpdateByQueryRethrottle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</pre></summary>
+	///<summary>descriptor for UpdateByQueryRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</para></summary>
 	public partial class UpdateByQueryRethrottleDescriptor : RequestDescriptorBase<UpdateByQueryRethrottleDescriptor, UpdateByQueryRethrottleRequestParameters, IUpdateByQueryRethrottleRequest>, IUpdateByQueryRethrottleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceUpdateByQueryRethrottle;

--- a/src/Nest/Descriptors.Nodes.cs
+++ b/src/Nest/Descriptors.Nodes.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.NodesApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for HotThreads <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</pre></summary>
+	///<summary>descriptor for HotThreads <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</para></summary>
 	public partial class NodesHotThreadsDescriptor : RequestDescriptorBase<NodesHotThreadsDescriptor, NodesHotThreadsRequestParameters, INodesHotThreadsRequest>, INodesHotThreadsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesHotThreads;
@@ -64,7 +64,7 @@ namespace Nest
 		public NodesHotThreadsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for Info <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</pre></summary>
+	///<summary>descriptor for Info <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</para></summary>
 	public partial class NodesInfoDescriptor : RequestDescriptorBase<NodesInfoDescriptor, NodesInfoRequestParameters, INodesInfoRequest>, INodesInfoRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesInfo;
@@ -106,7 +106,7 @@ namespace Nest
 		public NodesInfoDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for ReloadSecureSettings <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</pre></summary>
+	///<summary>descriptor for ReloadSecureSettings <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</para></summary>
 	public partial class ReloadSecureSettingsDescriptor : RequestDescriptorBase<ReloadSecureSettingsDescriptor, ReloadSecureSettingsRequestParameters, IReloadSecureSettingsRequest>, IReloadSecureSettingsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesReloadSecureSettings;
@@ -130,7 +130,7 @@ namespace Nest
 		public ReloadSecureSettingsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for Stats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</pre></summary>
+	///<summary>descriptor for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</para></summary>
 	public partial class NodesStatsDescriptor : RequestDescriptorBase<NodesStatsDescriptor, NodesStatsRequestParameters, INodesStatsRequest>, INodesStatsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesStats;
@@ -211,7 +211,7 @@ namespace Nest
 		public NodesStatsDescriptor Types(params string[] types) => Qs("types", types);
 	}
 
-	///<summary>descriptor for Usage <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</pre></summary>
+	///<summary>descriptor for Usage <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</para></summary>
 	public partial class NodesUsageDescriptor : RequestDescriptorBase<NodesUsageDescriptor, NodesUsageRequestParameters, INodesUsageRequest>, INodesUsageRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NodesUsage;

--- a/src/Nest/Descriptors.Rollup.cs
+++ b/src/Nest/Descriptors.Rollup.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.RollupApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for DeleteJob <pre></pre></summary>
+	///<summary>descriptor for DeleteJob <para></para></summary>
 	public partial class DeleteRollupJobDescriptor : RequestDescriptorBase<DeleteRollupJobDescriptor, DeleteRollupJobRequestParameters, IDeleteRollupJobRequest>, IDeleteRollupJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.RollupDeleteJob;
@@ -51,7 +51,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetJob <pre></pre></summary>
+	///<summary>descriptor for GetJob <para></para></summary>
 	public partial class GetRollupJobDescriptor : RequestDescriptorBase<GetRollupJobDescriptor, GetRollupJobRequestParameters, IGetRollupJobRequest>, IGetRollupJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.RollupGetJob;
@@ -73,7 +73,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetCapabilities <pre></pre></summary>
+	///<summary>descriptor for GetCapabilities <para></para></summary>
 	public partial class GetRollupCapabilitiesDescriptor : RequestDescriptorBase<GetRollupCapabilitiesDescriptor, GetRollupCapabilitiesRequestParameters, IGetRollupCapabilitiesRequest>, IGetRollupCapabilitiesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.RollupGetCapabilities;
@@ -95,7 +95,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetIndexCapabilities <pre></pre></summary>
+	///<summary>descriptor for GetIndexCapabilities <para></para></summary>
 	public partial class GetRollupIndexCapabilitiesDescriptor : RequestDescriptorBase<GetRollupIndexCapabilitiesDescriptor, GetRollupIndexCapabilitiesRequestParameters, IGetRollupIndexCapabilitiesRequest>, IGetRollupIndexCapabilitiesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.RollupGetIndexCapabilities;
@@ -121,7 +121,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for CreateJob <pre></pre></summary>
+	///<summary>descriptor for CreateJob <para></para></summary>
 	public partial class CreateRollupJobDescriptor<TDocument> : RequestDescriptorBase<CreateRollupJobDescriptor<TDocument>, CreateRollupJobRequestParameters, ICreateRollupJobRequest>, ICreateRollupJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.RollupCreateJob;
@@ -142,7 +142,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Search <pre></pre></summary>
+	///<summary>descriptor for Search <para></para></summary>
 	public partial class RollupSearchDescriptor<TDocument> : RequestDescriptorBase<RollupSearchDescriptor<TDocument>, RollupSearchRequestParameters, IRollupSearchRequest>, IRollupSearchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.RollupSearch;
@@ -173,7 +173,7 @@ namespace Nest
 		public RollupSearchDescriptor<TDocument> TypedKeys(bool? typedkeys = true) => Qs("typed_keys", typedkeys);
 	}
 
-	///<summary>descriptor for StartJob <pre></pre></summary>
+	///<summary>descriptor for StartJob <para></para></summary>
 	public partial class StartRollupJobDescriptor : RequestDescriptorBase<StartRollupJobDescriptor, StartRollupJobRequestParameters, IStartRollupJobRequest>, IStartRollupJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.RollupStartJob;
@@ -194,7 +194,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for StopJob <pre></pre></summary>
+	///<summary>descriptor for StopJob <para></para></summary>
 	public partial class StopRollupJobDescriptor : RequestDescriptorBase<StopRollupJobDescriptor, StopRollupJobRequestParameters, IStopRollupJobRequest>, IStopRollupJobRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.RollupStopJob;

--- a/src/Nest/Descriptors.Security.cs
+++ b/src/Nest/Descriptors.Security.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.SecurityApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Authenticate <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</pre></summary>
+	///<summary>descriptor for Authenticate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</para></summary>
 	public partial class AuthenticateDescriptor : RequestDescriptorBase<AuthenticateDescriptor, AuthenticateRequestParameters, IAuthenticateRequest>, IAuthenticateRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityAuthenticate;
@@ -38,7 +38,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for ChangePassword <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</pre></summary>
+	///<summary>descriptor for ChangePassword <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</para></summary>
 	public partial class ChangePasswordDescriptor : RequestDescriptorBase<ChangePasswordDescriptor, ChangePasswordRequestParameters, IChangePasswordRequest>, IChangePasswordRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityChangePassword;
@@ -62,7 +62,7 @@ namespace Nest
 		public ChangePasswordDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for ClearCachedRealms <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</pre></summary>
+	///<summary>descriptor for ClearCachedRealms <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</para></summary>
 	public partial class ClearCachedRealmsDescriptor : RequestDescriptorBase<ClearCachedRealmsDescriptor, ClearCachedRealmsRequestParameters, IClearCachedRealmsRequest>, IClearCachedRealmsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityClearCachedRealms;
@@ -85,7 +85,7 @@ namespace Nest
 		public ClearCachedRealmsDescriptor Usernames(params string[] usernames) => Qs("usernames", usernames);
 	}
 
-	///<summary>descriptor for ClearCachedRoles <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</pre></summary>
+	///<summary>descriptor for ClearCachedRoles <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</para></summary>
 	public partial class ClearCachedRolesDescriptor : RequestDescriptorBase<ClearCachedRolesDescriptor, ClearCachedRolesRequestParameters, IClearCachedRolesRequest>, IClearCachedRolesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityClearCachedRoles;
@@ -106,7 +106,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for CreateApiKey <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</pre></summary>
+	///<summary>descriptor for CreateApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</para></summary>
 	public partial class CreateApiKeyDescriptor : RequestDescriptorBase<CreateApiKeyDescriptor, CreateApiKeyRequestParameters, ICreateApiKeyRequest>, ICreateApiKeyRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityCreateApiKey;
@@ -116,7 +116,7 @@ namespace Nest
 		public CreateApiKeyDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for DeletePrivileges <pre>TODO</pre></summary>
+	///<summary>descriptor for DeletePrivileges <para>TODO</para></summary>
 	public partial class DeletePrivilegesDescriptor : RequestDescriptorBase<DeletePrivilegesDescriptor, DeletePrivilegesRequestParameters, IDeletePrivilegesRequest>, IDeletePrivilegesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityDeletePrivileges;
@@ -141,7 +141,7 @@ namespace Nest
 		public DeletePrivilegesDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for DeleteRole <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</pre></summary>
+	///<summary>descriptor for DeleteRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</para></summary>
 	public partial class DeleteRoleDescriptor : RequestDescriptorBase<DeleteRoleDescriptor, DeleteRoleRequestParameters, IDeleteRoleRequest>, IDeleteRoleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityDeleteRole;
@@ -164,7 +164,7 @@ namespace Nest
 		public DeleteRoleDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for DeleteRoleMapping <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</pre></summary>
+	///<summary>descriptor for DeleteRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</para></summary>
 	public partial class DeleteRoleMappingDescriptor : RequestDescriptorBase<DeleteRoleMappingDescriptor, DeleteRoleMappingRequestParameters, IDeleteRoleMappingRequest>, IDeleteRoleMappingRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityDeleteRoleMapping;
@@ -187,7 +187,7 @@ namespace Nest
 		public DeleteRoleMappingDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for DeleteUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</pre></summary>
+	///<summary>descriptor for DeleteUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</para></summary>
 	public partial class DeleteUserDescriptor : RequestDescriptorBase<DeleteUserDescriptor, DeleteUserRequestParameters, IDeleteUserRequest>, IDeleteUserRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityDeleteUser;
@@ -210,7 +210,7 @@ namespace Nest
 		public DeleteUserDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for DisableUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</pre></summary>
+	///<summary>descriptor for DisableUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</para></summary>
 	public partial class DisableUserDescriptor : RequestDescriptorBase<DisableUserDescriptor, DisableUserRequestParameters, IDisableUserRequest>, IDisableUserRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityDisableUser;
@@ -233,7 +233,7 @@ namespace Nest
 		public DisableUserDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for EnableUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</pre></summary>
+	///<summary>descriptor for EnableUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</para></summary>
 	public partial class EnableUserDescriptor : RequestDescriptorBase<EnableUserDescriptor, EnableUserRequestParameters, IEnableUserRequest>, IEnableUserRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityEnableUser;
@@ -256,7 +256,7 @@ namespace Nest
 		public EnableUserDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for GetApiKey <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</pre></summary>
+	///<summary>descriptor for GetApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</para></summary>
 	public partial class GetApiKeyDescriptor : RequestDescriptorBase<GetApiKeyDescriptor, GetApiKeyRequestParameters, IGetApiKeyRequest>, IGetApiKeyRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetApiKey;
@@ -272,7 +272,7 @@ namespace Nest
 		public GetApiKeyDescriptor Username(string username) => Qs("username", username);
 	}
 
-	///<summary>descriptor for GetPrivileges <pre>TODO</pre></summary>
+	///<summary>descriptor for GetPrivileges <para>TODO</para></summary>
 	public partial class GetPrivilegesDescriptor : RequestDescriptorBase<GetPrivilegesDescriptor, GetPrivilegesRequestParameters, IGetPrivilegesRequest>, IGetPrivilegesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetPrivileges;
@@ -304,7 +304,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetRole <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</pre></summary>
+	///<summary>descriptor for GetRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</para></summary>
 	public partial class GetRoleDescriptor : RequestDescriptorBase<GetRoleDescriptor, GetRoleRequestParameters, IGetRoleRequest>, IGetRoleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetRole;
@@ -326,7 +326,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetRoleMapping <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</pre></summary>
+	///<summary>descriptor for GetRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</para></summary>
 	public partial class GetRoleMappingDescriptor : RequestDescriptorBase<GetRoleMappingDescriptor, GetRoleMappingRequestParameters, IGetRoleMappingRequest>, IGetRoleMappingRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetRoleMapping;
@@ -348,7 +348,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetUserAccessToken <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</pre></summary>
+	///<summary>descriptor for GetUserAccessToken <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</para></summary>
 	public partial class GetUserAccessTokenDescriptor : RequestDescriptorBase<GetUserAccessTokenDescriptor, GetUserAccessTokenRequestParameters, IGetUserAccessTokenRequest>, IGetUserAccessTokenRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetUserAccessToken;
@@ -356,7 +356,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</pre></summary>
+	///<summary>descriptor for GetUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</para></summary>
 	public partial class GetUserDescriptor : RequestDescriptorBase<GetUserDescriptor, GetUserRequestParameters, IGetUserRequest>, IGetUserRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetUser;
@@ -378,7 +378,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for GetUserPrivileges <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</pre></summary>
+	///<summary>descriptor for GetUserPrivileges <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</para></summary>
 	public partial class GetUserPrivilegesDescriptor : RequestDescriptorBase<GetUserPrivilegesDescriptor, GetUserPrivilegesRequestParameters, IGetUserPrivilegesRequest>, IGetUserPrivilegesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetUserPrivileges;
@@ -386,7 +386,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for HasPrivileges <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</pre></summary>
+	///<summary>descriptor for HasPrivileges <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</para></summary>
 	public partial class HasPrivilegesDescriptor : RequestDescriptorBase<HasPrivilegesDescriptor, HasPrivilegesRequestParameters, IHasPrivilegesRequest>, IHasPrivilegesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityHasPrivileges;
@@ -409,7 +409,7 @@ namespace Nest
 	//TODO THIS METHOD IS UNMAPPED!
 	}
 
-	///<summary>descriptor for InvalidateApiKey <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</pre></summary>
+	///<summary>descriptor for InvalidateApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</para></summary>
 	public partial class InvalidateApiKeyDescriptor : RequestDescriptorBase<InvalidateApiKeyDescriptor, InvalidateApiKeyRequestParameters, IInvalidateApiKeyRequest>, IInvalidateApiKeyRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityInvalidateApiKey;
@@ -417,7 +417,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for InvalidateUserAccessToken <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</pre></summary>
+	///<summary>descriptor for InvalidateUserAccessToken <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</para></summary>
 	public partial class InvalidateUserAccessTokenDescriptor : RequestDescriptorBase<InvalidateUserAccessTokenDescriptor, InvalidateUserAccessTokenRequestParameters, IInvalidateUserAccessTokenRequest>, IInvalidateUserAccessTokenRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityInvalidateUserAccessToken;
@@ -425,7 +425,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for PutPrivileges <pre>TODO</pre></summary>
+	///<summary>descriptor for PutPrivileges <para>TODO</para></summary>
 	public partial class PutPrivilegesDescriptor : RequestDescriptorBase<PutPrivilegesDescriptor, PutPrivilegesRequestParameters, IPutPrivilegesRequest>, IPutPrivilegesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityPutPrivileges;
@@ -435,7 +435,7 @@ namespace Nest
 		public PutPrivilegesDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for PutRole <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</pre></summary>
+	///<summary>descriptor for PutRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</para></summary>
 	public partial class PutRoleDescriptor : RequestDescriptorBase<PutRoleDescriptor, PutRoleRequestParameters, IPutRoleRequest>, IPutRoleRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityPutRole;
@@ -458,7 +458,7 @@ namespace Nest
 		public PutRoleDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for PutRoleMapping <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</pre></summary>
+	///<summary>descriptor for PutRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</para></summary>
 	public partial class PutRoleMappingDescriptor : RequestDescriptorBase<PutRoleMappingDescriptor, PutRoleMappingRequestParameters, IPutRoleMappingRequest>, IPutRoleMappingRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityPutRoleMapping;
@@ -481,7 +481,7 @@ namespace Nest
 		public PutRoleMappingDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for PutUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</pre></summary>
+	///<summary>descriptor for PutUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</para></summary>
 	public partial class PutUserDescriptor : RequestDescriptorBase<PutUserDescriptor, PutUserRequestParameters, IPutUserRequest>, IPutUserRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityPutUser;
@@ -504,7 +504,7 @@ namespace Nest
 		public PutUserDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
-	///<summary>descriptor for GetCertificates <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</pre></summary>
+	///<summary>descriptor for GetCertificates <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</para></summary>
 	public partial class GetCertificatesDescriptor : RequestDescriptorBase<GetCertificatesDescriptor, GetCertificatesRequestParameters, IGetCertificatesRequest>, IGetCertificatesRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetCertificates;

--- a/src/Nest/Descriptors.Snapshot.cs
+++ b/src/Nest/Descriptors.Snapshot.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.SnapshotApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Snapshot <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for Snapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class SnapshotDescriptor : RequestDescriptorBase<SnapshotDescriptor, SnapshotRequestParameters, ISnapshotRequest>, ISnapshotRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotSnapshot;
@@ -57,7 +57,7 @@ namespace Nest
 		public SnapshotDescriptor WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
 
-	///<summary>descriptor for CreateRepository <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for CreateRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class CreateRepositoryDescriptor : RequestDescriptorBase<CreateRepositoryDescriptor, CreateRepositoryRequestParameters, ICreateRepositoryRequest>, ICreateRepositoryRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotCreateRepository;
@@ -84,7 +84,7 @@ namespace Nest
 		public CreateRepositoryDescriptor Verify(bool? verify = true) => Qs("verify", verify);
 	}
 
-	///<summary>descriptor for Delete <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class DeleteSnapshotDescriptor : RequestDescriptorBase<DeleteSnapshotDescriptor, DeleteSnapshotRequestParameters, IDeleteSnapshotRequest>, IDeleteSnapshotRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotDelete;
@@ -109,7 +109,7 @@ namespace Nest
 		public DeleteSnapshotDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for DeleteRepository <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for DeleteRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class DeleteRepositoryDescriptor : RequestDescriptorBase<DeleteRepositoryDescriptor, DeleteRepositoryRequestParameters, IDeleteRepositoryRequest>, IDeleteRepositoryRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotDeleteRepository;
@@ -134,7 +134,7 @@ namespace Nest
 		public DeleteRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
 
-	///<summary>descriptor for Get <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class GetSnapshotDescriptor : RequestDescriptorBase<GetSnapshotDescriptor, GetSnapshotRequestParameters, IGetSnapshotRequest>, IGetSnapshotRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotGet;
@@ -163,7 +163,7 @@ namespace Nest
 		public GetSnapshotDescriptor Verbose(bool? verbose = true) => Qs("verbose", verbose);
 	}
 
-	///<summary>descriptor for GetRepository <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for GetRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class GetRepositoryDescriptor : RequestDescriptorBase<GetRepositoryDescriptor, GetRepositoryRequestParameters, IGetRepositoryRequest>, IGetRepositoryRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotGetRepository;
@@ -189,7 +189,7 @@ namespace Nest
 		public GetRepositoryDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for Restore <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for Restore <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class RestoreDescriptor : RequestDescriptorBase<RestoreDescriptor, RestoreRequestParameters, IRestoreRequest>, IRestoreRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotRestore;
@@ -216,7 +216,7 @@ namespace Nest
 		public RestoreDescriptor WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
 
-	///<summary>descriptor for Status <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for Status <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class SnapshotStatusDescriptor : RequestDescriptorBase<SnapshotStatusDescriptor, SnapshotStatusRequestParameters, ISnapshotStatusRequest>, ISnapshotStatusRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotStatus;
@@ -252,7 +252,7 @@ namespace Nest
 		public SnapshotStatusDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
 	}
 
-	///<summary>descriptor for VerifyRepository <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>descriptor for VerifyRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class VerifyRepositoryDescriptor : RequestDescriptorBase<VerifyRepositoryDescriptor, VerifyRepositoryRequestParameters, IVerifyRepositoryRequest>, IVerifyRepositoryRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SnapshotVerifyRepository;

--- a/src/Nest/Descriptors.Sql.cs
+++ b/src/Nest/Descriptors.Sql.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.SqlApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for ClearCursor <pre>Clear SQL cursor</pre></summary>
+	///<summary>descriptor for ClearCursor <para>Clear SQL cursor</para></summary>
 	public partial class ClearSqlCursorDescriptor : RequestDescriptorBase<ClearSqlCursorDescriptor, ClearSqlCursorRequestParameters, IClearSqlCursorRequest>, IClearSqlCursorRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SqlClearCursor;
@@ -38,7 +38,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Query <pre>Execute SQL</pre></summary>
+	///<summary>descriptor for Query <para>Execute SQL</para></summary>
 	public partial class QuerySqlDescriptor : RequestDescriptorBase<QuerySqlDescriptor, QuerySqlRequestParameters, IQuerySqlRequest>, IQuerySqlRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SqlQuery;
@@ -48,7 +48,7 @@ namespace Nest
 		public QuerySqlDescriptor Format(string format) => Qs("format", format);
 	}
 
-	///<summary>descriptor for Translate <pre>Translate SQL into Elasticsearch queries</pre></summary>
+	///<summary>descriptor for Translate <para>Translate SQL into Elasticsearch queries</para></summary>
 	public partial class TranslateSqlDescriptor : RequestDescriptorBase<TranslateSqlDescriptor, TranslateSqlRequestParameters, ITranslateSqlRequest>, ITranslateSqlRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SqlTranslate;

--- a/src/Nest/Descriptors.Tasks.cs
+++ b/src/Nest/Descriptors.Tasks.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.TasksApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Cancel <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>descriptor for Cancel <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public partial class CancelTasksDescriptor : RequestDescriptorBase<CancelTasksDescriptor, CancelTasksRequestParameters, ICancelTasksRequest>, ICancelTasksRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.TasksCancel;
@@ -58,7 +58,7 @@ namespace Nest
 		public CancelTasksDescriptor ParentTaskId(string parenttaskid) => Qs("parent_task_id", parenttaskid);
 	}
 
-	///<summary>descriptor for GetTask <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>descriptor for GetTask <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public partial class GetTaskDescriptor : RequestDescriptorBase<GetTaskDescriptor, GetTaskRequestParameters, IGetTaskRequest>, IGetTaskRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.TasksGetTask;
@@ -83,7 +83,7 @@ namespace Nest
 		public GetTaskDescriptor WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
 
-	///<summary>descriptor for List <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>descriptor for List <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public partial class ListTasksDescriptor : RequestDescriptorBase<ListTasksDescriptor, ListTasksRequestParameters, IListTasksRequest>, IListTasksRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.TasksList;

--- a/src/Nest/Descriptors.Watcher.cs
+++ b/src/Nest/Descriptors.Watcher.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.WatcherApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Acknowledge <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</pre></summary>
+	///<summary>descriptor for Acknowledge <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</para></summary>
 	public partial class AcknowledgeWatchDescriptor : RequestDescriptorBase<AcknowledgeWatchDescriptor, AcknowledgeWatchRequestParameters, IAcknowledgeWatchRequest>, IAcknowledgeWatchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherAcknowledge;
@@ -61,7 +61,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Activate <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</pre></summary>
+	///<summary>descriptor for Activate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</para></summary>
 	public partial class ActivateWatchDescriptor : RequestDescriptorBase<ActivateWatchDescriptor, ActivateWatchRequestParameters, IActivateWatchRequest>, IActivateWatchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherActivate;
@@ -82,7 +82,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Deactivate <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</pre></summary>
+	///<summary>descriptor for Deactivate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</para></summary>
 	public partial class DeactivateWatchDescriptor : RequestDescriptorBase<DeactivateWatchDescriptor, DeactivateWatchRequestParameters, IDeactivateWatchRequest>, IDeactivateWatchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherDeactivate;
@@ -103,7 +103,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Delete <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</pre></summary>
+	///<summary>descriptor for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</para></summary>
 	public partial class DeleteWatchDescriptor : RequestDescriptorBase<DeleteWatchDescriptor, DeleteWatchRequestParameters, IDeleteWatchRequest>, IDeleteWatchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherDelete;
@@ -124,7 +124,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Execute <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</pre></summary>
+	///<summary>descriptor for Execute <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</para></summary>
 	public partial class ExecuteWatchDescriptor : RequestDescriptorBase<ExecuteWatchDescriptor, ExecuteWatchRequestParameters, IExecuteWatchRequest>, IExecuteWatchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherExecute;
@@ -148,7 +148,7 @@ namespace Nest
 		public ExecuteWatchDescriptor Debug(bool? debug = true) => Qs("debug", debug);
 	}
 
-	///<summary>descriptor for Get <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</pre></summary>
+	///<summary>descriptor for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</para></summary>
 	public partial class GetWatchDescriptor : RequestDescriptorBase<GetWatchDescriptor, GetWatchRequestParameters, IGetWatchRequest>, IGetWatchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherGet;
@@ -169,7 +169,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Put <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</pre></summary>
+	///<summary>descriptor for Put <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</para></summary>
 	public partial class PutWatchDescriptor : RequestDescriptorBase<PutWatchDescriptor, PutWatchRequestParameters, IPutWatchRequest>, IPutWatchRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherPut;
@@ -198,7 +198,7 @@ namespace Nest
 		public PutWatchDescriptor Version(long? version) => Qs("version", version);
 	}
 
-	///<summary>descriptor for Start <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</pre></summary>
+	///<summary>descriptor for Start <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</para></summary>
 	public partial class StartWatcherDescriptor : RequestDescriptorBase<StartWatcherDescriptor, StartWatcherRequestParameters, IStartWatcherRequest>, IStartWatcherRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherStart;
@@ -206,7 +206,7 @@ namespace Nest
 	// Request parameters
 	}
 
-	///<summary>descriptor for Stats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</pre></summary>
+	///<summary>descriptor for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</para></summary>
 	public partial class WatcherStatsDescriptor : RequestDescriptorBase<WatcherStatsDescriptor, WatcherStatsRequestParameters, IWatcherStatsRequest>, IWatcherStatsRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherStats;
@@ -230,7 +230,7 @@ namespace Nest
 		public WatcherStatsDescriptor EmitStacktraces(bool? emitstacktraces = true) => Qs("emit_stacktraces", emitstacktraces);
 	}
 
-	///<summary>descriptor for Stop <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</pre></summary>
+	///<summary>descriptor for Stop <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</para></summary>
 	public partial class StopWatcherDescriptor : RequestDescriptorBase<StopWatcherDescriptor, StopWatcherRequestParameters, IStopWatcherRequest>, IStopWatcherRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.WatcherStop;

--- a/src/Nest/Descriptors.XPack.cs
+++ b/src/Nest/Descriptors.XPack.cs
@@ -30,7 +30,7 @@ using Elasticsearch.Net.Specification.XPackApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
-	///<summary>descriptor for Info <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</pre></summary>
+	///<summary>descriptor for Info <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</para></summary>
 	public partial class XPackInfoDescriptor : RequestDescriptorBase<XPackInfoDescriptor, XPackInfoRequestParameters, IXPackInfoRequest>, IXPackInfoRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.XPackInfo;
@@ -40,7 +40,7 @@ namespace Nest
 		public XPackInfoDescriptor Categories(params string[] categories) => Qs("categories", categories);
 	}
 
-	///<summary>descriptor for Usage <pre>Retrieve information about xpack features usage</pre></summary>
+	///<summary>descriptor for Usage <para>Retrieve information about xpack features usage</para></summary>
 	public partial class XPackUsageDescriptor : RequestDescriptorBase<XPackUsageDescriptor, XPackUsageRequestParameters, IXPackUsageRequest>, IXPackUsageRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.XPackUsage;

--- a/src/Nest/Document/Multiple/BulkAll/ElasticClient-BulkAll.cs
+++ b/src/Nest/Document/Multiple/BulkAll/ElasticClient-BulkAll.cs
@@ -7,7 +7,7 @@ namespace Nest
 	public partial interface IElasticClient
 	{
 		/// <summary>
-		/// BulkAll is a generic helper that will partition any lazy stream of documents and send them to elasticsearch as bulks concurrently
+		/// BulkAll is a generic helper that will partition any lazy stream of documents and send them to Elasticsearch as bulks concurrently
 		/// </summary>
 		/// <param name="documents">The lazy stream of documents</param>
 		BulkAllObservable<T> BulkAll<T>(
@@ -18,7 +18,7 @@ namespace Nest
 			where T : class;
 
 		/// <summary>
-		/// BulkAll is a generic helper that will partition any lazy stream of documents and send them to elasticsearch as bulks concurrently
+		/// BulkAll is a generic helper that will partition any lazy stream of documents and send them to Elasticsearch as bulks concurrently
 		/// </summary>
 		BulkAllObservable<T> BulkAll<T>(IBulkAllRequest<T> request, CancellationToken cancellationToken = default) where T : class;
 	}

--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-SourceMany.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-SourceMany.cs
@@ -12,7 +12,7 @@ namespace Nest
 	public static class SourceManyExtensions
 	{
 		/// <summary>
-		/// SourceMany allows you to get a list of T documents out of elasticsearch, internally it calls into MultiGet()
+		/// SourceMany allows you to get a list of T documents out of Elasticsearch, internally it calls into MultiGet()
 		/// <para>
 		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
@@ -37,7 +37,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// SourceMany allows you to get a list of T documents out of elasticsearch, internally it calls into MultiGet()
+		/// SourceMany allows you to get a list of T documents out of Elasticsearch, internally it calls into MultiGet()
 		/// <para>
 		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
@@ -54,7 +54,7 @@ namespace Nest
 			where T : class => client.SourceMany<T>(ids.Select(i => i.ToString(CultureInfo.InvariantCulture)), index);
 
 		/// <summary>
-		/// SourceMany allows you to get a list of T documents out of elasticsearch, internally it calls into MultiGet()
+		/// SourceMany allows you to get a list of T documents out of Elasticsearch, internally it calls into MultiGet()
 		/// <para>
 		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
@@ -81,7 +81,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// SourceMany allows you to get a list of T documents out of elasticsearch, internally it calls into MultiGet()
+		/// SourceMany allows you to get a list of T documents out of Elasticsearch, internally it calls into MultiGet()
 		/// <para>
 		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document

--- a/src/Nest/Document/Multiple/ScrollAll/ElasticClient-ScrollAll.cs
+++ b/src/Nest/Document/Multiple/ScrollAll/ElasticClient-ScrollAll.cs
@@ -6,7 +6,8 @@ namespace Nest
 	public partial interface IElasticClient
 	{
 		/// <summary>
-		/// Helper method that can parallelize a scroll using the sliced scroll feature of elasticsearch and return the results as an IObservable.
+		/// Helper method that can parallelize a scroll using the sliced scroll feature of Elasticsearch, and return the results as an
+		/// <see cref="IObservable{T}"/>.
 		/// </summary>
 		/// <param name="scrollTime">The time to keep the scroll active on the server until we send another scroll request</param>
 		/// <param name="numberOfSlices">
@@ -19,7 +20,8 @@ namespace Nest
 			where T : class;
 
 		/// <summary>
-		/// Helper method that can parallelize a scroll using the sliced scroll feature of elasticsearch and return the results as an IObservable.
+		/// Helper method that can parallelize a scroll using the sliced scroll feature of Elasticsearch and return the results as an
+		/// <see cref="IObservable{T}"/>.
 		/// </summary>
 		IObservable<ScrollAllResponse<T>> ScrollAll<T>(IScrollAllRequest request, CancellationToken cancellationToken = default(CancellationToken))
 			where T : class;

--- a/src/Nest/ElasticClient.Cat.cs
+++ b/src/Nest/ElasticClient.Cat.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.CatApi;
 namespace Nest.Specification.CatApi
 {
 	///<summary>
-	/// Logically groups all <c>Cat</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Cat"/> property
+	/// Cat APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Cat"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,481 +38,481 @@ namespace Nest.Specification.CatApi
 
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.aliases</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</a>
 		/// </summary>
 		public CatResponse<CatAliasesRecord> Aliases(Func<CatAliasesDescriptor, ICatAliasesRequest> selector = null) => Aliases(selector.InvokeOrDefault(new CatAliasesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.aliases</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</a>
 		/// </summary>
 		public Task<CatResponse<CatAliasesRecord>> AliasesAsync(Func<CatAliasesDescriptor, ICatAliasesRequest> selector = null, CancellationToken ct = default) => AliasesAsync(selector.InvokeOrDefault(new CatAliasesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.aliases</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</a>
 		/// </summary>
 		public CatResponse<CatAliasesRecord> Aliases(ICatAliasesRequest request) => DoCat<ICatAliasesRequest, CatAliasesRequestParameters, CatAliasesRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.aliases</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</a>
 		/// </summary>
 		public Task<CatResponse<CatAliasesRecord>> AliasesAsync(ICatAliasesRequest request, CancellationToken ct = default) => DoCatAsync<ICatAliasesRequest, CatAliasesRequestParameters, CatAliasesRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.allocation</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</a>
 		/// </summary>
 		public CatResponse<CatAllocationRecord> Allocation(Func<CatAllocationDescriptor, ICatAllocationRequest> selector = null) => Allocation(selector.InvokeOrDefault(new CatAllocationDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.allocation</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</a>
 		/// </summary>
 		public Task<CatResponse<CatAllocationRecord>> AllocationAsync(Func<CatAllocationDescriptor, ICatAllocationRequest> selector = null, CancellationToken ct = default) => AllocationAsync(selector.InvokeOrDefault(new CatAllocationDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.allocation</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</a>
 		/// </summary>
 		public CatResponse<CatAllocationRecord> Allocation(ICatAllocationRequest request) => DoCat<ICatAllocationRequest, CatAllocationRequestParameters, CatAllocationRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.allocation</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</a>
 		/// </summary>
 		public Task<CatResponse<CatAllocationRecord>> AllocationAsync(ICatAllocationRequest request, CancellationToken ct = default) => DoCatAsync<ICatAllocationRequest, CatAllocationRequestParameters, CatAllocationRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</a>
 		/// </summary>
 		public CatResponse<CatCountRecord> Count(Func<CatCountDescriptor, ICatCountRequest> selector = null) => Count(selector.InvokeOrDefault(new CatCountDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</a>
 		/// </summary>
 		public Task<CatResponse<CatCountRecord>> CountAsync(Func<CatCountDescriptor, ICatCountRequest> selector = null, CancellationToken ct = default) => CountAsync(selector.InvokeOrDefault(new CatCountDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</a>
 		/// </summary>
 		public CatResponse<CatCountRecord> Count(ICatCountRequest request) => DoCat<ICatCountRequest, CatCountRequestParameters, CatCountRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</a>
 		/// </summary>
 		public Task<CatResponse<CatCountRecord>> CountAsync(ICatCountRequest request, CancellationToken ct = default) => DoCatAsync<ICatCountRequest, CatCountRequestParameters, CatCountRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.fielddata</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</a>
 		/// </summary>
 		public CatResponse<CatFielddataRecord> Fielddata(Func<CatFielddataDescriptor, ICatFielddataRequest> selector = null) => Fielddata(selector.InvokeOrDefault(new CatFielddataDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.fielddata</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</a>
 		/// </summary>
 		public Task<CatResponse<CatFielddataRecord>> FielddataAsync(Func<CatFielddataDescriptor, ICatFielddataRequest> selector = null, CancellationToken ct = default) => FielddataAsync(selector.InvokeOrDefault(new CatFielddataDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.fielddata</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</a>
 		/// </summary>
 		public CatResponse<CatFielddataRecord> Fielddata(ICatFielddataRequest request) => DoCat<ICatFielddataRequest, CatFielddataRequestParameters, CatFielddataRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.fielddata</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</a>
 		/// </summary>
 		public Task<CatResponse<CatFielddataRecord>> FielddataAsync(ICatFielddataRequest request, CancellationToken ct = default) => DoCatAsync<ICatFielddataRequest, CatFielddataRequestParameters, CatFielddataRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.health</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</a>
 		/// </summary>
 		public CatResponse<CatHealthRecord> Health(Func<CatHealthDescriptor, ICatHealthRequest> selector = null) => Health(selector.InvokeOrDefault(new CatHealthDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.health</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</a>
 		/// </summary>
 		public Task<CatResponse<CatHealthRecord>> HealthAsync(Func<CatHealthDescriptor, ICatHealthRequest> selector = null, CancellationToken ct = default) => HealthAsync(selector.InvokeOrDefault(new CatHealthDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.health</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</a>
 		/// </summary>
 		public CatResponse<CatHealthRecord> Health(ICatHealthRequest request) => DoCat<ICatHealthRequest, CatHealthRequestParameters, CatHealthRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.health</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</a>
 		/// </summary>
 		public Task<CatResponse<CatHealthRecord>> HealthAsync(ICatHealthRequest request, CancellationToken ct = default) => DoCatAsync<ICatHealthRequest, CatHealthRequestParameters, CatHealthRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.help</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</a>
 		/// </summary>
 		public CatResponse<CatHelpRecord> Help(Func<CatHelpDescriptor, ICatHelpRequest> selector = null) => Help(selector.InvokeOrDefault(new CatHelpDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.help</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</a>
 		/// </summary>
 		public Task<CatResponse<CatHelpRecord>> HelpAsync(Func<CatHelpDescriptor, ICatHelpRequest> selector = null, CancellationToken ct = default) => HelpAsync(selector.InvokeOrDefault(new CatHelpDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.help</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</a>
 		/// </summary>
 		public CatResponse<CatHelpRecord> Help(ICatHelpRequest request) => DoCat<ICatHelpRequest, CatHelpRequestParameters, CatHelpRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.help</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</a>
 		/// </summary>
 		public Task<CatResponse<CatHelpRecord>> HelpAsync(ICatHelpRequest request, CancellationToken ct = default) => DoCatAsync<ICatHelpRequest, CatHelpRequestParameters, CatHelpRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.indices</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</a>
 		/// </summary>
 		public CatResponse<CatIndicesRecord> Indices(Func<CatIndicesDescriptor, ICatIndicesRequest> selector = null) => Indices(selector.InvokeOrDefault(new CatIndicesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.indices</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</a>
 		/// </summary>
 		public Task<CatResponse<CatIndicesRecord>> IndicesAsync(Func<CatIndicesDescriptor, ICatIndicesRequest> selector = null, CancellationToken ct = default) => IndicesAsync(selector.InvokeOrDefault(new CatIndicesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.indices</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</a>
 		/// </summary>
 		public CatResponse<CatIndicesRecord> Indices(ICatIndicesRequest request) => DoCat<ICatIndicesRequest, CatIndicesRequestParameters, CatIndicesRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.indices</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</a>
 		/// </summary>
 		public Task<CatResponse<CatIndicesRecord>> IndicesAsync(ICatIndicesRequest request, CancellationToken ct = default) => DoCatAsync<ICatIndicesRequest, CatIndicesRequestParameters, CatIndicesRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</a>
 		/// </summary>
 		public CatResponse<CatMasterRecord> Master(Func<CatMasterDescriptor, ICatMasterRequest> selector = null) => Master(selector.InvokeOrDefault(new CatMasterDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</a>
 		/// </summary>
 		public Task<CatResponse<CatMasterRecord>> MasterAsync(Func<CatMasterDescriptor, ICatMasterRequest> selector = null, CancellationToken ct = default) => MasterAsync(selector.InvokeOrDefault(new CatMasterDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</a>
 		/// </summary>
 		public CatResponse<CatMasterRecord> Master(ICatMasterRequest request) => DoCat<ICatMasterRequest, CatMasterRequestParameters, CatMasterRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</a>
 		/// </summary>
 		public Task<CatResponse<CatMasterRecord>> MasterAsync(ICatMasterRequest request, CancellationToken ct = default) => DoCatAsync<ICatMasterRequest, CatMasterRequestParameters, CatMasterRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.nodeattrs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</a>
 		/// </summary>
 		public CatResponse<CatNodeAttributesRecord> NodeAttributes(Func<CatNodeAttributesDescriptor, ICatNodeAttributesRequest> selector = null) => NodeAttributes(selector.InvokeOrDefault(new CatNodeAttributesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.nodeattrs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</a>
 		/// </summary>
 		public Task<CatResponse<CatNodeAttributesRecord>> NodeAttributesAsync(Func<CatNodeAttributesDescriptor, ICatNodeAttributesRequest> selector = null, CancellationToken ct = default) => NodeAttributesAsync(selector.InvokeOrDefault(new CatNodeAttributesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.nodeattrs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</a>
 		/// </summary>
 		public CatResponse<CatNodeAttributesRecord> NodeAttributes(ICatNodeAttributesRequest request) => DoCat<ICatNodeAttributesRequest, CatNodeAttributesRequestParameters, CatNodeAttributesRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.nodeattrs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</a>
 		/// </summary>
 		public Task<CatResponse<CatNodeAttributesRecord>> NodeAttributesAsync(ICatNodeAttributesRequest request, CancellationToken ct = default) => DoCatAsync<ICatNodeAttributesRequest, CatNodeAttributesRequestParameters, CatNodeAttributesRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.nodes</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</a>
 		/// </summary>
 		public CatResponse<CatNodesRecord> Nodes(Func<CatNodesDescriptor, ICatNodesRequest> selector = null) => Nodes(selector.InvokeOrDefault(new CatNodesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.nodes</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</a>
 		/// </summary>
 		public Task<CatResponse<CatNodesRecord>> NodesAsync(Func<CatNodesDescriptor, ICatNodesRequest> selector = null, CancellationToken ct = default) => NodesAsync(selector.InvokeOrDefault(new CatNodesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.nodes</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</a>
 		/// </summary>
 		public CatResponse<CatNodesRecord> Nodes(ICatNodesRequest request) => DoCat<ICatNodesRequest, CatNodesRequestParameters, CatNodesRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.nodes</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</a>
 		/// </summary>
 		public Task<CatResponse<CatNodesRecord>> NodesAsync(ICatNodesRequest request, CancellationToken ct = default) => DoCatAsync<ICatNodesRequest, CatNodesRequestParameters, CatNodesRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.pending_tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</a>
 		/// </summary>
 		public CatResponse<CatPendingTasksRecord> PendingTasks(Func<CatPendingTasksDescriptor, ICatPendingTasksRequest> selector = null) => PendingTasks(selector.InvokeOrDefault(new CatPendingTasksDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.pending_tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</a>
 		/// </summary>
 		public Task<CatResponse<CatPendingTasksRecord>> PendingTasksAsync(Func<CatPendingTasksDescriptor, ICatPendingTasksRequest> selector = null, CancellationToken ct = default) => PendingTasksAsync(selector.InvokeOrDefault(new CatPendingTasksDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.pending_tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</a>
 		/// </summary>
 		public CatResponse<CatPendingTasksRecord> PendingTasks(ICatPendingTasksRequest request) => DoCat<ICatPendingTasksRequest, CatPendingTasksRequestParameters, CatPendingTasksRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.pending_tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</a>
 		/// </summary>
 		public Task<CatResponse<CatPendingTasksRecord>> PendingTasksAsync(ICatPendingTasksRequest request, CancellationToken ct = default) => DoCatAsync<ICatPendingTasksRequest, CatPendingTasksRequestParameters, CatPendingTasksRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.plugins</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</a>
 		/// </summary>
 		public CatResponse<CatPluginsRecord> Plugins(Func<CatPluginsDescriptor, ICatPluginsRequest> selector = null) => Plugins(selector.InvokeOrDefault(new CatPluginsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.plugins</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</a>
 		/// </summary>
 		public Task<CatResponse<CatPluginsRecord>> PluginsAsync(Func<CatPluginsDescriptor, ICatPluginsRequest> selector = null, CancellationToken ct = default) => PluginsAsync(selector.InvokeOrDefault(new CatPluginsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.plugins</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</a>
 		/// </summary>
 		public CatResponse<CatPluginsRecord> Plugins(ICatPluginsRequest request) => DoCat<ICatPluginsRequest, CatPluginsRequestParameters, CatPluginsRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.plugins</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</a>
 		/// </summary>
 		public Task<CatResponse<CatPluginsRecord>> PluginsAsync(ICatPluginsRequest request, CancellationToken ct = default) => DoCatAsync<ICatPluginsRequest, CatPluginsRequestParameters, CatPluginsRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.recovery</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</a>
 		/// </summary>
 		public CatResponse<CatRecoveryRecord> Recovery(Func<CatRecoveryDescriptor, ICatRecoveryRequest> selector = null) => Recovery(selector.InvokeOrDefault(new CatRecoveryDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.recovery</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</a>
 		/// </summary>
 		public Task<CatResponse<CatRecoveryRecord>> RecoveryAsync(Func<CatRecoveryDescriptor, ICatRecoveryRequest> selector = null, CancellationToken ct = default) => RecoveryAsync(selector.InvokeOrDefault(new CatRecoveryDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.recovery</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</a>
 		/// </summary>
 		public CatResponse<CatRecoveryRecord> Recovery(ICatRecoveryRequest request) => DoCat<ICatRecoveryRequest, CatRecoveryRequestParameters, CatRecoveryRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.recovery</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</a>
 		/// </summary>
 		public Task<CatResponse<CatRecoveryRecord>> RecoveryAsync(ICatRecoveryRequest request, CancellationToken ct = default) => DoCatAsync<ICatRecoveryRequest, CatRecoveryRequestParameters, CatRecoveryRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.repositories</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</a>
 		/// </summary>
 		public CatResponse<CatRepositoriesRecord> Repositories(Func<CatRepositoriesDescriptor, ICatRepositoriesRequest> selector = null) => Repositories(selector.InvokeOrDefault(new CatRepositoriesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.repositories</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</a>
 		/// </summary>
 		public Task<CatResponse<CatRepositoriesRecord>> RepositoriesAsync(Func<CatRepositoriesDescriptor, ICatRepositoriesRequest> selector = null, CancellationToken ct = default) => RepositoriesAsync(selector.InvokeOrDefault(new CatRepositoriesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.repositories</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</a>
 		/// </summary>
 		public CatResponse<CatRepositoriesRecord> Repositories(ICatRepositoriesRequest request) => DoCat<ICatRepositoriesRequest, CatRepositoriesRequestParameters, CatRepositoriesRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.repositories</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</a>
 		/// </summary>
 		public Task<CatResponse<CatRepositoriesRecord>> RepositoriesAsync(ICatRepositoriesRequest request, CancellationToken ct = default) => DoCatAsync<ICatRepositoriesRequest, CatRepositoriesRequestParameters, CatRepositoriesRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.segments</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</a>
 		/// </summary>
 		public CatResponse<CatSegmentsRecord> Segments(Func<CatSegmentsDescriptor, ICatSegmentsRequest> selector = null) => Segments(selector.InvokeOrDefault(new CatSegmentsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.segments</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</a>
 		/// </summary>
 		public Task<CatResponse<CatSegmentsRecord>> SegmentsAsync(Func<CatSegmentsDescriptor, ICatSegmentsRequest> selector = null, CancellationToken ct = default) => SegmentsAsync(selector.InvokeOrDefault(new CatSegmentsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.segments</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</a>
 		/// </summary>
 		public CatResponse<CatSegmentsRecord> Segments(ICatSegmentsRequest request) => DoCat<ICatSegmentsRequest, CatSegmentsRequestParameters, CatSegmentsRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.segments</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</a>
 		/// </summary>
 		public Task<CatResponse<CatSegmentsRecord>> SegmentsAsync(ICatSegmentsRequest request, CancellationToken ct = default) => DoCatAsync<ICatSegmentsRequest, CatSegmentsRequestParameters, CatSegmentsRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</a>
 		/// </summary>
 		public CatResponse<CatShardsRecord> Shards(Func<CatShardsDescriptor, ICatShardsRequest> selector = null) => Shards(selector.InvokeOrDefault(new CatShardsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</a>
 		/// </summary>
 		public Task<CatResponse<CatShardsRecord>> ShardsAsync(Func<CatShardsDescriptor, ICatShardsRequest> selector = null, CancellationToken ct = default) => ShardsAsync(selector.InvokeOrDefault(new CatShardsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</a>
 		/// </summary>
 		public CatResponse<CatShardsRecord> Shards(ICatShardsRequest request) => DoCat<ICatShardsRequest, CatShardsRequestParameters, CatShardsRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</a>
 		/// </summary>
 		public Task<CatResponse<CatShardsRecord>> ShardsAsync(ICatShardsRequest request, CancellationToken ct = default) => DoCatAsync<ICatShardsRequest, CatShardsRequestParameters, CatShardsRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.snapshots</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</a>
 		/// </summary>
 		public CatResponse<CatSnapshotsRecord> Snapshots(Func<CatSnapshotsDescriptor, ICatSnapshotsRequest> selector = null) => Snapshots(selector.InvokeOrDefault(new CatSnapshotsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.snapshots</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</a>
 		/// </summary>
 		public Task<CatResponse<CatSnapshotsRecord>> SnapshotsAsync(Func<CatSnapshotsDescriptor, ICatSnapshotsRequest> selector = null, CancellationToken ct = default) => SnapshotsAsync(selector.InvokeOrDefault(new CatSnapshotsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.snapshots</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</a>
 		/// </summary>
 		public CatResponse<CatSnapshotsRecord> Snapshots(ICatSnapshotsRequest request) => DoCat<ICatSnapshotsRequest, CatSnapshotsRequestParameters, CatSnapshotsRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.snapshots</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</a>
 		/// </summary>
 		public Task<CatResponse<CatSnapshotsRecord>> SnapshotsAsync(ICatSnapshotsRequest request, CancellationToken ct = default) => DoCatAsync<ICatSnapshotsRequest, CatSnapshotsRequestParameters, CatSnapshotsRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public CatResponse<CatTasksRecord> Tasks(Func<CatTasksDescriptor, ICatTasksRequest> selector = null) => Tasks(selector.InvokeOrDefault(new CatTasksDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public Task<CatResponse<CatTasksRecord>> TasksAsync(Func<CatTasksDescriptor, ICatTasksRequest> selector = null, CancellationToken ct = default) => TasksAsync(selector.InvokeOrDefault(new CatTasksDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public CatResponse<CatTasksRecord> Tasks(ICatTasksRequest request) => DoCat<ICatTasksRequest, CatTasksRequestParameters, CatTasksRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public Task<CatResponse<CatTasksRecord>> TasksAsync(ICatTasksRequest request, CancellationToken ct = default) => DoCatAsync<ICatTasksRequest, CatTasksRequestParameters, CatTasksRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.templates</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</a>
 		/// </summary>
 		public CatResponse<CatTemplatesRecord> Templates(Func<CatTemplatesDescriptor, ICatTemplatesRequest> selector = null) => Templates(selector.InvokeOrDefault(new CatTemplatesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.templates</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</a>
 		/// </summary>
 		public Task<CatResponse<CatTemplatesRecord>> TemplatesAsync(Func<CatTemplatesDescriptor, ICatTemplatesRequest> selector = null, CancellationToken ct = default) => TemplatesAsync(selector.InvokeOrDefault(new CatTemplatesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.templates</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</a>
 		/// </summary>
 		public CatResponse<CatTemplatesRecord> Templates(ICatTemplatesRequest request) => DoCat<ICatTemplatesRequest, CatTemplatesRequestParameters, CatTemplatesRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.templates</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</a>
 		/// </summary>
 		public Task<CatResponse<CatTemplatesRecord>> TemplatesAsync(ICatTemplatesRequest request, CancellationToken ct = default) => DoCatAsync<ICatTemplatesRequest, CatTemplatesRequestParameters, CatTemplatesRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.thread_pool</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</a>
 		/// </summary>
 		public CatResponse<CatThreadPoolRecord> ThreadPool(Func<CatThreadPoolDescriptor, ICatThreadPoolRequest> selector = null) => ThreadPool(selector.InvokeOrDefault(new CatThreadPoolDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.thread_pool</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</a>
 		/// </summary>
 		public Task<CatResponse<CatThreadPoolRecord>> ThreadPoolAsync(Func<CatThreadPoolDescriptor, ICatThreadPoolRequest> selector = null, CancellationToken ct = default) => ThreadPoolAsync(selector.InvokeOrDefault(new CatThreadPoolDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.thread_pool</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</a>
 		/// </summary>
 		public CatResponse<CatThreadPoolRecord> ThreadPool(ICatThreadPoolRequest request) => DoCat<ICatThreadPoolRequest, CatThreadPoolRequestParameters, CatThreadPoolRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.thread_pool</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</a>
 		/// </summary>
 		public Task<CatResponse<CatThreadPoolRecord>> ThreadPoolAsync(ICatThreadPoolRequest request, CancellationToken ct = default) => DoCatAsync<ICatThreadPoolRequest, CatThreadPoolRequestParameters, CatThreadPoolRecord>(request, ct);

--- a/src/Nest/ElasticClient.Cluster.cs
+++ b/src/Nest/ElasticClient.Cluster.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.ClusterApi;
 namespace Nest.Specification.ClusterApi
 {
 	///<summary>
-	/// Logically groups all <c>Cluster</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Cluster"/> property
+	/// Cluster APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Cluster"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,217 +38,217 @@ namespace Nest.Specification.ClusterApi
 
 		/// <summary>
 		/// <c>POST</c> request to the <c>cluster.allocation_explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</a>
 		/// </summary>
 		public ClusterAllocationExplainResponse AllocationExplain(Func<ClusterAllocationExplainDescriptor, IClusterAllocationExplainRequest> selector = null) => AllocationExplain(selector.InvokeOrDefault(new ClusterAllocationExplainDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>cluster.allocation_explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</a>
 		/// </summary>
 		public Task<ClusterAllocationExplainResponse> AllocationExplainAsync(Func<ClusterAllocationExplainDescriptor, IClusterAllocationExplainRequest> selector = null, CancellationToken ct = default) => AllocationExplainAsync(selector.InvokeOrDefault(new ClusterAllocationExplainDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>cluster.allocation_explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</a>
 		/// </summary>
 		public ClusterAllocationExplainResponse AllocationExplain(IClusterAllocationExplainRequest request) => DoRequest<IClusterAllocationExplainRequest, ClusterAllocationExplainResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>cluster.allocation_explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</a>
 		/// </summary>
 		public Task<ClusterAllocationExplainResponse> AllocationExplainAsync(IClusterAllocationExplainRequest request, CancellationToken ct = default) => DoRequestAsync<IClusterAllocationExplainRequest, ClusterAllocationExplainResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.get_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</a>
 		/// </summary>
 		public ClusterGetSettingsResponse GetSettings(Func<ClusterGetSettingsDescriptor, IClusterGetSettingsRequest> selector = null) => GetSettings(selector.InvokeOrDefault(new ClusterGetSettingsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.get_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</a>
 		/// </summary>
 		public Task<ClusterGetSettingsResponse> GetSettingsAsync(Func<ClusterGetSettingsDescriptor, IClusterGetSettingsRequest> selector = null, CancellationToken ct = default) => GetSettingsAsync(selector.InvokeOrDefault(new ClusterGetSettingsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.get_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</a>
 		/// </summary>
 		public ClusterGetSettingsResponse GetSettings(IClusterGetSettingsRequest request) => DoRequest<IClusterGetSettingsRequest, ClusterGetSettingsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.get_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</a>
 		/// </summary>
 		public Task<ClusterGetSettingsResponse> GetSettingsAsync(IClusterGetSettingsRequest request, CancellationToken ct = default) => DoRequestAsync<IClusterGetSettingsRequest, ClusterGetSettingsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.health</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</a>
 		/// </summary>
 		public ClusterHealthResponse Health(Indices index = null, Func<ClusterHealthDescriptor, IClusterHealthRequest> selector = null) => Health(selector.InvokeOrDefault(new ClusterHealthDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.health</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</a>
 		/// </summary>
 		public Task<ClusterHealthResponse> HealthAsync(Indices index = null, Func<ClusterHealthDescriptor, IClusterHealthRequest> selector = null, CancellationToken ct = default) => HealthAsync(selector.InvokeOrDefault(new ClusterHealthDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.health</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</a>
 		/// </summary>
 		public ClusterHealthResponse Health(IClusterHealthRequest request) => DoRequest<IClusterHealthRequest, ClusterHealthResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.health</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</a>
 		/// </summary>
 		public Task<ClusterHealthResponse> HealthAsync(IClusterHealthRequest request, CancellationToken ct = default) => DoRequestAsync<IClusterHealthRequest, ClusterHealthResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.pending_tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</a>
 		/// </summary>
 		public ClusterPendingTasksResponse PendingTasks(Func<ClusterPendingTasksDescriptor, IClusterPendingTasksRequest> selector = null) => PendingTasks(selector.InvokeOrDefault(new ClusterPendingTasksDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.pending_tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</a>
 		/// </summary>
 		public Task<ClusterPendingTasksResponse> PendingTasksAsync(Func<ClusterPendingTasksDescriptor, IClusterPendingTasksRequest> selector = null, CancellationToken ct = default) => PendingTasksAsync(selector.InvokeOrDefault(new ClusterPendingTasksDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.pending_tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</a>
 		/// </summary>
 		public ClusterPendingTasksResponse PendingTasks(IClusterPendingTasksRequest request) => DoRequest<IClusterPendingTasksRequest, ClusterPendingTasksResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.pending_tasks</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</a>
 		/// </summary>
 		public Task<ClusterPendingTasksResponse> PendingTasksAsync(IClusterPendingTasksRequest request, CancellationToken ct = default) => DoRequestAsync<IClusterPendingTasksRequest, ClusterPendingTasksResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>cluster.put_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</a>
 		/// </summary>
 		public ClusterPutSettingsResponse PutSettings(Func<ClusterPutSettingsDescriptor, IClusterPutSettingsRequest> selector) => PutSettings(selector.InvokeOrDefault(new ClusterPutSettingsDescriptor()));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>cluster.put_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</a>
 		/// </summary>
 		public Task<ClusterPutSettingsResponse> PutSettingsAsync(Func<ClusterPutSettingsDescriptor, IClusterPutSettingsRequest> selector, CancellationToken ct = default) => PutSettingsAsync(selector.InvokeOrDefault(new ClusterPutSettingsDescriptor()), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>cluster.put_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</a>
 		/// </summary>
 		public ClusterPutSettingsResponse PutSettings(IClusterPutSettingsRequest request) => DoRequest<IClusterPutSettingsRequest, ClusterPutSettingsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>cluster.put_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</a>
 		/// </summary>
 		public Task<ClusterPutSettingsResponse> PutSettingsAsync(IClusterPutSettingsRequest request, CancellationToken ct = default) => DoRequestAsync<IClusterPutSettingsRequest, ClusterPutSettingsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.remote_info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</a>
 		/// </summary>
 		public RemoteInfoResponse RemoteInfo(Func<RemoteInfoDescriptor, IRemoteInfoRequest> selector = null) => RemoteInfo(selector.InvokeOrDefault(new RemoteInfoDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.remote_info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</a>
 		/// </summary>
 		public Task<RemoteInfoResponse> RemoteInfoAsync(Func<RemoteInfoDescriptor, IRemoteInfoRequest> selector = null, CancellationToken ct = default) => RemoteInfoAsync(selector.InvokeOrDefault(new RemoteInfoDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.remote_info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</a>
 		/// </summary>
 		public RemoteInfoResponse RemoteInfo(IRemoteInfoRequest request) => DoRequest<IRemoteInfoRequest, RemoteInfoResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.remote_info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</a>
 		/// </summary>
 		public Task<RemoteInfoResponse> RemoteInfoAsync(IRemoteInfoRequest request, CancellationToken ct = default) => DoRequestAsync<IRemoteInfoRequest, RemoteInfoResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>cluster.reroute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</a>
 		/// </summary>
 		public ClusterRerouteResponse Reroute(Func<ClusterRerouteDescriptor, IClusterRerouteRequest> selector = null) => Reroute(selector.InvokeOrDefault(new ClusterRerouteDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>cluster.reroute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</a>
 		/// </summary>
 		public Task<ClusterRerouteResponse> RerouteAsync(Func<ClusterRerouteDescriptor, IClusterRerouteRequest> selector = null, CancellationToken ct = default) => RerouteAsync(selector.InvokeOrDefault(new ClusterRerouteDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>cluster.reroute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</a>
 		/// </summary>
 		public ClusterRerouteResponse Reroute(IClusterRerouteRequest request) => DoRequest<IClusterRerouteRequest, ClusterRerouteResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>cluster.reroute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</a>
 		/// </summary>
 		public Task<ClusterRerouteResponse> RerouteAsync(IClusterRerouteRequest request, CancellationToken ct = default) => DoRequestAsync<IClusterRerouteRequest, ClusterRerouteResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.state</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</a>
 		/// </summary>
 		public ClusterStateResponse State(Indices index = null, Func<ClusterStateDescriptor, IClusterStateRequest> selector = null) => State(selector.InvokeOrDefault(new ClusterStateDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.state</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</a>
 		/// </summary>
 		public Task<ClusterStateResponse> StateAsync(Indices index = null, Func<ClusterStateDescriptor, IClusterStateRequest> selector = null, CancellationToken ct = default) => StateAsync(selector.InvokeOrDefault(new ClusterStateDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.state</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</a>
 		/// </summary>
 		public ClusterStateResponse State(IClusterStateRequest request) => DoRequest<IClusterStateRequest, ClusterStateResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.state</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</a>
 		/// </summary>
 		public Task<ClusterStateResponse> StateAsync(IClusterStateRequest request, CancellationToken ct = default) => DoRequestAsync<IClusterStateRequest, ClusterStateResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</a>
 		/// </summary>
 		public ClusterStatsResponse Stats(Func<ClusterStatsDescriptor, IClusterStatsRequest> selector = null) => Stats(selector.InvokeOrDefault(new ClusterStatsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</a>
 		/// </summary>
 		public Task<ClusterStatsResponse> StatsAsync(Func<ClusterStatsDescriptor, IClusterStatsRequest> selector = null, CancellationToken ct = default) => StatsAsync(selector.InvokeOrDefault(new ClusterStatsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</a>
 		/// </summary>
 		public ClusterStatsResponse Stats(IClusterStatsRequest request) => DoRequest<IClusterStatsRequest, ClusterStatsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cluster.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</a>
 		/// </summary>
 		public Task<ClusterStatsResponse> StatsAsync(IClusterStatsRequest request, CancellationToken ct = default) => DoRequestAsync<IClusterStatsRequest, ClusterStatsResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.CrossClusterReplication.cs
+++ b/src/Nest/ElasticClient.CrossClusterReplication.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.CrossClusterReplicationApi;
 namespace Nest.Specification.CrossClusterReplicationApi
 {
 	///<summary>
-	/// Logically groups all <c>CrossClusterReplication</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.CrossClusterReplication"/> property
+	/// Cross Cluster Replication APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.CrossClusterReplication"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,217 +38,217 @@ namespace Nest.Specification.CrossClusterReplicationApi
 
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ccr.delete_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</a>
 		/// </summary>
 		public DeleteAutoFollowPatternResponse DeleteAutoFollowPattern(Name name, Func<DeleteAutoFollowPatternDescriptor, IDeleteAutoFollowPatternRequest> selector = null) => DeleteAutoFollowPattern(selector.InvokeOrDefault(new DeleteAutoFollowPatternDescriptor(name: name)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ccr.delete_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</a>
 		/// </summary>
 		public Task<DeleteAutoFollowPatternResponse> DeleteAutoFollowPatternAsync(Name name, Func<DeleteAutoFollowPatternDescriptor, IDeleteAutoFollowPatternRequest> selector = null, CancellationToken ct = default) => DeleteAutoFollowPatternAsync(selector.InvokeOrDefault(new DeleteAutoFollowPatternDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ccr.delete_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</a>
 		/// </summary>
 		public DeleteAutoFollowPatternResponse DeleteAutoFollowPattern(IDeleteAutoFollowPatternRequest request) => DoRequest<IDeleteAutoFollowPatternRequest, DeleteAutoFollowPatternResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ccr.delete_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</a>
 		/// </summary>
 		public Task<DeleteAutoFollowPatternResponse> DeleteAutoFollowPatternAsync(IDeleteAutoFollowPatternRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteAutoFollowPatternRequest, DeleteAutoFollowPatternResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ccr.follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</a>
 		/// </summary>
 		public CreateFollowIndexResponse CreateFollowIndex(IndexName index, Func<CreateFollowIndexDescriptor, ICreateFollowIndexRequest> selector) => CreateFollowIndex(selector.InvokeOrDefault(new CreateFollowIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ccr.follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</a>
 		/// </summary>
 		public Task<CreateFollowIndexResponse> CreateFollowIndexAsync(IndexName index, Func<CreateFollowIndexDescriptor, ICreateFollowIndexRequest> selector, CancellationToken ct = default) => CreateFollowIndexAsync(selector.InvokeOrDefault(new CreateFollowIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ccr.follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</a>
 		/// </summary>
 		public CreateFollowIndexResponse CreateFollowIndex(ICreateFollowIndexRequest request) => DoRequest<ICreateFollowIndexRequest, CreateFollowIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ccr.follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</a>
 		/// </summary>
 		public Task<CreateFollowIndexResponse> CreateFollowIndexAsync(ICreateFollowIndexRequest request, CancellationToken ct = default) => DoRequestAsync<ICreateFollowIndexRequest, CreateFollowIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.follow_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</a>
 		/// </summary>
 		public FollowIndexStatsResponse FollowIndexStats(Indices index, Func<FollowIndexStatsDescriptor, IFollowIndexStatsRequest> selector = null) => FollowIndexStats(selector.InvokeOrDefault(new FollowIndexStatsDescriptor(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.follow_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</a>
 		/// </summary>
 		public Task<FollowIndexStatsResponse> FollowIndexStatsAsync(Indices index, Func<FollowIndexStatsDescriptor, IFollowIndexStatsRequest> selector = null, CancellationToken ct = default) => FollowIndexStatsAsync(selector.InvokeOrDefault(new FollowIndexStatsDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.follow_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</a>
 		/// </summary>
 		public FollowIndexStatsResponse FollowIndexStats(IFollowIndexStatsRequest request) => DoRequest<IFollowIndexStatsRequest, FollowIndexStatsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.follow_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</a>
 		/// </summary>
 		public Task<FollowIndexStatsResponse> FollowIndexStatsAsync(IFollowIndexStatsRequest request, CancellationToken ct = default) => DoRequestAsync<IFollowIndexStatsRequest, FollowIndexStatsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.get_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</a>
 		/// </summary>
 		public GetAutoFollowPatternResponse GetAutoFollowPattern(Name name = null, Func<GetAutoFollowPatternDescriptor, IGetAutoFollowPatternRequest> selector = null) => GetAutoFollowPattern(selector.InvokeOrDefault(new GetAutoFollowPatternDescriptor().Name(name: name)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.get_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</a>
 		/// </summary>
 		public Task<GetAutoFollowPatternResponse> GetAutoFollowPatternAsync(Name name = null, Func<GetAutoFollowPatternDescriptor, IGetAutoFollowPatternRequest> selector = null, CancellationToken ct = default) => GetAutoFollowPatternAsync(selector.InvokeOrDefault(new GetAutoFollowPatternDescriptor().Name(name: name)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.get_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</a>
 		/// </summary>
 		public GetAutoFollowPatternResponse GetAutoFollowPattern(IGetAutoFollowPatternRequest request) => DoRequest<IGetAutoFollowPatternRequest, GetAutoFollowPatternResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.get_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</a>
 		/// </summary>
 		public Task<GetAutoFollowPatternResponse> GetAutoFollowPatternAsync(IGetAutoFollowPatternRequest request, CancellationToken ct = default) => DoRequestAsync<IGetAutoFollowPatternRequest, GetAutoFollowPatternResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.pause_follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</a>
 		/// </summary>
 		public PauseFollowIndexResponse PauseFollowIndex(IndexName index, Func<PauseFollowIndexDescriptor, IPauseFollowIndexRequest> selector = null) => PauseFollowIndex(selector.InvokeOrDefault(new PauseFollowIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.pause_follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</a>
 		/// </summary>
 		public Task<PauseFollowIndexResponse> PauseFollowIndexAsync(IndexName index, Func<PauseFollowIndexDescriptor, IPauseFollowIndexRequest> selector = null, CancellationToken ct = default) => PauseFollowIndexAsync(selector.InvokeOrDefault(new PauseFollowIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.pause_follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</a>
 		/// </summary>
 		public PauseFollowIndexResponse PauseFollowIndex(IPauseFollowIndexRequest request) => DoRequest<IPauseFollowIndexRequest, PauseFollowIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.pause_follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</a>
 		/// </summary>
 		public Task<PauseFollowIndexResponse> PauseFollowIndexAsync(IPauseFollowIndexRequest request, CancellationToken ct = default) => DoRequestAsync<IPauseFollowIndexRequest, PauseFollowIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ccr.put_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</a>
 		/// </summary>
 		public CreateAutoFollowPatternResponse CreateAutoFollowPattern(Name name, Func<CreateAutoFollowPatternDescriptor, ICreateAutoFollowPatternRequest> selector) => CreateAutoFollowPattern(selector.InvokeOrDefault(new CreateAutoFollowPatternDescriptor(name: name)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ccr.put_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</a>
 		/// </summary>
 		public Task<CreateAutoFollowPatternResponse> CreateAutoFollowPatternAsync(Name name, Func<CreateAutoFollowPatternDescriptor, ICreateAutoFollowPatternRequest> selector, CancellationToken ct = default) => CreateAutoFollowPatternAsync(selector.InvokeOrDefault(new CreateAutoFollowPatternDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ccr.put_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</a>
 		/// </summary>
 		public CreateAutoFollowPatternResponse CreateAutoFollowPattern(ICreateAutoFollowPatternRequest request) => DoRequest<ICreateAutoFollowPatternRequest, CreateAutoFollowPatternResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ccr.put_auto_follow_pattern</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</a>
 		/// </summary>
 		public Task<CreateAutoFollowPatternResponse> CreateAutoFollowPatternAsync(ICreateAutoFollowPatternRequest request, CancellationToken ct = default) => DoRequestAsync<ICreateAutoFollowPatternRequest, CreateAutoFollowPatternResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.resume_follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</a>
 		/// </summary>
 		public ResumeFollowIndexResponse ResumeFollowIndex(IndexName index, Func<ResumeFollowIndexDescriptor, IResumeFollowIndexRequest> selector = null) => ResumeFollowIndex(selector.InvokeOrDefault(new ResumeFollowIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.resume_follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</a>
 		/// </summary>
 		public Task<ResumeFollowIndexResponse> ResumeFollowIndexAsync(IndexName index, Func<ResumeFollowIndexDescriptor, IResumeFollowIndexRequest> selector = null, CancellationToken ct = default) => ResumeFollowIndexAsync(selector.InvokeOrDefault(new ResumeFollowIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.resume_follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</a>
 		/// </summary>
 		public ResumeFollowIndexResponse ResumeFollowIndex(IResumeFollowIndexRequest request) => DoRequest<IResumeFollowIndexRequest, ResumeFollowIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.resume_follow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</a>
 		/// </summary>
 		public Task<ResumeFollowIndexResponse> ResumeFollowIndexAsync(IResumeFollowIndexRequest request, CancellationToken ct = default) => DoRequestAsync<IResumeFollowIndexRequest, ResumeFollowIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</a>
 		/// </summary>
 		public CcrStatsResponse Stats(Func<CcrStatsDescriptor, ICcrStatsRequest> selector = null) => Stats(selector.InvokeOrDefault(new CcrStatsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</a>
 		/// </summary>
 		public Task<CcrStatsResponse> StatsAsync(Func<CcrStatsDescriptor, ICcrStatsRequest> selector = null, CancellationToken ct = default) => StatsAsync(selector.InvokeOrDefault(new CcrStatsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</a>
 		/// </summary>
 		public CcrStatsResponse Stats(ICcrStatsRequest request) => DoRequest<ICcrStatsRequest, CcrStatsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ccr.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</a>
 		/// </summary>
 		public Task<CcrStatsResponse> StatsAsync(ICcrStatsRequest request, CancellationToken ct = default) => DoRequestAsync<ICcrStatsRequest, CcrStatsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.unfollow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current">http://www.elastic.co/guide/en/elasticsearch/reference/current</a>
 		/// </summary>
 		public UnfollowIndexResponse UnfollowIndex(IndexName index, Func<UnfollowIndexDescriptor, IUnfollowIndexRequest> selector = null) => UnfollowIndex(selector.InvokeOrDefault(new UnfollowIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.unfollow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current">http://www.elastic.co/guide/en/elasticsearch/reference/current</a>
 		/// </summary>
 		public Task<UnfollowIndexResponse> UnfollowIndexAsync(IndexName index, Func<UnfollowIndexDescriptor, IUnfollowIndexRequest> selector = null, CancellationToken ct = default) => UnfollowIndexAsync(selector.InvokeOrDefault(new UnfollowIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.unfollow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current">http://www.elastic.co/guide/en/elasticsearch/reference/current</a>
 		/// </summary>
 		public UnfollowIndexResponse UnfollowIndex(IUnfollowIndexRequest request) => DoRequest<IUnfollowIndexRequest, UnfollowIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ccr.unfollow</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current">http://www.elastic.co/guide/en/elasticsearch/reference/current</a>
 		/// </summary>
 		public Task<UnfollowIndexResponse> UnfollowIndexAsync(IUnfollowIndexRequest request, CancellationToken ct = default) => DoRequestAsync<IUnfollowIndexRequest, UnfollowIndexResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Graph.cs
+++ b/src/Nest/ElasticClient.Graph.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.GraphApi;
 namespace Nest.Specification.GraphApi
 {
 	///<summary>
-	/// Logically groups all <c>Graph</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Graph"/> property
+	/// Graph APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Graph"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,27 +38,27 @@ namespace Nest.Specification.GraphApi
 
 		/// <summary>
 		/// <c>POST</c> request to the <c>graph.explore</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</a>
 		/// </summary>
 		public GraphExploreResponse Explore<TDocument>(Func<GraphExploreDescriptor<TDocument>, IGraphExploreRequest> selector = null)
 			where TDocument : class => Explore(selector.InvokeOrDefault(new GraphExploreDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>graph.explore</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</a>
 		/// </summary>
 		public Task<GraphExploreResponse> ExploreAsync<TDocument>(Func<GraphExploreDescriptor<TDocument>, IGraphExploreRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => ExploreAsync(selector.InvokeOrDefault(new GraphExploreDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>graph.explore</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</a>
 		/// </summary>
 		public GraphExploreResponse Explore(IGraphExploreRequest request) => DoRequest<IGraphExploreRequest, GraphExploreResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>graph.explore</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</a>
 		/// </summary>
 		public Task<GraphExploreResponse> ExploreAsync(IGraphExploreRequest request, CancellationToken ct = default) => DoRequestAsync<IGraphExploreRequest, GraphExploreResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.IndexLifecycleManagement.cs
+++ b/src/Nest/ElasticClient.IndexLifecycleManagement.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.IndexLifecycleManagementApi;
 namespace Nest.Specification.IndexLifecycleManagementApi
 {
 	///<summary>
-	/// Logically groups all <c>IndexLifecycleManagement</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.IndexLifecycleManagement"/> property
+	/// Index Lifecycle Management APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.IndexLifecycleManagement"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,241 +38,241 @@ namespace Nest.Specification.IndexLifecycleManagementApi
 
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ilm.delete_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</a>
 		/// </summary>
 		public DeleteLifecycleResponse DeleteLifecycle(Id policyId, Func<DeleteLifecycleDescriptor, IDeleteLifecycleRequest> selector = null) => DeleteLifecycle(selector.InvokeOrDefault(new DeleteLifecycleDescriptor(policyId: policyId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ilm.delete_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</a>
 		/// </summary>
 		public Task<DeleteLifecycleResponse> DeleteLifecycleAsync(Id policyId, Func<DeleteLifecycleDescriptor, IDeleteLifecycleRequest> selector = null, CancellationToken ct = default) => DeleteLifecycleAsync(selector.InvokeOrDefault(new DeleteLifecycleDescriptor(policyId: policyId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ilm.delete_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</a>
 		/// </summary>
 		public DeleteLifecycleResponse DeleteLifecycle(IDeleteLifecycleRequest request) => DoRequest<IDeleteLifecycleRequest, DeleteLifecycleResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ilm.delete_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</a>
 		/// </summary>
 		public Task<DeleteLifecycleResponse> DeleteLifecycleAsync(IDeleteLifecycleRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteLifecycleRequest, DeleteLifecycleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.explain_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</a>
 		/// </summary>
 		public ExplainLifecycleResponse ExplainLifecycle(IndexName index, Func<ExplainLifecycleDescriptor, IExplainLifecycleRequest> selector = null) => ExplainLifecycle(selector.InvokeOrDefault(new ExplainLifecycleDescriptor(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.explain_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</a>
 		/// </summary>
 		public Task<ExplainLifecycleResponse> ExplainLifecycleAsync(IndexName index, Func<ExplainLifecycleDescriptor, IExplainLifecycleRequest> selector = null, CancellationToken ct = default) => ExplainLifecycleAsync(selector.InvokeOrDefault(new ExplainLifecycleDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.explain_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</a>
 		/// </summary>
 		public ExplainLifecycleResponse ExplainLifecycle(IExplainLifecycleRequest request) => DoRequest<IExplainLifecycleRequest, ExplainLifecycleResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.explain_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</a>
 		/// </summary>
 		public Task<ExplainLifecycleResponse> ExplainLifecycleAsync(IExplainLifecycleRequest request, CancellationToken ct = default) => DoRequestAsync<IExplainLifecycleRequest, ExplainLifecycleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.get_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</a>
 		/// </summary>
 		public GetLifecycleResponse GetLifecycle(Func<GetLifecycleDescriptor, IGetLifecycleRequest> selector = null) => GetLifecycle(selector.InvokeOrDefault(new GetLifecycleDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.get_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</a>
 		/// </summary>
 		public Task<GetLifecycleResponse> GetLifecycleAsync(Func<GetLifecycleDescriptor, IGetLifecycleRequest> selector = null, CancellationToken ct = default) => GetLifecycleAsync(selector.InvokeOrDefault(new GetLifecycleDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.get_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</a>
 		/// </summary>
 		public GetLifecycleResponse GetLifecycle(IGetLifecycleRequest request) => DoRequest<IGetLifecycleRequest, GetLifecycleResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.get_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</a>
 		/// </summary>
 		public Task<GetLifecycleResponse> GetLifecycleAsync(IGetLifecycleRequest request, CancellationToken ct = default) => DoRequestAsync<IGetLifecycleRequest, GetLifecycleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.get_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</a>
 		/// </summary>
 		public GetIlmStatusResponse GetStatus(Func<GetIlmStatusDescriptor, IGetIlmStatusRequest> selector = null) => GetStatus(selector.InvokeOrDefault(new GetIlmStatusDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.get_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</a>
 		/// </summary>
 		public Task<GetIlmStatusResponse> GetStatusAsync(Func<GetIlmStatusDescriptor, IGetIlmStatusRequest> selector = null, CancellationToken ct = default) => GetStatusAsync(selector.InvokeOrDefault(new GetIlmStatusDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.get_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</a>
 		/// </summary>
 		public GetIlmStatusResponse GetStatus(IGetIlmStatusRequest request) => DoRequest<IGetIlmStatusRequest, GetIlmStatusResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ilm.get_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</a>
 		/// </summary>
 		public Task<GetIlmStatusResponse> GetStatusAsync(IGetIlmStatusRequest request, CancellationToken ct = default) => DoRequestAsync<IGetIlmStatusRequest, GetIlmStatusResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.move_to_step</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</a>
 		/// </summary>
 		public MoveToStepResponse MoveToStep(IndexName index, Func<MoveToStepDescriptor, IMoveToStepRequest> selector = null) => MoveToStep(selector.InvokeOrDefault(new MoveToStepDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.move_to_step</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</a>
 		/// </summary>
 		public Task<MoveToStepResponse> MoveToStepAsync(IndexName index, Func<MoveToStepDescriptor, IMoveToStepRequest> selector = null, CancellationToken ct = default) => MoveToStepAsync(selector.InvokeOrDefault(new MoveToStepDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.move_to_step</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</a>
 		/// </summary>
 		public MoveToStepResponse MoveToStep(IMoveToStepRequest request) => DoRequest<IMoveToStepRequest, MoveToStepResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.move_to_step</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</a>
 		/// </summary>
 		public Task<MoveToStepResponse> MoveToStepAsync(IMoveToStepRequest request, CancellationToken ct = default) => DoRequestAsync<IMoveToStepRequest, MoveToStepResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ilm.put_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</a>
 		/// </summary>
 		public PutLifecycleResponse PutLifecycle(Id policyId, Func<PutLifecycleDescriptor, IPutLifecycleRequest> selector = null) => PutLifecycle(selector.InvokeOrDefault(new PutLifecycleDescriptor(policyId: policyId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ilm.put_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</a>
 		/// </summary>
 		public Task<PutLifecycleResponse> PutLifecycleAsync(Id policyId, Func<PutLifecycleDescriptor, IPutLifecycleRequest> selector = null, CancellationToken ct = default) => PutLifecycleAsync(selector.InvokeOrDefault(new PutLifecycleDescriptor(policyId: policyId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ilm.put_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</a>
 		/// </summary>
 		public PutLifecycleResponse PutLifecycle(IPutLifecycleRequest request) => DoRequest<IPutLifecycleRequest, PutLifecycleResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ilm.put_lifecycle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</a>
 		/// </summary>
 		public Task<PutLifecycleResponse> PutLifecycleAsync(IPutLifecycleRequest request, CancellationToken ct = default) => DoRequestAsync<IPutLifecycleRequest, PutLifecycleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.remove_policy</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</a>
 		/// </summary>
 		public RemovePolicyResponse RemovePolicy(IndexName index, Func<RemovePolicyDescriptor, IRemovePolicyRequest> selector = null) => RemovePolicy(selector.InvokeOrDefault(new RemovePolicyDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.remove_policy</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</a>
 		/// </summary>
 		public Task<RemovePolicyResponse> RemovePolicyAsync(IndexName index, Func<RemovePolicyDescriptor, IRemovePolicyRequest> selector = null, CancellationToken ct = default) => RemovePolicyAsync(selector.InvokeOrDefault(new RemovePolicyDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.remove_policy</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</a>
 		/// </summary>
 		public RemovePolicyResponse RemovePolicy(IRemovePolicyRequest request) => DoRequest<IRemovePolicyRequest, RemovePolicyResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.remove_policy</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</a>
 		/// </summary>
 		public Task<RemovePolicyResponse> RemovePolicyAsync(IRemovePolicyRequest request, CancellationToken ct = default) => DoRequestAsync<IRemovePolicyRequest, RemovePolicyResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.retry</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</a>
 		/// </summary>
 		public RetryIlmResponse Retry(IndexName index, Func<RetryIlmDescriptor, IRetryIlmRequest> selector = null) => Retry(selector.InvokeOrDefault(new RetryIlmDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.retry</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</a>
 		/// </summary>
 		public Task<RetryIlmResponse> RetryAsync(IndexName index, Func<RetryIlmDescriptor, IRetryIlmRequest> selector = null, CancellationToken ct = default) => RetryAsync(selector.InvokeOrDefault(new RetryIlmDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.retry</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</a>
 		/// </summary>
 		public RetryIlmResponse Retry(IRetryIlmRequest request) => DoRequest<IRetryIlmRequest, RetryIlmResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.retry</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</a>
 		/// </summary>
 		public Task<RetryIlmResponse> RetryAsync(IRetryIlmRequest request, CancellationToken ct = default) => DoRequestAsync<IRetryIlmRequest, RetryIlmResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.start</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</a>
 		/// </summary>
 		public StartIlmResponse Start(Func<StartIlmDescriptor, IStartIlmRequest> selector = null) => Start(selector.InvokeOrDefault(new StartIlmDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.start</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</a>
 		/// </summary>
 		public Task<StartIlmResponse> StartAsync(Func<StartIlmDescriptor, IStartIlmRequest> selector = null, CancellationToken ct = default) => StartAsync(selector.InvokeOrDefault(new StartIlmDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.start</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</a>
 		/// </summary>
 		public StartIlmResponse Start(IStartIlmRequest request) => DoRequest<IStartIlmRequest, StartIlmResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.start</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</a>
 		/// </summary>
 		public Task<StartIlmResponse> StartAsync(IStartIlmRequest request, CancellationToken ct = default) => DoRequestAsync<IStartIlmRequest, StartIlmResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.stop</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</a>
 		/// </summary>
 		public StopIlmResponse Stop(Func<StopIlmDescriptor, IStopIlmRequest> selector = null) => Stop(selector.InvokeOrDefault(new StopIlmDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.stop</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</a>
 		/// </summary>
 		public Task<StopIlmResponse> StopAsync(Func<StopIlmDescriptor, IStopIlmRequest> selector = null, CancellationToken ct = default) => StopAsync(selector.InvokeOrDefault(new StopIlmDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.stop</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</a>
 		/// </summary>
 		public StopIlmResponse Stop(IStopIlmRequest request) => DoRequest<IStopIlmRequest, StopIlmResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ilm.stop</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</a>
 		/// </summary>
 		public Task<StopIlmResponse> StopAsync(IStopIlmRequest request, CancellationToken ct = default) => DoRequestAsync<IStopIlmRequest, StopIlmResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Indices.cs
+++ b/src/Nest/ElasticClient.Indices.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.IndicesApi;
 namespace Nest.Specification.IndicesApi
 {
 	///<summary>
-	/// Logically groups all <c>Indices</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Indices"/> property
+	/// Indices APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Indices"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,897 +38,897 @@ namespace Nest.Specification.IndicesApi
 
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.analyze</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</a>
 		/// </summary>
 		public AnalyzeResponse Analyze(Func<AnalyzeDescriptor, IAnalyzeRequest> selector = null) => Analyze(selector.InvokeOrDefault(new AnalyzeDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.analyze</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</a>
 		/// </summary>
 		public Task<AnalyzeResponse> AnalyzeAsync(Func<AnalyzeDescriptor, IAnalyzeRequest> selector = null, CancellationToken ct = default) => AnalyzeAsync(selector.InvokeOrDefault(new AnalyzeDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.analyze</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</a>
 		/// </summary>
 		public AnalyzeResponse Analyze(IAnalyzeRequest request) => DoRequest<IAnalyzeRequest, AnalyzeResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.analyze</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</a>
 		/// </summary>
 		public Task<AnalyzeResponse> AnalyzeAsync(IAnalyzeRequest request, CancellationToken ct = default) => DoRequestAsync<IAnalyzeRequest, AnalyzeResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.clear_cache</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</a>
 		/// </summary>
 		public ClearCacheResponse ClearCache(Indices index = null, Func<ClearCacheDescriptor, IClearCacheRequest> selector = null) => ClearCache(selector.InvokeOrDefault(new ClearCacheDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.clear_cache</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</a>
 		/// </summary>
 		public Task<ClearCacheResponse> ClearCacheAsync(Indices index = null, Func<ClearCacheDescriptor, IClearCacheRequest> selector = null, CancellationToken ct = default) => ClearCacheAsync(selector.InvokeOrDefault(new ClearCacheDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.clear_cache</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</a>
 		/// </summary>
 		public ClearCacheResponse ClearCache(IClearCacheRequest request) => DoRequest<IClearCacheRequest, ClearCacheResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.clear_cache</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</a>
 		/// </summary>
 		public Task<ClearCacheResponse> ClearCacheAsync(IClearCacheRequest request, CancellationToken ct = default) => DoRequestAsync<IClearCacheRequest, ClearCacheResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>
 		/// </summary>
 		public CloseIndexResponse Close(Indices index, Func<CloseIndexDescriptor, ICloseIndexRequest> selector = null) => Close(selector.InvokeOrDefault(new CloseIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>
 		/// </summary>
 		public Task<CloseIndexResponse> CloseAsync(Indices index, Func<CloseIndexDescriptor, ICloseIndexRequest> selector = null, CancellationToken ct = default) => CloseAsync(selector.InvokeOrDefault(new CloseIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>
 		/// </summary>
 		public CloseIndexResponse Close(ICloseIndexRequest request) => DoRequest<ICloseIndexRequest, CloseIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>
 		/// </summary>
 		public Task<CloseIndexResponse> CloseAsync(ICloseIndexRequest request, CancellationToken ct = default) => DoRequestAsync<ICloseIndexRequest, CloseIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</a>
 		/// </summary>
 		public CreateIndexResponse Create(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest> selector = null) => Create(selector.InvokeOrDefault(new CreateIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</a>
 		/// </summary>
 		public Task<CreateIndexResponse> CreateAsync(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest> selector = null, CancellationToken ct = default) => CreateAsync(selector.InvokeOrDefault(new CreateIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</a>
 		/// </summary>
 		public CreateIndexResponse Create(ICreateIndexRequest request) => DoRequest<ICreateIndexRequest, CreateIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</a>
 		/// </summary>
 		public Task<CreateIndexResponse> CreateAsync(ICreateIndexRequest request, CancellationToken ct = default) => DoRequestAsync<ICreateIndexRequest, CreateIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</a>
 		/// </summary>
 		public DeleteIndexResponse Delete(Indices index, Func<DeleteIndexDescriptor, IDeleteIndexRequest> selector = null) => Delete(selector.InvokeOrDefault(new DeleteIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</a>
 		/// </summary>
 		public Task<DeleteIndexResponse> DeleteAsync(Indices index, Func<DeleteIndexDescriptor, IDeleteIndexRequest> selector = null, CancellationToken ct = default) => DeleteAsync(selector.InvokeOrDefault(new DeleteIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</a>
 		/// </summary>
 		public DeleteIndexResponse Delete(IDeleteIndexRequest request) => DoRequest<IDeleteIndexRequest, DeleteIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</a>
 		/// </summary>
 		public Task<DeleteIndexResponse> DeleteAsync(IDeleteIndexRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteIndexRequest, DeleteIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public DeleteAliasResponse DeleteAlias(Indices index, Names name, Func<DeleteAliasDescriptor, IDeleteAliasRequest> selector = null) => DeleteAlias(selector.InvokeOrDefault(new DeleteAliasDescriptor(index: index, name: name)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<DeleteAliasResponse> DeleteAliasAsync(Indices index, Names name, Func<DeleteAliasDescriptor, IDeleteAliasRequest> selector = null, CancellationToken ct = default) => DeleteAliasAsync(selector.InvokeOrDefault(new DeleteAliasDescriptor(index: index, name: name)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public DeleteAliasResponse DeleteAlias(IDeleteAliasRequest request) => DoRequest<IDeleteAliasRequest, DeleteAliasResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<DeleteAliasResponse> DeleteAliasAsync(IDeleteAliasRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteAliasRequest, DeleteAliasResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public DeleteIndexTemplateResponse DeleteTemplate(Name name, Func<DeleteIndexTemplateDescriptor, IDeleteIndexTemplateRequest> selector = null) => DeleteTemplate(selector.InvokeOrDefault(new DeleteIndexTemplateDescriptor(name: name)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public Task<DeleteIndexTemplateResponse> DeleteTemplateAsync(Name name, Func<DeleteIndexTemplateDescriptor, IDeleteIndexTemplateRequest> selector = null, CancellationToken ct = default) => DeleteTemplateAsync(selector.InvokeOrDefault(new DeleteIndexTemplateDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public DeleteIndexTemplateResponse DeleteTemplate(IDeleteIndexTemplateRequest request) => DoRequest<IDeleteIndexTemplateRequest, DeleteIndexTemplateResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>indices.delete_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public Task<DeleteIndexTemplateResponse> DeleteTemplateAsync(IDeleteIndexTemplateRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteIndexTemplateRequest, DeleteIndexTemplateResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</a>
 		/// </summary>
 		public ExistsResponse Exists(Indices index, Func<IndexExistsDescriptor, IIndexExistsRequest> selector = null) => Exists(selector.InvokeOrDefault(new IndexExistsDescriptor(index: index)));
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</a>
 		/// </summary>
 		public Task<ExistsResponse> ExistsAsync(Indices index, Func<IndexExistsDescriptor, IIndexExistsRequest> selector = null, CancellationToken ct = default) => ExistsAsync(selector.InvokeOrDefault(new IndexExistsDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</a>
 		/// </summary>
 		public ExistsResponse Exists(IIndexExistsRequest request) => DoRequest<IIndexExistsRequest, ExistsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</a>
 		/// </summary>
 		public Task<ExistsResponse> ExistsAsync(IIndexExistsRequest request, CancellationToken ct = default) => DoRequestAsync<IIndexExistsRequest, ExistsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public ExistsResponse AliasExists(Names name, Func<AliasExistsDescriptor, IAliasExistsRequest> selector = null) => AliasExists(selector.InvokeOrDefault(new AliasExistsDescriptor(name: name)));
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<ExistsResponse> AliasExistsAsync(Names name, Func<AliasExistsDescriptor, IAliasExistsRequest> selector = null, CancellationToken ct = default) => AliasExistsAsync(selector.InvokeOrDefault(new AliasExistsDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public ExistsResponse AliasExists(IAliasExistsRequest request) => DoRequest<IAliasExistsRequest, ExistsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<ExistsResponse> AliasExistsAsync(IAliasExistsRequest request, CancellationToken ct = default) => DoRequestAsync<IAliasExistsRequest, ExistsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public ExistsResponse TemplateExists(Names name, Func<IndexTemplateExistsDescriptor, IIndexTemplateExistsRequest> selector = null) => TemplateExists(selector.InvokeOrDefault(new IndexTemplateExistsDescriptor(name: name)));
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public Task<ExistsResponse> TemplateExistsAsync(Names name, Func<IndexTemplateExistsDescriptor, IIndexTemplateExistsRequest> selector = null, CancellationToken ct = default) => TemplateExistsAsync(selector.InvokeOrDefault(new IndexTemplateExistsDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public ExistsResponse TemplateExists(IIndexTemplateExistsRequest request) => DoRequest<IIndexTemplateExistsRequest, ExistsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public Task<ExistsResponse> TemplateExistsAsync(IIndexTemplateExistsRequest request, CancellationToken ct = default) => DoRequestAsync<IIndexTemplateExistsRequest, ExistsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_type</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</a>
 		/// </summary>
 		public ExistsResponse TypeExists(Indices index, Names type, Func<TypeExistsDescriptor, ITypeExistsRequest> selector = null) => TypeExists(selector.InvokeOrDefault(new TypeExistsDescriptor(index: index, type: type)));
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_type</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</a>
 		/// </summary>
 		public Task<ExistsResponse> TypeExistsAsync(Indices index, Names type, Func<TypeExistsDescriptor, ITypeExistsRequest> selector = null, CancellationToken ct = default) => TypeExistsAsync(selector.InvokeOrDefault(new TypeExistsDescriptor(index: index, type: type)), ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_type</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</a>
 		/// </summary>
 		public ExistsResponse TypeExists(ITypeExistsRequest request) => DoRequest<ITypeExistsRequest, ExistsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>indices.exists_type</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</a>
 		/// </summary>
 		public Task<ExistsResponse> TypeExistsAsync(ITypeExistsRequest request, CancellationToken ct = default) => DoRequestAsync<ITypeExistsRequest, ExistsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.flush</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</a>
 		/// </summary>
 		public FlushResponse Flush(Indices index = null, Func<FlushDescriptor, IFlushRequest> selector = null) => Flush(selector.InvokeOrDefault(new FlushDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.flush</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</a>
 		/// </summary>
 		public Task<FlushResponse> FlushAsync(Indices index = null, Func<FlushDescriptor, IFlushRequest> selector = null, CancellationToken ct = default) => FlushAsync(selector.InvokeOrDefault(new FlushDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.flush</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</a>
 		/// </summary>
 		public FlushResponse Flush(IFlushRequest request) => DoRequest<IFlushRequest, FlushResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.flush</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</a>
 		/// </summary>
 		public Task<FlushResponse> FlushAsync(IFlushRequest request, CancellationToken ct = default) => DoRequestAsync<IFlushRequest, FlushResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.flush_synced</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</a>
 		/// </summary>
 		public SyncedFlushResponse SyncedFlush(Indices index = null, Func<SyncedFlushDescriptor, ISyncedFlushRequest> selector = null) => SyncedFlush(selector.InvokeOrDefault(new SyncedFlushDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.flush_synced</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</a>
 		/// </summary>
 		public Task<SyncedFlushResponse> SyncedFlushAsync(Indices index = null, Func<SyncedFlushDescriptor, ISyncedFlushRequest> selector = null, CancellationToken ct = default) => SyncedFlushAsync(selector.InvokeOrDefault(new SyncedFlushDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.flush_synced</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</a>
 		/// </summary>
 		public SyncedFlushResponse SyncedFlush(ISyncedFlushRequest request) => DoRequest<ISyncedFlushRequest, SyncedFlushResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.flush_synced</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</a>
 		/// </summary>
 		public Task<SyncedFlushResponse> SyncedFlushAsync(ISyncedFlushRequest request, CancellationToken ct = default) => DoRequestAsync<ISyncedFlushRequest, SyncedFlushResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.forcemerge</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</a>
 		/// </summary>
 		public ForceMergeResponse ForceMerge(Indices index = null, Func<ForceMergeDescriptor, IForceMergeRequest> selector = null) => ForceMerge(selector.InvokeOrDefault(new ForceMergeDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.forcemerge</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</a>
 		/// </summary>
 		public Task<ForceMergeResponse> ForceMergeAsync(Indices index = null, Func<ForceMergeDescriptor, IForceMergeRequest> selector = null, CancellationToken ct = default) => ForceMergeAsync(selector.InvokeOrDefault(new ForceMergeDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.forcemerge</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</a>
 		/// </summary>
 		public ForceMergeResponse ForceMerge(IForceMergeRequest request) => DoRequest<IForceMergeRequest, ForceMergeResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.forcemerge</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</a>
 		/// </summary>
 		public Task<ForceMergeResponse> ForceMergeAsync(IForceMergeRequest request, CancellationToken ct = default) => DoRequestAsync<IForceMergeRequest, ForceMergeResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</a>
 		/// </summary>
 		public GetIndexResponse Get(Indices index, Func<GetIndexDescriptor, IGetIndexRequest> selector = null) => Get(selector.InvokeOrDefault(new GetIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</a>
 		/// </summary>
 		public Task<GetIndexResponse> GetAsync(Indices index, Func<GetIndexDescriptor, IGetIndexRequest> selector = null, CancellationToken ct = default) => GetAsync(selector.InvokeOrDefault(new GetIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</a>
 		/// </summary>
 		public GetIndexResponse Get(IGetIndexRequest request) => DoRequest<IGetIndexRequest, GetIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</a>
 		/// </summary>
 		public Task<GetIndexResponse> GetAsync(IGetIndexRequest request, CancellationToken ct = default) => DoRequestAsync<IGetIndexRequest, GetIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public GetAliasResponse GetAlias(Indices index = null, Func<GetAliasDescriptor, IGetAliasRequest> selector = null) => GetAlias(selector.InvokeOrDefault(new GetAliasDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<GetAliasResponse> GetAliasAsync(Indices index = null, Func<GetAliasDescriptor, IGetAliasRequest> selector = null, CancellationToken ct = default) => GetAliasAsync(selector.InvokeOrDefault(new GetAliasDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public GetAliasResponse GetAlias(IGetAliasRequest request) => DoRequest<IGetAliasRequest, GetAliasResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<GetAliasResponse> GetAliasAsync(IGetAliasRequest request, CancellationToken ct = default) => DoRequestAsync<IGetAliasRequest, GetAliasResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_field_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</a>
 		/// </summary>
 		public GetFieldMappingResponse GetFieldMapping<TDocument>(Fields fields, Func<GetFieldMappingDescriptor<TDocument>, IGetFieldMappingRequest> selector = null)
 			where TDocument : class => GetFieldMapping(selector.InvokeOrDefault(new GetFieldMappingDescriptor<TDocument>(fields: fields)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_field_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</a>
 		/// </summary>
 		public Task<GetFieldMappingResponse> GetFieldMappingAsync<TDocument>(Fields fields, Func<GetFieldMappingDescriptor<TDocument>, IGetFieldMappingRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => GetFieldMappingAsync(selector.InvokeOrDefault(new GetFieldMappingDescriptor<TDocument>(fields: fields)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_field_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</a>
 		/// </summary>
 		public GetFieldMappingResponse GetFieldMapping(IGetFieldMappingRequest request) => DoRequest<IGetFieldMappingRequest, GetFieldMappingResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_field_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</a>
 		/// </summary>
 		public Task<GetFieldMappingResponse> GetFieldMappingAsync(IGetFieldMappingRequest request, CancellationToken ct = default) => DoRequestAsync<IGetFieldMappingRequest, GetFieldMappingResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</a>
 		/// </summary>
 		public GetMappingResponse GetMapping<TDocument>(Func<GetMappingDescriptor<TDocument>, IGetMappingRequest> selector = null)
 			where TDocument : class => GetMapping(selector.InvokeOrDefault(new GetMappingDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</a>
 		/// </summary>
 		public Task<GetMappingResponse> GetMappingAsync<TDocument>(Func<GetMappingDescriptor<TDocument>, IGetMappingRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => GetMappingAsync(selector.InvokeOrDefault(new GetMappingDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</a>
 		/// </summary>
 		public GetMappingResponse GetMapping(IGetMappingRequest request) => DoRequest<IGetMappingRequest, GetMappingResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</a>
 		/// </summary>
 		public Task<GetMappingResponse> GetMappingAsync(IGetMappingRequest request, CancellationToken ct = default) => DoRequestAsync<IGetMappingRequest, GetMappingResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</a>
 		/// </summary>
 		public GetIndexSettingsResponse GetSettings(Indices index = null, Func<GetIndexSettingsDescriptor, IGetIndexSettingsRequest> selector = null) => GetSettings(selector.InvokeOrDefault(new GetIndexSettingsDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</a>
 		/// </summary>
 		public Task<GetIndexSettingsResponse> GetSettingsAsync(Indices index = null, Func<GetIndexSettingsDescriptor, IGetIndexSettingsRequest> selector = null, CancellationToken ct = default) => GetSettingsAsync(selector.InvokeOrDefault(new GetIndexSettingsDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</a>
 		/// </summary>
 		public GetIndexSettingsResponse GetSettings(IGetIndexSettingsRequest request) => DoRequest<IGetIndexSettingsRequest, GetIndexSettingsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</a>
 		/// </summary>
 		public Task<GetIndexSettingsResponse> GetSettingsAsync(IGetIndexSettingsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetIndexSettingsRequest, GetIndexSettingsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public GetIndexTemplateResponse GetTemplate(Names name = null, Func<GetIndexTemplateDescriptor, IGetIndexTemplateRequest> selector = null) => GetTemplate(selector.InvokeOrDefault(new GetIndexTemplateDescriptor().Name(name: name)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public Task<GetIndexTemplateResponse> GetTemplateAsync(Names name = null, Func<GetIndexTemplateDescriptor, IGetIndexTemplateRequest> selector = null, CancellationToken ct = default) => GetTemplateAsync(selector.InvokeOrDefault(new GetIndexTemplateDescriptor().Name(name: name)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public GetIndexTemplateResponse GetTemplate(IGetIndexTemplateRequest request) => DoRequest<IGetIndexTemplateRequest, GetIndexTemplateResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public Task<GetIndexTemplateResponse> GetTemplateAsync(IGetIndexTemplateRequest request, CancellationToken ct = default) => DoRequestAsync<IGetIndexTemplateRequest, GetIndexTemplateResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</a>
 		/// </summary>
 		public UpgradeStatusResponse UpgradeStatus(Indices index = null, Func<UpgradeStatusDescriptor, IUpgradeStatusRequest> selector = null) => UpgradeStatus(selector.InvokeOrDefault(new UpgradeStatusDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</a>
 		/// </summary>
 		public Task<UpgradeStatusResponse> UpgradeStatusAsync(Indices index = null, Func<UpgradeStatusDescriptor, IUpgradeStatusRequest> selector = null, CancellationToken ct = default) => UpgradeStatusAsync(selector.InvokeOrDefault(new UpgradeStatusDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</a>
 		/// </summary>
 		public UpgradeStatusResponse UpgradeStatus(IUpgradeStatusRequest request) => DoRequest<IUpgradeStatusRequest, UpgradeStatusResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.get_upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</a>
 		/// </summary>
 		public Task<UpgradeStatusResponse> UpgradeStatusAsync(IUpgradeStatusRequest request, CancellationToken ct = default) => DoRequestAsync<IUpgradeStatusRequest, UpgradeStatusResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.open</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>
 		/// </summary>
 		public OpenIndexResponse Open(Indices index, Func<OpenIndexDescriptor, IOpenIndexRequest> selector = null) => Open(selector.InvokeOrDefault(new OpenIndexDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.open</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>
 		/// </summary>
 		public Task<OpenIndexResponse> OpenAsync(Indices index, Func<OpenIndexDescriptor, IOpenIndexRequest> selector = null, CancellationToken ct = default) => OpenAsync(selector.InvokeOrDefault(new OpenIndexDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.open</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>
 		/// </summary>
 		public OpenIndexResponse Open(IOpenIndexRequest request) => DoRequest<IOpenIndexRequest, OpenIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.open</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>
 		/// </summary>
 		public Task<OpenIndexResponse> OpenAsync(IOpenIndexRequest request, CancellationToken ct = default) => DoRequestAsync<IOpenIndexRequest, OpenIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public PutAliasResponse PutAlias(Indices index, Name name, Func<PutAliasDescriptor, IPutAliasRequest> selector = null) => PutAlias(selector.InvokeOrDefault(new PutAliasDescriptor(index: index, name: name)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<PutAliasResponse> PutAliasAsync(Indices index, Name name, Func<PutAliasDescriptor, IPutAliasRequest> selector = null, CancellationToken ct = default) => PutAliasAsync(selector.InvokeOrDefault(new PutAliasDescriptor(index: index, name: name)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public PutAliasResponse PutAlias(IPutAliasRequest request) => DoRequest<IPutAliasRequest, PutAliasResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_alias</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<PutAliasResponse> PutAliasAsync(IPutAliasRequest request, CancellationToken ct = default) => DoRequestAsync<IPutAliasRequest, PutAliasResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</a>
 		/// </summary>
 		public PutMappingResponse PutMapping<TDocument>(Func<PutMappingDescriptor<TDocument>, IPutMappingRequest> selector)
 			where TDocument : class => PutMapping(selector.InvokeOrDefault(new PutMappingDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</a>
 		/// </summary>
 		public Task<PutMappingResponse> PutMappingAsync<TDocument>(Func<PutMappingDescriptor<TDocument>, IPutMappingRequest> selector, CancellationToken ct = default)
 			where TDocument : class => PutMappingAsync(selector.InvokeOrDefault(new PutMappingDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</a>
 		/// </summary>
 		public PutMappingResponse PutMapping(IPutMappingRequest request) => DoRequest<IPutMappingRequest, PutMappingResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</a>
 		/// </summary>
 		public Task<PutMappingResponse> PutMappingAsync(IPutMappingRequest request, CancellationToken ct = default) => DoRequestAsync<IPutMappingRequest, PutMappingResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</a>
 		/// </summary>
 		public UpdateIndexSettingsResponse UpdateSettings(Indices index, Func<UpdateIndexSettingsDescriptor, IUpdateIndexSettingsRequest> selector) => UpdateSettings(selector.InvokeOrDefault(new UpdateIndexSettingsDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</a>
 		/// </summary>
 		public Task<UpdateIndexSettingsResponse> UpdateSettingsAsync(Indices index, Func<UpdateIndexSettingsDescriptor, IUpdateIndexSettingsRequest> selector, CancellationToken ct = default) => UpdateSettingsAsync(selector.InvokeOrDefault(new UpdateIndexSettingsDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</a>
 		/// </summary>
 		public UpdateIndexSettingsResponse UpdateSettings(IUpdateIndexSettingsRequest request) => DoRequest<IUpdateIndexSettingsRequest, UpdateIndexSettingsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</a>
 		/// </summary>
 		public Task<UpdateIndexSettingsResponse> UpdateSettingsAsync(IUpdateIndexSettingsRequest request, CancellationToken ct = default) => DoRequestAsync<IUpdateIndexSettingsRequest, UpdateIndexSettingsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public PutIndexTemplateResponse PutTemplate(Name name, Func<PutIndexTemplateDescriptor, IPutIndexTemplateRequest> selector) => PutTemplate(selector.InvokeOrDefault(new PutIndexTemplateDescriptor(name: name)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public Task<PutIndexTemplateResponse> PutTemplateAsync(Name name, Func<PutIndexTemplateDescriptor, IPutIndexTemplateRequest> selector, CancellationToken ct = default) => PutTemplateAsync(selector.InvokeOrDefault(new PutIndexTemplateDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public PutIndexTemplateResponse PutTemplate(IPutIndexTemplateRequest request) => DoRequest<IPutIndexTemplateRequest, PutIndexTemplateResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.put_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</a>
 		/// </summary>
 		public Task<PutIndexTemplateResponse> PutTemplateAsync(IPutIndexTemplateRequest request, CancellationToken ct = default) => DoRequestAsync<IPutIndexTemplateRequest, PutIndexTemplateResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.recovery</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</a>
 		/// </summary>
 		public RecoveryStatusResponse RecoveryStatus(Indices index = null, Func<RecoveryStatusDescriptor, IRecoveryStatusRequest> selector = null) => RecoveryStatus(selector.InvokeOrDefault(new RecoveryStatusDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.recovery</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</a>
 		/// </summary>
 		public Task<RecoveryStatusResponse> RecoveryStatusAsync(Indices index = null, Func<RecoveryStatusDescriptor, IRecoveryStatusRequest> selector = null, CancellationToken ct = default) => RecoveryStatusAsync(selector.InvokeOrDefault(new RecoveryStatusDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.recovery</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</a>
 		/// </summary>
 		public RecoveryStatusResponse RecoveryStatus(IRecoveryStatusRequest request) => DoRequest<IRecoveryStatusRequest, RecoveryStatusResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.recovery</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</a>
 		/// </summary>
 		public Task<RecoveryStatusResponse> RecoveryStatusAsync(IRecoveryStatusRequest request, CancellationToken ct = default) => DoRequestAsync<IRecoveryStatusRequest, RecoveryStatusResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.refresh</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</a>
 		/// </summary>
 		public RefreshResponse Refresh(Indices index = null, Func<RefreshDescriptor, IRefreshRequest> selector = null) => Refresh(selector.InvokeOrDefault(new RefreshDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.refresh</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</a>
 		/// </summary>
 		public Task<RefreshResponse> RefreshAsync(Indices index = null, Func<RefreshDescriptor, IRefreshRequest> selector = null, CancellationToken ct = default) => RefreshAsync(selector.InvokeOrDefault(new RefreshDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.refresh</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</a>
 		/// </summary>
 		public RefreshResponse Refresh(IRefreshRequest request) => DoRequest<IRefreshRequest, RefreshResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.refresh</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</a>
 		/// </summary>
 		public Task<RefreshResponse> RefreshAsync(IRefreshRequest request, CancellationToken ct = default) => DoRequestAsync<IRefreshRequest, RefreshResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.rollover</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</a>
 		/// </summary>
 		public RolloverIndexResponse Rollover(Name alias, Func<RolloverIndexDescriptor, IRolloverIndexRequest> selector = null) => Rollover(selector.InvokeOrDefault(new RolloverIndexDescriptor(alias: alias)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.rollover</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</a>
 		/// </summary>
 		public Task<RolloverIndexResponse> RolloverAsync(Name alias, Func<RolloverIndexDescriptor, IRolloverIndexRequest> selector = null, CancellationToken ct = default) => RolloverAsync(selector.InvokeOrDefault(new RolloverIndexDescriptor(alias: alias)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.rollover</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</a>
 		/// </summary>
 		public RolloverIndexResponse Rollover(IRolloverIndexRequest request) => DoRequest<IRolloverIndexRequest, RolloverIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.rollover</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</a>
 		/// </summary>
 		public Task<RolloverIndexResponse> RolloverAsync(IRolloverIndexRequest request, CancellationToken ct = default) => DoRequestAsync<IRolloverIndexRequest, RolloverIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.segments</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</a>
 		/// </summary>
 		public SegmentsResponse Segments(Indices index = null, Func<SegmentsDescriptor, ISegmentsRequest> selector = null) => Segments(selector.InvokeOrDefault(new SegmentsDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.segments</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</a>
 		/// </summary>
 		public Task<SegmentsResponse> SegmentsAsync(Indices index = null, Func<SegmentsDescriptor, ISegmentsRequest> selector = null, CancellationToken ct = default) => SegmentsAsync(selector.InvokeOrDefault(new SegmentsDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.segments</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</a>
 		/// </summary>
 		public SegmentsResponse Segments(ISegmentsRequest request) => DoRequest<ISegmentsRequest, SegmentsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.segments</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</a>
 		/// </summary>
 		public Task<SegmentsResponse> SegmentsAsync(ISegmentsRequest request, CancellationToken ct = default) => DoRequestAsync<ISegmentsRequest, SegmentsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.shard_stores</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</a>
 		/// </summary>
 		public IndicesShardStoresResponse ShardStores(Indices index = null, Func<IndicesShardStoresDescriptor, IIndicesShardStoresRequest> selector = null) => ShardStores(selector.InvokeOrDefault(new IndicesShardStoresDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.shard_stores</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</a>
 		/// </summary>
 		public Task<IndicesShardStoresResponse> ShardStoresAsync(Indices index = null, Func<IndicesShardStoresDescriptor, IIndicesShardStoresRequest> selector = null, CancellationToken ct = default) => ShardStoresAsync(selector.InvokeOrDefault(new IndicesShardStoresDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.shard_stores</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</a>
 		/// </summary>
 		public IndicesShardStoresResponse ShardStores(IIndicesShardStoresRequest request) => DoRequest<IIndicesShardStoresRequest, IndicesShardStoresResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.shard_stores</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</a>
 		/// </summary>
 		public Task<IndicesShardStoresResponse> ShardStoresAsync(IIndicesShardStoresRequest request, CancellationToken ct = default) => DoRequestAsync<IIndicesShardStoresRequest, IndicesShardStoresResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.shrink</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</a>
 		/// </summary>
 		public ShrinkIndexResponse Shrink(IndexName index, IndexName target, Func<ShrinkIndexDescriptor, IShrinkIndexRequest> selector = null) => Shrink(selector.InvokeOrDefault(new ShrinkIndexDescriptor(index: index, target: target)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.shrink</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</a>
 		/// </summary>
 		public Task<ShrinkIndexResponse> ShrinkAsync(IndexName index, IndexName target, Func<ShrinkIndexDescriptor, IShrinkIndexRequest> selector = null, CancellationToken ct = default) => ShrinkAsync(selector.InvokeOrDefault(new ShrinkIndexDescriptor(index: index, target: target)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.shrink</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</a>
 		/// </summary>
 		public ShrinkIndexResponse Shrink(IShrinkIndexRequest request) => DoRequest<IShrinkIndexRequest, ShrinkIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.shrink</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</a>
 		/// </summary>
 		public Task<ShrinkIndexResponse> ShrinkAsync(IShrinkIndexRequest request, CancellationToken ct = default) => DoRequestAsync<IShrinkIndexRequest, ShrinkIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.split</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</a>
 		/// </summary>
 		public SplitIndexResponse Split(IndexName index, IndexName target, Func<SplitIndexDescriptor, ISplitIndexRequest> selector = null) => Split(selector.InvokeOrDefault(new SplitIndexDescriptor(index: index, target: target)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.split</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</a>
 		/// </summary>
 		public Task<SplitIndexResponse> SplitAsync(IndexName index, IndexName target, Func<SplitIndexDescriptor, ISplitIndexRequest> selector = null, CancellationToken ct = default) => SplitAsync(selector.InvokeOrDefault(new SplitIndexDescriptor(index: index, target: target)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.split</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</a>
 		/// </summary>
 		public SplitIndexResponse Split(ISplitIndexRequest request) => DoRequest<ISplitIndexRequest, SplitIndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>indices.split</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</a>
 		/// </summary>
 		public Task<SplitIndexResponse> SplitAsync(ISplitIndexRequest request, CancellationToken ct = default) => DoRequestAsync<ISplitIndexRequest, SplitIndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</a>
 		/// </summary>
 		public IndicesStatsResponse Stats(Indices index = null, Func<IndicesStatsDescriptor, IIndicesStatsRequest> selector = null) => Stats(selector.InvokeOrDefault(new IndicesStatsDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</a>
 		/// </summary>
 		public Task<IndicesStatsResponse> StatsAsync(Indices index = null, Func<IndicesStatsDescriptor, IIndicesStatsRequest> selector = null, CancellationToken ct = default) => StatsAsync(selector.InvokeOrDefault(new IndicesStatsDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</a>
 		/// </summary>
 		public IndicesStatsResponse Stats(IIndicesStatsRequest request) => DoRequest<IIndicesStatsRequest, IndicesStatsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>indices.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</a>
 		/// </summary>
 		public Task<IndicesStatsResponse> StatsAsync(IIndicesStatsRequest request, CancellationToken ct = default) => DoRequestAsync<IIndicesStatsRequest, IndicesStatsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public BulkAliasResponse BulkAlias(Func<BulkAliasDescriptor, IBulkAliasRequest> selector) => BulkAlias(selector.InvokeOrDefault(new BulkAliasDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<BulkAliasResponse> BulkAliasAsync(Func<BulkAliasDescriptor, IBulkAliasRequest> selector, CancellationToken ct = default) => BulkAliasAsync(selector.InvokeOrDefault(new BulkAliasDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public BulkAliasResponse BulkAlias(IBulkAliasRequest request) => DoRequest<IBulkAliasRequest, BulkAliasResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.update_aliases</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</a>
 		/// </summary>
 		public Task<BulkAliasResponse> BulkAliasAsync(IBulkAliasRequest request, CancellationToken ct = default) => DoRequestAsync<IBulkAliasRequest, BulkAliasResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</a>
 		/// </summary>
 		public UpgradeResponse Upgrade(Indices index = null, Func<UpgradeDescriptor, IUpgradeRequest> selector = null) => Upgrade(selector.InvokeOrDefault(new UpgradeDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</a>
 		/// </summary>
 		public Task<UpgradeResponse> UpgradeAsync(Indices index = null, Func<UpgradeDescriptor, IUpgradeRequest> selector = null, CancellationToken ct = default) => UpgradeAsync(selector.InvokeOrDefault(new UpgradeDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</a>
 		/// </summary>
 		public UpgradeResponse Upgrade(IUpgradeRequest request) => DoRequest<IUpgradeRequest, UpgradeResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</a>
 		/// </summary>
 		public Task<UpgradeResponse> UpgradeAsync(IUpgradeRequest request, CancellationToken ct = default) => DoRequestAsync<IUpgradeRequest, UpgradeResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.validate_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</a>
 		/// </summary>
 		public ValidateQueryResponse ValidateQuery<TDocument>(Func<ValidateQueryDescriptor<TDocument>, IValidateQueryRequest> selector = null)
 			where TDocument : class => ValidateQuery(selector.InvokeOrDefault(new ValidateQueryDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.validate_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</a>
 		/// </summary>
 		public Task<ValidateQueryResponse> ValidateQueryAsync<TDocument>(Func<ValidateQueryDescriptor<TDocument>, IValidateQueryRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => ValidateQueryAsync(selector.InvokeOrDefault(new ValidateQueryDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.validate_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</a>
 		/// </summary>
 		public ValidateQueryResponse ValidateQuery(IValidateQueryRequest request) => DoRequest<IValidateQueryRequest, ValidateQueryResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>indices.validate_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</a>
 		/// </summary>
 		public Task<ValidateQueryResponse> ValidateQueryAsync(IValidateQueryRequest request, CancellationToken ct = default) => DoRequestAsync<IValidateQueryRequest, ValidateQueryResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Ingest.cs
+++ b/src/Nest/ElasticClient.Ingest.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.IngestApi;
 namespace Nest.Specification.IngestApi
 {
 	///<summary>
-	/// Logically groups all <c>Ingest</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Ingest"/> property
+	/// Ingest APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Ingest"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,121 +38,121 @@ namespace Nest.Specification.IngestApi
 
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ingest.delete_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public DeletePipelineResponse DeletePipeline(Id id, Func<DeletePipelineDescriptor, IDeletePipelineRequest> selector = null) => DeletePipeline(selector.InvokeOrDefault(new DeletePipelineDescriptor(id: id)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ingest.delete_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<DeletePipelineResponse> DeletePipelineAsync(Id id, Func<DeletePipelineDescriptor, IDeletePipelineRequest> selector = null, CancellationToken ct = default) => DeletePipelineAsync(selector.InvokeOrDefault(new DeletePipelineDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ingest.delete_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public DeletePipelineResponse DeletePipeline(IDeletePipelineRequest request) => DoRequest<IDeletePipelineRequest, DeletePipelineResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ingest.delete_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<DeletePipelineResponse> DeletePipelineAsync(IDeletePipelineRequest request, CancellationToken ct = default) => DoRequestAsync<IDeletePipelineRequest, DeletePipelineResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ingest.get_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public GetPipelineResponse GetPipeline(Func<GetPipelineDescriptor, IGetPipelineRequest> selector = null) => GetPipeline(selector.InvokeOrDefault(new GetPipelineDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ingest.get_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<GetPipelineResponse> GetPipelineAsync(Func<GetPipelineDescriptor, IGetPipelineRequest> selector = null, CancellationToken ct = default) => GetPipelineAsync(selector.InvokeOrDefault(new GetPipelineDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ingest.get_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public GetPipelineResponse GetPipeline(IGetPipelineRequest request) => DoRequest<IGetPipelineRequest, GetPipelineResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ingest.get_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<GetPipelineResponse> GetPipelineAsync(IGetPipelineRequest request, CancellationToken ct = default) => DoRequestAsync<IGetPipelineRequest, GetPipelineResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ingest.processor_grok</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public GrokProcessorPatternsResponse GrokProcessorPatterns(Func<GrokProcessorPatternsDescriptor, IGrokProcessorPatternsRequest> selector = null) => GrokProcessorPatterns(selector.InvokeOrDefault(new GrokProcessorPatternsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ingest.processor_grok</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<GrokProcessorPatternsResponse> GrokProcessorPatternsAsync(Func<GrokProcessorPatternsDescriptor, IGrokProcessorPatternsRequest> selector = null, CancellationToken ct = default) => GrokProcessorPatternsAsync(selector.InvokeOrDefault(new GrokProcessorPatternsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ingest.processor_grok</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public GrokProcessorPatternsResponse GrokProcessorPatterns(IGrokProcessorPatternsRequest request) => DoRequest<IGrokProcessorPatternsRequest, GrokProcessorPatternsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ingest.processor_grok</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<GrokProcessorPatternsResponse> GrokProcessorPatternsAsync(IGrokProcessorPatternsRequest request, CancellationToken ct = default) => DoRequestAsync<IGrokProcessorPatternsRequest, GrokProcessorPatternsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ingest.put_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public PutPipelineResponse PutPipeline(Id id, Func<PutPipelineDescriptor, IPutPipelineRequest> selector) => PutPipeline(selector.InvokeOrDefault(new PutPipelineDescriptor(id: id)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ingest.put_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<PutPipelineResponse> PutPipelineAsync(Id id, Func<PutPipelineDescriptor, IPutPipelineRequest> selector, CancellationToken ct = default) => PutPipelineAsync(selector.InvokeOrDefault(new PutPipelineDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ingest.put_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public PutPipelineResponse PutPipeline(IPutPipelineRequest request) => DoRequest<IPutPipelineRequest, PutPipelineResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ingest.put_pipeline</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<PutPipelineResponse> PutPipelineAsync(IPutPipelineRequest request, CancellationToken ct = default) => DoRequestAsync<IPutPipelineRequest, PutPipelineResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ingest.simulate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public SimulatePipelineResponse SimulatePipeline(Func<SimulatePipelineDescriptor, ISimulatePipelineRequest> selector = null) => SimulatePipeline(selector.InvokeOrDefault(new SimulatePipelineDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ingest.simulate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<SimulatePipelineResponse> SimulatePipelineAsync(Func<SimulatePipelineDescriptor, ISimulatePipelineRequest> selector = null, CancellationToken ct = default) => SimulatePipelineAsync(selector.InvokeOrDefault(new SimulatePipelineDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ingest.simulate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public SimulatePipelineResponse SimulatePipeline(ISimulatePipelineRequest request) => DoRequest<ISimulatePipelineRequest, SimulatePipelineResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ingest.simulate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html">https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</a>
 		/// </summary>
 		public Task<SimulatePipelineResponse> SimulatePipelineAsync(ISimulatePipelineRequest request, CancellationToken ct = default) => DoRequestAsync<ISimulatePipelineRequest, SimulatePipelineResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.License.cs
+++ b/src/Nest/ElasticClient.License.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.LicenseApi;
 namespace Nest.Specification.LicenseApi
 {
 	///<summary>
-	/// Logically groups all <c>License</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.License"/> property
+	/// License APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.License"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,169 +38,169 @@ namespace Nest.Specification.LicenseApi
 
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>license.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public DeleteLicenseResponse Delete(Func<DeleteLicenseDescriptor, IDeleteLicenseRequest> selector = null) => Delete(selector.InvokeOrDefault(new DeleteLicenseDescriptor()));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>license.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<DeleteLicenseResponse> DeleteAsync(Func<DeleteLicenseDescriptor, IDeleteLicenseRequest> selector = null, CancellationToken ct = default) => DeleteAsync(selector.InvokeOrDefault(new DeleteLicenseDescriptor()), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>license.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public DeleteLicenseResponse Delete(IDeleteLicenseRequest request) => DoRequest<IDeleteLicenseRequest, DeleteLicenseResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>license.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<DeleteLicenseResponse> DeleteAsync(IDeleteLicenseRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteLicenseRequest, DeleteLicenseResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public GetLicenseResponse Get(Func<GetLicenseDescriptor, IGetLicenseRequest> selector = null) => Get(selector.InvokeOrDefault(new GetLicenseDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<GetLicenseResponse> GetAsync(Func<GetLicenseDescriptor, IGetLicenseRequest> selector = null, CancellationToken ct = default) => GetAsync(selector.InvokeOrDefault(new GetLicenseDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public GetLicenseResponse Get(IGetLicenseRequest request) => DoRequest<IGetLicenseRequest, GetLicenseResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<GetLicenseResponse> GetAsync(IGetLicenseRequest request, CancellationToken ct = default) => DoRequestAsync<IGetLicenseRequest, GetLicenseResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get_basic_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public GetBasicLicenseStatusResponse GetBasicStatus(Func<GetBasicLicenseStatusDescriptor, IGetBasicLicenseStatusRequest> selector = null) => GetBasicStatus(selector.InvokeOrDefault(new GetBasicLicenseStatusDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get_basic_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<GetBasicLicenseStatusResponse> GetBasicStatusAsync(Func<GetBasicLicenseStatusDescriptor, IGetBasicLicenseStatusRequest> selector = null, CancellationToken ct = default) => GetBasicStatusAsync(selector.InvokeOrDefault(new GetBasicLicenseStatusDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get_basic_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public GetBasicLicenseStatusResponse GetBasicStatus(IGetBasicLicenseStatusRequest request) => DoRequest<IGetBasicLicenseStatusRequest, GetBasicLicenseStatusResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get_basic_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<GetBasicLicenseStatusResponse> GetBasicStatusAsync(IGetBasicLicenseStatusRequest request, CancellationToken ct = default) => DoRequestAsync<IGetBasicLicenseStatusRequest, GetBasicLicenseStatusResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get_trial_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public GetTrialLicenseStatusResponse GetTrialStatus(Func<GetTrialLicenseStatusDescriptor, IGetTrialLicenseStatusRequest> selector = null) => GetTrialStatus(selector.InvokeOrDefault(new GetTrialLicenseStatusDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get_trial_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<GetTrialLicenseStatusResponse> GetTrialStatusAsync(Func<GetTrialLicenseStatusDescriptor, IGetTrialLicenseStatusRequest> selector = null, CancellationToken ct = default) => GetTrialStatusAsync(selector.InvokeOrDefault(new GetTrialLicenseStatusDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get_trial_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public GetTrialLicenseStatusResponse GetTrialStatus(IGetTrialLicenseStatusRequest request) => DoRequest<IGetTrialLicenseStatusRequest, GetTrialLicenseStatusResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>license.get_trial_status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<GetTrialLicenseStatusResponse> GetTrialStatusAsync(IGetTrialLicenseStatusRequest request, CancellationToken ct = default) => DoRequestAsync<IGetTrialLicenseStatusRequest, GetTrialLicenseStatusResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>license.post</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public PostLicenseResponse Post(Func<PostLicenseDescriptor, IPostLicenseRequest> selector = null) => Post(selector.InvokeOrDefault(new PostLicenseDescriptor()));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>license.post</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<PostLicenseResponse> PostAsync(Func<PostLicenseDescriptor, IPostLicenseRequest> selector = null, CancellationToken ct = default) => PostAsync(selector.InvokeOrDefault(new PostLicenseDescriptor()), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>license.post</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public PostLicenseResponse Post(IPostLicenseRequest request) => DoRequest<IPostLicenseRequest, PostLicenseResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>license.post</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<PostLicenseResponse> PostAsync(IPostLicenseRequest request, CancellationToken ct = default) => DoRequestAsync<IPostLicenseRequest, PostLicenseResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>license.post_start_basic</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public StartBasicLicenseResponse StartBasic(Func<StartBasicLicenseDescriptor, IStartBasicLicenseRequest> selector = null) => StartBasic(selector.InvokeOrDefault(new StartBasicLicenseDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>license.post_start_basic</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<StartBasicLicenseResponse> StartBasicAsync(Func<StartBasicLicenseDescriptor, IStartBasicLicenseRequest> selector = null, CancellationToken ct = default) => StartBasicAsync(selector.InvokeOrDefault(new StartBasicLicenseDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>license.post_start_basic</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public StartBasicLicenseResponse StartBasic(IStartBasicLicenseRequest request) => DoRequest<IStartBasicLicenseRequest, StartBasicLicenseResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>license.post_start_basic</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<StartBasicLicenseResponse> StartBasicAsync(IStartBasicLicenseRequest request, CancellationToken ct = default) => DoRequestAsync<IStartBasicLicenseRequest, StartBasicLicenseResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>license.post_start_trial</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public StartTrialLicenseResponse StartTrial(Func<StartTrialLicenseDescriptor, IStartTrialLicenseRequest> selector = null) => StartTrial(selector.InvokeOrDefault(new StartTrialLicenseDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>license.post_start_trial</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<StartTrialLicenseResponse> StartTrialAsync(Func<StartTrialLicenseDescriptor, IStartTrialLicenseRequest> selector = null, CancellationToken ct = default) => StartTrialAsync(selector.InvokeOrDefault(new StartTrialLicenseDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>license.post_start_trial</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public StartTrialLicenseResponse StartTrial(IStartTrialLicenseRequest request) => DoRequest<IStartTrialLicenseRequest, StartTrialLicenseResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>license.post_start_trial</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/x-pack/current/license-management.html">https://www.elastic.co/guide/en/x-pack/current/license-management.html</a>
 		/// </summary>
 		public Task<StartTrialLicenseResponse> StartTrialAsync(IStartTrialLicenseRequest request, CancellationToken ct = default) => DoRequestAsync<IStartTrialLicenseRequest, StartTrialLicenseResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.MachineLearning.cs
+++ b/src/Nest/ElasticClient.MachineLearning.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.MachineLearningApi;
 namespace Nest.Specification.MachineLearningApi
 {
 	///<summary>
-	/// Logically groups all <c>MachineLearning</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.MachineLearning"/> property
+	/// Machine Learning APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.MachineLearning"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,1069 +38,1069 @@ namespace Nest.Specification.MachineLearningApi
 
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.close_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</a>
 		/// </summary>
 		public CloseJobResponse CloseJob(Id jobId, Func<CloseJobDescriptor, ICloseJobRequest> selector = null) => CloseJob(selector.InvokeOrDefault(new CloseJobDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.close_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</a>
 		/// </summary>
 		public Task<CloseJobResponse> CloseJobAsync(Id jobId, Func<CloseJobDescriptor, ICloseJobRequest> selector = null, CancellationToken ct = default) => CloseJobAsync(selector.InvokeOrDefault(new CloseJobDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.close_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</a>
 		/// </summary>
 		public CloseJobResponse CloseJob(ICloseJobRequest request) => DoRequest<ICloseJobRequest, CloseJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.close_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</a>
 		/// </summary>
 		public Task<CloseJobResponse> CloseJobAsync(ICloseJobRequest request, CancellationToken ct = default) => DoRequestAsync<ICloseJobRequest, CloseJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteCalendarResponse DeleteCalendar(Id calendarId, Func<DeleteCalendarDescriptor, IDeleteCalendarRequest> selector = null) => DeleteCalendar(selector.InvokeOrDefault(new DeleteCalendarDescriptor(calendarId: calendarId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteCalendarResponse> DeleteCalendarAsync(Id calendarId, Func<DeleteCalendarDescriptor, IDeleteCalendarRequest> selector = null, CancellationToken ct = default) => DeleteCalendarAsync(selector.InvokeOrDefault(new DeleteCalendarDescriptor(calendarId: calendarId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteCalendarResponse DeleteCalendar(IDeleteCalendarRequest request) => DoRequest<IDeleteCalendarRequest, DeleteCalendarResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteCalendarResponse> DeleteCalendarAsync(IDeleteCalendarRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteCalendarRequest, DeleteCalendarResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar_event</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteCalendarEventResponse DeleteCalendarEvent(Id calendarId, Id eventId, Func<DeleteCalendarEventDescriptor, IDeleteCalendarEventRequest> selector = null) => DeleteCalendarEvent(selector.InvokeOrDefault(new DeleteCalendarEventDescriptor(calendarId: calendarId, eventId: eventId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar_event</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteCalendarEventResponse> DeleteCalendarEventAsync(Id calendarId, Id eventId, Func<DeleteCalendarEventDescriptor, IDeleteCalendarEventRequest> selector = null, CancellationToken ct = default) => DeleteCalendarEventAsync(selector.InvokeOrDefault(new DeleteCalendarEventDescriptor(calendarId: calendarId, eventId: eventId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar_event</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteCalendarEventResponse DeleteCalendarEvent(IDeleteCalendarEventRequest request) => DoRequest<IDeleteCalendarEventRequest, DeleteCalendarEventResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar_event</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteCalendarEventResponse> DeleteCalendarEventAsync(IDeleteCalendarEventRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteCalendarEventRequest, DeleteCalendarEventResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteCalendarJobResponse DeleteCalendarJob(Id calendarId, Id jobId, Func<DeleteCalendarJobDescriptor, IDeleteCalendarJobRequest> selector = null) => DeleteCalendarJob(selector.InvokeOrDefault(new DeleteCalendarJobDescriptor(calendarId: calendarId, jobId: jobId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteCalendarJobResponse> DeleteCalendarJobAsync(Id calendarId, Id jobId, Func<DeleteCalendarJobDescriptor, IDeleteCalendarJobRequest> selector = null, CancellationToken ct = default) => DeleteCalendarJobAsync(selector.InvokeOrDefault(new DeleteCalendarJobDescriptor(calendarId: calendarId, jobId: jobId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteCalendarJobResponse DeleteCalendarJob(IDeleteCalendarJobRequest request) => DoRequest<IDeleteCalendarJobRequest, DeleteCalendarJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_calendar_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteCalendarJobResponse> DeleteCalendarJobAsync(IDeleteCalendarJobRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteCalendarJobRequest, DeleteCalendarJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</a>
 		/// </summary>
 		public DeleteDatafeedResponse DeleteDatafeed(Id datafeedId, Func<DeleteDatafeedDescriptor, IDeleteDatafeedRequest> selector = null) => DeleteDatafeed(selector.InvokeOrDefault(new DeleteDatafeedDescriptor(datafeedId: datafeedId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</a>
 		/// </summary>
 		public Task<DeleteDatafeedResponse> DeleteDatafeedAsync(Id datafeedId, Func<DeleteDatafeedDescriptor, IDeleteDatafeedRequest> selector = null, CancellationToken ct = default) => DeleteDatafeedAsync(selector.InvokeOrDefault(new DeleteDatafeedDescriptor(datafeedId: datafeedId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</a>
 		/// </summary>
 		public DeleteDatafeedResponse DeleteDatafeed(IDeleteDatafeedRequest request) => DoRequest<IDeleteDatafeedRequest, DeleteDatafeedResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</a>
 		/// </summary>
 		public Task<DeleteDatafeedResponse> DeleteDatafeedAsync(IDeleteDatafeedRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteDatafeedRequest, DeleteDatafeedResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_expired_data</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteExpiredDataResponse DeleteExpiredData(Func<DeleteExpiredDataDescriptor, IDeleteExpiredDataRequest> selector = null) => DeleteExpiredData(selector.InvokeOrDefault(new DeleteExpiredDataDescriptor()));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_expired_data</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteExpiredDataResponse> DeleteExpiredDataAsync(Func<DeleteExpiredDataDescriptor, IDeleteExpiredDataRequest> selector = null, CancellationToken ct = default) => DeleteExpiredDataAsync(selector.InvokeOrDefault(new DeleteExpiredDataDescriptor()), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_expired_data</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteExpiredDataResponse DeleteExpiredData(IDeleteExpiredDataRequest request) => DoRequest<IDeleteExpiredDataRequest, DeleteExpiredDataResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_expired_data</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteExpiredDataResponse> DeleteExpiredDataAsync(IDeleteExpiredDataRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteExpiredDataRequest, DeleteExpiredDataResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteFilterResponse DeleteFilter(Id filterId, Func<DeleteFilterDescriptor, IDeleteFilterRequest> selector = null) => DeleteFilter(selector.InvokeOrDefault(new DeleteFilterDescriptor(filterId: filterId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteFilterResponse> DeleteFilterAsync(Id filterId, Func<DeleteFilterDescriptor, IDeleteFilterRequest> selector = null, CancellationToken ct = default) => DeleteFilterAsync(selector.InvokeOrDefault(new DeleteFilterDescriptor(filterId: filterId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public DeleteFilterResponse DeleteFilter(IDeleteFilterRequest request) => DoRequest<IDeleteFilterRequest, DeleteFilterResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<DeleteFilterResponse> DeleteFilterAsync(IDeleteFilterRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteFilterRequest, DeleteFilterResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_forecast</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</a>
 		/// </summary>
 		public DeleteForecastResponse DeleteForecast(Id jobId, Ids forecastId, Func<DeleteForecastDescriptor, IDeleteForecastRequest> selector = null) => DeleteForecast(selector.InvokeOrDefault(new DeleteForecastDescriptor(jobId: jobId, forecastId: forecastId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_forecast</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</a>
 		/// </summary>
 		public Task<DeleteForecastResponse> DeleteForecastAsync(Id jobId, Ids forecastId, Func<DeleteForecastDescriptor, IDeleteForecastRequest> selector = null, CancellationToken ct = default) => DeleteForecastAsync(selector.InvokeOrDefault(new DeleteForecastDescriptor(jobId: jobId, forecastId: forecastId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_forecast</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</a>
 		/// </summary>
 		public DeleteForecastResponse DeleteForecast(IDeleteForecastRequest request) => DoRequest<IDeleteForecastRequest, DeleteForecastResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_forecast</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</a>
 		/// </summary>
 		public Task<DeleteForecastResponse> DeleteForecastAsync(IDeleteForecastRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteForecastRequest, DeleteForecastResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</a>
 		/// </summary>
 		public DeleteJobResponse DeleteJob(Id jobId, Func<DeleteJobDescriptor, IDeleteJobRequest> selector = null) => DeleteJob(selector.InvokeOrDefault(new DeleteJobDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</a>
 		/// </summary>
 		public Task<DeleteJobResponse> DeleteJobAsync(Id jobId, Func<DeleteJobDescriptor, IDeleteJobRequest> selector = null, CancellationToken ct = default) => DeleteJobAsync(selector.InvokeOrDefault(new DeleteJobDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</a>
 		/// </summary>
 		public DeleteJobResponse DeleteJob(IDeleteJobRequest request) => DoRequest<IDeleteJobRequest, DeleteJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</a>
 		/// </summary>
 		public Task<DeleteJobResponse> DeleteJobAsync(IDeleteJobRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteJobRequest, DeleteJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</a>
 		/// </summary>
 		public DeleteModelSnapshotResponse DeleteModelSnapshot(Id jobId, Id snapshotId, Func<DeleteModelSnapshotDescriptor, IDeleteModelSnapshotRequest> selector = null) => DeleteModelSnapshot(selector.InvokeOrDefault(new DeleteModelSnapshotDescriptor(jobId: jobId, snapshotId: snapshotId)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</a>
 		/// </summary>
 		public Task<DeleteModelSnapshotResponse> DeleteModelSnapshotAsync(Id jobId, Id snapshotId, Func<DeleteModelSnapshotDescriptor, IDeleteModelSnapshotRequest> selector = null, CancellationToken ct = default) => DeleteModelSnapshotAsync(selector.InvokeOrDefault(new DeleteModelSnapshotDescriptor(jobId: jobId, snapshotId: snapshotId)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</a>
 		/// </summary>
 		public DeleteModelSnapshotResponse DeleteModelSnapshot(IDeleteModelSnapshotRequest request) => DoRequest<IDeleteModelSnapshotRequest, DeleteModelSnapshotResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>ml.delete_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</a>
 		/// </summary>
 		public Task<DeleteModelSnapshotResponse> DeleteModelSnapshotAsync(IDeleteModelSnapshotRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteModelSnapshotRequest, DeleteModelSnapshotResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.flush_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</a>
 		/// </summary>
 		public FlushJobResponse FlushJob(Id jobId, Func<FlushJobDescriptor, IFlushJobRequest> selector = null) => FlushJob(selector.InvokeOrDefault(new FlushJobDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.flush_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</a>
 		/// </summary>
 		public Task<FlushJobResponse> FlushJobAsync(Id jobId, Func<FlushJobDescriptor, IFlushJobRequest> selector = null, CancellationToken ct = default) => FlushJobAsync(selector.InvokeOrDefault(new FlushJobDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.flush_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</a>
 		/// </summary>
 		public FlushJobResponse FlushJob(IFlushJobRequest request) => DoRequest<IFlushJobRequest, FlushJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.flush_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</a>
 		/// </summary>
 		public Task<FlushJobResponse> FlushJobAsync(IFlushJobRequest request, CancellationToken ct = default) => DoRequestAsync<IFlushJobRequest, FlushJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.forecast</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public ForecastJobResponse ForecastJob(Id jobId, Func<ForecastJobDescriptor, IForecastJobRequest> selector = null) => ForecastJob(selector.InvokeOrDefault(new ForecastJobDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.forecast</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<ForecastJobResponse> ForecastJobAsync(Id jobId, Func<ForecastJobDescriptor, IForecastJobRequest> selector = null, CancellationToken ct = default) => ForecastJobAsync(selector.InvokeOrDefault(new ForecastJobDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.forecast</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public ForecastJobResponse ForecastJob(IForecastJobRequest request) => DoRequest<IForecastJobRequest, ForecastJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.forecast</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<ForecastJobResponse> ForecastJobAsync(IForecastJobRequest request, CancellationToken ct = default) => DoRequestAsync<IForecastJobRequest, ForecastJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_buckets</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</a>
 		/// </summary>
 		public GetBucketsResponse GetBuckets(Id jobId, Func<GetBucketsDescriptor, IGetBucketsRequest> selector = null) => GetBuckets(selector.InvokeOrDefault(new GetBucketsDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_buckets</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</a>
 		/// </summary>
 		public Task<GetBucketsResponse> GetBucketsAsync(Id jobId, Func<GetBucketsDescriptor, IGetBucketsRequest> selector = null, CancellationToken ct = default) => GetBucketsAsync(selector.InvokeOrDefault(new GetBucketsDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_buckets</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</a>
 		/// </summary>
 		public GetBucketsResponse GetBuckets(IGetBucketsRequest request) => DoRequest<IGetBucketsRequest, GetBucketsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_buckets</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</a>
 		/// </summary>
 		public Task<GetBucketsResponse> GetBucketsAsync(IGetBucketsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetBucketsRequest, GetBucketsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_calendar_events</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public GetCalendarEventsResponse GetCalendarEvents(Id calendarId, Func<GetCalendarEventsDescriptor, IGetCalendarEventsRequest> selector = null) => GetCalendarEvents(selector.InvokeOrDefault(new GetCalendarEventsDescriptor(calendarId: calendarId)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_calendar_events</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<GetCalendarEventsResponse> GetCalendarEventsAsync(Id calendarId, Func<GetCalendarEventsDescriptor, IGetCalendarEventsRequest> selector = null, CancellationToken ct = default) => GetCalendarEventsAsync(selector.InvokeOrDefault(new GetCalendarEventsDescriptor(calendarId: calendarId)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_calendar_events</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public GetCalendarEventsResponse GetCalendarEvents(IGetCalendarEventsRequest request) => DoRequest<IGetCalendarEventsRequest, GetCalendarEventsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_calendar_events</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<GetCalendarEventsResponse> GetCalendarEventsAsync(IGetCalendarEventsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetCalendarEventsRequest, GetCalendarEventsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_calendars</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public GetCalendarsResponse GetCalendars(Func<GetCalendarsDescriptor, IGetCalendarsRequest> selector = null) => GetCalendars(selector.InvokeOrDefault(new GetCalendarsDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_calendars</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<GetCalendarsResponse> GetCalendarsAsync(Func<GetCalendarsDescriptor, IGetCalendarsRequest> selector = null, CancellationToken ct = default) => GetCalendarsAsync(selector.InvokeOrDefault(new GetCalendarsDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_calendars</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public GetCalendarsResponse GetCalendars(IGetCalendarsRequest request) => DoRequest<IGetCalendarsRequest, GetCalendarsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_calendars</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<GetCalendarsResponse> GetCalendarsAsync(IGetCalendarsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetCalendarsRequest, GetCalendarsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_categories</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</a>
 		/// </summary>
 		public GetCategoriesResponse GetCategories(Id jobId, Func<GetCategoriesDescriptor, IGetCategoriesRequest> selector = null) => GetCategories(selector.InvokeOrDefault(new GetCategoriesDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_categories</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</a>
 		/// </summary>
 		public Task<GetCategoriesResponse> GetCategoriesAsync(Id jobId, Func<GetCategoriesDescriptor, IGetCategoriesRequest> selector = null, CancellationToken ct = default) => GetCategoriesAsync(selector.InvokeOrDefault(new GetCategoriesDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_categories</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</a>
 		/// </summary>
 		public GetCategoriesResponse GetCategories(IGetCategoriesRequest request) => DoRequest<IGetCategoriesRequest, GetCategoriesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_categories</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</a>
 		/// </summary>
 		public Task<GetCategoriesResponse> GetCategoriesAsync(IGetCategoriesRequest request, CancellationToken ct = default) => DoRequestAsync<IGetCategoriesRequest, GetCategoriesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_datafeed_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</a>
 		/// </summary>
 		public GetDatafeedStatsResponse GetDatafeedStats(Func<GetDatafeedStatsDescriptor, IGetDatafeedStatsRequest> selector = null) => GetDatafeedStats(selector.InvokeOrDefault(new GetDatafeedStatsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_datafeed_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</a>
 		/// </summary>
 		public Task<GetDatafeedStatsResponse> GetDatafeedStatsAsync(Func<GetDatafeedStatsDescriptor, IGetDatafeedStatsRequest> selector = null, CancellationToken ct = default) => GetDatafeedStatsAsync(selector.InvokeOrDefault(new GetDatafeedStatsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_datafeed_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</a>
 		/// </summary>
 		public GetDatafeedStatsResponse GetDatafeedStats(IGetDatafeedStatsRequest request) => DoRequest<IGetDatafeedStatsRequest, GetDatafeedStatsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_datafeed_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</a>
 		/// </summary>
 		public Task<GetDatafeedStatsResponse> GetDatafeedStatsAsync(IGetDatafeedStatsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetDatafeedStatsRequest, GetDatafeedStatsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_datafeeds</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</a>
 		/// </summary>
 		public GetDatafeedsResponse GetDatafeeds(Func<GetDatafeedsDescriptor, IGetDatafeedsRequest> selector = null) => GetDatafeeds(selector.InvokeOrDefault(new GetDatafeedsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_datafeeds</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</a>
 		/// </summary>
 		public Task<GetDatafeedsResponse> GetDatafeedsAsync(Func<GetDatafeedsDescriptor, IGetDatafeedsRequest> selector = null, CancellationToken ct = default) => GetDatafeedsAsync(selector.InvokeOrDefault(new GetDatafeedsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_datafeeds</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</a>
 		/// </summary>
 		public GetDatafeedsResponse GetDatafeeds(IGetDatafeedsRequest request) => DoRequest<IGetDatafeedsRequest, GetDatafeedsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_datafeeds</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</a>
 		/// </summary>
 		public Task<GetDatafeedsResponse> GetDatafeedsAsync(IGetDatafeedsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetDatafeedsRequest, GetDatafeedsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_filters</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public GetFiltersResponse GetFilters(Func<GetFiltersDescriptor, IGetFiltersRequest> selector = null) => GetFilters(selector.InvokeOrDefault(new GetFiltersDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_filters</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<GetFiltersResponse> GetFiltersAsync(Func<GetFiltersDescriptor, IGetFiltersRequest> selector = null, CancellationToken ct = default) => GetFiltersAsync(selector.InvokeOrDefault(new GetFiltersDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_filters</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public GetFiltersResponse GetFilters(IGetFiltersRequest request) => DoRequest<IGetFiltersRequest, GetFiltersResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_filters</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<GetFiltersResponse> GetFiltersAsync(IGetFiltersRequest request, CancellationToken ct = default) => DoRequestAsync<IGetFiltersRequest, GetFiltersResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_influencers</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</a>
 		/// </summary>
 		public GetInfluencersResponse GetInfluencers(Id jobId, Func<GetInfluencersDescriptor, IGetInfluencersRequest> selector = null) => GetInfluencers(selector.InvokeOrDefault(new GetInfluencersDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_influencers</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</a>
 		/// </summary>
 		public Task<GetInfluencersResponse> GetInfluencersAsync(Id jobId, Func<GetInfluencersDescriptor, IGetInfluencersRequest> selector = null, CancellationToken ct = default) => GetInfluencersAsync(selector.InvokeOrDefault(new GetInfluencersDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_influencers</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</a>
 		/// </summary>
 		public GetInfluencersResponse GetInfluencers(IGetInfluencersRequest request) => DoRequest<IGetInfluencersRequest, GetInfluencersResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_influencers</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</a>
 		/// </summary>
 		public Task<GetInfluencersResponse> GetInfluencersAsync(IGetInfluencersRequest request, CancellationToken ct = default) => DoRequestAsync<IGetInfluencersRequest, GetInfluencersResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_job_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</a>
 		/// </summary>
 		public GetJobStatsResponse GetJobStats(Func<GetJobStatsDescriptor, IGetJobStatsRequest> selector = null) => GetJobStats(selector.InvokeOrDefault(new GetJobStatsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_job_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</a>
 		/// </summary>
 		public Task<GetJobStatsResponse> GetJobStatsAsync(Func<GetJobStatsDescriptor, IGetJobStatsRequest> selector = null, CancellationToken ct = default) => GetJobStatsAsync(selector.InvokeOrDefault(new GetJobStatsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_job_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</a>
 		/// </summary>
 		public GetJobStatsResponse GetJobStats(IGetJobStatsRequest request) => DoRequest<IGetJobStatsRequest, GetJobStatsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_job_stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</a>
 		/// </summary>
 		public Task<GetJobStatsResponse> GetJobStatsAsync(IGetJobStatsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetJobStatsRequest, GetJobStatsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_jobs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</a>
 		/// </summary>
 		public GetJobsResponse GetJobs(Func<GetJobsDescriptor, IGetJobsRequest> selector = null) => GetJobs(selector.InvokeOrDefault(new GetJobsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_jobs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</a>
 		/// </summary>
 		public Task<GetJobsResponse> GetJobsAsync(Func<GetJobsDescriptor, IGetJobsRequest> selector = null, CancellationToken ct = default) => GetJobsAsync(selector.InvokeOrDefault(new GetJobsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_jobs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</a>
 		/// </summary>
 		public GetJobsResponse GetJobs(IGetJobsRequest request) => DoRequest<IGetJobsRequest, GetJobsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.get_jobs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</a>
 		/// </summary>
 		public Task<GetJobsResponse> GetJobsAsync(IGetJobsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetJobsRequest, GetJobsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_model_snapshots</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</a>
 		/// </summary>
 		public GetModelSnapshotsResponse GetModelSnapshots(Id jobId, Func<GetModelSnapshotsDescriptor, IGetModelSnapshotsRequest> selector = null) => GetModelSnapshots(selector.InvokeOrDefault(new GetModelSnapshotsDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_model_snapshots</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</a>
 		/// </summary>
 		public Task<GetModelSnapshotsResponse> GetModelSnapshotsAsync(Id jobId, Func<GetModelSnapshotsDescriptor, IGetModelSnapshotsRequest> selector = null, CancellationToken ct = default) => GetModelSnapshotsAsync(selector.InvokeOrDefault(new GetModelSnapshotsDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_model_snapshots</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</a>
 		/// </summary>
 		public GetModelSnapshotsResponse GetModelSnapshots(IGetModelSnapshotsRequest request) => DoRequest<IGetModelSnapshotsRequest, GetModelSnapshotsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_model_snapshots</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</a>
 		/// </summary>
 		public Task<GetModelSnapshotsResponse> GetModelSnapshotsAsync(IGetModelSnapshotsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetModelSnapshotsRequest, GetModelSnapshotsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_overall_buckets</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</a>
 		/// </summary>
 		public GetOverallBucketsResponse GetOverallBuckets(Id jobId, Func<GetOverallBucketsDescriptor, IGetOverallBucketsRequest> selector = null) => GetOverallBuckets(selector.InvokeOrDefault(new GetOverallBucketsDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_overall_buckets</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</a>
 		/// </summary>
 		public Task<GetOverallBucketsResponse> GetOverallBucketsAsync(Id jobId, Func<GetOverallBucketsDescriptor, IGetOverallBucketsRequest> selector = null, CancellationToken ct = default) => GetOverallBucketsAsync(selector.InvokeOrDefault(new GetOverallBucketsDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_overall_buckets</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</a>
 		/// </summary>
 		public GetOverallBucketsResponse GetOverallBuckets(IGetOverallBucketsRequest request) => DoRequest<IGetOverallBucketsRequest, GetOverallBucketsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_overall_buckets</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</a>
 		/// </summary>
 		public Task<GetOverallBucketsResponse> GetOverallBucketsAsync(IGetOverallBucketsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetOverallBucketsRequest, GetOverallBucketsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_records</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</a>
 		/// </summary>
 		public GetAnomalyRecordsResponse GetAnomalyRecords(Id jobId, Func<GetAnomalyRecordsDescriptor, IGetAnomalyRecordsRequest> selector = null) => GetAnomalyRecords(selector.InvokeOrDefault(new GetAnomalyRecordsDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_records</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</a>
 		/// </summary>
 		public Task<GetAnomalyRecordsResponse> GetAnomalyRecordsAsync(Id jobId, Func<GetAnomalyRecordsDescriptor, IGetAnomalyRecordsRequest> selector = null, CancellationToken ct = default) => GetAnomalyRecordsAsync(selector.InvokeOrDefault(new GetAnomalyRecordsDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_records</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</a>
 		/// </summary>
 		public GetAnomalyRecordsResponse GetAnomalyRecords(IGetAnomalyRecordsRequest request) => DoRequest<IGetAnomalyRecordsRequest, GetAnomalyRecordsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.get_records</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</a>
 		/// </summary>
 		public Task<GetAnomalyRecordsResponse> GetAnomalyRecordsAsync(IGetAnomalyRecordsRequest request, CancellationToken ct = default) => DoRequestAsync<IGetAnomalyRecordsRequest, GetAnomalyRecordsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public MachineLearningInfoResponse Info(Func<MachineLearningInfoDescriptor, IMachineLearningInfoRequest> selector = null) => Info(selector.InvokeOrDefault(new MachineLearningInfoDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<MachineLearningInfoResponse> InfoAsync(Func<MachineLearningInfoDescriptor, IMachineLearningInfoRequest> selector = null, CancellationToken ct = default) => InfoAsync(selector.InvokeOrDefault(new MachineLearningInfoDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public MachineLearningInfoResponse Info(IMachineLearningInfoRequest request) => DoRequest<IMachineLearningInfoRequest, MachineLearningInfoResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<MachineLearningInfoResponse> InfoAsync(IMachineLearningInfoRequest request, CancellationToken ct = default) => DoRequestAsync<IMachineLearningInfoRequest, MachineLearningInfoResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.open_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</a>
 		/// </summary>
 		public OpenJobResponse OpenJob(Id jobId, Func<OpenJobDescriptor, IOpenJobRequest> selector = null) => OpenJob(selector.InvokeOrDefault(new OpenJobDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.open_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</a>
 		/// </summary>
 		public Task<OpenJobResponse> OpenJobAsync(Id jobId, Func<OpenJobDescriptor, IOpenJobRequest> selector = null, CancellationToken ct = default) => OpenJobAsync(selector.InvokeOrDefault(new OpenJobDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.open_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</a>
 		/// </summary>
 		public OpenJobResponse OpenJob(IOpenJobRequest request) => DoRequest<IOpenJobRequest, OpenJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.open_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</a>
 		/// </summary>
 		public Task<OpenJobResponse> OpenJobAsync(IOpenJobRequest request, CancellationToken ct = default) => DoRequestAsync<IOpenJobRequest, OpenJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.post_calendar_events</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public PostCalendarEventsResponse PostCalendarEvents(Id calendarId, Func<PostCalendarEventsDescriptor, IPostCalendarEventsRequest> selector) => PostCalendarEvents(selector.InvokeOrDefault(new PostCalendarEventsDescriptor(calendarId: calendarId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.post_calendar_events</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<PostCalendarEventsResponse> PostCalendarEventsAsync(Id calendarId, Func<PostCalendarEventsDescriptor, IPostCalendarEventsRequest> selector, CancellationToken ct = default) => PostCalendarEventsAsync(selector.InvokeOrDefault(new PostCalendarEventsDescriptor(calendarId: calendarId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.post_calendar_events</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public PostCalendarEventsResponse PostCalendarEvents(IPostCalendarEventsRequest request) => DoRequest<IPostCalendarEventsRequest, PostCalendarEventsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.post_calendar_events</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<PostCalendarEventsResponse> PostCalendarEventsAsync(IPostCalendarEventsRequest request, CancellationToken ct = default) => DoRequestAsync<IPostCalendarEventsRequest, PostCalendarEventsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.post_data</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</a>
 		/// </summary>
 		public PostJobDataResponse PostJobData(Id jobId, Func<PostJobDataDescriptor, IPostJobDataRequest> selector) => PostJobData(selector.InvokeOrDefault(new PostJobDataDescriptor(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.post_data</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</a>
 		/// </summary>
 		public Task<PostJobDataResponse> PostJobDataAsync(Id jobId, Func<PostJobDataDescriptor, IPostJobDataRequest> selector, CancellationToken ct = default) => PostJobDataAsync(selector.InvokeOrDefault(new PostJobDataDescriptor(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.post_data</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</a>
 		/// </summary>
 		public PostJobDataResponse PostJobData(IPostJobDataRequest request) => DoRequest<IPostJobDataRequest, PostJobDataResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.post_data</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</a>
 		/// </summary>
 		public Task<PostJobDataResponse> PostJobDataAsync(IPostJobDataRequest request, CancellationToken ct = default) => DoRequestAsync<IPostJobDataRequest, PostJobDataResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.preview_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</a>
 		/// </summary>
 		public PreviewDatafeedResponse<TResult> PreviewDatafeed<TResult>(Id datafeedId, Func<PreviewDatafeedDescriptor, IPreviewDatafeedRequest> selector = null) => PreviewDatafeed<TResult>(selector.InvokeOrDefault(new PreviewDatafeedDescriptor(datafeedId: datafeedId)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.preview_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</a>
 		/// </summary>
 		public Task<PreviewDatafeedResponse<TResult>> PreviewDatafeedAsync<TResult>(Id datafeedId, Func<PreviewDatafeedDescriptor, IPreviewDatafeedRequest> selector = null, CancellationToken ct = default) => PreviewDatafeedAsync<TResult>(selector.InvokeOrDefault(new PreviewDatafeedDescriptor(datafeedId: datafeedId)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.preview_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</a>
 		/// </summary>
 		public PreviewDatafeedResponse<TResult> PreviewDatafeed<TResult>(IPreviewDatafeedRequest request) => DoRequest<IPreviewDatafeedRequest, PreviewDatafeedResponse<TResult>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ml.preview_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</a>
 		/// </summary>
 		public Task<PreviewDatafeedResponse<TResult>> PreviewDatafeedAsync<TResult>(IPreviewDatafeedRequest request, CancellationToken ct = default) => DoRequestAsync<IPreviewDatafeedRequest, PreviewDatafeedResponse<TResult>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_calendar</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public PutCalendarResponse PutCalendar(Id calendarId, Func<PutCalendarDescriptor, IPutCalendarRequest> selector = null) => PutCalendar(selector.InvokeOrDefault(new PutCalendarDescriptor(calendarId: calendarId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_calendar</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<PutCalendarResponse> PutCalendarAsync(Id calendarId, Func<PutCalendarDescriptor, IPutCalendarRequest> selector = null, CancellationToken ct = default) => PutCalendarAsync(selector.InvokeOrDefault(new PutCalendarDescriptor(calendarId: calendarId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_calendar</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public PutCalendarResponse PutCalendar(IPutCalendarRequest request) => DoRequest<IPutCalendarRequest, PutCalendarResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_calendar</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<PutCalendarResponse> PutCalendarAsync(IPutCalendarRequest request, CancellationToken ct = default) => DoRequestAsync<IPutCalendarRequest, PutCalendarResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_calendar_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public PutCalendarJobResponse PutCalendarJob(Id calendarId, Id jobId, Func<PutCalendarJobDescriptor, IPutCalendarJobRequest> selector = null) => PutCalendarJob(selector.InvokeOrDefault(new PutCalendarJobDescriptor(calendarId: calendarId, jobId: jobId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_calendar_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<PutCalendarJobResponse> PutCalendarJobAsync(Id calendarId, Id jobId, Func<PutCalendarJobDescriptor, IPutCalendarJobRequest> selector = null, CancellationToken ct = default) => PutCalendarJobAsync(selector.InvokeOrDefault(new PutCalendarJobDescriptor(calendarId: calendarId, jobId: jobId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_calendar_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public PutCalendarJobResponse PutCalendarJob(IPutCalendarJobRequest request) => DoRequest<IPutCalendarJobRequest, PutCalendarJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_calendar_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<PutCalendarJobResponse> PutCalendarJobAsync(IPutCalendarJobRequest request, CancellationToken ct = default) => DoRequestAsync<IPutCalendarJobRequest, PutCalendarJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</a>
 		/// </summary>
 		public PutDatafeedResponse PutDatafeed<TDocument>(Id datafeedId, Func<PutDatafeedDescriptor<TDocument>, IPutDatafeedRequest> selector)
 			where TDocument : class => PutDatafeed(selector.InvokeOrDefault(new PutDatafeedDescriptor<TDocument>(datafeedId: datafeedId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</a>
 		/// </summary>
 		public Task<PutDatafeedResponse> PutDatafeedAsync<TDocument>(Id datafeedId, Func<PutDatafeedDescriptor<TDocument>, IPutDatafeedRequest> selector, CancellationToken ct = default)
 			where TDocument : class => PutDatafeedAsync(selector.InvokeOrDefault(new PutDatafeedDescriptor<TDocument>(datafeedId: datafeedId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</a>
 		/// </summary>
 		public PutDatafeedResponse PutDatafeed(IPutDatafeedRequest request) => DoRequest<IPutDatafeedRequest, PutDatafeedResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</a>
 		/// </summary>
 		public Task<PutDatafeedResponse> PutDatafeedAsync(IPutDatafeedRequest request, CancellationToken ct = default) => DoRequestAsync<IPutDatafeedRequest, PutDatafeedResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public PutFilterResponse PutFilter(Id filterId, Func<PutFilterDescriptor, IPutFilterRequest> selector) => PutFilter(selector.InvokeOrDefault(new PutFilterDescriptor(filterId: filterId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<PutFilterResponse> PutFilterAsync(Id filterId, Func<PutFilterDescriptor, IPutFilterRequest> selector, CancellationToken ct = default) => PutFilterAsync(selector.InvokeOrDefault(new PutFilterDescriptor(filterId: filterId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public PutFilterResponse PutFilter(IPutFilterRequest request) => DoRequest<IPutFilterRequest, PutFilterResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<PutFilterResponse> PutFilterAsync(IPutFilterRequest request, CancellationToken ct = default) => DoRequestAsync<IPutFilterRequest, PutFilterResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</a>
 		/// </summary>
 		public PutJobResponse PutJob<TDocument>(Id jobId, Func<PutJobDescriptor<TDocument>, IPutJobRequest> selector)
 			where TDocument : class => PutJob(selector.InvokeOrDefault(new PutJobDescriptor<TDocument>(jobId: jobId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</a>
 		/// </summary>
 		public Task<PutJobResponse> PutJobAsync<TDocument>(Id jobId, Func<PutJobDescriptor<TDocument>, IPutJobRequest> selector, CancellationToken ct = default)
 			where TDocument : class => PutJobAsync(selector.InvokeOrDefault(new PutJobDescriptor<TDocument>(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</a>
 		/// </summary>
 		public PutJobResponse PutJob(IPutJobRequest request) => DoRequest<IPutJobRequest, PutJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>ml.put_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</a>
 		/// </summary>
 		public Task<PutJobResponse> PutJobAsync(IPutJobRequest request, CancellationToken ct = default) => DoRequestAsync<IPutJobRequest, PutJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.revert_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</a>
 		/// </summary>
 		public RevertModelSnapshotResponse RevertModelSnapshot(Id jobId, Id snapshotId, Func<RevertModelSnapshotDescriptor, IRevertModelSnapshotRequest> selector = null) => RevertModelSnapshot(selector.InvokeOrDefault(new RevertModelSnapshotDescriptor(jobId: jobId, snapshotId: snapshotId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.revert_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</a>
 		/// </summary>
 		public Task<RevertModelSnapshotResponse> RevertModelSnapshotAsync(Id jobId, Id snapshotId, Func<RevertModelSnapshotDescriptor, IRevertModelSnapshotRequest> selector = null, CancellationToken ct = default) => RevertModelSnapshotAsync(selector.InvokeOrDefault(new RevertModelSnapshotDescriptor(jobId: jobId, snapshotId: snapshotId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.revert_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</a>
 		/// </summary>
 		public RevertModelSnapshotResponse RevertModelSnapshot(IRevertModelSnapshotRequest request) => DoRequest<IRevertModelSnapshotRequest, RevertModelSnapshotResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.revert_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</a>
 		/// </summary>
 		public Task<RevertModelSnapshotResponse> RevertModelSnapshotAsync(IRevertModelSnapshotRequest request, CancellationToken ct = default) => DoRequestAsync<IRevertModelSnapshotRequest, RevertModelSnapshotResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.start_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</a>
 		/// </summary>
 		public StartDatafeedResponse StartDatafeed(Id datafeedId, Func<StartDatafeedDescriptor, IStartDatafeedRequest> selector = null) => StartDatafeed(selector.InvokeOrDefault(new StartDatafeedDescriptor(datafeedId: datafeedId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.start_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</a>
 		/// </summary>
 		public Task<StartDatafeedResponse> StartDatafeedAsync(Id datafeedId, Func<StartDatafeedDescriptor, IStartDatafeedRequest> selector = null, CancellationToken ct = default) => StartDatafeedAsync(selector.InvokeOrDefault(new StartDatafeedDescriptor(datafeedId: datafeedId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.start_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</a>
 		/// </summary>
 		public StartDatafeedResponse StartDatafeed(IStartDatafeedRequest request) => DoRequest<IStartDatafeedRequest, StartDatafeedResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.start_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</a>
 		/// </summary>
 		public Task<StartDatafeedResponse> StartDatafeedAsync(IStartDatafeedRequest request, CancellationToken ct = default) => DoRequestAsync<IStartDatafeedRequest, StartDatafeedResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.stop_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</a>
 		/// </summary>
 		public StopDatafeedResponse StopDatafeed(Id datafeedId, Func<StopDatafeedDescriptor, IStopDatafeedRequest> selector = null) => StopDatafeed(selector.InvokeOrDefault(new StopDatafeedDescriptor(datafeedId: datafeedId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.stop_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</a>
 		/// </summary>
 		public Task<StopDatafeedResponse> StopDatafeedAsync(Id datafeedId, Func<StopDatafeedDescriptor, IStopDatafeedRequest> selector = null, CancellationToken ct = default) => StopDatafeedAsync(selector.InvokeOrDefault(new StopDatafeedDescriptor(datafeedId: datafeedId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.stop_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</a>
 		/// </summary>
 		public StopDatafeedResponse StopDatafeed(IStopDatafeedRequest request) => DoRequest<IStopDatafeedRequest, StopDatafeedResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.stop_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</a>
 		/// </summary>
 		public Task<StopDatafeedResponse> StopDatafeedAsync(IStopDatafeedRequest request, CancellationToken ct = default) => DoRequestAsync<IStopDatafeedRequest, StopDatafeedResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</a>
 		/// </summary>
 		public UpdateDatafeedResponse UpdateDatafeed<TDocument>(Id datafeedId, Func<UpdateDatafeedDescriptor<TDocument>, IUpdateDatafeedRequest> selector)
 			where TDocument : class => UpdateDatafeed(selector.InvokeOrDefault(new UpdateDatafeedDescriptor<TDocument>(datafeedId: datafeedId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</a>
 		/// </summary>
 		public Task<UpdateDatafeedResponse> UpdateDatafeedAsync<TDocument>(Id datafeedId, Func<UpdateDatafeedDescriptor<TDocument>, IUpdateDatafeedRequest> selector, CancellationToken ct = default)
 			where TDocument : class => UpdateDatafeedAsync(selector.InvokeOrDefault(new UpdateDatafeedDescriptor<TDocument>(datafeedId: datafeedId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</a>
 		/// </summary>
 		public UpdateDatafeedResponse UpdateDatafeed(IUpdateDatafeedRequest request) => DoRequest<IUpdateDatafeedRequest, UpdateDatafeedResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_datafeed</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</a>
 		/// </summary>
 		public Task<UpdateDatafeedResponse> UpdateDatafeedAsync(IUpdateDatafeedRequest request, CancellationToken ct = default) => DoRequestAsync<IUpdateDatafeedRequest, UpdateDatafeedResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public UpdateFilterResponse UpdateFilter(Id filterId, Func<UpdateFilterDescriptor, IUpdateFilterRequest> selector) => UpdateFilter(selector.InvokeOrDefault(new UpdateFilterDescriptor(filterId: filterId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<UpdateFilterResponse> UpdateFilterAsync(Id filterId, Func<UpdateFilterDescriptor, IUpdateFilterRequest> selector, CancellationToken ct = default) => UpdateFilterAsync(selector.InvokeOrDefault(new UpdateFilterDescriptor(filterId: filterId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public UpdateFilterResponse UpdateFilter(IUpdateFilterRequest request) => DoRequest<IUpdateFilterRequest, UpdateFilterResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_filter</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<UpdateFilterResponse> UpdateFilterAsync(IUpdateFilterRequest request, CancellationToken ct = default) => DoRequestAsync<IUpdateFilterRequest, UpdateFilterResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</a>
 		/// </summary>
 		public UpdateJobResponse UpdateJob<TDocument>(Id jobId, Func<UpdateJobDescriptor<TDocument>, IUpdateJobRequest> selector)
 			where TDocument : class => UpdateJob(selector.InvokeOrDefault(new UpdateJobDescriptor<TDocument>(jobId: jobId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</a>
 		/// </summary>
 		public Task<UpdateJobResponse> UpdateJobAsync<TDocument>(Id jobId, Func<UpdateJobDescriptor<TDocument>, IUpdateJobRequest> selector, CancellationToken ct = default)
 			where TDocument : class => UpdateJobAsync(selector.InvokeOrDefault(new UpdateJobDescriptor<TDocument>(jobId: jobId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</a>
 		/// </summary>
 		public UpdateJobResponse UpdateJob(IUpdateJobRequest request) => DoRequest<IUpdateJobRequest, UpdateJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</a>
 		/// </summary>
 		public Task<UpdateJobResponse> UpdateJobAsync(IUpdateJobRequest request, CancellationToken ct = default) => DoRequestAsync<IUpdateJobRequest, UpdateJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</a>
 		/// </summary>
 		public UpdateModelSnapshotResponse UpdateModelSnapshot(Id jobId, Id snapshotId, Func<UpdateModelSnapshotDescriptor, IUpdateModelSnapshotRequest> selector) => UpdateModelSnapshot(selector.InvokeOrDefault(new UpdateModelSnapshotDescriptor(jobId: jobId, snapshotId: snapshotId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</a>
 		/// </summary>
 		public Task<UpdateModelSnapshotResponse> UpdateModelSnapshotAsync(Id jobId, Id snapshotId, Func<UpdateModelSnapshotDescriptor, IUpdateModelSnapshotRequest> selector, CancellationToken ct = default) => UpdateModelSnapshotAsync(selector.InvokeOrDefault(new UpdateModelSnapshotDescriptor(jobId: jobId, snapshotId: snapshotId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</a>
 		/// </summary>
 		public UpdateModelSnapshotResponse UpdateModelSnapshot(IUpdateModelSnapshotRequest request) => DoRequest<IUpdateModelSnapshotRequest, UpdateModelSnapshotResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.update_model_snapshot</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</a>
 		/// </summary>
 		public Task<UpdateModelSnapshotResponse> UpdateModelSnapshotAsync(IUpdateModelSnapshotRequest request, CancellationToken ct = default) => DoRequestAsync<IUpdateModelSnapshotRequest, UpdateModelSnapshotResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.validate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public ValidateJobResponse ValidateJob<TDocument>(Func<ValidateJobDescriptor<TDocument>, IValidateJobRequest> selector)
 			where TDocument : class => ValidateJob(selector.InvokeOrDefault(new ValidateJobDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.validate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<ValidateJobResponse> ValidateJobAsync<TDocument>(Func<ValidateJobDescriptor<TDocument>, IValidateJobRequest> selector, CancellationToken ct = default)
 			where TDocument : class => ValidateJobAsync(selector.InvokeOrDefault(new ValidateJobDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.validate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public ValidateJobResponse ValidateJob(IValidateJobRequest request) => DoRequest<IValidateJobRequest, ValidateJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.validate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<ValidateJobResponse> ValidateJobAsync(IValidateJobRequest request, CancellationToken ct = default) => DoRequestAsync<IValidateJobRequest, ValidateJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.validate_detector</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public ValidateDetectorResponse ValidateDetector<TDocument>(Func<ValidateDetectorDescriptor<TDocument>, IValidateDetectorRequest> selector)
 			where TDocument : class => ValidateDetector(selector.InvokeOrDefault(new ValidateDetectorDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.validate_detector</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<ValidateDetectorResponse> ValidateDetectorAsync<TDocument>(Func<ValidateDetectorDescriptor<TDocument>, IValidateDetectorRequest> selector, CancellationToken ct = default)
 			where TDocument : class => ValidateDetectorAsync(selector.InvokeOrDefault(new ValidateDetectorDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.validate_detector</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public ValidateDetectorResponse ValidateDetector(IValidateDetectorRequest request) => DoRequest<IValidateDetectorRequest, ValidateDetectorResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>ml.validate_detector</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a></a>
 		/// </summary>
 		public Task<ValidateDetectorResponse> ValidateDetectorAsync(IValidateDetectorRequest request, CancellationToken ct = default) => DoRequestAsync<IValidateDetectorRequest, ValidateDetectorResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Migration.cs
+++ b/src/Nest/ElasticClient.Migration.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.MigrationApi;
 namespace Nest.Specification.MigrationApi
 {
 	///<summary>
-	/// Logically groups all <c>Migration</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Migration"/> property
+	/// Migration APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Migration"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,73 +38,73 @@ namespace Nest.Specification.MigrationApi
 
 		/// <summary>
 		/// <c>GET</c> request to the <c>migration.deprecations</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html">http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</a>
 		/// </summary>
 		public DeprecationInfoResponse DeprecationInfo(Func<DeprecationInfoDescriptor, IDeprecationInfoRequest> selector = null) => DeprecationInfo(selector.InvokeOrDefault(new DeprecationInfoDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>migration.deprecations</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html">http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</a>
 		/// </summary>
 		public Task<DeprecationInfoResponse> DeprecationInfoAsync(Func<DeprecationInfoDescriptor, IDeprecationInfoRequest> selector = null, CancellationToken ct = default) => DeprecationInfoAsync(selector.InvokeOrDefault(new DeprecationInfoDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>migration.deprecations</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html">http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</a>
 		/// </summary>
 		public DeprecationInfoResponse DeprecationInfo(IDeprecationInfoRequest request) => DoRequest<IDeprecationInfoRequest, DeprecationInfoResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>migration.deprecations</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html">http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</a>
 		/// </summary>
 		public Task<DeprecationInfoResponse> DeprecationInfoAsync(IDeprecationInfoRequest request, CancellationToken ct = default) => DoRequestAsync<IDeprecationInfoRequest, DeprecationInfoResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>migration.get_assistance</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</a>
 		/// </summary>
 		public MigrationAssistanceResponse Assistance(Indices index = null, Func<MigrationAssistanceDescriptor, IMigrationAssistanceRequest> selector = null) => Assistance(selector.InvokeOrDefault(new MigrationAssistanceDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>migration.get_assistance</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</a>
 		/// </summary>
 		public Task<MigrationAssistanceResponse> AssistanceAsync(Indices index = null, Func<MigrationAssistanceDescriptor, IMigrationAssistanceRequest> selector = null, CancellationToken ct = default) => AssistanceAsync(selector.InvokeOrDefault(new MigrationAssistanceDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>migration.get_assistance</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</a>
 		/// </summary>
 		public MigrationAssistanceResponse Assistance(IMigrationAssistanceRequest request) => DoRequest<IMigrationAssistanceRequest, MigrationAssistanceResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>migration.get_assistance</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</a>
 		/// </summary>
 		public Task<MigrationAssistanceResponse> AssistanceAsync(IMigrationAssistanceRequest request, CancellationToken ct = default) => DoRequestAsync<IMigrationAssistanceRequest, MigrationAssistanceResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>migration.upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</a>
 		/// </summary>
 		public MigrationUpgradeResponse Upgrade(IndexName index, Func<MigrationUpgradeDescriptor, IMigrationUpgradeRequest> selector = null) => Upgrade(selector.InvokeOrDefault(new MigrationUpgradeDescriptor(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>migration.upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</a>
 		/// </summary>
 		public Task<MigrationUpgradeResponse> UpgradeAsync(IndexName index, Func<MigrationUpgradeDescriptor, IMigrationUpgradeRequest> selector = null, CancellationToken ct = default) => UpgradeAsync(selector.InvokeOrDefault(new MigrationUpgradeDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>migration.upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</a>
 		/// </summary>
 		public MigrationUpgradeResponse Upgrade(IMigrationUpgradeRequest request) => DoRequest<IMigrationUpgradeRequest, MigrationUpgradeResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>migration.upgrade</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</a>
 		/// </summary>
 		public Task<MigrationUpgradeResponse> UpgradeAsync(IMigrationUpgradeRequest request, CancellationToken ct = default) => DoRequestAsync<IMigrationUpgradeRequest, MigrationUpgradeResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.NoNamespace.cs
+++ b/src/Nest/ElasticClient.NoNamespace.cs
@@ -165,7 +165,7 @@ namespace Nest
 			private set;
 		}
 
-		///<summary>X Pack APIs</summary>
+		///<summary>XPack APIs</summary>
 		public XPackNamespace XPack
 		{
 			get;

--- a/src/Nest/ElasticClient.NoNamespace.cs
+++ b/src/Nest/ElasticClient.NoNamespace.cs
@@ -42,130 +42,130 @@ using Nest.Specification.XPackApi;
 namespace Nest
 {
 	///<summary>
-	///Raw operations with elasticsearch
+	///Elasticsearch high level client
 	///</summary>
 	public partial class ElasticClient : IElasticClient
 	{
-		///<summary> This property logically groups all <c>Cat</c> API's together.</summary>
+		///<summary>Cat APIs</summary>
 		public CatNamespace Cat
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Cluster</c> API's together.</summary>
+		///<summary>Cluster APIs</summary>
 		public ClusterNamespace Cluster
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>CrossClusterReplication</c> API's together.</summary>
+		///<summary>Cross Cluster Replication APIs</summary>
 		public CrossClusterReplicationNamespace CrossClusterReplication
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Graph</c> API's together.</summary>
+		///<summary>Graph APIs</summary>
 		public GraphNamespace Graph
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>IndexLifecycleManagement</c> API's together.</summary>
+		///<summary>Index Lifecycle Management APIs</summary>
 		public IndexLifecycleManagementNamespace IndexLifecycleManagement
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Indices</c> API's together.</summary>
+		///<summary>Indices APIs</summary>
 		public IndicesNamespace Indices
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Ingest</c> API's together.</summary>
+		///<summary>Ingest APIs</summary>
 		public IngestNamespace Ingest
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>License</c> API's together.</summary>
+		///<summary>License APIs</summary>
 		public LicenseNamespace License
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>MachineLearning</c> API's together.</summary>
+		///<summary>Machine Learning APIs</summary>
 		public MachineLearningNamespace MachineLearning
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Migration</c> API's together.</summary>
+		///<summary>Migration APIs</summary>
 		public MigrationNamespace Migration
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Nodes</c> API's together.</summary>
+		///<summary>Nodes APIs</summary>
 		public NodesNamespace Nodes
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Rollup</c> API's together.</summary>
+		///<summary>Rollup APIs</summary>
 		public RollupNamespace Rollup
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Security</c> API's together.</summary>
+		///<summary>Security APIs</summary>
 		public SecurityNamespace Security
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Snapshot</c> API's together.</summary>
+		///<summary>Snapshot APIs</summary>
 		public SnapshotNamespace Snapshot
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Sql</c> API's together.</summary>
+		///<summary>Sql APIs</summary>
 		public SqlNamespace Sql
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Tasks</c> API's together.</summary>
+		///<summary>Tasks APIs</summary>
 		public TasksNamespace Tasks
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>Watcher</c> API's together.</summary>
+		///<summary>Watcher APIs</summary>
 		public WatcherNamespace Watcher
 		{
 			get;
 			private set;
 		}
 
-		///<summary> This property logically groups all <c>XPack</c> API's together.</summary>
+		///<summary>X Pack APIs</summary>
 		public XPackNamespace XPack
 		{
 			get;
@@ -196,937 +196,937 @@ namespace Nest
 
 		/// <summary>
 		/// <c>POST</c> request to the <c>bulk</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</a>
 		/// </summary>
 		public BulkResponse Bulk(Func<BulkDescriptor, IBulkRequest> selector) => Bulk(selector.InvokeOrDefault(new BulkDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>bulk</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</a>
 		/// </summary>
 		public Task<BulkResponse> BulkAsync(Func<BulkDescriptor, IBulkRequest> selector, CancellationToken ct = default) => BulkAsync(selector.InvokeOrDefault(new BulkDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>bulk</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</a>
 		/// </summary>
 		public BulkResponse Bulk(IBulkRequest request) => DoRequest<IBulkRequest, BulkResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>bulk</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</a>
 		/// </summary>
 		public Task<BulkResponse> BulkAsync(IBulkRequest request, CancellationToken ct = default) => DoRequestAsync<IBulkRequest, BulkResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>clear_scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public ClearScrollResponse ClearScroll(Func<ClearScrollDescriptor, IClearScrollRequest> selector = null) => ClearScroll(selector.InvokeOrDefault(new ClearScrollDescriptor()));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>clear_scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public Task<ClearScrollResponse> ClearScrollAsync(Func<ClearScrollDescriptor, IClearScrollRequest> selector = null, CancellationToken ct = default) => ClearScrollAsync(selector.InvokeOrDefault(new ClearScrollDescriptor()), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>clear_scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public ClearScrollResponse ClearScroll(IClearScrollRequest request) => DoRequest<IClearScrollRequest, ClearScrollResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>clear_scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public Task<ClearScrollResponse> ClearScrollAsync(IClearScrollRequest request, CancellationToken ct = default) => DoRequestAsync<IClearScrollRequest, ClearScrollResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</a>
 		/// </summary>
 		public CountResponse Count<TDocument>(Func<CountDescriptor<TDocument>, ICountRequest> selector = null)
 			where TDocument : class => Count(selector.InvokeOrDefault(new CountDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</a>
 		/// </summary>
 		public Task<CountResponse> CountAsync<TDocument>(Func<CountDescriptor<TDocument>, ICountRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => CountAsync(selector.InvokeOrDefault(new CountDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</a>
 		/// </summary>
 		public CountResponse Count(ICountRequest request) => DoRequest<ICountRequest, CountResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</a>
 		/// </summary>
 		public Task<CountResponse> CountAsync(ICountRequest request, CancellationToken ct = default) => DoRequestAsync<ICountRequest, CountResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		public CreateResponse Create<TDocument>(TDocument document, Func<CreateDescriptor<TDocument>, ICreateRequest<TDocument>> selector)
 			where TDocument : class => Create<TDocument>(selector.InvokeOrDefault(new CreateDescriptor<TDocument>(documentWithId: document)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		public Task<CreateResponse> CreateAsync<TDocument>(TDocument document, Func<CreateDescriptor<TDocument>, ICreateRequest<TDocument>> selector, CancellationToken ct = default)
 			where TDocument : class => CreateAsync<TDocument>(selector.InvokeOrDefault(new CreateDescriptor<TDocument>(documentWithId: document)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		public CreateResponse Create<TDocument>(ICreateRequest<TDocument> request)
 			where TDocument : class => DoRequest<ICreateRequest<TDocument>, CreateResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		public Task<CreateResponse> CreateAsync<TDocument>(ICreateRequest<TDocument> request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<ICreateRequest<TDocument>, CreateResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</a>
 		/// </summary>
 		public DeleteResponse Delete<TDocument>(DocumentPath<TDocument> id, Func<DeleteDescriptor<TDocument>, IDeleteRequest> selector = null)
 			where TDocument : class => Delete(selector.InvokeOrDefault(new DeleteDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</a>
 		/// </summary>
 		public Task<DeleteResponse> DeleteAsync<TDocument>(DocumentPath<TDocument> id, Func<DeleteDescriptor<TDocument>, IDeleteRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => DeleteAsync(selector.InvokeOrDefault(new DeleteDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</a>
 		/// </summary>
 		public DeleteResponse Delete(IDeleteRequest request) => DoRequest<IDeleteRequest, DeleteResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</a>
 		/// </summary>
 		public Task<DeleteResponse> DeleteAsync(IDeleteRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteRequest, DeleteResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</a>
 		/// </summary>
 		public DeleteByQueryResponse DeleteByQuery<TDocument>(Func<DeleteByQueryDescriptor<TDocument>, IDeleteByQueryRequest> selector)
 			where TDocument : class => DeleteByQuery(selector.InvokeOrDefault(new DeleteByQueryDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</a>
 		/// </summary>
 		public Task<DeleteByQueryResponse> DeleteByQueryAsync<TDocument>(Func<DeleteByQueryDescriptor<TDocument>, IDeleteByQueryRequest> selector, CancellationToken ct = default)
 			where TDocument : class => DeleteByQueryAsync(selector.InvokeOrDefault(new DeleteByQueryDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</a>
 		/// </summary>
 		public DeleteByQueryResponse DeleteByQuery(IDeleteByQueryRequest request) => DoRequest<IDeleteByQueryRequest, DeleteByQueryResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</a>
 		/// </summary>
 		public Task<DeleteByQueryResponse> DeleteByQueryAsync(IDeleteByQueryRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteByQueryRequest, DeleteByQueryResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
 		/// </summary>
 		public ListTasksResponse DeleteByQueryRethrottle(TaskId taskId, Func<DeleteByQueryRethrottleDescriptor, IDeleteByQueryRethrottleRequest> selector = null) => DeleteByQueryRethrottle(selector.InvokeOrDefault(new DeleteByQueryRethrottleDescriptor(taskId: taskId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
 		/// </summary>
 		public Task<ListTasksResponse> DeleteByQueryRethrottleAsync(TaskId taskId, Func<DeleteByQueryRethrottleDescriptor, IDeleteByQueryRethrottleRequest> selector = null, CancellationToken ct = default) => DeleteByQueryRethrottleAsync(selector.InvokeOrDefault(new DeleteByQueryRethrottleDescriptor(taskId: taskId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
 		/// </summary>
 		public ListTasksResponse DeleteByQueryRethrottle(IDeleteByQueryRethrottleRequest request) => DoRequest<IDeleteByQueryRethrottleRequest, ListTasksResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
 		/// </summary>
 		public Task<ListTasksResponse> DeleteByQueryRethrottleAsync(IDeleteByQueryRethrottleRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteByQueryRethrottleRequest, ListTasksResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public DeleteScriptResponse DeleteScript(Id id, Func<DeleteScriptDescriptor, IDeleteScriptRequest> selector = null) => DeleteScript(selector.InvokeOrDefault(new DeleteScriptDescriptor(id: id)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public Task<DeleteScriptResponse> DeleteScriptAsync(Id id, Func<DeleteScriptDescriptor, IDeleteScriptRequest> selector = null, CancellationToken ct = default) => DeleteScriptAsync(selector.InvokeOrDefault(new DeleteScriptDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public DeleteScriptResponse DeleteScript(IDeleteScriptRequest request) => DoRequest<IDeleteScriptRequest, DeleteScriptResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public Task<DeleteScriptResponse> DeleteScriptAsync(IDeleteScriptRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteScriptRequest, DeleteScriptResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public ExistsResponse DocumentExists<TDocument>(DocumentPath<TDocument> id, Func<DocumentExistsDescriptor<TDocument>, IDocumentExistsRequest> selector = null)
 			where TDocument : class => DocumentExists(selector.InvokeOrDefault(new DocumentExistsDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)));
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public Task<ExistsResponse> DocumentExistsAsync<TDocument>(DocumentPath<TDocument> id, Func<DocumentExistsDescriptor<TDocument>, IDocumentExistsRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => DocumentExistsAsync(selector.InvokeOrDefault(new DocumentExistsDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)), ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public ExistsResponse DocumentExists(IDocumentExistsRequest request) => DoRequest<IDocumentExistsRequest, ExistsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public Task<ExistsResponse> DocumentExistsAsync(IDocumentExistsRequest request, CancellationToken ct = default) => DoRequestAsync<IDocumentExistsRequest, ExistsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public ExistsResponse SourceExists<TDocument>(DocumentPath<TDocument> id, Func<SourceExistsDescriptor<TDocument>, ISourceExistsRequest> selector = null)
 			where TDocument : class => SourceExists(selector.InvokeOrDefault(new SourceExistsDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)));
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public Task<ExistsResponse> SourceExistsAsync<TDocument>(DocumentPath<TDocument> id, Func<SourceExistsDescriptor<TDocument>, ISourceExistsRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => SourceExistsAsync(selector.InvokeOrDefault(new SourceExistsDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)), ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public ExistsResponse SourceExists(ISourceExistsRequest request) => DoRequest<ISourceExistsRequest, ExistsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public Task<ExistsResponse> SourceExistsAsync(ISourceExistsRequest request, CancellationToken ct = default) => DoRequestAsync<ISourceExistsRequest, ExistsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</a>
 		/// </summary>
 		public ExplainResponse<TDocument> Explain<TDocument>(DocumentPath<TDocument> id, Func<ExplainDescriptor<TDocument>, IExplainRequest> selector = null)
 			where TDocument : class => Explain<TDocument>(selector.InvokeOrDefault(new ExplainDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</a>
 		/// </summary>
 		public Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(DocumentPath<TDocument> id, Func<ExplainDescriptor<TDocument>, IExplainRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => ExplainAsync<TDocument>(selector.InvokeOrDefault(new ExplainDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</a>
 		/// </summary>
 		public ExplainResponse<TDocument> Explain<TDocument>(IExplainRequest request)
 			where TDocument : class => DoRequest<IExplainRequest, ExplainResponse<TDocument>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</a>
 		/// </summary>
 		public Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(IExplainRequest request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<IExplainRequest, ExplainResponse<TDocument>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>field_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</a>
 		/// </summary>
 		public FieldCapabilitiesResponse FieldCapabilities(Indices index = null, Func<FieldCapabilitiesDescriptor, IFieldCapabilitiesRequest> selector = null) => FieldCapabilities(selector.InvokeOrDefault(new FieldCapabilitiesDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>field_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</a>
 		/// </summary>
 		public Task<FieldCapabilitiesResponse> FieldCapabilitiesAsync(Indices index = null, Func<FieldCapabilitiesDescriptor, IFieldCapabilitiesRequest> selector = null, CancellationToken ct = default) => FieldCapabilitiesAsync(selector.InvokeOrDefault(new FieldCapabilitiesDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>field_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</a>
 		/// </summary>
 		public FieldCapabilitiesResponse FieldCapabilities(IFieldCapabilitiesRequest request) => DoRequest<IFieldCapabilitiesRequest, FieldCapabilitiesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>field_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</a>
 		/// </summary>
 		public Task<FieldCapabilitiesResponse> FieldCapabilitiesAsync(IFieldCapabilitiesRequest request, CancellationToken ct = default) => DoRequestAsync<IFieldCapabilitiesRequest, FieldCapabilitiesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public GetResponse<TDocument> Get<TDocument>(DocumentPath<TDocument> id, Func<GetDescriptor<TDocument>, IGetRequest> selector = null)
 			where TDocument : class => Get<TDocument>(selector.InvokeOrDefault(new GetDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public Task<GetResponse<TDocument>> GetAsync<TDocument>(DocumentPath<TDocument> id, Func<GetDescriptor<TDocument>, IGetRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => GetAsync<TDocument>(selector.InvokeOrDefault(new GetDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public GetResponse<TDocument> Get<TDocument>(IGetRequest request)
 			where TDocument : class => DoRequest<IGetRequest, GetResponse<TDocument>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public Task<GetResponse<TDocument>> GetAsync<TDocument>(IGetRequest request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<IGetRequest, GetResponse<TDocument>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public GetScriptResponse GetScript(Id id, Func<GetScriptDescriptor, IGetScriptRequest> selector = null) => GetScript(selector.InvokeOrDefault(new GetScriptDescriptor(id: id)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public Task<GetScriptResponse> GetScriptAsync(Id id, Func<GetScriptDescriptor, IGetScriptRequest> selector = null, CancellationToken ct = default) => GetScriptAsync(selector.InvokeOrDefault(new GetScriptDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public GetScriptResponse GetScript(IGetScriptRequest request) => DoRequest<IGetScriptRequest, GetScriptResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public Task<GetScriptResponse> GetScriptAsync(IGetScriptRequest request, CancellationToken ct = default) => DoRequestAsync<IGetScriptRequest, GetScriptResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public SourceResponse<TDocument> Source<TDocument>(DocumentPath<TDocument> id, Func<SourceDescriptor<TDocument>, ISourceRequest> selector = null)
 			where TDocument : class => Source<TDocument>(selector.InvokeOrDefault(new SourceDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public Task<SourceResponse<TDocument>> SourceAsync<TDocument>(DocumentPath<TDocument> id, Func<SourceDescriptor<TDocument>, ISourceRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => SourceAsync<TDocument>(selector.InvokeOrDefault(new SourceDescriptor<TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public SourceResponse<TDocument> Source<TDocument>(ISourceRequest request)
 			where TDocument : class => DoRequest<ISourceRequest, SourceResponse<TDocument>>(request, ResponseBuilder(request.RequestParameters, SourceRequestResponseBuilder<TDocument>.Instance));
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		public Task<SourceResponse<TDocument>> SourceAsync<TDocument>(ISourceRequest request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<ISourceRequest, SourceResponse<TDocument>>(request, ResponseBuilder(request.RequestParameters, SourceRequestResponseBuilder<TDocument>.Instance), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>index</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		public IndexResponse Index<TDocument>(TDocument document, Func<IndexDescriptor<TDocument>, IIndexRequest<TDocument>> selector)
 			where TDocument : class => Index<TDocument>(selector.InvokeOrDefault(new IndexDescriptor<TDocument>(documentWithId: document)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>index</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		public Task<IndexResponse> IndexAsync<TDocument>(TDocument document, Func<IndexDescriptor<TDocument>, IIndexRequest<TDocument>> selector, CancellationToken ct = default)
 			where TDocument : class => IndexAsync<TDocument>(selector.InvokeOrDefault(new IndexDescriptor<TDocument>(documentWithId: document)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>index</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		public IndexResponse Index<TDocument>(IIndexRequest<TDocument> request)
 			where TDocument : class => DoRequest<IIndexRequest<TDocument>, IndexResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>index</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		public Task<IndexResponse> IndexAsync<TDocument>(IIndexRequest<TDocument> request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<IIndexRequest<TDocument>, IndexResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		public RootNodeInfoResponse RootNodeInfo(Func<RootNodeInfoDescriptor, IRootNodeInfoRequest> selector = null) => RootNodeInfo(selector.InvokeOrDefault(new RootNodeInfoDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		public Task<RootNodeInfoResponse> RootNodeInfoAsync(Func<RootNodeInfoDescriptor, IRootNodeInfoRequest> selector = null, CancellationToken ct = default) => RootNodeInfoAsync(selector.InvokeOrDefault(new RootNodeInfoDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		public RootNodeInfoResponse RootNodeInfo(IRootNodeInfoRequest request) => DoRequest<IRootNodeInfoRequest, RootNodeInfoResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		public Task<RootNodeInfoResponse> RootNodeInfoAsync(IRootNodeInfoRequest request, CancellationToken ct = default) => DoRequestAsync<IRootNodeInfoRequest, RootNodeInfoResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mget</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</a>
 		/// </summary>
 		public MultiGetResponse MultiGet(Func<MultiGetDescriptor, IMultiGetRequest> selector = null) => MultiGet(selector.InvokeOrDefault(new MultiGetDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>mget</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</a>
 		/// </summary>
 		public Task<MultiGetResponse> MultiGetAsync(Func<MultiGetDescriptor, IMultiGetRequest> selector = null, CancellationToken ct = default) => MultiGetAsync(selector.InvokeOrDefault(new MultiGetDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mget</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</a>
 		/// </summary>
 		public MultiGetResponse MultiGet(IMultiGetRequest request) => DoRequest<IMultiGetRequest, MultiGetResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mget</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</a>
 		/// </summary>
 		public Task<MultiGetResponse> MultiGetAsync(IMultiGetRequest request, CancellationToken ct = default) => DoRequestAsync<IMultiGetRequest, MultiGetResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</a>
 		/// </summary>
 		public MultiSearchResponse MultiSearch(Indices index = null, Func<MultiSearchDescriptor, IMultiSearchRequest> selector = null) => MultiSearch(selector.InvokeOrDefault(new MultiSearchDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</a>
 		/// </summary>
 		public Task<MultiSearchResponse> MultiSearchAsync(Indices index = null, Func<MultiSearchDescriptor, IMultiSearchRequest> selector = null, CancellationToken ct = default) => MultiSearchAsync(selector.InvokeOrDefault(new MultiSearchDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</a>
 		/// </summary>
 		public MultiSearchResponse MultiSearch(IMultiSearchRequest request) => DoRequest<IMultiSearchRequest, MultiSearchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</a>
 		/// </summary>
 		public Task<MultiSearchResponse> MultiSearchAsync(IMultiSearchRequest request, CancellationToken ct = default) => DoRequestAsync<IMultiSearchRequest, MultiSearchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</a>
 		/// </summary>
 		public MultiSearchResponse MultiSearchTemplate(Indices index = null, Func<MultiSearchTemplateDescriptor, IMultiSearchTemplateRequest> selector = null) => MultiSearchTemplate(selector.InvokeOrDefault(new MultiSearchTemplateDescriptor().Index(index: index)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</a>
 		/// </summary>
 		public Task<MultiSearchResponse> MultiSearchTemplateAsync(Indices index = null, Func<MultiSearchTemplateDescriptor, IMultiSearchTemplateRequest> selector = null, CancellationToken ct = default) => MultiSearchTemplateAsync(selector.InvokeOrDefault(new MultiSearchTemplateDescriptor().Index(index: index)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</a>
 		/// </summary>
 		public MultiSearchResponse MultiSearchTemplate(IMultiSearchTemplateRequest request) => DoRequest<IMultiSearchTemplateRequest, MultiSearchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</a>
 		/// </summary>
 		public Task<MultiSearchResponse> MultiSearchTemplateAsync(IMultiSearchTemplateRequest request, CancellationToken ct = default) => DoRequestAsync<IMultiSearchTemplateRequest, MultiSearchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mtermvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</a>
 		/// </summary>
 		public MultiTermVectorsResponse MultiTermVectors(Func<MultiTermVectorsDescriptor, IMultiTermVectorsRequest> selector = null) => MultiTermVectors(selector.InvokeOrDefault(new MultiTermVectorsDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>mtermvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</a>
 		/// </summary>
 		public Task<MultiTermVectorsResponse> MultiTermVectorsAsync(Func<MultiTermVectorsDescriptor, IMultiTermVectorsRequest> selector = null, CancellationToken ct = default) => MultiTermVectorsAsync(selector.InvokeOrDefault(new MultiTermVectorsDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mtermvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</a>
 		/// </summary>
 		public MultiTermVectorsResponse MultiTermVectors(IMultiTermVectorsRequest request) => DoRequest<IMultiTermVectorsRequest, MultiTermVectorsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mtermvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</a>
 		/// </summary>
 		public Task<MultiTermVectorsResponse> MultiTermVectorsAsync(IMultiTermVectorsRequest request, CancellationToken ct = default) => DoRequestAsync<IMultiTermVectorsRequest, MultiTermVectorsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>ping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		public PingResponse Ping(Func<PingDescriptor, IPingRequest> selector = null) => Ping(selector.InvokeOrDefault(new PingDescriptor()));
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>ping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		public Task<PingResponse> PingAsync(Func<PingDescriptor, IPingRequest> selector = null, CancellationToken ct = default) => PingAsync(selector.InvokeOrDefault(new PingDescriptor()), ct);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>ping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		public PingResponse Ping(IPingRequest request) => DoRequest<IPingRequest, PingResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>ping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		public Task<PingResponse> PingAsync(IPingRequest request, CancellationToken ct = default) => DoRequestAsync<IPingRequest, PingResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>put_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public PutScriptResponse PutScript(Id id, Func<PutScriptDescriptor, IPutScriptRequest> selector) => PutScript(selector.InvokeOrDefault(new PutScriptDescriptor(id: id)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>put_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public Task<PutScriptResponse> PutScriptAsync(Id id, Func<PutScriptDescriptor, IPutScriptRequest> selector, CancellationToken ct = default) => PutScriptAsync(selector.InvokeOrDefault(new PutScriptDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>put_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public PutScriptResponse PutScript(IPutScriptRequest request) => DoRequest<IPutScriptRequest, PutScriptResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>put_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		public Task<PutScriptResponse> PutScriptAsync(IPutScriptRequest request, CancellationToken ct = default) => DoRequestAsync<IPutScriptRequest, PutScriptResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		public ReindexOnServerResponse ReindexOnServer(Func<ReindexOnServerDescriptor, IReindexOnServerRequest> selector) => ReindexOnServer(selector.InvokeOrDefault(new ReindexOnServerDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		public Task<ReindexOnServerResponse> ReindexOnServerAsync(Func<ReindexOnServerDescriptor, IReindexOnServerRequest> selector, CancellationToken ct = default) => ReindexOnServerAsync(selector.InvokeOrDefault(new ReindexOnServerDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		public ReindexOnServerResponse ReindexOnServer(IReindexOnServerRequest request) => DoRequest<IReindexOnServerRequest, ReindexOnServerResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		public Task<ReindexOnServerResponse> ReindexOnServerAsync(IReindexOnServerRequest request, CancellationToken ct = default) => DoRequestAsync<IReindexOnServerRequest, ReindexOnServerResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		public ReindexRethrottleResponse ReindexRethrottle(TaskId taskId, Func<ReindexRethrottleDescriptor, IReindexRethrottleRequest> selector = null) => ReindexRethrottle(selector.InvokeOrDefault(new ReindexRethrottleDescriptor(taskId: taskId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		public Task<ReindexRethrottleResponse> ReindexRethrottleAsync(TaskId taskId, Func<ReindexRethrottleDescriptor, IReindexRethrottleRequest> selector = null, CancellationToken ct = default) => ReindexRethrottleAsync(selector.InvokeOrDefault(new ReindexRethrottleDescriptor(taskId: taskId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		public ReindexRethrottleResponse ReindexRethrottle(IReindexRethrottleRequest request) => DoRequest<IReindexRethrottleRequest, ReindexRethrottleResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		public Task<ReindexRethrottleResponse> ReindexRethrottleAsync(IReindexRethrottleRequest request, CancellationToken ct = default) => DoRequestAsync<IReindexRethrottleRequest, ReindexRethrottleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>render_search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</a>
 		/// </summary>
 		public RenderSearchTemplateResponse RenderSearchTemplate(Func<RenderSearchTemplateDescriptor, IRenderSearchTemplateRequest> selector = null) => RenderSearchTemplate(selector.InvokeOrDefault(new RenderSearchTemplateDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>render_search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</a>
 		/// </summary>
 		public Task<RenderSearchTemplateResponse> RenderSearchTemplateAsync(Func<RenderSearchTemplateDescriptor, IRenderSearchTemplateRequest> selector = null, CancellationToken ct = default) => RenderSearchTemplateAsync(selector.InvokeOrDefault(new RenderSearchTemplateDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>render_search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</a>
 		/// </summary>
 		public RenderSearchTemplateResponse RenderSearchTemplate(IRenderSearchTemplateRequest request) => DoRequest<IRenderSearchTemplateRequest, RenderSearchTemplateResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>render_search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</a>
 		/// </summary>
 		public Task<RenderSearchTemplateResponse> RenderSearchTemplateAsync(IRenderSearchTemplateRequest request, CancellationToken ct = default) => DoRequestAsync<IRenderSearchTemplateRequest, RenderSearchTemplateResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scripts_painless_execute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</a>
 		/// </summary>
 		public ExecutePainlessScriptResponse<TResult> ExecutePainlessScript<TResult>(Func<ExecutePainlessScriptDescriptor, IExecutePainlessScriptRequest> selector = null) => ExecutePainlessScript<TResult>(selector.InvokeOrDefault(new ExecutePainlessScriptDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>scripts_painless_execute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</a>
 		/// </summary>
 		public Task<ExecutePainlessScriptResponse<TResult>> ExecutePainlessScriptAsync<TResult>(Func<ExecutePainlessScriptDescriptor, IExecutePainlessScriptRequest> selector = null, CancellationToken ct = default) => ExecutePainlessScriptAsync<TResult>(selector.InvokeOrDefault(new ExecutePainlessScriptDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scripts_painless_execute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</a>
 		/// </summary>
 		public ExecutePainlessScriptResponse<TResult> ExecutePainlessScript<TResult>(IExecutePainlessScriptRequest request) => DoRequest<IExecutePainlessScriptRequest, ExecutePainlessScriptResponse<TResult>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scripts_painless_execute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</a>
 		/// </summary>
 		public Task<ExecutePainlessScriptResponse<TResult>> ExecutePainlessScriptAsync<TResult>(IExecutePainlessScriptRequest request, CancellationToken ct = default) => DoRequestAsync<IExecutePainlessScriptRequest, ExecutePainlessScriptResponse<TResult>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public SearchResponse<TDocument> Scroll<TInferDocument, TDocument>(Time scroll, string scrollId, Func<ScrollDescriptor<TInferDocument>, IScrollRequest> selector = null)
 			where TInferDocument : class where TDocument : class => Scroll<TDocument>(selector.InvokeOrDefault(new ScrollDescriptor<TInferDocument>(scroll, scrollId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public Task<SearchResponse<TDocument>> ScrollAsync<TInferDocument, TDocument>(Time scroll, string scrollId, Func<ScrollDescriptor<TInferDocument>, IScrollRequest> selector = null, CancellationToken ct = default)
 			where TInferDocument : class where TDocument : class => ScrollAsync<TDocument>(selector.InvokeOrDefault(new ScrollDescriptor<TInferDocument>(scroll, scrollId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public SearchResponse<TDocument> Scroll<TDocument>(Time scroll, string scrollId, Func<ScrollDescriptor<TDocument>, IScrollRequest> selector = null)
 			where TDocument : class => Scroll<TDocument>(selector.InvokeOrDefault(new ScrollDescriptor<TDocument>(scroll, scrollId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public Task<SearchResponse<TDocument>> ScrollAsync<TDocument>(Time scroll, string scrollId, Func<ScrollDescriptor<TDocument>, IScrollRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => ScrollAsync<TDocument>(selector.InvokeOrDefault(new ScrollDescriptor<TDocument>(scroll, scrollId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public SearchResponse<TDocument> Scroll<TDocument>(IScrollRequest request)
 			where TDocument : class => DoRequest<IScrollRequest, SearchResponse<TDocument>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		public Task<SearchResponse<TDocument>> ScrollAsync<TDocument>(IScrollRequest request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<IScrollRequest, SearchResponse<TDocument>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		public SearchResponse<TDocument> Search<TInferDocument, TDocument>(Func<SearchDescriptor<TInferDocument>, ISearchRequest> selector = null)
 			where TInferDocument : class where TDocument : class => Search<TDocument>(selector.InvokeOrDefault(new SearchDescriptor<TInferDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		public Task<SearchResponse<TDocument>> SearchAsync<TInferDocument, TDocument>(Func<SearchDescriptor<TInferDocument>, ISearchRequest> selector = null, CancellationToken ct = default)
 			where TInferDocument : class where TDocument : class => SearchAsync<TDocument>(selector.InvokeOrDefault(new SearchDescriptor<TInferDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		public SearchResponse<TDocument> Search<TDocument>(Func<SearchDescriptor<TDocument>, ISearchRequest> selector = null)
 			where TDocument : class => Search<TDocument>(selector.InvokeOrDefault(new SearchDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		public Task<SearchResponse<TDocument>> SearchAsync<TDocument>(Func<SearchDescriptor<TDocument>, ISearchRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => SearchAsync<TDocument>(selector.InvokeOrDefault(new SearchDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		public SearchResponse<TDocument> Search<TDocument>(ISearchRequest request)
 			where TDocument : class => DoRequest<ISearchRequest, SearchResponse<TDocument>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		public Task<SearchResponse<TDocument>> SearchAsync<TDocument>(ISearchRequest request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<ISearchRequest, SearchResponse<TDocument>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</a>
 		/// </summary>
 		public SearchShardsResponse SearchShards<TDocument>(Func<SearchShardsDescriptor<TDocument>, ISearchShardsRequest> selector = null)
 			where TDocument : class => SearchShards(selector.InvokeOrDefault(new SearchShardsDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</a>
 		/// </summary>
 		public Task<SearchShardsResponse> SearchShardsAsync<TDocument>(Func<SearchShardsDescriptor<TDocument>, ISearchShardsRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => SearchShardsAsync(selector.InvokeOrDefault(new SearchShardsDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</a>
 		/// </summary>
 		public SearchShardsResponse SearchShards(ISearchShardsRequest request) => DoRequest<ISearchShardsRequest, SearchShardsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</a>
 		/// </summary>
 		public Task<SearchShardsResponse> SearchShardsAsync(ISearchShardsRequest request, CancellationToken ct = default) => DoRequestAsync<ISearchShardsRequest, SearchShardsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</a>
 		/// </summary>
 		public SearchResponse<TDocument> SearchTemplate<TDocument>(Func<SearchTemplateDescriptor<TDocument>, ISearchTemplateRequest> selector = null)
 			where TDocument : class => SearchTemplate<TDocument>(selector.InvokeOrDefault(new SearchTemplateDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</a>
 		/// </summary>
 		public Task<SearchResponse<TDocument>> SearchTemplateAsync<TDocument>(Func<SearchTemplateDescriptor<TDocument>, ISearchTemplateRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => SearchTemplateAsync<TDocument>(selector.InvokeOrDefault(new SearchTemplateDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</a>
 		/// </summary>
 		public SearchResponse<TDocument> SearchTemplate<TDocument>(ISearchTemplateRequest request)
 			where TDocument : class => DoRequest<ISearchTemplateRequest, SearchResponse<TDocument>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</a>
 		/// </summary>
 		public Task<SearchResponse<TDocument>> SearchTemplateAsync<TDocument>(ISearchTemplateRequest request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<ISearchTemplateRequest, SearchResponse<TDocument>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>termvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</a>
 		/// </summary>
 		public TermVectorsResponse TermVectors<TDocument>(Func<TermVectorsDescriptor<TDocument>, ITermVectorsRequest<TDocument>> selector = null)
 			where TDocument : class => TermVectors<TDocument>(selector.InvokeOrDefault(new TermVectorsDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>termvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</a>
 		/// </summary>
 		public Task<TermVectorsResponse> TermVectorsAsync<TDocument>(Func<TermVectorsDescriptor<TDocument>, ITermVectorsRequest<TDocument>> selector = null, CancellationToken ct = default)
 			where TDocument : class => TermVectorsAsync<TDocument>(selector.InvokeOrDefault(new TermVectorsDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>termvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</a>
 		/// </summary>
 		public TermVectorsResponse TermVectors<TDocument>(ITermVectorsRequest<TDocument> request)
 			where TDocument : class => DoRequest<ITermVectorsRequest<TDocument>, TermVectorsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>termvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</a>
 		/// </summary>
 		public Task<TermVectorsResponse> TermVectorsAsync<TDocument>(ITermVectorsRequest<TDocument> request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<ITermVectorsRequest<TDocument>, TermVectorsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(DocumentPath<TDocument> id, Func<UpdateDescriptor<TDocument, TPartialDocument>, IUpdateRequest<TDocument, TPartialDocument>> selector)
 			where TDocument : class where TPartialDocument : class => Update<TDocument, TPartialDocument>(selector.InvokeOrDefault(new UpdateDescriptor<TDocument, TPartialDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(DocumentPath<TDocument> id, Func<UpdateDescriptor<TDocument, TPartialDocument>, IUpdateRequest<TDocument, TPartialDocument>> selector, CancellationToken ct = default)
 			where TDocument : class where TPartialDocument : class => UpdateAsync<TDocument, TPartialDocument>(selector.InvokeOrDefault(new UpdateDescriptor<TDocument, TPartialDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		public UpdateResponse<TDocument> Update<TDocument>(DocumentPath<TDocument> id, Func<UpdateDescriptor<TDocument, TDocument>, IUpdateRequest<TDocument, TDocument>> selector)
 			where TDocument : class => Update<TDocument, TDocument>(selector.InvokeOrDefault(new UpdateDescriptor<TDocument, TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument>(DocumentPath<TDocument> id, Func<UpdateDescriptor<TDocument, TDocument>, IUpdateRequest<TDocument, TDocument>> selector, CancellationToken ct = default)
 			where TDocument : class => UpdateAsync<TDocument, TDocument>(selector.InvokeOrDefault(new UpdateDescriptor<TDocument, TDocument>(documentWithId: id?.Document, index: id?.Self?.Index, id: id?.Self?.Id)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(IUpdateRequest<TDocument, TPartialDocument> request)
 			where TDocument : class where TPartialDocument : class => DoRequest<IUpdateRequest<TDocument, TPartialDocument>, UpdateResponse<TDocument>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(IUpdateRequest<TDocument, TPartialDocument> request, CancellationToken ct = default)
 			where TDocument : class where TPartialDocument : class => DoRequestAsync<IUpdateRequest<TDocument, TPartialDocument>, UpdateResponse<TDocument>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</a>
 		/// </summary>
 		public UpdateByQueryResponse UpdateByQuery<TDocument>(Func<UpdateByQueryDescriptor<TDocument>, IUpdateByQueryRequest> selector = null)
 			where TDocument : class => UpdateByQuery(selector.InvokeOrDefault(new UpdateByQueryDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</a>
 		/// </summary>
 		public Task<UpdateByQueryResponse> UpdateByQueryAsync<TDocument>(Func<UpdateByQueryDescriptor<TDocument>, IUpdateByQueryRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => UpdateByQueryAsync(selector.InvokeOrDefault(new UpdateByQueryDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</a>
 		/// </summary>
 		public UpdateByQueryResponse UpdateByQuery(IUpdateByQueryRequest request) => DoRequest<IUpdateByQueryRequest, UpdateByQueryResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</a>
 		/// </summary>
 		public Task<UpdateByQueryResponse> UpdateByQueryAsync(IUpdateByQueryRequest request, CancellationToken ct = default) => DoRequestAsync<IUpdateByQueryRequest, UpdateByQueryResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</a>
 		/// </summary>
 		public ListTasksResponse UpdateByQueryRethrottle(TaskId taskId, Func<UpdateByQueryRethrottleDescriptor, IUpdateByQueryRethrottleRequest> selector = null) => UpdateByQueryRethrottle(selector.InvokeOrDefault(new UpdateByQueryRethrottleDescriptor(taskId: taskId)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</a>
 		/// </summary>
 		public Task<ListTasksResponse> UpdateByQueryRethrottleAsync(TaskId taskId, Func<UpdateByQueryRethrottleDescriptor, IUpdateByQueryRethrottleRequest> selector = null, CancellationToken ct = default) => UpdateByQueryRethrottleAsync(selector.InvokeOrDefault(new UpdateByQueryRethrottleDescriptor(taskId: taskId)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</a>
 		/// </summary>
 		public ListTasksResponse UpdateByQueryRethrottle(IUpdateByQueryRethrottleRequest request) => DoRequest<IUpdateByQueryRethrottleRequest, ListTasksResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</a>
 		/// </summary>
 		public Task<ListTasksResponse> UpdateByQueryRethrottleAsync(IUpdateByQueryRethrottleRequest request, CancellationToken ct = default) => DoRequestAsync<IUpdateByQueryRethrottleRequest, ListTasksResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Nodes.cs
+++ b/src/Nest/ElasticClient.Nodes.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.NodesApi;
 namespace Nest.Specification.NodesApi
 {
 	///<summary>
-	/// Logically groups all <c>Nodes</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Nodes"/> property
+	/// Nodes APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Nodes"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,121 +38,121 @@ namespace Nest.Specification.NodesApi
 
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.hot_threads</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</a>
 		/// </summary>
 		public NodesHotThreadsResponse HotThreads(Func<NodesHotThreadsDescriptor, INodesHotThreadsRequest> selector = null) => HotThreads(selector.InvokeOrDefault(new NodesHotThreadsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.hot_threads</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</a>
 		/// </summary>
 		public Task<NodesHotThreadsResponse> HotThreadsAsync(Func<NodesHotThreadsDescriptor, INodesHotThreadsRequest> selector = null, CancellationToken ct = default) => HotThreadsAsync(selector.InvokeOrDefault(new NodesHotThreadsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.hot_threads</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</a>
 		/// </summary>
 		public NodesHotThreadsResponse HotThreads(INodesHotThreadsRequest request) => DoRequest<INodesHotThreadsRequest, NodesHotThreadsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.hot_threads</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</a>
 		/// </summary>
 		public Task<NodesHotThreadsResponse> HotThreadsAsync(INodesHotThreadsRequest request, CancellationToken ct = default) => DoRequestAsync<INodesHotThreadsRequest, NodesHotThreadsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</a>
 		/// </summary>
 		public NodesInfoResponse Info(Func<NodesInfoDescriptor, INodesInfoRequest> selector = null) => Info(selector.InvokeOrDefault(new NodesInfoDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</a>
 		/// </summary>
 		public Task<NodesInfoResponse> InfoAsync(Func<NodesInfoDescriptor, INodesInfoRequest> selector = null, CancellationToken ct = default) => InfoAsync(selector.InvokeOrDefault(new NodesInfoDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</a>
 		/// </summary>
 		public NodesInfoResponse Info(INodesInfoRequest request) => DoRequest<INodesInfoRequest, NodesInfoResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</a>
 		/// </summary>
 		public Task<NodesInfoResponse> InfoAsync(INodesInfoRequest request, CancellationToken ct = default) => DoRequestAsync<INodesInfoRequest, NodesInfoResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>nodes.reload_secure_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</a>
 		/// </summary>
 		public ReloadSecureSettingsResponse ReloadSecureSettings(Func<ReloadSecureSettingsDescriptor, IReloadSecureSettingsRequest> selector = null) => ReloadSecureSettings(selector.InvokeOrDefault(new ReloadSecureSettingsDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>nodes.reload_secure_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</a>
 		/// </summary>
 		public Task<ReloadSecureSettingsResponse> ReloadSecureSettingsAsync(Func<ReloadSecureSettingsDescriptor, IReloadSecureSettingsRequest> selector = null, CancellationToken ct = default) => ReloadSecureSettingsAsync(selector.InvokeOrDefault(new ReloadSecureSettingsDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>nodes.reload_secure_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</a>
 		/// </summary>
 		public ReloadSecureSettingsResponse ReloadSecureSettings(IReloadSecureSettingsRequest request) => DoRequest<IReloadSecureSettingsRequest, ReloadSecureSettingsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>nodes.reload_secure_settings</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</a>
 		/// </summary>
 		public Task<ReloadSecureSettingsResponse> ReloadSecureSettingsAsync(IReloadSecureSettingsRequest request, CancellationToken ct = default) => DoRequestAsync<IReloadSecureSettingsRequest, ReloadSecureSettingsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</a>
 		/// </summary>
 		public NodesStatsResponse Stats(Func<NodesStatsDescriptor, INodesStatsRequest> selector = null) => Stats(selector.InvokeOrDefault(new NodesStatsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</a>
 		/// </summary>
 		public Task<NodesStatsResponse> StatsAsync(Func<NodesStatsDescriptor, INodesStatsRequest> selector = null, CancellationToken ct = default) => StatsAsync(selector.InvokeOrDefault(new NodesStatsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</a>
 		/// </summary>
 		public NodesStatsResponse Stats(INodesStatsRequest request) => DoRequest<INodesStatsRequest, NodesStatsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</a>
 		/// </summary>
 		public Task<NodesStatsResponse> StatsAsync(INodesStatsRequest request, CancellationToken ct = default) => DoRequestAsync<INodesStatsRequest, NodesStatsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.usage</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</a>
 		/// </summary>
 		public NodesUsageResponse Usage(Func<NodesUsageDescriptor, INodesUsageRequest> selector = null) => Usage(selector.InvokeOrDefault(new NodesUsageDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.usage</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</a>
 		/// </summary>
 		public Task<NodesUsageResponse> UsageAsync(Func<NodesUsageDescriptor, INodesUsageRequest> selector = null, CancellationToken ct = default) => UsageAsync(selector.InvokeOrDefault(new NodesUsageDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.usage</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</a>
 		/// </summary>
 		public NodesUsageResponse Usage(INodesUsageRequest request) => DoRequest<INodesUsageRequest, NodesUsageResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>nodes.usage</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</a>
 		/// </summary>
 		public Task<NodesUsageResponse> UsageAsync(INodesUsageRequest request, CancellationToken ct = default) => DoRequestAsync<INodesUsageRequest, NodesUsageResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Rollup.cs
+++ b/src/Nest/ElasticClient.Rollup.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.RollupApi;
 namespace Nest.Specification.RollupApi
 {
 	///<summary>
-	/// Logically groups all <c>Rollup</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Rollup"/> property
+	/// Rollup APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Rollup"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,199 +38,199 @@ namespace Nest.Specification.RollupApi
 
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>rollup.delete_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public DeleteRollupJobResponse DeleteJob(Id id, Func<DeleteRollupJobDescriptor, IDeleteRollupJobRequest> selector = null) => DeleteJob(selector.InvokeOrDefault(new DeleteRollupJobDescriptor(id: id)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>rollup.delete_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<DeleteRollupJobResponse> DeleteJobAsync(Id id, Func<DeleteRollupJobDescriptor, IDeleteRollupJobRequest> selector = null, CancellationToken ct = default) => DeleteJobAsync(selector.InvokeOrDefault(new DeleteRollupJobDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>rollup.delete_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public DeleteRollupJobResponse DeleteJob(IDeleteRollupJobRequest request) => DoRequest<IDeleteRollupJobRequest, DeleteRollupJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>rollup.delete_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<DeleteRollupJobResponse> DeleteJobAsync(IDeleteRollupJobRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteRollupJobRequest, DeleteRollupJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_jobs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public GetRollupJobResponse GetJob(Func<GetRollupJobDescriptor, IGetRollupJobRequest> selector = null) => GetJob(selector.InvokeOrDefault(new GetRollupJobDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_jobs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<GetRollupJobResponse> GetJobAsync(Func<GetRollupJobDescriptor, IGetRollupJobRequest> selector = null, CancellationToken ct = default) => GetJobAsync(selector.InvokeOrDefault(new GetRollupJobDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_jobs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public GetRollupJobResponse GetJob(IGetRollupJobRequest request) => DoRequest<IGetRollupJobRequest, GetRollupJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_jobs</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<GetRollupJobResponse> GetJobAsync(IGetRollupJobRequest request, CancellationToken ct = default) => DoRequestAsync<IGetRollupJobRequest, GetRollupJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_rollup_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public GetRollupCapabilitiesResponse GetCapabilities(Func<GetRollupCapabilitiesDescriptor, IGetRollupCapabilitiesRequest> selector = null) => GetCapabilities(selector.InvokeOrDefault(new GetRollupCapabilitiesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_rollup_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<GetRollupCapabilitiesResponse> GetCapabilitiesAsync(Func<GetRollupCapabilitiesDescriptor, IGetRollupCapabilitiesRequest> selector = null, CancellationToken ct = default) => GetCapabilitiesAsync(selector.InvokeOrDefault(new GetRollupCapabilitiesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_rollup_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public GetRollupCapabilitiesResponse GetCapabilities(IGetRollupCapabilitiesRequest request) => DoRequest<IGetRollupCapabilitiesRequest, GetRollupCapabilitiesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_rollup_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<GetRollupCapabilitiesResponse> GetCapabilitiesAsync(IGetRollupCapabilitiesRequest request, CancellationToken ct = default) => DoRequestAsync<IGetRollupCapabilitiesRequest, GetRollupCapabilitiesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_rollup_index_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public GetRollupIndexCapabilitiesResponse GetIndexCapabilities(IndexName index, Func<GetRollupIndexCapabilitiesDescriptor, IGetRollupIndexCapabilitiesRequest> selector = null) => GetIndexCapabilities(selector.InvokeOrDefault(new GetRollupIndexCapabilitiesDescriptor(index: index)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_rollup_index_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<GetRollupIndexCapabilitiesResponse> GetIndexCapabilitiesAsync(IndexName index, Func<GetRollupIndexCapabilitiesDescriptor, IGetRollupIndexCapabilitiesRequest> selector = null, CancellationToken ct = default) => GetIndexCapabilitiesAsync(selector.InvokeOrDefault(new GetRollupIndexCapabilitiesDescriptor(index: index)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_rollup_index_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public GetRollupIndexCapabilitiesResponse GetIndexCapabilities(IGetRollupIndexCapabilitiesRequest request) => DoRequest<IGetRollupIndexCapabilitiesRequest, GetRollupIndexCapabilitiesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>rollup.get_rollup_index_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<GetRollupIndexCapabilitiesResponse> GetIndexCapabilitiesAsync(IGetRollupIndexCapabilitiesRequest request, CancellationToken ct = default) => DoRequestAsync<IGetRollupIndexCapabilitiesRequest, GetRollupIndexCapabilitiesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>rollup.put_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public CreateRollupJobResponse CreateJob<TDocument>(Id id, Func<CreateRollupJobDescriptor<TDocument>, ICreateRollupJobRequest> selector)
 			where TDocument : class => CreateJob(selector.InvokeOrDefault(new CreateRollupJobDescriptor<TDocument>(id: id)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>rollup.put_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<CreateRollupJobResponse> CreateJobAsync<TDocument>(Id id, Func<CreateRollupJobDescriptor<TDocument>, ICreateRollupJobRequest> selector, CancellationToken ct = default)
 			where TDocument : class => CreateJobAsync(selector.InvokeOrDefault(new CreateRollupJobDescriptor<TDocument>(id: id)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>rollup.put_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public CreateRollupJobResponse CreateJob(ICreateRollupJobRequest request) => DoRequest<ICreateRollupJobRequest, CreateRollupJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>rollup.put_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<CreateRollupJobResponse> CreateJobAsync(ICreateRollupJobRequest request, CancellationToken ct = default) => DoRequestAsync<ICreateRollupJobRequest, CreateRollupJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.rollup_search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public RollupSearchResponse<TDocument> Search<TDocument>(Func<RollupSearchDescriptor<TDocument>, IRollupSearchRequest> selector = null)
 			where TDocument : class => Search<TDocument>(selector.InvokeOrDefault(new RollupSearchDescriptor<TDocument>()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.rollup_search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<RollupSearchResponse<TDocument>> SearchAsync<TDocument>(Func<RollupSearchDescriptor<TDocument>, IRollupSearchRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class => SearchAsync<TDocument>(selector.InvokeOrDefault(new RollupSearchDescriptor<TDocument>()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.rollup_search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public RollupSearchResponse<TDocument> Search<TDocument>(IRollupSearchRequest request)
 			where TDocument : class => DoRequest<IRollupSearchRequest, RollupSearchResponse<TDocument>>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.rollup_search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<RollupSearchResponse<TDocument>> SearchAsync<TDocument>(IRollupSearchRequest request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<IRollupSearchRequest, RollupSearchResponse<TDocument>>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.start_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public StartRollupJobResponse StartJob(Id id, Func<StartRollupJobDescriptor, IStartRollupJobRequest> selector = null) => StartJob(selector.InvokeOrDefault(new StartRollupJobDescriptor(id: id)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.start_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<StartRollupJobResponse> StartJobAsync(Id id, Func<StartRollupJobDescriptor, IStartRollupJobRequest> selector = null, CancellationToken ct = default) => StartJobAsync(selector.InvokeOrDefault(new StartRollupJobDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.start_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public StartRollupJobResponse StartJob(IStartRollupJobRequest request) => DoRequest<IStartRollupJobRequest, StartRollupJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.start_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<StartRollupJobResponse> StartJobAsync(IStartRollupJobRequest request, CancellationToken ct = default) => DoRequestAsync<IStartRollupJobRequest, StartRollupJobResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.stop_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public StopRollupJobResponse StopJob(Id id, Func<StopRollupJobDescriptor, IStopRollupJobRequest> selector = null) => StopJob(selector.InvokeOrDefault(new StopRollupJobDescriptor(id: id)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.stop_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<StopRollupJobResponse> StopJobAsync(Id id, Func<StopRollupJobDescriptor, IStopRollupJobRequest> selector = null, CancellationToken ct = default) => StopJobAsync(selector.InvokeOrDefault(new StopRollupJobDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.stop_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public StopRollupJobResponse StopJob(IStopRollupJobRequest request) => DoRequest<IStopRollupJobRequest, StopRollupJobResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>rollup.stop_job</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = ""></a>
 		/// </summary>
 		public Task<StopRollupJobResponse> StopJobAsync(IStopRollupJobRequest request, CancellationToken ct = default) => DoRequestAsync<IStopRollupJobRequest, StopRollupJobResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Security.cs
+++ b/src/Nest/ElasticClient.Security.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.SecurityApi;
 namespace Nest.Specification.SecurityApi
 {
 	///<summary>
-	/// Logically groups all <c>Security</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Security"/> property
+	/// Security APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Security"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,625 +38,625 @@ namespace Nest.Specification.SecurityApi
 
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.authenticate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</a>
 		/// </summary>
 		public AuthenticateResponse Authenticate(Func<AuthenticateDescriptor, IAuthenticateRequest> selector = null) => Authenticate(selector.InvokeOrDefault(new AuthenticateDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.authenticate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</a>
 		/// </summary>
 		public Task<AuthenticateResponse> AuthenticateAsync(Func<AuthenticateDescriptor, IAuthenticateRequest> selector = null, CancellationToken ct = default) => AuthenticateAsync(selector.InvokeOrDefault(new AuthenticateDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.authenticate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</a>
 		/// </summary>
 		public AuthenticateResponse Authenticate(IAuthenticateRequest request) => DoRequest<IAuthenticateRequest, AuthenticateResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.authenticate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</a>
 		/// </summary>
 		public Task<AuthenticateResponse> AuthenticateAsync(IAuthenticateRequest request, CancellationToken ct = default) => DoRequestAsync<IAuthenticateRequest, AuthenticateResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.change_password</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</a>
 		/// </summary>
 		public ChangePasswordResponse ChangePassword(Func<ChangePasswordDescriptor, IChangePasswordRequest> selector) => ChangePassword(selector.InvokeOrDefault(new ChangePasswordDescriptor()));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.change_password</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</a>
 		/// </summary>
 		public Task<ChangePasswordResponse> ChangePasswordAsync(Func<ChangePasswordDescriptor, IChangePasswordRequest> selector, CancellationToken ct = default) => ChangePasswordAsync(selector.InvokeOrDefault(new ChangePasswordDescriptor()), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.change_password</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</a>
 		/// </summary>
 		public ChangePasswordResponse ChangePassword(IChangePasswordRequest request) => DoRequest<IChangePasswordRequest, ChangePasswordResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.change_password</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</a>
 		/// </summary>
 		public Task<ChangePasswordResponse> ChangePasswordAsync(IChangePasswordRequest request, CancellationToken ct = default) => DoRequestAsync<IChangePasswordRequest, ChangePasswordResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_realms</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</a>
 		/// </summary>
 		public ClearCachedRealmsResponse ClearCachedRealms(Names realms, Func<ClearCachedRealmsDescriptor, IClearCachedRealmsRequest> selector = null) => ClearCachedRealms(selector.InvokeOrDefault(new ClearCachedRealmsDescriptor(realms: realms)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_realms</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</a>
 		/// </summary>
 		public Task<ClearCachedRealmsResponse> ClearCachedRealmsAsync(Names realms, Func<ClearCachedRealmsDescriptor, IClearCachedRealmsRequest> selector = null, CancellationToken ct = default) => ClearCachedRealmsAsync(selector.InvokeOrDefault(new ClearCachedRealmsDescriptor(realms: realms)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_realms</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</a>
 		/// </summary>
 		public ClearCachedRealmsResponse ClearCachedRealms(IClearCachedRealmsRequest request) => DoRequest<IClearCachedRealmsRequest, ClearCachedRealmsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_realms</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</a>
 		/// </summary>
 		public Task<ClearCachedRealmsResponse> ClearCachedRealmsAsync(IClearCachedRealmsRequest request, CancellationToken ct = default) => DoRequestAsync<IClearCachedRealmsRequest, ClearCachedRealmsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_roles</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</a>
 		/// </summary>
 		public ClearCachedRolesResponse ClearCachedRoles(Names name, Func<ClearCachedRolesDescriptor, IClearCachedRolesRequest> selector = null) => ClearCachedRoles(selector.InvokeOrDefault(new ClearCachedRolesDescriptor(name: name)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_roles</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</a>
 		/// </summary>
 		public Task<ClearCachedRolesResponse> ClearCachedRolesAsync(Names name, Func<ClearCachedRolesDescriptor, IClearCachedRolesRequest> selector = null, CancellationToken ct = default) => ClearCachedRolesAsync(selector.InvokeOrDefault(new ClearCachedRolesDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_roles</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</a>
 		/// </summary>
 		public ClearCachedRolesResponse ClearCachedRoles(IClearCachedRolesRequest request) => DoRequest<IClearCachedRolesRequest, ClearCachedRolesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_roles</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</a>
 		/// </summary>
 		public Task<ClearCachedRolesResponse> ClearCachedRolesAsync(IClearCachedRolesRequest request, CancellationToken ct = default) => DoRequestAsync<IClearCachedRolesRequest, ClearCachedRolesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.create_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</a>
 		/// </summary>
 		public CreateApiKeyResponse CreateApiKey(Func<CreateApiKeyDescriptor, ICreateApiKeyRequest> selector) => CreateApiKey(selector.InvokeOrDefault(new CreateApiKeyDescriptor()));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.create_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</a>
 		/// </summary>
 		public Task<CreateApiKeyResponse> CreateApiKeyAsync(Func<CreateApiKeyDescriptor, ICreateApiKeyRequest> selector, CancellationToken ct = default) => CreateApiKeyAsync(selector.InvokeOrDefault(new CreateApiKeyDescriptor()), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.create_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</a>
 		/// </summary>
 		public CreateApiKeyResponse CreateApiKey(ICreateApiKeyRequest request) => DoRequest<ICreateApiKeyRequest, CreateApiKeyResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.create_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</a>
 		/// </summary>
 		public Task<CreateApiKeyResponse> CreateApiKeyAsync(ICreateApiKeyRequest request, CancellationToken ct = default) => DoRequestAsync<ICreateApiKeyRequest, CreateApiKeyResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public DeletePrivilegesResponse DeletePrivileges(Name application, Name name, Func<DeletePrivilegesDescriptor, IDeletePrivilegesRequest> selector = null) => DeletePrivileges(selector.InvokeOrDefault(new DeletePrivilegesDescriptor(application: application, name: name)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public Task<DeletePrivilegesResponse> DeletePrivilegesAsync(Name application, Name name, Func<DeletePrivilegesDescriptor, IDeletePrivilegesRequest> selector = null, CancellationToken ct = default) => DeletePrivilegesAsync(selector.InvokeOrDefault(new DeletePrivilegesDescriptor(application: application, name: name)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public DeletePrivilegesResponse DeletePrivileges(IDeletePrivilegesRequest request) => DoRequest<IDeletePrivilegesRequest, DeletePrivilegesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public Task<DeletePrivilegesResponse> DeletePrivilegesAsync(IDeletePrivilegesRequest request, CancellationToken ct = default) => DoRequestAsync<IDeletePrivilegesRequest, DeletePrivilegesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</a>
 		/// </summary>
 		public DeleteRoleResponse DeleteRole(Name name, Func<DeleteRoleDescriptor, IDeleteRoleRequest> selector = null) => DeleteRole(selector.InvokeOrDefault(new DeleteRoleDescriptor(name: name)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</a>
 		/// </summary>
 		public Task<DeleteRoleResponse> DeleteRoleAsync(Name name, Func<DeleteRoleDescriptor, IDeleteRoleRequest> selector = null, CancellationToken ct = default) => DeleteRoleAsync(selector.InvokeOrDefault(new DeleteRoleDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</a>
 		/// </summary>
 		public DeleteRoleResponse DeleteRole(IDeleteRoleRequest request) => DoRequest<IDeleteRoleRequest, DeleteRoleResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</a>
 		/// </summary>
 		public Task<DeleteRoleResponse> DeleteRoleAsync(IDeleteRoleRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteRoleRequest, DeleteRoleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</a>
 		/// </summary>
 		public DeleteRoleMappingResponse DeleteRoleMapping(Name name, Func<DeleteRoleMappingDescriptor, IDeleteRoleMappingRequest> selector = null) => DeleteRoleMapping(selector.InvokeOrDefault(new DeleteRoleMappingDescriptor(name: name)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</a>
 		/// </summary>
 		public Task<DeleteRoleMappingResponse> DeleteRoleMappingAsync(Name name, Func<DeleteRoleMappingDescriptor, IDeleteRoleMappingRequest> selector = null, CancellationToken ct = default) => DeleteRoleMappingAsync(selector.InvokeOrDefault(new DeleteRoleMappingDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</a>
 		/// </summary>
 		public DeleteRoleMappingResponse DeleteRoleMapping(IDeleteRoleMappingRequest request) => DoRequest<IDeleteRoleMappingRequest, DeleteRoleMappingResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</a>
 		/// </summary>
 		public Task<DeleteRoleMappingResponse> DeleteRoleMappingAsync(IDeleteRoleMappingRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteRoleMappingRequest, DeleteRoleMappingResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</a>
 		/// </summary>
 		public DeleteUserResponse DeleteUser(Name username, Func<DeleteUserDescriptor, IDeleteUserRequest> selector = null) => DeleteUser(selector.InvokeOrDefault(new DeleteUserDescriptor(username: username)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</a>
 		/// </summary>
 		public Task<DeleteUserResponse> DeleteUserAsync(Name username, Func<DeleteUserDescriptor, IDeleteUserRequest> selector = null, CancellationToken ct = default) => DeleteUserAsync(selector.InvokeOrDefault(new DeleteUserDescriptor(username: username)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</a>
 		/// </summary>
 		public DeleteUserResponse DeleteUser(IDeleteUserRequest request) => DoRequest<IDeleteUserRequest, DeleteUserResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.delete_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</a>
 		/// </summary>
 		public Task<DeleteUserResponse> DeleteUserAsync(IDeleteUserRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteUserRequest, DeleteUserResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.disable_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</a>
 		/// </summary>
 		public DisableUserResponse DisableUser(Name username, Func<DisableUserDescriptor, IDisableUserRequest> selector = null) => DisableUser(selector.InvokeOrDefault(new DisableUserDescriptor(username: username)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.disable_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</a>
 		/// </summary>
 		public Task<DisableUserResponse> DisableUserAsync(Name username, Func<DisableUserDescriptor, IDisableUserRequest> selector = null, CancellationToken ct = default) => DisableUserAsync(selector.InvokeOrDefault(new DisableUserDescriptor(username: username)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.disable_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</a>
 		/// </summary>
 		public DisableUserResponse DisableUser(IDisableUserRequest request) => DoRequest<IDisableUserRequest, DisableUserResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.disable_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</a>
 		/// </summary>
 		public Task<DisableUserResponse> DisableUserAsync(IDisableUserRequest request, CancellationToken ct = default) => DoRequestAsync<IDisableUserRequest, DisableUserResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.enable_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</a>
 		/// </summary>
 		public EnableUserResponse EnableUser(Name username, Func<EnableUserDescriptor, IEnableUserRequest> selector = null) => EnableUser(selector.InvokeOrDefault(new EnableUserDescriptor(username: username)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.enable_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</a>
 		/// </summary>
 		public Task<EnableUserResponse> EnableUserAsync(Name username, Func<EnableUserDescriptor, IEnableUserRequest> selector = null, CancellationToken ct = default) => EnableUserAsync(selector.InvokeOrDefault(new EnableUserDescriptor(username: username)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.enable_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</a>
 		/// </summary>
 		public EnableUserResponse EnableUser(IEnableUserRequest request) => DoRequest<IEnableUserRequest, EnableUserResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.enable_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</a>
 		/// </summary>
 		public Task<EnableUserResponse> EnableUserAsync(IEnableUserRequest request, CancellationToken ct = default) => DoRequestAsync<IEnableUserRequest, EnableUserResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</a>
 		/// </summary>
 		public GetApiKeyResponse GetApiKey(Func<GetApiKeyDescriptor, IGetApiKeyRequest> selector = null) => GetApiKey(selector.InvokeOrDefault(new GetApiKeyDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</a>
 		/// </summary>
 		public Task<GetApiKeyResponse> GetApiKeyAsync(Func<GetApiKeyDescriptor, IGetApiKeyRequest> selector = null, CancellationToken ct = default) => GetApiKeyAsync(selector.InvokeOrDefault(new GetApiKeyDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</a>
 		/// </summary>
 		public GetApiKeyResponse GetApiKey(IGetApiKeyRequest request) => DoRequest<IGetApiKeyRequest, GetApiKeyResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</a>
 		/// </summary>
 		public Task<GetApiKeyResponse> GetApiKeyAsync(IGetApiKeyRequest request, CancellationToken ct = default) => DoRequestAsync<IGetApiKeyRequest, GetApiKeyResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public GetPrivilegesResponse GetPrivileges(Name name = null, Func<GetPrivilegesDescriptor, IGetPrivilegesRequest> selector = null) => GetPrivileges(selector.InvokeOrDefault(new GetPrivilegesDescriptor().Name(name: name)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public Task<GetPrivilegesResponse> GetPrivilegesAsync(Name name = null, Func<GetPrivilegesDescriptor, IGetPrivilegesRequest> selector = null, CancellationToken ct = default) => GetPrivilegesAsync(selector.InvokeOrDefault(new GetPrivilegesDescriptor().Name(name: name)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public GetPrivilegesResponse GetPrivileges(IGetPrivilegesRequest request) => DoRequest<IGetPrivilegesRequest, GetPrivilegesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public Task<GetPrivilegesResponse> GetPrivilegesAsync(IGetPrivilegesRequest request, CancellationToken ct = default) => DoRequestAsync<IGetPrivilegesRequest, GetPrivilegesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</a>
 		/// </summary>
 		public GetRoleResponse GetRole(Name name = null, Func<GetRoleDescriptor, IGetRoleRequest> selector = null) => GetRole(selector.InvokeOrDefault(new GetRoleDescriptor().Name(name: name)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</a>
 		/// </summary>
 		public Task<GetRoleResponse> GetRoleAsync(Name name = null, Func<GetRoleDescriptor, IGetRoleRequest> selector = null, CancellationToken ct = default) => GetRoleAsync(selector.InvokeOrDefault(new GetRoleDescriptor().Name(name: name)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</a>
 		/// </summary>
 		public GetRoleResponse GetRole(IGetRoleRequest request) => DoRequest<IGetRoleRequest, GetRoleResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</a>
 		/// </summary>
 		public Task<GetRoleResponse> GetRoleAsync(IGetRoleRequest request, CancellationToken ct = default) => DoRequestAsync<IGetRoleRequest, GetRoleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</a>
 		/// </summary>
 		public GetRoleMappingResponse GetRoleMapping(Name name = null, Func<GetRoleMappingDescriptor, IGetRoleMappingRequest> selector = null) => GetRoleMapping(selector.InvokeOrDefault(new GetRoleMappingDescriptor().Name(name: name)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</a>
 		/// </summary>
 		public Task<GetRoleMappingResponse> GetRoleMappingAsync(Name name = null, Func<GetRoleMappingDescriptor, IGetRoleMappingRequest> selector = null, CancellationToken ct = default) => GetRoleMappingAsync(selector.InvokeOrDefault(new GetRoleMappingDescriptor().Name(name: name)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</a>
 		/// </summary>
 		public GetRoleMappingResponse GetRoleMapping(IGetRoleMappingRequest request) => DoRequest<IGetRoleMappingRequest, GetRoleMappingResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</a>
 		/// </summary>
 		public Task<GetRoleMappingResponse> GetRoleMappingAsync(IGetRoleMappingRequest request, CancellationToken ct = default) => DoRequestAsync<IGetRoleMappingRequest, GetRoleMappingResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.get_token</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</a>
 		/// </summary>
 		public GetUserAccessTokenResponse GetUserAccessToken(string username, string password, Func<GetUserAccessTokenDescriptor, IGetUserAccessTokenRequest> selector = null) => GetUserAccessToken(selector.InvokeOrDefault(new GetUserAccessTokenDescriptor(username, password)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.get_token</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</a>
 		/// </summary>
 		public Task<GetUserAccessTokenResponse> GetUserAccessTokenAsync(string username, string password, Func<GetUserAccessTokenDescriptor, IGetUserAccessTokenRequest> selector = null, CancellationToken ct = default) => GetUserAccessTokenAsync(selector.InvokeOrDefault(new GetUserAccessTokenDescriptor(username, password)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.get_token</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</a>
 		/// </summary>
 		public GetUserAccessTokenResponse GetUserAccessToken(IGetUserAccessTokenRequest request) => DoRequest<IGetUserAccessTokenRequest, GetUserAccessTokenResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.get_token</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</a>
 		/// </summary>
 		public Task<GetUserAccessTokenResponse> GetUserAccessTokenAsync(IGetUserAccessTokenRequest request, CancellationToken ct = default) => DoRequestAsync<IGetUserAccessTokenRequest, GetUserAccessTokenResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</a>
 		/// </summary>
 		public GetUserResponse GetUser(Func<GetUserDescriptor, IGetUserRequest> selector = null) => GetUser(selector.InvokeOrDefault(new GetUserDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</a>
 		/// </summary>
 		public Task<GetUserResponse> GetUserAsync(Func<GetUserDescriptor, IGetUserRequest> selector = null, CancellationToken ct = default) => GetUserAsync(selector.InvokeOrDefault(new GetUserDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</a>
 		/// </summary>
 		public GetUserResponse GetUser(IGetUserRequest request) => DoRequest<IGetUserRequest, GetUserResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</a>
 		/// </summary>
 		public Task<GetUserResponse> GetUserAsync(IGetUserRequest request, CancellationToken ct = default) => DoRequestAsync<IGetUserRequest, GetUserResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_user_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</a>
 		/// </summary>
 		public GetUserPrivilegesResponse GetUserPrivileges(Func<GetUserPrivilegesDescriptor, IGetUserPrivilegesRequest> selector = null) => GetUserPrivileges(selector.InvokeOrDefault(new GetUserPrivilegesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_user_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</a>
 		/// </summary>
 		public Task<GetUserPrivilegesResponse> GetUserPrivilegesAsync(Func<GetUserPrivilegesDescriptor, IGetUserPrivilegesRequest> selector = null, CancellationToken ct = default) => GetUserPrivilegesAsync(selector.InvokeOrDefault(new GetUserPrivilegesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_user_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</a>
 		/// </summary>
 		public GetUserPrivilegesResponse GetUserPrivileges(IGetUserPrivilegesRequest request) => DoRequest<IGetUserPrivilegesRequest, GetUserPrivilegesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_user_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</a>
 		/// </summary>
 		public Task<GetUserPrivilegesResponse> GetUserPrivilegesAsync(IGetUserPrivilegesRequest request, CancellationToken ct = default) => DoRequestAsync<IGetUserPrivilegesRequest, GetUserPrivilegesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.has_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</a>
 		/// </summary>
 		public HasPrivilegesResponse HasPrivileges(Func<HasPrivilegesDescriptor, IHasPrivilegesRequest> selector = null) => HasPrivileges(selector.InvokeOrDefault(new HasPrivilegesDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.has_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</a>
 		/// </summary>
 		public Task<HasPrivilegesResponse> HasPrivilegesAsync(Func<HasPrivilegesDescriptor, IHasPrivilegesRequest> selector = null, CancellationToken ct = default) => HasPrivilegesAsync(selector.InvokeOrDefault(new HasPrivilegesDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.has_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</a>
 		/// </summary>
 		public HasPrivilegesResponse HasPrivileges(IHasPrivilegesRequest request) => DoRequest<IHasPrivilegesRequest, HasPrivilegesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.has_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</a>
 		/// </summary>
 		public Task<HasPrivilegesResponse> HasPrivilegesAsync(IHasPrivilegesRequest request, CancellationToken ct = default) => DoRequestAsync<IHasPrivilegesRequest, HasPrivilegesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.invalidate_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</a>
 		/// </summary>
 		public InvalidateApiKeyResponse InvalidateApiKey(Func<InvalidateApiKeyDescriptor, IInvalidateApiKeyRequest> selector) => InvalidateApiKey(selector.InvokeOrDefault(new InvalidateApiKeyDescriptor()));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.invalidate_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</a>
 		/// </summary>
 		public Task<InvalidateApiKeyResponse> InvalidateApiKeyAsync(Func<InvalidateApiKeyDescriptor, IInvalidateApiKeyRequest> selector, CancellationToken ct = default) => InvalidateApiKeyAsync(selector.InvokeOrDefault(new InvalidateApiKeyDescriptor()), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.invalidate_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</a>
 		/// </summary>
 		public InvalidateApiKeyResponse InvalidateApiKey(IInvalidateApiKeyRequest request) => DoRequest<IInvalidateApiKeyRequest, InvalidateApiKeyResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.invalidate_api_key</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</a>
 		/// </summary>
 		public Task<InvalidateApiKeyResponse> InvalidateApiKeyAsync(IInvalidateApiKeyRequest request, CancellationToken ct = default) => DoRequestAsync<IInvalidateApiKeyRequest, InvalidateApiKeyResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.invalidate_token</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</a>
 		/// </summary>
 		public InvalidateUserAccessTokenResponse InvalidateUserAccessToken(string token, Func<InvalidateUserAccessTokenDescriptor, IInvalidateUserAccessTokenRequest> selector = null) => InvalidateUserAccessToken(selector.InvokeOrDefault(new InvalidateUserAccessTokenDescriptor(token)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.invalidate_token</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</a>
 		/// </summary>
 		public Task<InvalidateUserAccessTokenResponse> InvalidateUserAccessTokenAsync(string token, Func<InvalidateUserAccessTokenDescriptor, IInvalidateUserAccessTokenRequest> selector = null, CancellationToken ct = default) => InvalidateUserAccessTokenAsync(selector.InvokeOrDefault(new InvalidateUserAccessTokenDescriptor(token)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.invalidate_token</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</a>
 		/// </summary>
 		public InvalidateUserAccessTokenResponse InvalidateUserAccessToken(IInvalidateUserAccessTokenRequest request) => DoRequest<IInvalidateUserAccessTokenRequest, InvalidateUserAccessTokenResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>security.invalidate_token</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</a>
 		/// </summary>
 		public Task<InvalidateUserAccessTokenResponse> InvalidateUserAccessTokenAsync(IInvalidateUserAccessTokenRequest request, CancellationToken ct = default) => DoRequestAsync<IInvalidateUserAccessTokenRequest, InvalidateUserAccessTokenResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public PutPrivilegesResponse PutPrivileges(Func<PutPrivilegesDescriptor, IPutPrivilegesRequest> selector) => PutPrivileges(selector.InvokeOrDefault(new PutPrivilegesDescriptor()));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public Task<PutPrivilegesResponse> PutPrivilegesAsync(Func<PutPrivilegesDescriptor, IPutPrivilegesRequest> selector, CancellationToken ct = default) => PutPrivilegesAsync(selector.InvokeOrDefault(new PutPrivilegesDescriptor()), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public PutPrivilegesResponse PutPrivileges(IPutPrivilegesRequest request) => DoRequest<IPutPrivilegesRequest, PutPrivilegesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_privileges</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "TODO">TODO</a>
 		/// </summary>
 		public Task<PutPrivilegesResponse> PutPrivilegesAsync(IPutPrivilegesRequest request, CancellationToken ct = default) => DoRequestAsync<IPutPrivilegesRequest, PutPrivilegesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</a>
 		/// </summary>
 		public PutRoleResponse PutRole(Name name, Func<PutRoleDescriptor, IPutRoleRequest> selector) => PutRole(selector.InvokeOrDefault(new PutRoleDescriptor(name: name)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</a>
 		/// </summary>
 		public Task<PutRoleResponse> PutRoleAsync(Name name, Func<PutRoleDescriptor, IPutRoleRequest> selector, CancellationToken ct = default) => PutRoleAsync(selector.InvokeOrDefault(new PutRoleDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</a>
 		/// </summary>
 		public PutRoleResponse PutRole(IPutRoleRequest request) => DoRequest<IPutRoleRequest, PutRoleResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_role</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</a>
 		/// </summary>
 		public Task<PutRoleResponse> PutRoleAsync(IPutRoleRequest request, CancellationToken ct = default) => DoRequestAsync<IPutRoleRequest, PutRoleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</a>
 		/// </summary>
 		public PutRoleMappingResponse PutRoleMapping(Name name, Func<PutRoleMappingDescriptor, IPutRoleMappingRequest> selector) => PutRoleMapping(selector.InvokeOrDefault(new PutRoleMappingDescriptor(name: name)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</a>
 		/// </summary>
 		public Task<PutRoleMappingResponse> PutRoleMappingAsync(Name name, Func<PutRoleMappingDescriptor, IPutRoleMappingRequest> selector, CancellationToken ct = default) => PutRoleMappingAsync(selector.InvokeOrDefault(new PutRoleMappingDescriptor(name: name)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</a>
 		/// </summary>
 		public PutRoleMappingResponse PutRoleMapping(IPutRoleMappingRequest request) => DoRequest<IPutRoleMappingRequest, PutRoleMappingResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_role_mapping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</a>
 		/// </summary>
 		public Task<PutRoleMappingResponse> PutRoleMappingAsync(IPutRoleMappingRequest request, CancellationToken ct = default) => DoRequestAsync<IPutRoleMappingRequest, PutRoleMappingResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</a>
 		/// </summary>
 		public PutUserResponse PutUser(Name username, Func<PutUserDescriptor, IPutUserRequest> selector) => PutUser(selector.InvokeOrDefault(new PutUserDescriptor(username: username)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</a>
 		/// </summary>
 		public Task<PutUserResponse> PutUserAsync(Name username, Func<PutUserDescriptor, IPutUserRequest> selector, CancellationToken ct = default) => PutUserAsync(selector.InvokeOrDefault(new PutUserDescriptor(username: username)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</a>
 		/// </summary>
 		public PutUserResponse PutUser(IPutUserRequest request) => DoRequest<IPutUserRequest, PutUserResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>security.put_user</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</a>
 		/// </summary>
 		public Task<PutUserResponse> PutUserAsync(IPutUserRequest request, CancellationToken ct = default) => DoRequestAsync<IPutUserRequest, PutUserResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ssl.certificates</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</a>
 		/// </summary>
 		public GetCertificatesResponse GetCertificates(Func<GetCertificatesDescriptor, IGetCertificatesRequest> selector = null) => GetCertificates(selector.InvokeOrDefault(new GetCertificatesDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>ssl.certificates</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</a>
 		/// </summary>
 		public Task<GetCertificatesResponse> GetCertificatesAsync(Func<GetCertificatesDescriptor, IGetCertificatesRequest> selector = null, CancellationToken ct = default) => GetCertificatesAsync(selector.InvokeOrDefault(new GetCertificatesDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ssl.certificates</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</a>
 		/// </summary>
 		public GetCertificatesResponse GetCertificates(IGetCertificatesRequest request) => DoRequest<IGetCertificatesRequest, GetCertificatesResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>ssl.certificates</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</a>
 		/// </summary>
 		public Task<GetCertificatesResponse> GetCertificatesAsync(IGetCertificatesRequest request, CancellationToken ct = default) => DoRequestAsync<IGetCertificatesRequest, GetCertificatesResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Snapshot.cs
+++ b/src/Nest/ElasticClient.Snapshot.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.SnapshotApi;
 namespace Nest.Specification.SnapshotApi
 {
 	///<summary>
-	/// Logically groups all <c>Snapshot</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Snapshot"/> property
+	/// Snapshot APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Snapshot"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,217 +38,217 @@ namespace Nest.Specification.SnapshotApi
 
 		/// <summary>
 		/// <c>PUT</c> request to the <c>snapshot.create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public SnapshotResponse Snapshot(Name repository, Name snapshot, Func<SnapshotDescriptor, ISnapshotRequest> selector = null) => Snapshot(selector.InvokeOrDefault(new SnapshotDescriptor(repository: repository, snapshot: snapshot)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>snapshot.create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<SnapshotResponse> SnapshotAsync(Name repository, Name snapshot, Func<SnapshotDescriptor, ISnapshotRequest> selector = null, CancellationToken ct = default) => SnapshotAsync(selector.InvokeOrDefault(new SnapshotDescriptor(repository: repository, snapshot: snapshot)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>snapshot.create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public SnapshotResponse Snapshot(ISnapshotRequest request) => DoRequest<ISnapshotRequest, SnapshotResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>snapshot.create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<SnapshotResponse> SnapshotAsync(ISnapshotRequest request, CancellationToken ct = default) => DoRequestAsync<ISnapshotRequest, SnapshotResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>snapshot.create_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public CreateRepositoryResponse CreateRepository(Name repository, Func<CreateRepositoryDescriptor, ICreateRepositoryRequest> selector) => CreateRepository(selector.InvokeOrDefault(new CreateRepositoryDescriptor(repository: repository)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>snapshot.create_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<CreateRepositoryResponse> CreateRepositoryAsync(Name repository, Func<CreateRepositoryDescriptor, ICreateRepositoryRequest> selector, CancellationToken ct = default) => CreateRepositoryAsync(selector.InvokeOrDefault(new CreateRepositoryDescriptor(repository: repository)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>snapshot.create_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public CreateRepositoryResponse CreateRepository(ICreateRepositoryRequest request) => DoRequest<ICreateRepositoryRequest, CreateRepositoryResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>snapshot.create_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<CreateRepositoryResponse> CreateRepositoryAsync(ICreateRepositoryRequest request, CancellationToken ct = default) => DoRequestAsync<ICreateRepositoryRequest, CreateRepositoryResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>snapshot.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public DeleteSnapshotResponse Delete(Name repository, Name snapshot, Func<DeleteSnapshotDescriptor, IDeleteSnapshotRequest> selector = null) => Delete(selector.InvokeOrDefault(new DeleteSnapshotDescriptor(repository: repository, snapshot: snapshot)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>snapshot.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<DeleteSnapshotResponse> DeleteAsync(Name repository, Name snapshot, Func<DeleteSnapshotDescriptor, IDeleteSnapshotRequest> selector = null, CancellationToken ct = default) => DeleteAsync(selector.InvokeOrDefault(new DeleteSnapshotDescriptor(repository: repository, snapshot: snapshot)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>snapshot.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public DeleteSnapshotResponse Delete(IDeleteSnapshotRequest request) => DoRequest<IDeleteSnapshotRequest, DeleteSnapshotResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>snapshot.delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<DeleteSnapshotResponse> DeleteAsync(IDeleteSnapshotRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteSnapshotRequest, DeleteSnapshotResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>snapshot.delete_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public DeleteRepositoryResponse DeleteRepository(Names repository, Func<DeleteRepositoryDescriptor, IDeleteRepositoryRequest> selector = null) => DeleteRepository(selector.InvokeOrDefault(new DeleteRepositoryDescriptor(repository: repository)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>snapshot.delete_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<DeleteRepositoryResponse> DeleteRepositoryAsync(Names repository, Func<DeleteRepositoryDescriptor, IDeleteRepositoryRequest> selector = null, CancellationToken ct = default) => DeleteRepositoryAsync(selector.InvokeOrDefault(new DeleteRepositoryDescriptor(repository: repository)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>snapshot.delete_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public DeleteRepositoryResponse DeleteRepository(IDeleteRepositoryRequest request) => DoRequest<IDeleteRepositoryRequest, DeleteRepositoryResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>snapshot.delete_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<DeleteRepositoryResponse> DeleteRepositoryAsync(IDeleteRepositoryRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteRepositoryRequest, DeleteRepositoryResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public GetSnapshotResponse Get(Name repository, Names snapshot, Func<GetSnapshotDescriptor, IGetSnapshotRequest> selector = null) => Get(selector.InvokeOrDefault(new GetSnapshotDescriptor(repository: repository, snapshot: snapshot)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<GetSnapshotResponse> GetAsync(Name repository, Names snapshot, Func<GetSnapshotDescriptor, IGetSnapshotRequest> selector = null, CancellationToken ct = default) => GetAsync(selector.InvokeOrDefault(new GetSnapshotDescriptor(repository: repository, snapshot: snapshot)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public GetSnapshotResponse Get(IGetSnapshotRequest request) => DoRequest<IGetSnapshotRequest, GetSnapshotResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<GetSnapshotResponse> GetAsync(IGetSnapshotRequest request, CancellationToken ct = default) => DoRequestAsync<IGetSnapshotRequest, GetSnapshotResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.get_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public GetRepositoryResponse GetRepository(Func<GetRepositoryDescriptor, IGetRepositoryRequest> selector = null) => GetRepository(selector.InvokeOrDefault(new GetRepositoryDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.get_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<GetRepositoryResponse> GetRepositoryAsync(Func<GetRepositoryDescriptor, IGetRepositoryRequest> selector = null, CancellationToken ct = default) => GetRepositoryAsync(selector.InvokeOrDefault(new GetRepositoryDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.get_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public GetRepositoryResponse GetRepository(IGetRepositoryRequest request) => DoRequest<IGetRepositoryRequest, GetRepositoryResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.get_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<GetRepositoryResponse> GetRepositoryAsync(IGetRepositoryRequest request, CancellationToken ct = default) => DoRequestAsync<IGetRepositoryRequest, GetRepositoryResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>snapshot.restore</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public RestoreResponse Restore(Name repository, Name snapshot, Func<RestoreDescriptor, IRestoreRequest> selector = null) => Restore(selector.InvokeOrDefault(new RestoreDescriptor(repository: repository, snapshot: snapshot)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>snapshot.restore</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<RestoreResponse> RestoreAsync(Name repository, Name snapshot, Func<RestoreDescriptor, IRestoreRequest> selector = null, CancellationToken ct = default) => RestoreAsync(selector.InvokeOrDefault(new RestoreDescriptor(repository: repository, snapshot: snapshot)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>snapshot.restore</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public RestoreResponse Restore(IRestoreRequest request) => DoRequest<IRestoreRequest, RestoreResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>snapshot.restore</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<RestoreResponse> RestoreAsync(IRestoreRequest request, CancellationToken ct = default) => DoRequestAsync<IRestoreRequest, RestoreResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public SnapshotStatusResponse Status(Func<SnapshotStatusDescriptor, ISnapshotStatusRequest> selector = null) => Status(selector.InvokeOrDefault(new SnapshotStatusDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<SnapshotStatusResponse> StatusAsync(Func<SnapshotStatusDescriptor, ISnapshotStatusRequest> selector = null, CancellationToken ct = default) => StatusAsync(selector.InvokeOrDefault(new SnapshotStatusDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public SnapshotStatusResponse Status(ISnapshotStatusRequest request) => DoRequest<ISnapshotStatusRequest, SnapshotStatusResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>snapshot.status</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<SnapshotStatusResponse> StatusAsync(ISnapshotStatusRequest request, CancellationToken ct = default) => DoRequestAsync<ISnapshotStatusRequest, SnapshotStatusResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>snapshot.verify_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public VerifyRepositoryResponse VerifyRepository(Name repository, Func<VerifyRepositoryDescriptor, IVerifyRepositoryRequest> selector = null) => VerifyRepository(selector.InvokeOrDefault(new VerifyRepositoryDescriptor(repository: repository)));
 		/// <summary>
 		/// <c>POST</c> request to the <c>snapshot.verify_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<VerifyRepositoryResponse> VerifyRepositoryAsync(Name repository, Func<VerifyRepositoryDescriptor, IVerifyRepositoryRequest> selector = null, CancellationToken ct = default) => VerifyRepositoryAsync(selector.InvokeOrDefault(new VerifyRepositoryDescriptor(repository: repository)), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>snapshot.verify_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public VerifyRepositoryResponse VerifyRepository(IVerifyRepositoryRequest request) => DoRequest<IVerifyRepositoryRequest, VerifyRepositoryResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>snapshot.verify_repository</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</a>
 		/// </summary>
 		public Task<VerifyRepositoryResponse> VerifyRepositoryAsync(IVerifyRepositoryRequest request, CancellationToken ct = default) => DoRequestAsync<IVerifyRepositoryRequest, VerifyRepositoryResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Sql.cs
+++ b/src/Nest/ElasticClient.Sql.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.SqlApi;
 namespace Nest.Specification.SqlApi
 {
 	///<summary>
-	/// Logically groups all <c>Sql</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Sql"/> property
+	/// Sql APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Sql"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,73 +38,73 @@ namespace Nest.Specification.SqlApi
 
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.clear_cursor</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Clear SQL cursor">Clear SQL cursor</a>
 		/// </summary>
 		public ClearSqlCursorResponse ClearCursor(Func<ClearSqlCursorDescriptor, IClearSqlCursorRequest> selector) => ClearCursor(selector.InvokeOrDefault(new ClearSqlCursorDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.clear_cursor</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Clear SQL cursor">Clear SQL cursor</a>
 		/// </summary>
 		public Task<ClearSqlCursorResponse> ClearCursorAsync(Func<ClearSqlCursorDescriptor, IClearSqlCursorRequest> selector, CancellationToken ct = default) => ClearCursorAsync(selector.InvokeOrDefault(new ClearSqlCursorDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.clear_cursor</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Clear SQL cursor">Clear SQL cursor</a>
 		/// </summary>
 		public ClearSqlCursorResponse ClearCursor(IClearSqlCursorRequest request) => DoRequest<IClearSqlCursorRequest, ClearSqlCursorResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.clear_cursor</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Clear SQL cursor">Clear SQL cursor</a>
 		/// </summary>
 		public Task<ClearSqlCursorResponse> ClearCursorAsync(IClearSqlCursorRequest request, CancellationToken ct = default) => DoRequestAsync<IClearSqlCursorRequest, ClearSqlCursorResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Execute SQL">Execute SQL</a>
 		/// </summary>
 		public QuerySqlResponse Query(Func<QuerySqlDescriptor, IQuerySqlRequest> selector = null) => Query(selector.InvokeOrDefault(new QuerySqlDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Execute SQL">Execute SQL</a>
 		/// </summary>
 		public Task<QuerySqlResponse> QueryAsync(Func<QuerySqlDescriptor, IQuerySqlRequest> selector = null, CancellationToken ct = default) => QueryAsync(selector.InvokeOrDefault(new QuerySqlDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Execute SQL">Execute SQL</a>
 		/// </summary>
 		public QuerySqlResponse Query(IQuerySqlRequest request) => DoRequest<IQuerySqlRequest, QuerySqlResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Execute SQL">Execute SQL</a>
 		/// </summary>
 		public Task<QuerySqlResponse> QueryAsync(IQuerySqlRequest request, CancellationToken ct = default) => DoRequestAsync<IQuerySqlRequest, QuerySqlResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.translate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Translate SQL into Elasticsearch queries">Translate SQL into Elasticsearch queries</a>
 		/// </summary>
 		public TranslateSqlResponse Translate(Func<TranslateSqlDescriptor, ITranslateSqlRequest> selector = null) => Translate(selector.InvokeOrDefault(new TranslateSqlDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.translate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Translate SQL into Elasticsearch queries">Translate SQL into Elasticsearch queries</a>
 		/// </summary>
 		public Task<TranslateSqlResponse> TranslateAsync(Func<TranslateSqlDescriptor, ITranslateSqlRequest> selector = null, CancellationToken ct = default) => TranslateAsync(selector.InvokeOrDefault(new TranslateSqlDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.translate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Translate SQL into Elasticsearch queries">Translate SQL into Elasticsearch queries</a>
 		/// </summary>
 		public TranslateSqlResponse Translate(ITranslateSqlRequest request) => DoRequest<ITranslateSqlRequest, TranslateSqlResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>sql.translate</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Translate SQL into Elasticsearch queries">Translate SQL into Elasticsearch queries</a>
 		/// </summary>
 		public Task<TranslateSqlResponse> TranslateAsync(ITranslateSqlRequest request, CancellationToken ct = default) => DoRequestAsync<ITranslateSqlRequest, TranslateSqlResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Tasks.cs
+++ b/src/Nest/ElasticClient.Tasks.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.TasksApi;
 namespace Nest.Specification.TasksApi
 {
 	///<summary>
-	/// Logically groups all <c>Tasks</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Tasks"/> property
+	/// Tasks APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Tasks"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,73 +38,73 @@ namespace Nest.Specification.TasksApi
 
 		/// <summary>
 		/// <c>POST</c> request to the <c>tasks.cancel</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public CancelTasksResponse Cancel(Func<CancelTasksDescriptor, ICancelTasksRequest> selector = null) => Cancel(selector.InvokeOrDefault(new CancelTasksDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>tasks.cancel</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public Task<CancelTasksResponse> CancelAsync(Func<CancelTasksDescriptor, ICancelTasksRequest> selector = null, CancellationToken ct = default) => CancelAsync(selector.InvokeOrDefault(new CancelTasksDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>tasks.cancel</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public CancelTasksResponse Cancel(ICancelTasksRequest request) => DoRequest<ICancelTasksRequest, CancelTasksResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>tasks.cancel</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public Task<CancelTasksResponse> CancelAsync(ICancelTasksRequest request, CancellationToken ct = default) => DoRequestAsync<ICancelTasksRequest, CancelTasksResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>tasks.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public GetTaskResponse GetTask(TaskId taskId, Func<GetTaskDescriptor, IGetTaskRequest> selector = null) => GetTask(selector.InvokeOrDefault(new GetTaskDescriptor(taskId: taskId)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>tasks.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public Task<GetTaskResponse> GetTaskAsync(TaskId taskId, Func<GetTaskDescriptor, IGetTaskRequest> selector = null, CancellationToken ct = default) => GetTaskAsync(selector.InvokeOrDefault(new GetTaskDescriptor(taskId: taskId)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>tasks.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public GetTaskResponse GetTask(IGetTaskRequest request) => DoRequest<IGetTaskRequest, GetTaskResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>tasks.get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public Task<GetTaskResponse> GetTaskAsync(IGetTaskRequest request, CancellationToken ct = default) => DoRequestAsync<IGetTaskRequest, GetTaskResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>tasks.list</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public ListTasksResponse List(Func<ListTasksDescriptor, IListTasksRequest> selector = null) => List(selector.InvokeOrDefault(new ListTasksDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>tasks.list</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public Task<ListTasksResponse> ListAsync(Func<ListTasksDescriptor, IListTasksRequest> selector = null, CancellationToken ct = default) => ListAsync(selector.InvokeOrDefault(new ListTasksDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>tasks.list</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public ListTasksResponse List(IListTasksRequest request) => DoRequest<IListTasksRequest, ListTasksResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>tasks.list</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</a>
 		/// </summary>
 		public Task<ListTasksResponse> ListAsync(IListTasksRequest request, CancellationToken ct = default) => DoRequestAsync<IListTasksRequest, ListTasksResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.Watcher.cs
+++ b/src/Nest/ElasticClient.Watcher.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.WatcherApi;
 namespace Nest.Specification.WatcherApi
 {
 	///<summary>
-	/// Logically groups all <c>Watcher</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.Watcher"/> property
+	/// Watcher APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.Watcher"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,241 +38,241 @@ namespace Nest.Specification.WatcherApi
 
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.ack_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</a>
 		/// </summary>
 		public AcknowledgeWatchResponse Acknowledge(Id watchId, Func<AcknowledgeWatchDescriptor, IAcknowledgeWatchRequest> selector = null) => Acknowledge(selector.InvokeOrDefault(new AcknowledgeWatchDescriptor(watchId: watchId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.ack_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</a>
 		/// </summary>
 		public Task<AcknowledgeWatchResponse> AcknowledgeAsync(Id watchId, Func<AcknowledgeWatchDescriptor, IAcknowledgeWatchRequest> selector = null, CancellationToken ct = default) => AcknowledgeAsync(selector.InvokeOrDefault(new AcknowledgeWatchDescriptor(watchId: watchId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.ack_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</a>
 		/// </summary>
 		public AcknowledgeWatchResponse Acknowledge(IAcknowledgeWatchRequest request) => DoRequest<IAcknowledgeWatchRequest, AcknowledgeWatchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.ack_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</a>
 		/// </summary>
 		public Task<AcknowledgeWatchResponse> AcknowledgeAsync(IAcknowledgeWatchRequest request, CancellationToken ct = default) => DoRequestAsync<IAcknowledgeWatchRequest, AcknowledgeWatchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.activate_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</a>
 		/// </summary>
 		public ActivateWatchResponse Activate(Id watchId, Func<ActivateWatchDescriptor, IActivateWatchRequest> selector = null) => Activate(selector.InvokeOrDefault(new ActivateWatchDescriptor(watchId: watchId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.activate_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</a>
 		/// </summary>
 		public Task<ActivateWatchResponse> ActivateAsync(Id watchId, Func<ActivateWatchDescriptor, IActivateWatchRequest> selector = null, CancellationToken ct = default) => ActivateAsync(selector.InvokeOrDefault(new ActivateWatchDescriptor(watchId: watchId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.activate_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</a>
 		/// </summary>
 		public ActivateWatchResponse Activate(IActivateWatchRequest request) => DoRequest<IActivateWatchRequest, ActivateWatchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.activate_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</a>
 		/// </summary>
 		public Task<ActivateWatchResponse> ActivateAsync(IActivateWatchRequest request, CancellationToken ct = default) => DoRequestAsync<IActivateWatchRequest, ActivateWatchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.deactivate_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</a>
 		/// </summary>
 		public DeactivateWatchResponse Deactivate(Id watchId, Func<DeactivateWatchDescriptor, IDeactivateWatchRequest> selector = null) => Deactivate(selector.InvokeOrDefault(new DeactivateWatchDescriptor(watchId: watchId)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.deactivate_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</a>
 		/// </summary>
 		public Task<DeactivateWatchResponse> DeactivateAsync(Id watchId, Func<DeactivateWatchDescriptor, IDeactivateWatchRequest> selector = null, CancellationToken ct = default) => DeactivateAsync(selector.InvokeOrDefault(new DeactivateWatchDescriptor(watchId: watchId)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.deactivate_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</a>
 		/// </summary>
 		public DeactivateWatchResponse Deactivate(IDeactivateWatchRequest request) => DoRequest<IDeactivateWatchRequest, DeactivateWatchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.deactivate_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</a>
 		/// </summary>
 		public Task<DeactivateWatchResponse> DeactivateAsync(IDeactivateWatchRequest request, CancellationToken ct = default) => DoRequestAsync<IDeactivateWatchRequest, DeactivateWatchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>watcher.delete_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</a>
 		/// </summary>
 		public DeleteWatchResponse Delete(Id id, Func<DeleteWatchDescriptor, IDeleteWatchRequest> selector = null) => Delete(selector.InvokeOrDefault(new DeleteWatchDescriptor(id: id)));
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>watcher.delete_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</a>
 		/// </summary>
 		public Task<DeleteWatchResponse> DeleteAsync(Id id, Func<DeleteWatchDescriptor, IDeleteWatchRequest> selector = null, CancellationToken ct = default) => DeleteAsync(selector.InvokeOrDefault(new DeleteWatchDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>watcher.delete_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</a>
 		/// </summary>
 		public DeleteWatchResponse Delete(IDeleteWatchRequest request) => DoRequest<IDeleteWatchRequest, DeleteWatchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>watcher.delete_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</a>
 		/// </summary>
 		public Task<DeleteWatchResponse> DeleteAsync(IDeleteWatchRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteWatchRequest, DeleteWatchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.execute_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</a>
 		/// </summary>
 		public ExecuteWatchResponse Execute(Func<ExecuteWatchDescriptor, IExecuteWatchRequest> selector = null) => Execute(selector.InvokeOrDefault(new ExecuteWatchDescriptor()));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.execute_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</a>
 		/// </summary>
 		public Task<ExecuteWatchResponse> ExecuteAsync(Func<ExecuteWatchDescriptor, IExecuteWatchRequest> selector = null, CancellationToken ct = default) => ExecuteAsync(selector.InvokeOrDefault(new ExecuteWatchDescriptor()), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.execute_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</a>
 		/// </summary>
 		public ExecuteWatchResponse Execute(IExecuteWatchRequest request) => DoRequest<IExecuteWatchRequest, ExecuteWatchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.execute_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</a>
 		/// </summary>
 		public Task<ExecuteWatchResponse> ExecuteAsync(IExecuteWatchRequest request, CancellationToken ct = default) => DoRequestAsync<IExecuteWatchRequest, ExecuteWatchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>watcher.get_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</a>
 		/// </summary>
 		public GetWatchResponse Get(Id id, Func<GetWatchDescriptor, IGetWatchRequest> selector = null) => Get(selector.InvokeOrDefault(new GetWatchDescriptor(id: id)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>watcher.get_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</a>
 		/// </summary>
 		public Task<GetWatchResponse> GetAsync(Id id, Func<GetWatchDescriptor, IGetWatchRequest> selector = null, CancellationToken ct = default) => GetAsync(selector.InvokeOrDefault(new GetWatchDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>watcher.get_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</a>
 		/// </summary>
 		public GetWatchResponse Get(IGetWatchRequest request) => DoRequest<IGetWatchRequest, GetWatchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>watcher.get_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</a>
 		/// </summary>
 		public Task<GetWatchResponse> GetAsync(IGetWatchRequest request, CancellationToken ct = default) => DoRequestAsync<IGetWatchRequest, GetWatchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.put_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</a>
 		/// </summary>
 		public PutWatchResponse Put(Id id, Func<PutWatchDescriptor, IPutWatchRequest> selector = null) => Put(selector.InvokeOrDefault(new PutWatchDescriptor(id: id)));
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.put_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</a>
 		/// </summary>
 		public Task<PutWatchResponse> PutAsync(Id id, Func<PutWatchDescriptor, IPutWatchRequest> selector = null, CancellationToken ct = default) => PutAsync(selector.InvokeOrDefault(new PutWatchDescriptor(id: id)), ct);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.put_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</a>
 		/// </summary>
 		public PutWatchResponse Put(IPutWatchRequest request) => DoRequest<IPutWatchRequest, PutWatchResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>watcher.put_watch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</a>
 		/// </summary>
 		public Task<PutWatchResponse> PutAsync(IPutWatchRequest request, CancellationToken ct = default) => DoRequestAsync<IPutWatchRequest, PutWatchResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>watcher.start</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</a>
 		/// </summary>
 		public StartWatcherResponse Start(Func<StartWatcherDescriptor, IStartWatcherRequest> selector = null) => Start(selector.InvokeOrDefault(new StartWatcherDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>watcher.start</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</a>
 		/// </summary>
 		public Task<StartWatcherResponse> StartAsync(Func<StartWatcherDescriptor, IStartWatcherRequest> selector = null, CancellationToken ct = default) => StartAsync(selector.InvokeOrDefault(new StartWatcherDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>watcher.start</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</a>
 		/// </summary>
 		public StartWatcherResponse Start(IStartWatcherRequest request) => DoRequest<IStartWatcherRequest, StartWatcherResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>watcher.start</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</a>
 		/// </summary>
 		public Task<StartWatcherResponse> StartAsync(IStartWatcherRequest request, CancellationToken ct = default) => DoRequestAsync<IStartWatcherRequest, StartWatcherResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>watcher.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</a>
 		/// </summary>
 		public WatcherStatsResponse Stats(Func<WatcherStatsDescriptor, IWatcherStatsRequest> selector = null) => Stats(selector.InvokeOrDefault(new WatcherStatsDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>watcher.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</a>
 		/// </summary>
 		public Task<WatcherStatsResponse> StatsAsync(Func<WatcherStatsDescriptor, IWatcherStatsRequest> selector = null, CancellationToken ct = default) => StatsAsync(selector.InvokeOrDefault(new WatcherStatsDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>watcher.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</a>
 		/// </summary>
 		public WatcherStatsResponse Stats(IWatcherStatsRequest request) => DoRequest<IWatcherStatsRequest, WatcherStatsResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>watcher.stats</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</a>
 		/// </summary>
 		public Task<WatcherStatsResponse> StatsAsync(IWatcherStatsRequest request, CancellationToken ct = default) => DoRequestAsync<IWatcherStatsRequest, WatcherStatsResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>watcher.stop</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</a>
 		/// </summary>
 		public StopWatcherResponse Stop(Func<StopWatcherDescriptor, IStopWatcherRequest> selector = null) => Stop(selector.InvokeOrDefault(new StopWatcherDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>watcher.stop</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</a>
 		/// </summary>
 		public Task<StopWatcherResponse> StopAsync(Func<StopWatcherDescriptor, IStopWatcherRequest> selector = null, CancellationToken ct = default) => StopAsync(selector.InvokeOrDefault(new StopWatcherDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>watcher.stop</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</a>
 		/// </summary>
 		public StopWatcherResponse Stop(IStopWatcherRequest request) => DoRequest<IStopWatcherRequest, StopWatcherResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>POST</c> request to the <c>watcher.stop</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</a>
 		/// </summary>
 		public Task<StopWatcherResponse> StopAsync(IStopWatcherRequest request, CancellationToken ct = default) => DoRequestAsync<IStopWatcherRequest, StopWatcherResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/ElasticClient.XPack.cs
+++ b/src/Nest/ElasticClient.XPack.cs
@@ -25,7 +25,7 @@ using Elasticsearch.Net.Specification.XPackApi;
 namespace Nest.Specification.XPackApi
 {
 	///<summary>
-	/// X Pack APIs.
+	/// XPack APIs.
 	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.XPack"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>

--- a/src/Nest/ElasticClient.XPack.cs
+++ b/src/Nest/ElasticClient.XPack.cs
@@ -25,8 +25,8 @@ using Elasticsearch.Net.Specification.XPackApi;
 namespace Nest.Specification.XPackApi
 {
 	///<summary>
-	/// Logically groups all <c>XPack</c> API's together so that they may be discovered more naturally.
-	/// <para>Not intended to be instantiated directly please defer to the <see cref = "IElasticClient.XPack"/> property
+	/// X Pack APIs.
+	/// <para>Not intended to be instantiated directly. Use the <see cref = "IElasticClient.XPack"/> property
 	/// on <see cref = "IElasticClient"/>.
 	///</para>
 	///</summary>
@@ -38,49 +38,49 @@ namespace Nest.Specification.XPackApi
 
 		/// <summary>
 		/// <c>GET</c> request to the <c>xpack.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</a>
 		/// </summary>
 		public XPackInfoResponse Info(Func<XPackInfoDescriptor, IXPackInfoRequest> selector = null) => Info(selector.InvokeOrDefault(new XPackInfoDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>xpack.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</a>
 		/// </summary>
 		public Task<XPackInfoResponse> InfoAsync(Func<XPackInfoDescriptor, IXPackInfoRequest> selector = null, CancellationToken ct = default) => InfoAsync(selector.InvokeOrDefault(new XPackInfoDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>xpack.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</a>
 		/// </summary>
 		public XPackInfoResponse Info(IXPackInfoRequest request) => DoRequest<IXPackInfoRequest, XPackInfoResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>xpack.info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</a>
 		/// </summary>
 		public Task<XPackInfoResponse> InfoAsync(IXPackInfoRequest request, CancellationToken ct = default) => DoRequestAsync<IXPackInfoRequest, XPackInfoResponse>(request, request.RequestParameters, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>xpack.usage</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Retrieve information about xpack features usage">Retrieve information about xpack features usage</a>
 		/// </summary>
 		public XPackUsageResponse Usage(Func<XPackUsageDescriptor, IXPackUsageRequest> selector = null) => Usage(selector.InvokeOrDefault(new XPackUsageDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>xpack.usage</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Retrieve information about xpack features usage">Retrieve information about xpack features usage</a>
 		/// </summary>
 		public Task<XPackUsageResponse> UsageAsync(Func<XPackUsageDescriptor, IXPackUsageRequest> selector = null, CancellationToken ct = default) => UsageAsync(selector.InvokeOrDefault(new XPackUsageDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>xpack.usage</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Retrieve information about xpack features usage">Retrieve information about xpack features usage</a>
 		/// </summary>
 		public XPackUsageResponse Usage(IXPackUsageRequest request) => DoRequest<IXPackUsageRequest, XPackUsageResponse>(request, request.RequestParameters);
 		/// <summary>
 		/// <c>GET</c> request to the <c>xpack.usage</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "Retrieve information about xpack features usage">Retrieve information about xpack features usage</a>
 		/// </summary>
 		public Task<XPackUsageResponse> UsageAsync(IXPackUsageRequest request, CancellationToken ct = default) => DoRequestAsync<IXPackUsageRequest, XPackUsageResponse>(request, request.RequestParameters, ct);

--- a/src/Nest/IElasticClient.Generated.cs
+++ b/src/Nest/IElasticClient.Generated.cs
@@ -43,71 +43,71 @@ using Nest.Specification.XPackApi;
 namespace Nest
 {
 	///<summary>
-	///Raw operations with elasticsearch
+	///Elasticsearch high level client 
 	///</summary>
 	public partial interface IElasticClient
 	{
-		///<summary> This property logically groups all <c>Cat</c> API's together.</summary>
+		///<summary>Cat APIs</summary>
 		CatNamespace Cat
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Cluster</c> API's together.</summary>
+		///<summary>Cluster APIs</summary>
 		ClusterNamespace Cluster
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>CrossClusterReplication</c> API's together.</summary>
+		///<summary>Cross Cluster Replication APIs</summary>
 		CrossClusterReplicationNamespace CrossClusterReplication
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Graph</c> API's together.</summary>
+		///<summary>Graph APIs</summary>
 		GraphNamespace Graph
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>IndexLifecycleManagement</c> API's together.</summary>
+		///<summary>Index Lifecycle Management APIs</summary>
 		IndexLifecycleManagementNamespace IndexLifecycleManagement
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Indices</c> API's together.</summary>
+		///<summary>Indices APIs</summary>
 		IndicesNamespace Indices
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Ingest</c> API's together.</summary>
+		///<summary>Ingest APIs</summary>
 		IngestNamespace Ingest
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>License</c> API's together.</summary>
+		///<summary>License APIs</summary>
 		LicenseNamespace License
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>MachineLearning</c> API's together.</summary>
+		///<summary>Machine Learning APIs</summary>
 		MachineLearningNamespace MachineLearning
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Migration</c> API's together.</summary>
+		///<summary>Migration APIs</summary>
 		MigrationNamespace Migration
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Nodes</c> API's together.</summary>
+		///<summary>Nodes APIs</summary>
 		NodesNamespace Nodes
 		{
 			get;
@@ -115,977 +115,977 @@ namespace Nest
 
 		/// <summary>
 		/// <c>POST</c> request to the <c>bulk</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</a>
 		/// </summary>
 		BulkResponse Bulk(Func<BulkDescriptor, IBulkRequest> selector);
 		/// <summary>
 		/// <c>POST</c> request to the <c>bulk</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</a>
 		/// </summary>
 		Task<BulkResponse> BulkAsync(Func<BulkDescriptor, IBulkRequest> selector, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>bulk</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</a>
 		/// </summary>
 		BulkResponse Bulk(IBulkRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>bulk</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</a>
 		/// </summary>
 		Task<BulkResponse> BulkAsync(IBulkRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>clear_scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		ClearScrollResponse ClearScroll(Func<ClearScrollDescriptor, IClearScrollRequest> selector = null);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>clear_scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		Task<ClearScrollResponse> ClearScrollAsync(Func<ClearScrollDescriptor, IClearScrollRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>clear_scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		ClearScrollResponse ClearScroll(IClearScrollRequest request);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>clear_scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		Task<ClearScrollResponse> ClearScrollAsync(IClearScrollRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</a>
 		/// </summary>
 		CountResponse Count<TDocument>(Func<CountDescriptor<TDocument>, ICountRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</a>
 		/// </summary>
 		Task<CountResponse> CountAsync<TDocument>(Func<CountDescriptor<TDocument>, ICountRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</a>
 		/// </summary>
 		CountResponse Count(ICountRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>count</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</a>
 		/// </summary>
 		Task<CountResponse> CountAsync(ICountRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		CreateResponse Create<TDocument>(TDocument document, Func<CreateDescriptor<TDocument>, ICreateRequest<TDocument>> selector)
 			where TDocument : class;
 		/// <summary>
 		/// <c>PUT</c> request to the <c>create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		Task<CreateResponse> CreateAsync<TDocument>(TDocument document, Func<CreateDescriptor<TDocument>, ICreateRequest<TDocument>> selector, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>PUT</c> request to the <c>create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		CreateResponse Create<TDocument>(ICreateRequest<TDocument> request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>PUT</c> request to the <c>create</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		Task<CreateResponse> CreateAsync<TDocument>(ICreateRequest<TDocument> request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</a>
 		/// </summary>
 		DeleteResponse Delete<TDocument>(DocumentPath<TDocument> id, Func<DeleteDescriptor<TDocument>, IDeleteRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</a>
 		/// </summary>
 		Task<DeleteResponse> DeleteAsync<TDocument>(DocumentPath<TDocument> id, Func<DeleteDescriptor<TDocument>, IDeleteRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</a>
 		/// </summary>
 		DeleteResponse Delete(IDeleteRequest request);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</a>
 		/// </summary>
 		Task<DeleteResponse> DeleteAsync(IDeleteRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</a>
 		/// </summary>
 		DeleteByQueryResponse DeleteByQuery<TDocument>(Func<DeleteByQueryDescriptor<TDocument>, IDeleteByQueryRequest> selector)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</a>
 		/// </summary>
 		Task<DeleteByQueryResponse> DeleteByQueryAsync<TDocument>(Func<DeleteByQueryDescriptor<TDocument>, IDeleteByQueryRequest> selector, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</a>
 		/// </summary>
 		DeleteByQueryResponse DeleteByQuery(IDeleteByQueryRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</a>
 		/// </summary>
 		Task<DeleteByQueryResponse> DeleteByQueryAsync(IDeleteByQueryRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
 		/// </summary>
 		ListTasksResponse DeleteByQueryRethrottle(TaskId taskId, Func<DeleteByQueryRethrottleDescriptor, IDeleteByQueryRethrottleRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
 		/// </summary>
 		Task<ListTasksResponse> DeleteByQueryRethrottleAsync(TaskId taskId, Func<DeleteByQueryRethrottleDescriptor, IDeleteByQueryRethrottleRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
 		/// </summary>
 		ListTasksResponse DeleteByQueryRethrottle(IDeleteByQueryRethrottleRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>delete_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</a>
 		/// </summary>
 		Task<ListTasksResponse> DeleteByQueryRethrottleAsync(IDeleteByQueryRethrottleRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		DeleteScriptResponse DeleteScript(Id id, Func<DeleteScriptDescriptor, IDeleteScriptRequest> selector = null);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		Task<DeleteScriptResponse> DeleteScriptAsync(Id id, Func<DeleteScriptDescriptor, IDeleteScriptRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		DeleteScriptResponse DeleteScript(IDeleteScriptRequest request);
 		/// <summary>
 		/// <c>DELETE</c> request to the <c>delete_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		Task<DeleteScriptResponse> DeleteScriptAsync(IDeleteScriptRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		ExistsResponse DocumentExists<TDocument>(DocumentPath<TDocument> id, Func<DocumentExistsDescriptor<TDocument>, IDocumentExistsRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		Task<ExistsResponse> DocumentExistsAsync<TDocument>(DocumentPath<TDocument> id, Func<DocumentExistsDescriptor<TDocument>, IDocumentExistsRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		ExistsResponse DocumentExists(IDocumentExistsRequest request);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		Task<ExistsResponse> DocumentExistsAsync(IDocumentExistsRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		ExistsResponse SourceExists<TDocument>(DocumentPath<TDocument> id, Func<SourceExistsDescriptor<TDocument>, ISourceExistsRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		Task<ExistsResponse> SourceExistsAsync<TDocument>(DocumentPath<TDocument> id, Func<SourceExistsDescriptor<TDocument>, ISourceExistsRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		ExistsResponse SourceExists(ISourceExistsRequest request);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>exists_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		Task<ExistsResponse> SourceExistsAsync(ISourceExistsRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</a>
 		/// </summary>
 		ExplainResponse<TDocument> Explain<TDocument>(DocumentPath<TDocument> id, Func<ExplainDescriptor<TDocument>, IExplainRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</a>
 		/// </summary>
 		Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(DocumentPath<TDocument> id, Func<ExplainDescriptor<TDocument>, IExplainRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</a>
 		/// </summary>
 		ExplainResponse<TDocument> Explain<TDocument>(IExplainRequest request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>explain</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</a>
 		/// </summary>
 		Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(IExplainRequest request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>field_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</a>
 		/// </summary>
 		FieldCapabilitiesResponse FieldCapabilities(Indices index = null, Func<FieldCapabilitiesDescriptor, IFieldCapabilitiesRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>field_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</a>
 		/// </summary>
 		Task<FieldCapabilitiesResponse> FieldCapabilitiesAsync(Indices index = null, Func<FieldCapabilitiesDescriptor, IFieldCapabilitiesRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>field_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</a>
 		/// </summary>
 		FieldCapabilitiesResponse FieldCapabilities(IFieldCapabilitiesRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>field_caps</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</a>
 		/// </summary>
 		Task<FieldCapabilitiesResponse> FieldCapabilitiesAsync(IFieldCapabilitiesRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		GetResponse<TDocument> Get<TDocument>(DocumentPath<TDocument> id, Func<GetDescriptor<TDocument>, IGetRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>GET</c> request to the <c>get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		Task<GetResponse<TDocument>> GetAsync<TDocument>(DocumentPath<TDocument> id, Func<GetDescriptor<TDocument>, IGetRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>GET</c> request to the <c>get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		GetResponse<TDocument> Get<TDocument>(IGetRequest request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>GET</c> request to the <c>get</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		Task<GetResponse<TDocument>> GetAsync<TDocument>(IGetRequest request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		GetScriptResponse GetScript(Id id, Func<GetScriptDescriptor, IGetScriptRequest> selector = null);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		Task<GetScriptResponse> GetScriptAsync(Id id, Func<GetScriptDescriptor, IGetScriptRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		GetScriptResponse GetScript(IGetScriptRequest request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		Task<GetScriptResponse> GetScriptAsync(IGetScriptRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		SourceResponse<TDocument> Source<TDocument>(DocumentPath<TDocument> id, Func<SourceDescriptor<TDocument>, ISourceRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		Task<SourceResponse<TDocument>> SourceAsync<TDocument>(DocumentPath<TDocument> id, Func<SourceDescriptor<TDocument>, ISourceRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		SourceResponse<TDocument> Source<TDocument>(ISourceRequest request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>GET</c> request to the <c>get_source</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</a>
 		/// </summary>
 		Task<SourceResponse<TDocument>> SourceAsync<TDocument>(ISourceRequest request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>index</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		IndexResponse Index<TDocument>(TDocument document, Func<IndexDescriptor<TDocument>, IIndexRequest<TDocument>> selector)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>index</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		Task<IndexResponse> IndexAsync<TDocument>(TDocument document, Func<IndexDescriptor<TDocument>, IIndexRequest<TDocument>> selector, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>index</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		IndexResponse Index<TDocument>(IIndexRequest<TDocument> request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>index</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</a>
 		/// </summary>
 		Task<IndexResponse> IndexAsync<TDocument>(IIndexRequest<TDocument> request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>GET</c> request to the <c>info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		RootNodeInfoResponse RootNodeInfo(Func<RootNodeInfoDescriptor, IRootNodeInfoRequest> selector = null);
 		/// <summary>
 		/// <c>GET</c> request to the <c>info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		Task<RootNodeInfoResponse> RootNodeInfoAsync(Func<RootNodeInfoDescriptor, IRootNodeInfoRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>GET</c> request to the <c>info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		RootNodeInfoResponse RootNodeInfo(IRootNodeInfoRequest request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>info</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		Task<RootNodeInfoResponse> RootNodeInfoAsync(IRootNodeInfoRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mget</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</a>
 		/// </summary>
 		MultiGetResponse MultiGet(Func<MultiGetDescriptor, IMultiGetRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mget</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</a>
 		/// </summary>
 		Task<MultiGetResponse> MultiGetAsync(Func<MultiGetDescriptor, IMultiGetRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mget</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</a>
 		/// </summary>
 		MultiGetResponse MultiGet(IMultiGetRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mget</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</a>
 		/// </summary>
 		Task<MultiGetResponse> MultiGetAsync(IMultiGetRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</a>
 		/// </summary>
 		MultiSearchResponse MultiSearch(Indices index = null, Func<MultiSearchDescriptor, IMultiSearchRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</a>
 		/// </summary>
 		Task<MultiSearchResponse> MultiSearchAsync(Indices index = null, Func<MultiSearchDescriptor, IMultiSearchRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</a>
 		/// </summary>
 		MultiSearchResponse MultiSearch(IMultiSearchRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</a>
 		/// </summary>
 		Task<MultiSearchResponse> MultiSearchAsync(IMultiSearchRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</a>
 		/// </summary>
 		MultiSearchResponse MultiSearchTemplate(Indices index = null, Func<MultiSearchTemplateDescriptor, IMultiSearchTemplateRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</a>
 		/// </summary>
 		Task<MultiSearchResponse> MultiSearchTemplateAsync(Indices index = null, Func<MultiSearchTemplateDescriptor, IMultiSearchTemplateRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</a>
 		/// </summary>
 		MultiSearchResponse MultiSearchTemplate(IMultiSearchTemplateRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>msearch_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</a>
 		/// </summary>
 		Task<MultiSearchResponse> MultiSearchTemplateAsync(IMultiSearchTemplateRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mtermvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</a>
 		/// </summary>
 		MultiTermVectorsResponse MultiTermVectors(Func<MultiTermVectorsDescriptor, IMultiTermVectorsRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mtermvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</a>
 		/// </summary>
 		Task<MultiTermVectorsResponse> MultiTermVectorsAsync(Func<MultiTermVectorsDescriptor, IMultiTermVectorsRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mtermvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</a>
 		/// </summary>
 		MultiTermVectorsResponse MultiTermVectors(IMultiTermVectorsRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>mtermvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</a>
 		/// </summary>
 		Task<MultiTermVectorsResponse> MultiTermVectorsAsync(IMultiTermVectorsRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>ping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		PingResponse Ping(Func<PingDescriptor, IPingRequest> selector = null);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>ping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		Task<PingResponse> PingAsync(Func<PingDescriptor, IPingRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>ping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		PingResponse Ping(IPingRequest request);
 		/// <summary>
 		/// <c>HEAD</c> request to the <c>ping</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/">http://www.elastic.co/guide/</a>
 		/// </summary>
 		Task<PingResponse> PingAsync(IPingRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>put_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		PutScriptResponse PutScript(Id id, Func<PutScriptDescriptor, IPutScriptRequest> selector);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>put_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		Task<PutScriptResponse> PutScriptAsync(Id id, Func<PutScriptDescriptor, IPutScriptRequest> selector, CancellationToken ct = default);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>put_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		PutScriptResponse PutScript(IPutScriptRequest request);
 		/// <summary>
 		/// <c>PUT</c> request to the <c>put_script</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</a>
 		/// </summary>
 		Task<PutScriptResponse> PutScriptAsync(IPutScriptRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		ReindexOnServerResponse ReindexOnServer(Func<ReindexOnServerDescriptor, IReindexOnServerRequest> selector);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		Task<ReindexOnServerResponse> ReindexOnServerAsync(Func<ReindexOnServerDescriptor, IReindexOnServerRequest> selector, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		ReindexOnServerResponse ReindexOnServer(IReindexOnServerRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		Task<ReindexOnServerResponse> ReindexOnServerAsync(IReindexOnServerRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		ReindexRethrottleResponse ReindexRethrottle(TaskId taskId, Func<ReindexRethrottleDescriptor, IReindexRethrottleRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		Task<ReindexRethrottleResponse> ReindexRethrottleAsync(TaskId taskId, Func<ReindexRethrottleDescriptor, IReindexRethrottleRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		ReindexRethrottleResponse ReindexRethrottle(IReindexRethrottleRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>reindex_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</a>
 		/// </summary>
 		Task<ReindexRethrottleResponse> ReindexRethrottleAsync(IReindexRethrottleRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>render_search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</a>
 		/// </summary>
 		RenderSearchTemplateResponse RenderSearchTemplate(Func<RenderSearchTemplateDescriptor, IRenderSearchTemplateRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>render_search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</a>
 		/// </summary>
 		Task<RenderSearchTemplateResponse> RenderSearchTemplateAsync(Func<RenderSearchTemplateDescriptor, IRenderSearchTemplateRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>render_search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</a>
 		/// </summary>
 		RenderSearchTemplateResponse RenderSearchTemplate(IRenderSearchTemplateRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>render_search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</a>
 		/// </summary>
 		Task<RenderSearchTemplateResponse> RenderSearchTemplateAsync(IRenderSearchTemplateRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scripts_painless_execute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</a>
 		/// </summary>
 		ExecutePainlessScriptResponse<TResult> ExecutePainlessScript<TResult>(Func<ExecutePainlessScriptDescriptor, IExecutePainlessScriptRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scripts_painless_execute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</a>
 		/// </summary>
 		Task<ExecutePainlessScriptResponse<TResult>> ExecutePainlessScriptAsync<TResult>(Func<ExecutePainlessScriptDescriptor, IExecutePainlessScriptRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scripts_painless_execute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</a>
 		/// </summary>
 		ExecutePainlessScriptResponse<TResult> ExecutePainlessScript<TResult>(IExecutePainlessScriptRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scripts_painless_execute</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</a>
 		/// </summary>
 		Task<ExecutePainlessScriptResponse<TResult>> ExecutePainlessScriptAsync<TResult>(IExecutePainlessScriptRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		SearchResponse<TDocument> Scroll<TInferDocument, TDocument>(Time scroll, string scrollId, Func<ScrollDescriptor<TInferDocument>, IScrollRequest> selector = null)
 			where TInferDocument : class where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		Task<SearchResponse<TDocument>> ScrollAsync<TInferDocument, TDocument>(Time scroll, string scrollId, Func<ScrollDescriptor<TInferDocument>, IScrollRequest> selector = null, CancellationToken ct = default)
 			where TInferDocument : class where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		SearchResponse<TDocument> Scroll<TDocument>(Time scroll, string scrollId, Func<ScrollDescriptor<TDocument>, IScrollRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		Task<SearchResponse<TDocument>> ScrollAsync<TDocument>(Time scroll, string scrollId, Func<ScrollDescriptor<TDocument>, IScrollRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		SearchResponse<TDocument> Scroll<TDocument>(IScrollRequest request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>scroll</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</a>
 		/// </summary>
 		Task<SearchResponse<TDocument>> ScrollAsync<TDocument>(IScrollRequest request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		SearchResponse<TDocument> Search<TInferDocument, TDocument>(Func<SearchDescriptor<TInferDocument>, ISearchRequest> selector = null)
 			where TInferDocument : class where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		Task<SearchResponse<TDocument>> SearchAsync<TInferDocument, TDocument>(Func<SearchDescriptor<TInferDocument>, ISearchRequest> selector = null, CancellationToken ct = default)
 			where TInferDocument : class where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		SearchResponse<TDocument> Search<TDocument>(Func<SearchDescriptor<TDocument>, ISearchRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		Task<SearchResponse<TDocument>> SearchAsync<TDocument>(Func<SearchDescriptor<TDocument>, ISearchRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		SearchResponse<TDocument> Search<TDocument>(ISearchRequest request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</a>
 		/// </summary>
 		Task<SearchResponse<TDocument>> SearchAsync<TDocument>(ISearchRequest request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</a>
 		/// </summary>
 		SearchShardsResponse SearchShards<TDocument>(Func<SearchShardsDescriptor<TDocument>, ISearchShardsRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</a>
 		/// </summary>
 		Task<SearchShardsResponse> SearchShardsAsync<TDocument>(Func<SearchShardsDescriptor<TDocument>, ISearchShardsRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</a>
 		/// </summary>
 		SearchShardsResponse SearchShards(ISearchShardsRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_shards</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</a>
 		/// </summary>
 		Task<SearchShardsResponse> SearchShardsAsync(ISearchShardsRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</a>
 		/// </summary>
 		SearchResponse<TDocument> SearchTemplate<TDocument>(Func<SearchTemplateDescriptor<TDocument>, ISearchTemplateRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</a>
 		/// </summary>
 		Task<SearchResponse<TDocument>> SearchTemplateAsync<TDocument>(Func<SearchTemplateDescriptor<TDocument>, ISearchTemplateRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</a>
 		/// </summary>
 		SearchResponse<TDocument> SearchTemplate<TDocument>(ISearchTemplateRequest request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>search_template</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</a>
 		/// </summary>
 		Task<SearchResponse<TDocument>> SearchTemplateAsync<TDocument>(ISearchTemplateRequest request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>termvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</a>
 		/// </summary>
 		TermVectorsResponse TermVectors<TDocument>(Func<TermVectorsDescriptor<TDocument>, ITermVectorsRequest<TDocument>> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>termvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</a>
 		/// </summary>
 		Task<TermVectorsResponse> TermVectorsAsync<TDocument>(Func<TermVectorsDescriptor<TDocument>, ITermVectorsRequest<TDocument>> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>termvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</a>
 		/// </summary>
 		TermVectorsResponse TermVectors<TDocument>(ITermVectorsRequest<TDocument> request)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>termvectors</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</a>
 		/// </summary>
 		Task<TermVectorsResponse> TermVectorsAsync<TDocument>(ITermVectorsRequest<TDocument> request, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(DocumentPath<TDocument> id, Func<UpdateDescriptor<TDocument, TPartialDocument>, IUpdateRequest<TDocument, TPartialDocument>> selector)
 			where TDocument : class where TPartialDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(DocumentPath<TDocument> id, Func<UpdateDescriptor<TDocument, TPartialDocument>, IUpdateRequest<TDocument, TPartialDocument>> selector, CancellationToken ct = default)
 			where TDocument : class where TPartialDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		UpdateResponse<TDocument> Update<TDocument>(DocumentPath<TDocument> id, Func<UpdateDescriptor<TDocument, TDocument>, IUpdateRequest<TDocument, TDocument>> selector)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		Task<UpdateResponse<TDocument>> UpdateAsync<TDocument>(DocumentPath<TDocument> id, Func<UpdateDescriptor<TDocument, TDocument>, IUpdateRequest<TDocument, TDocument>> selector, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(IUpdateRequest<TDocument, TPartialDocument> request)
 			where TDocument : class where TPartialDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</a>
 		/// </summary>
 		Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(IUpdateRequest<TDocument, TPartialDocument> request, CancellationToken ct = default)
 			where TDocument : class where TPartialDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</a>
 		/// </summary>
 		UpdateByQueryResponse UpdateByQuery<TDocument>(Func<UpdateByQueryDescriptor<TDocument>, IUpdateByQueryRequest> selector = null)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</a>
 		/// </summary>
 		Task<UpdateByQueryResponse> UpdateByQueryAsync<TDocument>(Func<UpdateByQueryDescriptor<TDocument>, IUpdateByQueryRequest> selector = null, CancellationToken ct = default)
 			where TDocument : class;
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</a>
 		/// </summary>
 		UpdateByQueryResponse UpdateByQuery(IUpdateByQueryRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</a>
 		/// </summary>
 		Task<UpdateByQueryResponse> UpdateByQueryAsync(IUpdateByQueryRequest request, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</a>
 		/// </summary>
 		ListTasksResponse UpdateByQueryRethrottle(TaskId taskId, Func<UpdateByQueryRethrottleDescriptor, IUpdateByQueryRethrottleRequest> selector = null);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</a>
 		/// </summary>
 		Task<ListTasksResponse> UpdateByQueryRethrottleAsync(TaskId taskId, Func<UpdateByQueryRethrottleDescriptor, IUpdateByQueryRethrottleRequest> selector = null, CancellationToken ct = default);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</a>
 		/// </summary>
 		ListTasksResponse UpdateByQueryRethrottle(IUpdateByQueryRethrottleRequest request);
 		/// <summary>
 		/// <c>POST</c> request to the <c>update_by_query_rethrottle</c> API, read more about this API online:
-		/// <para> </para>
+		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</a>
 		/// </summary>
 		Task<ListTasksResponse> UpdateByQueryRethrottleAsync(IUpdateByQueryRethrottleRequest request, CancellationToken ct = default);
-		///<summary> This property logically groups all <c>Rollup</c> API's together.</summary>
+		///<summary>Rollup APIs</summary>
 		RollupNamespace Rollup
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Security</c> API's together.</summary>
+		///<summary>Security APIs</summary>
 		SecurityNamespace Security
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Snapshot</c> API's together.</summary>
+		///<summary>Snapshot APIs</summary>
 		SnapshotNamespace Snapshot
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Sql</c> API's together.</summary>
+		///<summary>Sql APIs</summary>
 		SqlNamespace Sql
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Tasks</c> API's together.</summary>
+		///<summary>Tasks APIs</summary>
 		TasksNamespace Tasks
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>Watcher</c> API's together.</summary>
+		///<summary>Watcher APIs</summary>
 		WatcherNamespace Watcher
 		{
 			get;
 		}
 
-		///<summary> This property logically groups all <c>XPack</c> API's together.</summary>
+		///<summary>X Pack APIs</summary>
 		XPackNamespace XPack
 		{
 			get;

--- a/src/Nest/IElasticClient.Generated.cs
+++ b/src/Nest/IElasticClient.Generated.cs
@@ -1085,7 +1085,7 @@ namespace Nest
 			get;
 		}
 
-		///<summary>X Pack APIs</summary>
+		///<summary>XPack APIs</summary>
 		XPackNamespace XPack
 		{
 			get;

--- a/src/Nest/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
@@ -85,7 +85,7 @@ namespace Nest
 		ISimilarities Similarity { get; set; }
 
 		/// <summary>
-		/// Configure logging thresholds and levels in elasticsearch for search/fetch and indexing
+		/// Configure logging thresholds and levels in Elasticsearch for search/fetch and indexing
 		/// </summary>
 		ISlowLog SlowLog { get; set; }
 

--- a/src/Nest/Indices/AliasManagement/Alias/Actions/AliasAddOperation.cs
+++ b/src/Nest/Indices/AliasManagement/Alias/Actions/AliasAddOperation.cs
@@ -17,8 +17,8 @@ namespace Nest
 		public string IndexRouting { get; set; }
 
 		/// <summary>
-		/// If an alias points to multiple indices elasticsearch will reject the write operations
-		/// unless one is explicitly marked with as the write alias using this property.
+		/// If an alias points to multiple indices, Elasticsearch will reject the write operations
+		/// unless one is explicitly marked as the write alias using this property.
 		/// </summary>
 		[DataMember(Name ="is_write_index")]
 		public bool? IsWriteIndex { get; set; }

--- a/src/Nest/Indices/MappingManagement/PutMapping/ElasticClient-Map.cs
+++ b/src/Nest/Indices/MappingManagement/PutMapping/ElasticClient-Map.cs
@@ -11,7 +11,7 @@ namespace Nest
 		/// <para> </para>
 		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html
 		/// </summary>
-		/// <typeparam name="T">The type we want to map in elasticsearch</typeparam>
+		/// <typeparam name="T">The type we want to map in Elasticsearch</typeparam>
 		/// <param name="selector">A descriptor to describe the mapping of our type</param>
 		PutMappingResponse Map<T>(Func<PutMappingDescriptor<T>, IPutMappingRequest> selector)
 			where T : class;

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -54,7 +54,7 @@ namespace Nest
 
 		/// <summary>
 		/// object type, no need to set this manually if its not a value type this will be set.
-		/// Only set this if you need to force a value type to be mapped to an elasticsearch object type.
+		/// Only set this if you need to force a value type to be mapped to an Elasticsearch object type.
 		/// </summary>
 		[EnumMember(Value = "object")]
 		Object,

--- a/src/Nest/Requests.Cat.cs
+++ b/src/Nest/Requests.Cat.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Aliases <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</pre></summary>
+	///<summary>Request for Aliases <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html</para></summary>
 	public partial class CatAliasesRequest : PlainRequestBase<CatAliasesRequestParameters>, ICatAliasesRequest
 	{
 		protected ICatAliasesRequest Self => this;
@@ -121,7 +121,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Allocation <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</pre></summary>
+	///<summary>Request for Allocation <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html</para></summary>
 	public partial class CatAllocationRequest : PlainRequestBase<CatAllocationRequestParameters>, ICatAllocationRequest
 	{
 		protected ICatAllocationRequest Self => this;
@@ -208,7 +208,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Count <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</pre></summary>
+	///<summary>Request for Count <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html</para></summary>
 	public partial class CatCountRequest : PlainRequestBase<CatCountRequestParameters>, ICatCountRequest
 	{
 		protected ICatCountRequest Self => this;
@@ -288,7 +288,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Fielddata <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</pre></summary>
+	///<summary>Request for Fielddata <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html</para></summary>
 	public partial class CatFielddataRequest : PlainRequestBase<CatFielddataRequestParameters>, ICatFielddataRequest
 	{
 		protected ICatFielddataRequest Self => this;
@@ -370,7 +370,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Health <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</pre></summary>
+	///<summary>Request for Health <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html</para></summary>
 	public partial class CatHealthRequest : PlainRequestBase<CatHealthRequestParameters>, ICatHealthRequest
 	{
 		protected ICatHealthRequest Self => this;
@@ -439,7 +439,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Help <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</pre></summary>
+	///<summary>Request for Help <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html</para></summary>
 	public partial class CatHelpRequest : PlainRequestBase<CatHelpRequestParameters>, ICatHelpRequest
 	{
 		protected ICatHelpRequest Self => this;
@@ -471,7 +471,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Indices <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</pre></summary>
+	///<summary>Request for Indices <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html</para></summary>
 	public partial class CatIndicesRequest : PlainRequestBase<CatIndicesRequestParameters>, ICatIndicesRequest
 	{
 		protected ICatIndicesRequest Self => this;
@@ -567,7 +567,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Master <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</pre></summary>
+	///<summary>Request for Master <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html</para></summary>
 	public partial class CatMasterRequest : PlainRequestBase<CatMasterRequestParameters>, ICatMasterRequest
 	{
 		protected ICatMasterRequest Self => this;
@@ -629,7 +629,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for NodeAttributes <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</pre></summary>
+	///<summary>Request for NodeAttributes <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html</para></summary>
 	public partial class CatNodeAttributesRequest : PlainRequestBase<CatNodeAttributesRequestParameters>, ICatNodeAttributesRequest
 	{
 		protected ICatNodeAttributesRequest Self => this;
@@ -691,7 +691,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Nodes <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</pre></summary>
+	///<summary>Request for Nodes <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html</para></summary>
 	public partial class CatNodesRequest : PlainRequestBase<CatNodesRequestParameters>, ICatNodesRequest
 	{
 		protected ICatNodesRequest Self => this;
@@ -760,7 +760,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for PendingTasks <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</pre></summary>
+	///<summary>Request for PendingTasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html</para></summary>
 	public partial class CatPendingTasksRequest : PlainRequestBase<CatPendingTasksRequestParameters>, ICatPendingTasksRequest
 	{
 		protected ICatPendingTasksRequest Self => this;
@@ -822,7 +822,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Plugins <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</pre></summary>
+	///<summary>Request for Plugins <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html</para></summary>
 	public partial class CatPluginsRequest : PlainRequestBase<CatPluginsRequestParameters>, ICatPluginsRequest
 	{
 		protected ICatPluginsRequest Self => this;
@@ -889,7 +889,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Recovery <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</pre></summary>
+	///<summary>Request for Recovery <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html</para></summary>
 	public partial class CatRecoveryRequest : PlainRequestBase<CatRecoveryRequestParameters>, ICatRecoveryRequest
 	{
 		protected ICatRecoveryRequest Self => this;
@@ -964,7 +964,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Repositories <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</pre></summary>
+	///<summary>Request for Repositories <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html</para></summary>
 	public partial class CatRepositoriesRequest : PlainRequestBase<CatRepositoriesRequestParameters>, ICatRepositoriesRequest
 	{
 		protected ICatRepositoriesRequest Self => this;
@@ -1031,7 +1031,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Segments <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</pre></summary>
+	///<summary>Request for Segments <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html</para></summary>
 	public partial class CatSegmentsRequest : PlainRequestBase<CatSegmentsRequestParameters>, ICatSegmentsRequest
 	{
 		protected ICatSegmentsRequest Self => this;
@@ -1104,7 +1104,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Shards <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</pre></summary>
+	///<summary>Request for Shards <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html</para></summary>
 	public partial class CatShardsRequest : PlainRequestBase<CatShardsRequestParameters>, ICatShardsRequest
 	{
 		protected ICatShardsRequest Self => this;
@@ -1191,7 +1191,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Snapshots <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</pre></summary>
+	///<summary>Request for Snapshots <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html</para></summary>
 	public partial class CatSnapshotsRequest : PlainRequestBase<CatSnapshotsRequestParameters>, ICatSnapshotsRequest
 	{
 		protected ICatSnapshotsRequest Self => this;
@@ -1266,7 +1266,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Tasks <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>Request for Tasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public partial class CatTasksRequest : PlainRequestBase<CatTasksRequestParameters>, ICatTasksRequest
 	{
 		protected ICatTasksRequest Self => this;
@@ -1350,7 +1350,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Templates <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</pre></summary>
+	///<summary>Request for Templates <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html</para></summary>
 	public partial class CatTemplatesRequest : PlainRequestBase<CatTemplatesRequestParameters>, ICatTemplatesRequest
 	{
 		protected ICatTemplatesRequest Self => this;
@@ -1430,7 +1430,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ThreadPool <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</pre></summary>
+	///<summary>Request for ThreadPool <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html</para></summary>
 	public partial class CatThreadPoolRequest : PlainRequestBase<CatThreadPoolRequestParameters>, ICatThreadPoolRequest
 	{
 		protected ICatThreadPoolRequest Self => this;

--- a/src/Nest/Requests.Cluster.cs
+++ b/src/Nest/Requests.Cluster.cs
@@ -36,7 +36,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for AllocationExplain <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</pre></summary>
+	///<summary>Request for AllocationExplain <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html</para></summary>
 	public partial class ClusterAllocationExplainRequest : PlainRequestBase<ClusterAllocationExplainRequestParameters>, IClusterAllocationExplainRequest
 	{
 		protected IClusterAllocationExplainRequest Self => this;
@@ -63,7 +63,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GetSettings <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</pre></summary>
+	///<summary>Request for GetSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</para></summary>
 	public partial class ClusterGetSettingsRequest : PlainRequestBase<ClusterGetSettingsRequestParameters>, IClusterGetSettingsRequest
 	{
 		protected IClusterGetSettingsRequest Self => this;
@@ -109,7 +109,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Health <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</pre></summary>
+	///<summary>Request for Health <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html</para></summary>
 	public partial class ClusterHealthRequest : PlainRequestBase<ClusterHealthRequestParameters>, IClusterHealthRequest
 	{
 		protected IClusterHealthRequest Self => this;
@@ -205,7 +205,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for PendingTasks <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</pre></summary>
+	///<summary>Request for PendingTasks <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html</para></summary>
 	public partial class ClusterPendingTasksRequest : PlainRequestBase<ClusterPendingTasksRequestParameters>, IClusterPendingTasksRequest
 	{
 		protected IClusterPendingTasksRequest Self => this;
@@ -232,7 +232,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for PutSettings <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</pre></summary>
+	///<summary>Request for PutSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html</para></summary>
 	public partial class ClusterPutSettingsRequest : PlainRequestBase<ClusterPutSettingsRequestParameters>, IClusterPutSettingsRequest
 	{
 		protected IClusterPutSettingsRequest Self => this;
@@ -266,7 +266,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for RemoteInfo <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</pre></summary>
+	///<summary>Request for RemoteInfo <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html</para></summary>
 	public partial class RemoteInfoRequest : PlainRequestBase<RemoteInfoRequestParameters>, IRemoteInfoRequest
 	{
 		protected IRemoteInfoRequest Self => this;
@@ -280,7 +280,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Reroute <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</pre></summary>
+	///<summary>Request for Reroute <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html</para></summary>
 	public partial class ClusterRerouteRequest : PlainRequestBase<ClusterRerouteRequestParameters>, IClusterRerouteRequest
 	{
 		protected IClusterRerouteRequest Self => this;
@@ -346,7 +346,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for State <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</pre></summary>
+	///<summary>Request for State <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html</para></summary>
 	public partial class ClusterStateRequest : PlainRequestBase<ClusterStateRequestParameters>, IClusterStateRequest
 	{
 		protected IClusterStateRequest Self => this;
@@ -445,7 +445,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Stats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</pre></summary>
+	///<summary>Request for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html</para></summary>
 	public partial class ClusterStatsRequest : PlainRequestBase<ClusterStatsRequestParameters>, IClusterStatsRequest
 	{
 		protected IClusterStatsRequest Self => this;

--- a/src/Nest/Requests.CrossClusterReplication.cs
+++ b/src/Nest/Requests.CrossClusterReplication.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteAutoFollowPattern <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</pre></summary>
+	///<summary>Request for DeleteAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html</para></summary>
 	public partial class DeleteAutoFollowPatternRequest : PlainRequestBase<DeleteAutoFollowPatternRequestParameters>, IDeleteAutoFollowPatternRequest
 	{
 		protected IDeleteAutoFollowPatternRequest Self => this;
@@ -74,7 +74,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for CreateFollowIndex <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</pre></summary>
+	///<summary>Request for CreateFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html</para></summary>
 	public partial class CreateFollowIndexRequest : PlainRequestBase<CreateFollowIndexRequestParameters>, ICreateFollowIndexRequest
 	{
 		protected ICreateFollowIndexRequest Self => this;
@@ -116,7 +116,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for FollowIndexStats <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</pre></summary>
+	///<summary>Request for FollowIndexStats <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html</para></summary>
 	public partial class FollowIndexStatsRequest : PlainRequestBase<FollowIndexStatsRequestParameters>, IFollowIndexStatsRequest
 	{
 		protected IFollowIndexStatsRequest Self => this;
@@ -149,7 +149,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetAutoFollowPattern <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</pre></summary>
+	///<summary>Request for GetAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html</para></summary>
 	public partial class GetAutoFollowPatternRequest : PlainRequestBase<GetAutoFollowPatternRequestParameters>, IGetAutoFollowPatternRequest
 	{
 		protected IGetAutoFollowPatternRequest Self => this;
@@ -181,7 +181,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PauseFollowIndex <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</pre></summary>
+	///<summary>Request for PauseFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html</para></summary>
 	public partial class PauseFollowIndexRequest : PlainRequestBase<PauseFollowIndexRequestParameters>, IPauseFollowIndexRequest
 	{
 		protected IPauseFollowIndexRequest Self => this;
@@ -214,7 +214,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for CreateAutoFollowPattern <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</pre></summary>
+	///<summary>Request for CreateAutoFollowPattern <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html</para></summary>
 	public partial class CreateAutoFollowPatternRequest : PlainRequestBase<CreateAutoFollowPatternRequestParameters>, ICreateAutoFollowPatternRequest
 	{
 		protected ICreateAutoFollowPatternRequest Self => this;
@@ -247,7 +247,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ResumeFollowIndex <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</pre></summary>
+	///<summary>Request for ResumeFollowIndex <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html</para></summary>
 	public partial class ResumeFollowIndexRequest : PlainRequestBase<ResumeFollowIndexRequestParameters>, IResumeFollowIndexRequest
 	{
 		protected IResumeFollowIndexRequest Self => this;
@@ -275,7 +275,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Stats <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</pre></summary>
+	///<summary>Request for Stats <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html</para></summary>
 	public partial class CcrStatsRequest : PlainRequestBase<CcrStatsRequestParameters>, ICcrStatsRequest
 	{
 		protected ICcrStatsRequest Self => this;
@@ -294,7 +294,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for UnfollowIndex <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current</pre></summary>
+	///<summary>Request for UnfollowIndex <para>http://www.elastic.co/guide/en/elasticsearch/reference/current</para></summary>
 	public partial class UnfollowIndexRequest : PlainRequestBase<UnfollowIndexRequestParameters>, IUnfollowIndexRequest
 	{
 		protected IUnfollowIndexRequest Self => this;

--- a/src/Nest/Requests.Graph.cs
+++ b/src/Nest/Requests.Graph.cs
@@ -45,7 +45,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Explore <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</pre></summary>
+	///<summary>Request for Explore <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html</para></summary>
 	public partial class GraphExploreRequest : PlainRequestBase<GraphExploreRequestParameters>, IGraphExploreRequest
 	{
 		protected IGraphExploreRequest Self => this;

--- a/src/Nest/Requests.IndexLifecycleManagement.cs
+++ b/src/Nest/Requests.IndexLifecycleManagement.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteLifecycle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</pre></summary>
+	///<summary>Request for DeleteLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html</para></summary>
 	public partial class DeleteLifecycleRequest : PlainRequestBase<DeleteLifecycleRequestParameters>, IDeleteLifecycleRequest
 	{
 		protected IDeleteLifecycleRequest Self => this;
@@ -74,7 +74,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ExplainLifecycle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</pre></summary>
+	///<summary>Request for ExplainLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html</para></summary>
 	public partial class ExplainLifecycleRequest : PlainRequestBase<ExplainLifecycleRequestParameters>, IExplainLifecycleRequest
 	{
 		protected IExplainLifecycleRequest Self => this;
@@ -107,7 +107,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetLifecycle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</pre></summary>
+	///<summary>Request for GetLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html</para></summary>
 	public partial class GetLifecycleRequest : PlainRequestBase<GetLifecycleRequestParameters>, IGetLifecycleRequest
 	{
 		protected IGetLifecycleRequest Self => this;
@@ -134,7 +134,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GetStatus <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</pre></summary>
+	///<summary>Request for GetStatus <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html</para></summary>
 	public partial class GetIlmStatusRequest : PlainRequestBase<GetIlmStatusRequestParameters>, IGetIlmStatusRequest
 	{
 		protected IGetIlmStatusRequest Self => this;
@@ -153,7 +153,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for MoveToStep <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</pre></summary>
+	///<summary>Request for MoveToStep <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html</para></summary>
 	public partial class MoveToStepRequest : PlainRequestBase<MoveToStepRequestParameters>, IMoveToStepRequest
 	{
 		protected IMoveToStepRequest Self => this;
@@ -187,7 +187,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutLifecycle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</pre></summary>
+	///<summary>Request for PutLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</para></summary>
 	public partial class PutLifecycleRequest : PlainRequestBase<PutLifecycleRequestParameters>, IPutLifecycleRequest
 	{
 		protected IPutLifecycleRequest Self => this;
@@ -220,7 +220,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for RemovePolicy <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</pre></summary>
+	///<summary>Request for RemovePolicy <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html</para></summary>
 	public partial class RemovePolicyRequest : PlainRequestBase<RemovePolicyRequestParameters>, IRemovePolicyRequest
 	{
 		protected IRemovePolicyRequest Self => this;
@@ -253,7 +253,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Retry <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</pre></summary>
+	///<summary>Request for Retry <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html</para></summary>
 	public partial class RetryIlmRequest : PlainRequestBase<RetryIlmRequestParameters>, IRetryIlmRequest
 	{
 		protected IRetryIlmRequest Self => this;
@@ -281,7 +281,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Start <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</pre></summary>
+	///<summary>Request for Start <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html</para></summary>
 	public partial class StartIlmRequest : PlainRequestBase<StartIlmRequestParameters>, IStartIlmRequest
 	{
 		protected IStartIlmRequest Self => this;
@@ -295,7 +295,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Stop <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</pre></summary>
+	///<summary>Request for Stop <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html</para></summary>
 	public partial class StopIlmRequest : PlainRequestBase<StopIlmRequestParameters>, IStopIlmRequest
 	{
 		protected IStopIlmRequest Self => this;

--- a/src/Nest/Requests.Indices.cs
+++ b/src/Nest/Requests.Indices.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Analyze <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</pre></summary>
+	///<summary>Request for Analyze <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html</para></summary>
 	public partial class AnalyzeRequest : PlainRequestBase<AnalyzeRequestParameters>, IAnalyzeRequest
 	{
 		protected IAnalyzeRequest Self => this;
@@ -73,7 +73,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ClearCache <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</pre></summary>
+	///<summary>Request for ClearCache <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html</para></summary>
 	public partial class ClearCacheRequest : PlainRequestBase<ClearCacheRequestParameters>, IClearCacheRequest
 	{
 		protected IClearCacheRequest Self => this;
@@ -156,7 +156,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Close <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</pre></summary>
+	///<summary>Request for Close <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 	public partial class CloseIndexRequest : PlainRequestBase<CloseIndexRequestParameters>, ICloseIndexRequest
 	{
 		protected ICloseIndexRequest Self => this;
@@ -226,7 +226,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Create <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</pre></summary>
+	///<summary>Request for Create <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html</para></summary>
 	public partial class CreateIndexRequest : PlainRequestBase<CreateIndexRequestParameters>, ICreateIndexRequest
 	{
 		protected ICreateIndexRequest Self => this;
@@ -286,7 +286,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Delete <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</pre></summary>
+	///<summary>Request for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html</para></summary>
 	public partial class DeleteIndexRequest : PlainRequestBase<DeleteIndexRequestParameters>, IDeleteIndexRequest
 	{
 		protected IDeleteIndexRequest Self => this;
@@ -359,7 +359,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteAlias <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request for DeleteAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class DeleteAliasRequest : PlainRequestBase<DeleteAliasRequestParameters>, IDeleteAliasRequest
 	{
 		protected IDeleteAliasRequest Self => this;
@@ -408,7 +408,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>Request for DeleteTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public partial class DeleteIndexTemplateRequest : PlainRequestBase<DeleteIndexTemplateRequestParameters>, IDeleteIndexTemplateRequest
 	{
 		protected IDeleteIndexTemplateRequest Self => this;
@@ -454,7 +454,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Exists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</pre></summary>
+	///<summary>Request for Exists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html</para></summary>
 	public partial class IndexExistsRequest : PlainRequestBase<IndexExistsRequestParameters>, IIndexExistsRequest
 	{
 		protected IIndexExistsRequest Self => this;
@@ -534,7 +534,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for AliasExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request for AliasExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class AliasExistsRequest : PlainRequestBase<AliasExistsRequestParameters>, IAliasExistsRequest
 	{
 		protected IAliasExistsRequest Self => this;
@@ -606,7 +606,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for TemplateExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>Request for TemplateExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public partial class IndexTemplateExistsRequest : PlainRequestBase<IndexTemplateExistsRequestParameters>, IIndexTemplateExistsRequest
 	{
 		protected IIndexTemplateExistsRequest Self => this;
@@ -665,7 +665,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for TypeExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</pre></summary>
+	///<summary>Request for TypeExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html</para></summary>
 	public partial class TypeExistsRequest : PlainRequestBase<TypeExistsRequestParameters>, ITypeExistsRequest
 	{
 		protected ITypeExistsRequest Self => this;
@@ -731,7 +731,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Flush <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</pre></summary>
+	///<summary>Request for Flush <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html</para></summary>
 	public partial class FlushRequest : PlainRequestBase<FlushRequestParameters>, IFlushRequest
 	{
 		protected IFlushRequest Self => this;
@@ -806,7 +806,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for SyncedFlush <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</pre></summary>
+	///<summary>Request for SyncedFlush <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html</para></summary>
 	public partial class SyncedFlushRequest : PlainRequestBase<SyncedFlushRequestParameters>, ISyncedFlushRequest
 	{
 		protected ISyncedFlushRequest Self => this;
@@ -861,7 +861,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ForceMerge <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</pre></summary>
+	///<summary>Request for ForceMerge <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html</para></summary>
 	public partial class ForceMergeRequest : PlainRequestBase<ForceMergeRequestParameters>, IForceMergeRequest
 	{
 		protected IForceMergeRequest Self => this;
@@ -937,7 +937,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Get <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</pre></summary>
+	///<summary>Request for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html</para></summary>
 	public partial class GetIndexRequest : PlainRequestBase<GetIndexRequestParameters>, IGetIndexRequest
 	{
 		protected IGetIndexRequest Self => this;
@@ -1031,7 +1031,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetAlias <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request for GetAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class GetAliasRequest : PlainRequestBase<GetAliasRequestParameters>, IGetAliasRequest
 	{
 		protected IGetAliasRequest Self => this;
@@ -1114,7 +1114,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetFieldMapping <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</pre></summary>
+	///<summary>Request for GetFieldMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html</para></summary>
 	public partial class GetFieldMappingRequest : PlainRequestBase<GetFieldMappingRequestParameters>, IGetFieldMappingRequest
 	{
 		protected IGetFieldMappingRequest Self => this;
@@ -1200,7 +1200,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetMapping <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</pre></summary>
+	///<summary>Request for GetMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html</para></summary>
 	public partial class GetMappingRequest : PlainRequestBase<GetMappingRequestParameters>, IGetMappingRequest
 	{
 		protected IGetMappingRequest Self => this;
@@ -1282,7 +1282,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetSettings <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</pre></summary>
+	///<summary>Request for GetSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html</para></summary>
 	public partial class GetIndexSettingsRequest : PlainRequestBase<GetIndexSettingsRequestParameters>, IGetIndexSettingsRequest
 	{
 		protected IGetIndexSettingsRequest Self => this;
@@ -1380,7 +1380,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>Request for GetTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public partial class GetIndexTemplateRequest : PlainRequestBase<GetIndexTemplateRequestParameters>, IGetIndexTemplateRequest
 	{
 		protected IGetIndexTemplateRequest Self => this;
@@ -1439,7 +1439,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for UpgradeStatus <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</pre></summary>
+	///<summary>Request for UpgradeStatus <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para></summary>
 	public partial class UpgradeStatusRequest : PlainRequestBase<UpgradeStatusRequestParameters>, IUpgradeStatusRequest
 	{
 		protected IUpgradeStatusRequest Self => this;
@@ -1494,7 +1494,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Open <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</pre></summary>
+	///<summary>Request for Open <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 	public partial class OpenIndexRequest : PlainRequestBase<OpenIndexRequestParameters>, IOpenIndexRequest
 	{
 		protected IOpenIndexRequest Self => this;
@@ -1577,7 +1577,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutAlias <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request for PutAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class PutAliasRequest : PlainRequestBase<PutAliasRequestParameters>, IPutAliasRequest
 	{
 		protected IPutAliasRequest Self => this;
@@ -1630,7 +1630,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for PutMapping <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</pre></summary>
+	///<summary>Request for PutMapping <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html</para></summary>
 	public partial class PutMappingRequest : PlainRequestBase<PutMappingRequestParameters>, IPutMappingRequest
 	{
 		protected IPutMappingRequest Self => this;
@@ -1722,7 +1722,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for UpdateSettings <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</pre></summary>
+	///<summary>Request for UpdateSettings <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html</para></summary>
 	public partial class UpdateIndexSettingsRequest : PlainRequestBase<UpdateIndexSettingsRequestParameters>, IUpdateIndexSettingsRequest
 	{
 		protected IUpdateIndexSettingsRequest Self => this;
@@ -1805,7 +1805,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</pre></summary>
+	///<summary>Request for PutTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html</para></summary>
 	public partial class PutIndexTemplateRequest : PlainRequestBase<PutIndexTemplateRequestParameters>, IPutIndexTemplateRequest
 	{
 		protected IPutIndexTemplateRequest Self => this;
@@ -1872,7 +1872,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for RecoveryStatus <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</pre></summary>
+	///<summary>Request for RecoveryStatus <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html</para></summary>
 	public partial class RecoveryStatusRequest : PlainRequestBase<RecoveryStatusRequestParameters>, IRecoveryStatusRequest
 	{
 		protected IRecoveryStatusRequest Self => this;
@@ -1917,7 +1917,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Refresh <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</pre></summary>
+	///<summary>Request for Refresh <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html</para></summary>
 	public partial class RefreshRequest : PlainRequestBase<RefreshRequestParameters>, IRefreshRequest
 	{
 		protected IRefreshRequest Self => this;
@@ -1978,7 +1978,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Rollover <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</pre></summary>
+	///<summary>Request for Rollover <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html</para></summary>
 	public partial class RolloverIndexRequest : PlainRequestBase<RolloverIndexRequestParameters>, IRolloverIndexRequest
 	{
 		protected IRolloverIndexRequest Self => this;
@@ -2054,7 +2054,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Segments <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</pre></summary>
+	///<summary>Request for Segments <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html</para></summary>
 	public partial class SegmentsRequest : PlainRequestBase<SegmentsRequestParameters>, ISegmentsRequest
 	{
 		protected ISegmentsRequest Self => this;
@@ -2116,7 +2116,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ShardStores <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</pre></summary>
+	///<summary>Request for ShardStores <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html</para></summary>
 	public partial class IndicesShardStoresRequest : PlainRequestBase<IndicesShardStoresRequestParameters>, IIndicesShardStoresRequest
 	{
 		protected IIndicesShardStoresRequest Self => this;
@@ -2184,7 +2184,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Shrink <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</pre></summary>
+	///<summary>Request for Shrink <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html</para></summary>
 	public partial class ShrinkIndexRequest : PlainRequestBase<ShrinkIndexRequestParameters>, IShrinkIndexRequest
 	{
 		protected IShrinkIndexRequest Self => this;
@@ -2246,7 +2246,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Split <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</pre></summary>
+	///<summary>Request for Split <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html</para></summary>
 	public partial class SplitIndexRequest : PlainRequestBase<SplitIndexRequestParameters>, ISplitIndexRequest
 	{
 		protected ISplitIndexRequest Self => this;
@@ -2308,7 +2308,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Stats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</pre></summary>
+	///<summary>Request for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html</para></summary>
 	public partial class IndicesStatsRequest : PlainRequestBase<IndicesStatsRequestParameters>, IIndicesStatsRequest
 	{
 		protected IIndicesStatsRequest Self => this;
@@ -2391,7 +2391,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for BulkAlias <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</pre></summary>
+	///<summary>Request for BulkAlias <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html</para></summary>
 	public partial class BulkAliasRequest : PlainRequestBase<BulkAliasRequestParameters>, IBulkAliasRequest
 	{
 		protected IBulkAliasRequest Self => this;
@@ -2423,7 +2423,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Upgrade <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</pre></summary>
+	///<summary>Request for Upgrade <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html</para></summary>
 	public partial class UpgradeRequest : PlainRequestBase<UpgradeRequestParameters>, IUpgradeRequest
 	{
 		protected IUpgradeRequest Self => this;
@@ -2496,7 +2496,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for ValidateQuery <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</pre></summary>
+	///<summary>Request for ValidateQuery <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html</para></summary>
 	public partial class ValidateQueryRequest : PlainRequestBase<ValidateQueryRequestParameters>, IValidateQueryRequest
 	{
 		protected IValidateQueryRequest Self => this;

--- a/src/Nest/Requests.Ingest.cs
+++ b/src/Nest/Requests.Ingest.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeletePipeline <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request for DeletePipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class DeletePipelineRequest : PlainRequestBase<DeletePipelineRequestParameters>, IDeletePipelineRequest
 	{
 		protected IDeletePipelineRequest Self => this;
@@ -87,7 +87,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetPipeline <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request for GetPipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class GetPipelineRequest : PlainRequestBase<GetPipelineRequestParameters>, IGetPipelineRequest
 	{
 		protected IGetPipelineRequest Self => this;
@@ -120,7 +120,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GrokProcessorPatterns <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request for GrokProcessorPatterns <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class GrokProcessorPatternsRequest : PlainRequestBase<GrokProcessorPatternsRequestParameters>, IGrokProcessorPatternsRequest
 	{
 		protected IGrokProcessorPatternsRequest Self => this;
@@ -139,7 +139,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutPipeline <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request for PutPipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class PutPipelineRequest : PlainRequestBase<PutPipelineRequestParameters>, IPutPipelineRequest
 	{
 		protected IPutPipelineRequest Self => this;
@@ -185,7 +185,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for SimulatePipeline <pre>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</pre></summary>
+	///<summary>Request for SimulatePipeline <para>https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html</para></summary>
 	public partial class SimulatePipelineRequest : PlainRequestBase<SimulatePipelineRequestParameters>, ISimulatePipelineRequest
 	{
 		protected ISimulatePipelineRequest Self => this;

--- a/src/Nest/Requests.License.cs
+++ b/src/Nest/Requests.License.cs
@@ -36,7 +36,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Delete <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request for Delete <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class DeleteLicenseRequest : PlainRequestBase<DeleteLicenseRequestParameters>, IDeleteLicenseRequest
 	{
 		protected IDeleteLicenseRequest Self => this;
@@ -50,7 +50,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Get <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request for Get <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class GetLicenseRequest : PlainRequestBase<GetLicenseRequestParameters>, IGetLicenseRequest
 	{
 		protected IGetLicenseRequest Self => this;
@@ -70,7 +70,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GetBasicStatus <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request for GetBasicStatus <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class GetBasicLicenseStatusRequest : PlainRequestBase<GetBasicLicenseStatusRequestParameters>, IGetBasicLicenseStatusRequest
 	{
 		protected IGetBasicLicenseStatusRequest Self => this;
@@ -84,7 +84,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GetTrialStatus <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request for GetTrialStatus <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class GetTrialLicenseStatusRequest : PlainRequestBase<GetTrialLicenseStatusRequestParameters>, IGetTrialLicenseStatusRequest
 	{
 		protected IGetTrialLicenseStatusRequest Self => this;
@@ -98,7 +98,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Post <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request for Post <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class PostLicenseRequest : PlainRequestBase<PostLicenseRequestParameters>, IPostLicenseRequest
 	{
 		protected IPostLicenseRequest Self => this;
@@ -118,7 +118,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for StartBasic <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request for StartBasic <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class StartBasicLicenseRequest : PlainRequestBase<StartBasicLicenseRequestParameters>, IStartBasicLicenseRequest
 	{
 		protected IStartBasicLicenseRequest Self => this;
@@ -138,7 +138,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for StartTrial <pre>https://www.elastic.co/guide/en/x-pack/current/license-management.html</pre></summary>
+	///<summary>Request for StartTrial <para>https://www.elastic.co/guide/en/x-pack/current/license-management.html</para></summary>
 	public partial class StartTrialLicenseRequest : PlainRequestBase<StartTrialLicenseRequestParameters>, IStartTrialLicenseRequest
 	{
 		protected IStartTrialLicenseRequest Self => this;

--- a/src/Nest/Requests.MachineLearning.cs
+++ b/src/Nest/Requests.MachineLearning.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for CloseJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</pre></summary>
+	///<summary>Request for CloseJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html</para></summary>
 	public partial class CloseJobRequest : PlainRequestBase<CloseJobRequestParameters>, ICloseJobRequest
 	{
 		protected ICloseJobRequest Self => this;
@@ -94,7 +94,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteCalendar <pre></pre></summary>
+	///<summary>Request for DeleteCalendar <para></para></summary>
 	public partial class DeleteCalendarRequest : PlainRequestBase<DeleteCalendarRequestParameters>, IDeleteCalendarRequest
 	{
 		protected IDeleteCalendarRequest Self => this;
@@ -133,7 +133,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteCalendarEvent <pre></pre></summary>
+	///<summary>Request for DeleteCalendarEvent <para></para></summary>
 	public partial class DeleteCalendarEventRequest : PlainRequestBase<DeleteCalendarEventRequestParameters>, IDeleteCalendarEventRequest
 	{
 		protected IDeleteCalendarEventRequest Self => this;
@@ -175,7 +175,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteCalendarJob <pre></pre></summary>
+	///<summary>Request for DeleteCalendarJob <para></para></summary>
 	public partial class DeleteCalendarJobRequest : PlainRequestBase<DeleteCalendarJobRequestParameters>, IDeleteCalendarJobRequest
 	{
 		protected IDeleteCalendarJobRequest Self => this;
@@ -211,7 +211,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</pre></summary>
+	///<summary>Request for DeleteDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html</para></summary>
 	public partial class DeleteDatafeedRequest : PlainRequestBase<DeleteDatafeedRequestParameters>, IDeleteDatafeedRequest
 	{
 		protected IDeleteDatafeedRequest Self => this;
@@ -245,7 +245,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for DeleteExpiredData <pre></pre></summary>
+	///<summary>Request for DeleteExpiredData <para></para></summary>
 	public partial class DeleteExpiredDataRequest : PlainRequestBase<DeleteExpiredDataRequestParameters>, IDeleteExpiredDataRequest
 	{
 		protected IDeleteExpiredDataRequest Self => this;
@@ -264,7 +264,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteFilter <pre></pre></summary>
+	///<summary>Request for DeleteFilter <para></para></summary>
 	public partial class DeleteFilterRequest : PlainRequestBase<DeleteFilterRequestParameters>, IDeleteFilterRequest
 	{
 		protected IDeleteFilterRequest Self => this;
@@ -303,7 +303,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteForecast <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</pre></summary>
+	///<summary>Request for DeleteForecast <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html</para></summary>
 	public partial class DeleteForecastRequest : PlainRequestBase<DeleteForecastRequestParameters>, IDeleteForecastRequest
 	{
 		protected IDeleteForecastRequest Self => this;
@@ -352,7 +352,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</pre></summary>
+	///<summary>Request for DeleteJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html</para></summary>
 	public partial class DeleteJobRequest : PlainRequestBase<DeleteJobRequestParameters>, IDeleteJobRequest
 	{
 		protected IDeleteJobRequest Self => this;
@@ -404,7 +404,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteModelSnapshot <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</pre></summary>
+	///<summary>Request for DeleteModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html</para></summary>
 	public partial class DeleteModelSnapshotRequest : PlainRequestBase<DeleteModelSnapshotRequestParameters>, IDeleteModelSnapshotRequest
 	{
 		protected IDeleteModelSnapshotRequest Self => this;
@@ -440,7 +440,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for FlushJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</pre></summary>
+	///<summary>Request for FlushJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html</para></summary>
 	public partial class FlushJobRequest : PlainRequestBase<FlushJobRequestParameters>, IFlushJobRequest
 	{
 		protected IFlushJobRequest Self => this;
@@ -479,7 +479,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ForecastJob <pre></pre></summary>
+	///<summary>Request for ForecastJob <para></para></summary>
 	public partial class ForecastJobRequest : PlainRequestBase<ForecastJobRequestParameters>, IForecastJobRequest
 	{
 		protected IForecastJobRequest Self => this;
@@ -518,7 +518,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetBuckets <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</pre></summary>
+	///<summary>Request for GetBuckets <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html</para></summary>
 	public partial class GetBucketsRequest : PlainRequestBase<GetBucketsRequestParameters>, IGetBucketsRequest
 	{
 		protected IGetBucketsRequest Self => this;
@@ -560,7 +560,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetCalendarEvents <pre></pre></summary>
+	///<summary>Request for GetCalendarEvents <para></para></summary>
 	public partial class GetCalendarEventsRequest : PlainRequestBase<GetCalendarEventsRequestParameters>, IGetCalendarEventsRequest
 	{
 		protected IGetCalendarEventsRequest Self => this;
@@ -613,7 +613,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetCalendars <pre></pre></summary>
+	///<summary>Request for GetCalendars <para></para></summary>
 	public partial class GetCalendarsRequest : PlainRequestBase<GetCalendarsRequestParameters>, IGetCalendarsRequest
 	{
 		protected IGetCalendarsRequest Self => this;
@@ -651,7 +651,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetCategories <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</pre></summary>
+	///<summary>Request for GetCategories <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html</para></summary>
 	public partial class GetCategoriesRequest : PlainRequestBase<GetCategoriesRequestParameters>, IGetCategoriesRequest
 	{
 		protected IGetCategoriesRequest Self => this;
@@ -693,7 +693,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetDatafeedStats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</pre></summary>
+	///<summary>Request for GetDatafeedStats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html</para></summary>
 	public partial class GetDatafeedStatsRequest : PlainRequestBase<GetDatafeedStatsRequestParameters>, IGetDatafeedStatsRequest
 	{
 		protected IGetDatafeedStatsRequest Self => this;
@@ -731,7 +731,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetDatafeeds <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</pre></summary>
+	///<summary>Request for GetDatafeeds <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html</para></summary>
 	public partial class GetDatafeedsRequest : PlainRequestBase<GetDatafeedsRequestParameters>, IGetDatafeedsRequest
 	{
 		protected IGetDatafeedsRequest Self => this;
@@ -769,7 +769,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetFilters <pre></pre></summary>
+	///<summary>Request for GetFilters <para></para></summary>
 	public partial class GetFiltersRequest : PlainRequestBase<GetFiltersRequestParameters>, IGetFiltersRequest
 	{
 		protected IGetFiltersRequest Self => this;
@@ -814,7 +814,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetInfluencers <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</pre></summary>
+	///<summary>Request for GetInfluencers <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html</para></summary>
 	public partial class GetInfluencersRequest : PlainRequestBase<GetInfluencersRequestParameters>, IGetInfluencersRequest
 	{
 		protected IGetInfluencersRequest Self => this;
@@ -847,7 +847,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetJobStats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</pre></summary>
+	///<summary>Request for GetJobStats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html</para></summary>
 	public partial class GetJobStatsRequest : PlainRequestBase<GetJobStatsRequestParameters>, IGetJobStatsRequest
 	{
 		protected IGetJobStatsRequest Self => this;
@@ -885,7 +885,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetJobs <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</pre></summary>
+	///<summary>Request for GetJobs <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html</para></summary>
 	public partial class GetJobsRequest : PlainRequestBase<GetJobsRequestParameters>, IGetJobsRequest
 	{
 		protected IGetJobsRequest Self => this;
@@ -929,7 +929,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetModelSnapshots <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</pre></summary>
+	///<summary>Request for GetModelSnapshots <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html</para></summary>
 	public partial class GetModelSnapshotsRequest : PlainRequestBase<GetModelSnapshotsRequestParameters>, IGetModelSnapshotsRequest
 	{
 		protected IGetModelSnapshotsRequest Self => this;
@@ -971,7 +971,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetOverallBuckets <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</pre></summary>
+	///<summary>Request for GetOverallBuckets <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html</para></summary>
 	public partial class GetOverallBucketsRequest : PlainRequestBase<GetOverallBucketsRequestParameters>, IGetOverallBucketsRequest
 	{
 		protected IGetOverallBucketsRequest Self => this;
@@ -1004,7 +1004,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetAnomalyRecords <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</pre></summary>
+	///<summary>Request for GetAnomalyRecords <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html</para></summary>
 	public partial class GetAnomalyRecordsRequest : PlainRequestBase<GetAnomalyRecordsRequestParameters>, IGetAnomalyRecordsRequest
 	{
 		protected IGetAnomalyRecordsRequest Self => this;
@@ -1032,7 +1032,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Info <pre></pre></summary>
+	///<summary>Request for Info <para></para></summary>
 	public partial class MachineLearningInfoRequest : PlainRequestBase<MachineLearningInfoRequestParameters>, IMachineLearningInfoRequest
 	{
 		protected IMachineLearningInfoRequest Self => this;
@@ -1051,7 +1051,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for OpenJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</pre></summary>
+	///<summary>Request for OpenJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html</para></summary>
 	public partial class OpenJobRequest : PlainRequestBase<OpenJobRequestParameters>, IOpenJobRequest
 	{
 		protected IOpenJobRequest Self => this;
@@ -1084,7 +1084,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PostCalendarEvents <pre></pre></summary>
+	///<summary>Request for PostCalendarEvents <para></para></summary>
 	public partial class PostCalendarEventsRequest : PlainRequestBase<PostCalendarEventsRequestParameters>, IPostCalendarEventsRequest
 	{
 		protected IPostCalendarEventsRequest Self => this;
@@ -1117,7 +1117,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PostJobData <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</pre></summary>
+	///<summary>Request for PostJobData <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html</para></summary>
 	public partial class PostJobDataRequest : PlainRequestBase<PostJobDataRequestParameters>, IPostJobDataRequest
 	{
 		protected IPostJobDataRequest Self => this;
@@ -1163,7 +1163,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PreviewDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</pre></summary>
+	///<summary>Request for PreviewDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
 	public partial class PreviewDatafeedRequest : PlainRequestBase<PreviewDatafeedRequestParameters>, IPreviewDatafeedRequest
 	{
 		protected IPreviewDatafeedRequest Self => this;
@@ -1196,7 +1196,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutCalendar <pre></pre></summary>
+	///<summary>Request for PutCalendar <para></para></summary>
 	public partial class PutCalendarRequest : PlainRequestBase<PutCalendarRequestParameters>, IPutCalendarRequest
 	{
 		protected IPutCalendarRequest Self => this;
@@ -1235,7 +1235,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutCalendarJob <pre></pre></summary>
+	///<summary>Request for PutCalendarJob <para></para></summary>
 	public partial class PutCalendarJobRequest : PlainRequestBase<PutCalendarJobRequestParameters>, IPutCalendarJobRequest
 	{
 		protected IPutCalendarJobRequest Self => this;
@@ -1271,7 +1271,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</pre></summary>
+	///<summary>Request for PutDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html</para></summary>
 	public partial class PutDatafeedRequest : PlainRequestBase<PutDatafeedRequestParameters>, IPutDatafeedRequest
 	{
 		protected IPutDatafeedRequest Self => this;
@@ -1304,7 +1304,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutFilter <pre></pre></summary>
+	///<summary>Request for PutFilter <para></para></summary>
 	public partial class PutFilterRequest : PlainRequestBase<PutFilterRequestParameters>, IPutFilterRequest
 	{
 		protected IPutFilterRequest Self => this;
@@ -1337,7 +1337,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</pre></summary>
+	///<summary>Request for PutJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html</para></summary>
 	public partial class PutJobRequest : PlainRequestBase<PutJobRequestParameters>, IPutJobRequest
 	{
 		protected IPutJobRequest Self => this;
@@ -1376,7 +1376,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for RevertModelSnapshot <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</pre></summary>
+	///<summary>Request for RevertModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html</para></summary>
 	public partial class RevertModelSnapshotRequest : PlainRequestBase<RevertModelSnapshotRequestParameters>, IRevertModelSnapshotRequest
 	{
 		protected IRevertModelSnapshotRequest Self => this;
@@ -1412,7 +1412,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for StartDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</pre></summary>
+	///<summary>Request for StartDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html</para></summary>
 	public partial class StartDatafeedRequest : PlainRequestBase<StartDatafeedRequestParameters>, IStartDatafeedRequest
 	{
 		protected IStartDatafeedRequest Self => this;
@@ -1445,7 +1445,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for StopDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</pre></summary>
+	///<summary>Request for StopDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html</para></summary>
 	public partial class StopDatafeedRequest : PlainRequestBase<StopDatafeedRequestParameters>, IStopDatafeedRequest
 	{
 		protected IStopDatafeedRequest Self => this;
@@ -1484,7 +1484,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for UpdateDatafeed <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</pre></summary>
+	///<summary>Request for UpdateDatafeed <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html</para></summary>
 	public partial class UpdateDatafeedRequest : PlainRequestBase<UpdateDatafeedRequestParameters>, IUpdateDatafeedRequest
 	{
 		protected IUpdateDatafeedRequest Self => this;
@@ -1517,7 +1517,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for UpdateFilter <pre></pre></summary>
+	///<summary>Request for UpdateFilter <para></para></summary>
 	public partial class UpdateFilterRequest : PlainRequestBase<UpdateFilterRequestParameters>, IUpdateFilterRequest
 	{
 		protected IUpdateFilterRequest Self => this;
@@ -1550,7 +1550,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for UpdateJob <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</pre></summary>
+	///<summary>Request for UpdateJob <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html</para></summary>
 	public partial class UpdateJobRequest : PlainRequestBase<UpdateJobRequestParameters>, IUpdateJobRequest
 	{
 		protected IUpdateJobRequest Self => this;
@@ -1589,7 +1589,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for UpdateModelSnapshot <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</pre></summary>
+	///<summary>Request for UpdateModelSnapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html</para></summary>
 	public partial class UpdateModelSnapshotRequest : PlainRequestBase<UpdateModelSnapshotRequestParameters>, IUpdateModelSnapshotRequest
 	{
 		protected IUpdateModelSnapshotRequest Self => this;
@@ -1620,7 +1620,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for ValidateJob <pre></pre></summary>
+	///<summary>Request for ValidateJob <para></para></summary>
 	public partial class ValidateJobRequest : PlainRequestBase<ValidateJobRequestParameters>, IValidateJobRequest
 	{
 		protected IValidateJobRequest Self => this;
@@ -1634,7 +1634,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for ValidateDetector <pre></pre></summary>
+	///<summary>Request for ValidateDetector <para></para></summary>
 	public partial class ValidateDetectorRequest : PlainRequestBase<ValidateDetectorRequestParameters>, IValidateDetectorRequest
 	{
 		protected IValidateDetectorRequest Self => this;

--- a/src/Nest/Requests.Migration.cs
+++ b/src/Nest/Requests.Migration.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeprecationInfo <pre>http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</pre></summary>
+	///<summary>Request for DeprecationInfo <para>http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html</para></summary>
 	public partial class DeprecationInfoRequest : PlainRequestBase<DeprecationInfoRequestParameters>, IDeprecationInfoRequest
 	{
 		protected IDeprecationInfoRequest Self => this;
@@ -73,7 +73,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Assistance <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</pre></summary>
+	///<summary>Request for Assistance <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-assistance.html</para></summary>
 	public partial class MigrationAssistanceRequest : PlainRequestBase<MigrationAssistanceRequestParameters>, IMigrationAssistanceRequest
 	{
 		protected IMigrationAssistanceRequest Self => this;
@@ -128,7 +128,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Upgrade <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</pre></summary>
+	///<summary>Request for Upgrade <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-upgrade.html</para></summary>
 	public partial class MigrationUpgradeRequest : PlainRequestBase<MigrationUpgradeRequestParameters>, IMigrationUpgradeRequest
 	{
 		protected IMigrationUpgradeRequest Self => this;

--- a/src/Nest/Requests.NoNamespace.cs
+++ b/src/Nest/Requests.NoNamespace.cs
@@ -40,7 +40,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Bulk <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</pre></summary>
+	///<summary>Request for Bulk <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html</para></summary>
 	public partial class BulkRequest : PlainRequestBase<BulkRequestParameters>, IBulkRequest
 	{
 		protected IBulkRequest Self => this;
@@ -143,7 +143,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for ClearScroll <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</pre></summary>
+	///<summary>Request for ClearScroll <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</para></summary>
 	public partial class ClearScrollRequest : PlainRequestBase<ClearScrollRequestParameters>, IClearScrollRequest
 	{
 		protected IClearScrollRequest Self => this;
@@ -166,7 +166,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Count <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</pre></summary>
+	///<summary>Request for Count <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html</para></summary>
 	public partial class CountRequest : PlainRequestBase<CountRequestParameters>, ICountRequest
 	{
 		protected ICountRequest Self => this;
@@ -326,7 +326,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Create <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</pre></summary>
+	///<summary>Request for Create <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 	public partial class CreateRequest<TDocument> : PlainRequestBase<CreateRequestParameters>, ICreateRequest<TDocument>
 	{
 		protected ICreateRequest<TDocument> Self => this;
@@ -444,7 +444,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Delete <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</pre></summary>
+	///<summary>Request for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html</para></summary>
 	public partial class DeleteRequest : PlainRequestBase<DeleteRequestParameters>, IDeleteRequest
 	{
 		protected IDeleteRequest Self => this;
@@ -580,7 +580,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for DeleteByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</pre></summary>
+	///<summary>Request for DeleteByQuery <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html</para></summary>
 	public partial class DeleteByQueryRequest : PlainRequestBase<DeleteByQueryRequestParameters>, IDeleteByQueryRequest
 	{
 		protected IDeleteByQueryRequest Self => this;
@@ -865,7 +865,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteByQueryRethrottle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</pre></summary>
+	///<summary>Request for DeleteByQueryRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html</para></summary>
 	public partial class DeleteByQueryRethrottleRequest : PlainRequestBase<DeleteByQueryRethrottleRequestParameters>, IDeleteByQueryRethrottleRequest
 	{
 		protected IDeleteByQueryRethrottleRequest Self => this;
@@ -904,7 +904,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteScript <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>Request for DeleteScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public partial class DeleteScriptRequest : PlainRequestBase<DeleteScriptRequestParameters>, IDeleteScriptRequest
 	{
 		protected IDeleteScriptRequest Self => this;
@@ -960,7 +960,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for DocumentExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>Request for DocumentExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public partial class DocumentExistsRequest : PlainRequestBase<DocumentExistsRequestParameters>, IDocumentExistsRequest
 	{
 		protected IDocumentExistsRequest Self => this;
@@ -1109,7 +1109,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for SourceExists <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>Request for SourceExists <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public partial class SourceExistsRequest : PlainRequestBase<SourceExistsRequestParameters>, ISourceExistsRequest
 	{
 		protected ISourceExistsRequest Self => this;
@@ -1258,7 +1258,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Explain <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</pre></summary>
+	///<summary>Request for Explain <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html</para></summary>
 	public partial class ExplainRequest : PlainRequestBase<ExplainRequestParameters>, IExplainRequest
 	{
 		protected IExplainRequest Self => this;
@@ -1404,7 +1404,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for FieldCapabilities <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</pre></summary>
+	///<summary>Request for FieldCapabilities <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html</para></summary>
 	public partial class FieldCapabilitiesRequest : PlainRequestBase<FieldCapabilitiesRequestParameters>, IFieldCapabilitiesRequest
 	{
 		protected IFieldCapabilitiesRequest Self => this;
@@ -1476,7 +1476,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Get <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>Request for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public partial class GetRequest : PlainRequestBase<GetRequestParameters>, IGetRequest
 	{
 		protected IGetRequest Self => this;
@@ -1615,7 +1615,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetScript <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>Request for GetScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public partial class GetScriptRequest : PlainRequestBase<GetScriptRequestParameters>, IGetScriptRequest
 	{
 		protected IGetScriptRequest Self => this;
@@ -1664,7 +1664,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Source <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</pre></summary>
+	///<summary>Request for Source <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html</para></summary>
 	public partial class SourceRequest : PlainRequestBase<SourceRequestParameters>, ISourceRequest
 	{
 		protected ISourceRequest Self => this;
@@ -1802,7 +1802,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Index <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</pre></summary>
+	///<summary>Request for Index <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 	public partial class IndexRequest<TDocument> : PlainRequestBase<IndexRequestParameters>, IIndexRequest<TDocument>
 	{
 		protected IIndexRequest<TDocument> Self => this;
@@ -1931,7 +1931,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for RootNodeInfo <pre>http://www.elastic.co/guide/</pre></summary>
+	///<summary>Request for RootNodeInfo <para>http://www.elastic.co/guide/</para></summary>
 	public partial class RootNodeInfoRequest : PlainRequestBase<RootNodeInfoRequestParameters>, IRootNodeInfoRequest
 	{
 		protected IRootNodeInfoRequest Self => this;
@@ -1957,7 +1957,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for MultiGet <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</pre></summary>
+	///<summary>Request for MultiGet <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html</para></summary>
 	public partial class MultiGetRequest : PlainRequestBase<MultiGetRequestParameters>, IMultiGetRequest
 	{
 		protected IMultiGetRequest Self => this;
@@ -2044,7 +2044,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for MultiSearch <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</pre></summary>
+	///<summary>Request for MultiSearch <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html</para></summary>
 	public partial class MultiSearchRequest : PlainRequestBase<MultiSearchRequestParameters>, IMultiSearchRequest
 	{
 		protected IMultiSearchRequest Self => this;
@@ -2132,7 +2132,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for MultiSearchTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</pre></summary>
+	///<summary>Request for MultiSearchTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html</para></summary>
 	public partial class MultiSearchTemplateRequest : PlainRequestBase<MultiSearchTemplateRequestParameters>, IMultiSearchTemplateRequest
 	{
 		protected IMultiSearchTemplateRequest Self => this;
@@ -2198,7 +2198,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for MultiTermVectors <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</pre></summary>
+	///<summary>Request for MultiTermVectors <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html</para></summary>
 	public partial class MultiTermVectorsRequest : PlainRequestBase<MultiTermVectorsRequestParameters>, IMultiTermVectorsRequest
 	{
 		protected IMultiTermVectorsRequest Self => this;
@@ -2317,7 +2317,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Ping <pre>http://www.elastic.co/guide/</pre></summary>
+	///<summary>Request for Ping <para>http://www.elastic.co/guide/</para></summary>
 	public partial class PingRequest : PlainRequestBase<PingRequestParameters>, IPingRequest
 	{
 		protected IPingRequest Self => this;
@@ -2342,7 +2342,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutScript <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</pre></summary>
+	///<summary>Request for PutScript <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html</para></summary>
 	public partial class PutScriptRequest : PlainRequestBase<PutScriptRequestParameters>, IPutScriptRequest
 	{
 		protected IPutScriptRequest Self => this;
@@ -2392,7 +2392,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for ReindexOnServer <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</pre></summary>
+	///<summary>Request for ReindexOnServer <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</para></summary>
 	public partial class ReindexOnServerRequest : PlainRequestBase<ReindexOnServerRequestParameters>, IReindexOnServerRequest
 	{
 		protected IReindexOnServerRequest Self => this;
@@ -2463,7 +2463,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ReindexRethrottle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</pre></summary>
+	///<summary>Request for ReindexRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html</para></summary>
 	public partial class ReindexRethrottleRequest : PlainRequestBase<ReindexRethrottleRequestParameters>, IReindexRethrottleRequest
 	{
 		protected IReindexRethrottleRequest Self => this;
@@ -2502,7 +2502,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for RenderSearchTemplate <pre>http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</pre></summary>
+	///<summary>Request for RenderSearchTemplate <para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html</para></summary>
 	public partial class RenderSearchTemplateRequest : PlainRequestBase<RenderSearchTemplateRequestParameters>, IRenderSearchTemplateRequest
 	{
 		protected IRenderSearchTemplateRequest Self => this;
@@ -2529,7 +2529,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for ExecutePainlessScript <pre>https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</pre></summary>
+	///<summary>Request for ExecutePainlessScript <para>https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html</para></summary>
 	public partial class ExecutePainlessScriptRequest : PlainRequestBase<ExecutePainlessScriptRequestParameters>, IExecutePainlessScriptRequest
 	{
 		protected IExecutePainlessScriptRequest Self => this;
@@ -2543,7 +2543,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Scroll <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</pre></summary>
+	///<summary>Request for Scroll <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html</para></summary>
 	public partial class ScrollRequest : PlainRequestBase<ScrollRequestParameters>, IScrollRequest
 	{
 		protected IScrollRequest Self => this;
@@ -2586,7 +2586,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Search <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</pre></summary>
+	///<summary>Request for Search <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html</para></summary>
 	public partial class SearchRequest : PlainRequestBase<SearchRequestParameters>, ISearchRequest
 	{
 		protected ISearchRequest Self => this;
@@ -2853,7 +2853,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for SearchShards <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</pre></summary>
+	///<summary>Request for SearchShards <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html</para></summary>
 	public partial class SearchShardsRequest : PlainRequestBase<SearchShardsRequestParameters>, ISearchShardsRequest
 	{
 		protected ISearchShardsRequest Self => this;
@@ -2951,7 +2951,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for SearchTemplate <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</pre></summary>
+	///<summary>Request for SearchTemplate <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html</para></summary>
 	public partial class SearchTemplateRequest : PlainRequestBase<SearchTemplateRequestParameters>, ISearchTemplateRequest
 	{
 		protected ISearchTemplateRequest Self => this;
@@ -3089,7 +3089,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for TermVectors <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</pre></summary>
+	///<summary>Request for TermVectors <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html</para></summary>
 	public partial class TermVectorsRequest<TDocument> : PlainRequestBase<TermVectorsRequestParameters>, ITermVectorsRequest<TDocument>
 	{
 		protected ITermVectorsRequest<TDocument> Self => this;
@@ -3229,7 +3229,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Update <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</pre></summary>
+	///<summary>Request for Update <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html</para></summary>
 	public partial class UpdateRequest<TDocument, TPartialDocument> : PlainRequestBase<UpdateRequestParameters>, IUpdateRequest<TDocument, TPartialDocument>
 	{
 		protected IUpdateRequest<TDocument, TPartialDocument> Self => this;
@@ -3355,7 +3355,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for UpdateByQuery <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</pre></summary>
+	///<summary>Request for UpdateByQuery <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html</para></summary>
 	public partial class UpdateByQueryRequest : PlainRequestBase<UpdateByQueryRequestParameters>, IUpdateByQueryRequest
 	{
 		protected IUpdateByQueryRequest Self => this;
@@ -3654,7 +3654,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for UpdateByQueryRethrottle <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</pre></summary>
+	///<summary>Request for UpdateByQueryRethrottle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html</para></summary>
 	public partial class UpdateByQueryRethrottleRequest : PlainRequestBase<UpdateByQueryRethrottleRequestParameters>, IUpdateByQueryRethrottleRequest
 	{
 		protected IUpdateByQueryRethrottleRequest Self => this;

--- a/src/Nest/Requests.Nodes.cs
+++ b/src/Nest/Requests.Nodes.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for HotThreads <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</pre></summary>
+	///<summary>Request for HotThreads <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html</para></summary>
 	public partial class NodesHotThreadsRequest : PlainRequestBase<NodesHotThreadsRequestParameters>, INodesHotThreadsRequest
 	{
 		protected INodesHotThreadsRequest Self => this;
@@ -120,7 +120,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Info <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</pre></summary>
+	///<summary>Request for Info <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html</para></summary>
 	public partial class NodesInfoRequest : PlainRequestBase<NodesInfoRequestParameters>, INodesInfoRequest
 	{
 		protected INodesInfoRequest Self => this;
@@ -180,7 +180,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ReloadSecureSettings <pre>https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</pre></summary>
+	///<summary>Request for ReloadSecureSettings <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings</para></summary>
 	public partial class ReloadSecureSettingsRequest : PlainRequestBase<ReloadSecureSettingsRequestParameters>, IReloadSecureSettingsRequest
 	{
 		protected IReloadSecureSettingsRequest Self => this;
@@ -230,7 +230,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Stats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</pre></summary>
+	///<summary>Request for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html</para></summary>
 	public partial class NodesStatsRequest : PlainRequestBase<NodesStatsRequestParameters>, INodesStatsRequest
 	{
 		protected INodesStatsRequest Self => this;
@@ -355,7 +355,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Usage <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</pre></summary>
+	///<summary>Request for Usage <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html</para></summary>
 	public partial class NodesUsageRequest : PlainRequestBase<NodesUsageRequestParameters>, INodesUsageRequest
 	{
 		protected INodesUsageRequest Self => this;

--- a/src/Nest/Requests.Rollup.cs
+++ b/src/Nest/Requests.Rollup.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteJob <pre></pre></summary>
+	///<summary>Request for DeleteJob <para></para></summary>
 	public partial class DeleteRollupJobRequest : PlainRequestBase<DeleteRollupJobRequestParameters>, IDeleteRollupJobRequest
 	{
 		protected IDeleteRollupJobRequest Self => this;
@@ -74,7 +74,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetJob <pre></pre></summary>
+	///<summary>Request for GetJob <para></para></summary>
 	public partial class GetRollupJobRequest : PlainRequestBase<GetRollupJobRequestParameters>, IGetRollupJobRequest
 	{
 		protected IGetRollupJobRequest Self => this;
@@ -106,7 +106,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetCapabilities <pre></pre></summary>
+	///<summary>Request for GetCapabilities <para></para></summary>
 	public partial class GetRollupCapabilitiesRequest : PlainRequestBase<GetRollupCapabilitiesRequestParameters>, IGetRollupCapabilitiesRequest
 	{
 		protected IGetRollupCapabilitiesRequest Self => this;
@@ -138,7 +138,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetIndexCapabilities <pre></pre></summary>
+	///<summary>Request for GetIndexCapabilities <para></para></summary>
 	public partial class GetRollupIndexCapabilitiesRequest : PlainRequestBase<GetRollupIndexCapabilitiesRequestParameters>, IGetRollupIndexCapabilitiesRequest
 	{
 		protected IGetRollupIndexCapabilitiesRequest Self => this;
@@ -171,7 +171,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for CreateJob <pre></pre></summary>
+	///<summary>Request for CreateJob <para></para></summary>
 	public partial class CreateRollupJobRequest : PlainRequestBase<CreateRollupJobRequestParameters>, ICreateRollupJobRequest
 	{
 		protected ICreateRollupJobRequest Self => this;
@@ -204,7 +204,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Search <pre></pre></summary>
+	///<summary>Request for Search <para></para></summary>
 	public partial class RollupSearchRequest : PlainRequestBase<RollupSearchRequestParameters>, IRollupSearchRequest
 	{
 		protected IRollupSearchRequest Self => this;
@@ -250,7 +250,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for StartJob <pre></pre></summary>
+	///<summary>Request for StartJob <para></para></summary>
 	public partial class StartRollupJobRequest : PlainRequestBase<StartRollupJobRequestParameters>, IStartRollupJobRequest
 	{
 		protected IStartRollupJobRequest Self => this;
@@ -283,7 +283,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for StopJob <pre></pre></summary>
+	///<summary>Request for StopJob <para></para></summary>
 	public partial class StopRollupJobRequest : PlainRequestBase<StopRollupJobRequestParameters>, IStopRollupJobRequest
 	{
 		protected IStopRollupJobRequest Self => this;

--- a/src/Nest/Requests.Security.cs
+++ b/src/Nest/Requests.Security.cs
@@ -36,7 +36,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Authenticate <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</pre></summary>
+	///<summary>Request for Authenticate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html</para></summary>
 	public partial class AuthenticateRequest : PlainRequestBase<AuthenticateRequestParameters>, IAuthenticateRequest
 	{
 		protected IAuthenticateRequest Self => this;
@@ -55,7 +55,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ChangePassword <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</pre></summary>
+	///<summary>Request for ChangePassword <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html</para></summary>
 	public partial class ChangePasswordRequest : PlainRequestBase<ChangePasswordRequestParameters>, IChangePasswordRequest
 	{
 		protected IChangePasswordRequest Self => this;
@@ -96,7 +96,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ClearCachedRealms <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</pre></summary>
+	///<summary>Request for ClearCachedRealms <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html</para></summary>
 	public partial class ClearCachedRealmsRequest : PlainRequestBase<ClearCachedRealmsRequestParameters>, IClearCachedRealmsRequest
 	{
 		protected IClearCachedRealmsRequest Self => this;
@@ -135,7 +135,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for ClearCachedRoles <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</pre></summary>
+	///<summary>Request for ClearCachedRoles <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html</para></summary>
 	public partial class ClearCachedRolesRequest : PlainRequestBase<ClearCachedRolesRequestParameters>, IClearCachedRolesRequest
 	{
 		protected IClearCachedRolesRequest Self => this;
@@ -163,7 +163,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for CreateApiKey <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</pre></summary>
+	///<summary>Request for CreateApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html</para></summary>
 	public partial class CreateApiKeyRequest : PlainRequestBase<CreateApiKeyRequestParameters>, ICreateApiKeyRequest
 	{
 		protected ICreateApiKeyRequest Self => this;
@@ -197,7 +197,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeletePrivileges <pre>TODO</pre></summary>
+	///<summary>Request for DeletePrivileges <para>TODO</para></summary>
 	public partial class DeletePrivilegesRequest : PlainRequestBase<DeletePrivilegesRequestParameters>, IDeletePrivilegesRequest
 	{
 		protected IDeletePrivilegesRequest Self => this;
@@ -242,7 +242,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteRole <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</pre></summary>
+	///<summary>Request for DeleteRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html</para></summary>
 	public partial class DeleteRoleRequest : PlainRequestBase<DeleteRoleRequestParameters>, IDeleteRoleRequest
 	{
 		protected IDeleteRoleRequest Self => this;
@@ -284,7 +284,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteRoleMapping <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</pre></summary>
+	///<summary>Request for DeleteRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html</para></summary>
 	public partial class DeleteRoleMappingRequest : PlainRequestBase<DeleteRoleMappingRequestParameters>, IDeleteRoleMappingRequest
 	{
 		protected IDeleteRoleMappingRequest Self => this;
@@ -326,7 +326,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</pre></summary>
+	///<summary>Request for DeleteUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html</para></summary>
 	public partial class DeleteUserRequest : PlainRequestBase<DeleteUserRequestParameters>, IDeleteUserRequest
 	{
 		protected IDeleteUserRequest Self => this;
@@ -368,7 +368,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DisableUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</pre></summary>
+	///<summary>Request for DisableUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html</para></summary>
 	public partial class DisableUserRequest : PlainRequestBase<DisableUserRequestParameters>, IDisableUserRequest
 	{
 		protected IDisableUserRequest Self => this;
@@ -410,7 +410,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for EnableUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</pre></summary>
+	///<summary>Request for EnableUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html</para></summary>
 	public partial class EnableUserRequest : PlainRequestBase<EnableUserRequestParameters>, IEnableUserRequest
 	{
 		protected IEnableUserRequest Self => this;
@@ -447,7 +447,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GetApiKey <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</pre></summary>
+	///<summary>Request for GetApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html</para></summary>
 	public partial class GetApiKeyRequest : PlainRequestBase<GetApiKeyRequestParameters>, IGetApiKeyRequest
 	{
 		protected IGetApiKeyRequest Self => this;
@@ -499,7 +499,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetPrivileges <pre>TODO</pre></summary>
+	///<summary>Request for GetPrivileges <para>TODO</para></summary>
 	public partial class GetPrivilegesRequest : PlainRequestBase<GetPrivilegesRequestParameters>, IGetPrivilegesRequest
 	{
 		protected IGetPrivilegesRequest Self => this;
@@ -540,7 +540,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetRole <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</pre></summary>
+	///<summary>Request for GetRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</para></summary>
 	public partial class GetRoleRequest : PlainRequestBase<GetRoleRequestParameters>, IGetRoleRequest
 	{
 		protected IGetRoleRequest Self => this;
@@ -572,7 +572,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetRoleMapping <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</pre></summary>
+	///<summary>Request for GetRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</para></summary>
 	public partial class GetRoleMappingRequest : PlainRequestBase<GetRoleMappingRequestParameters>, IGetRoleMappingRequest
 	{
 		protected IGetRoleMappingRequest Self => this;
@@ -599,7 +599,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GetUserAccessToken <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</pre></summary>
+	///<summary>Request for GetUserAccessToken <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html</para></summary>
 	public partial class GetUserAccessTokenRequest : PlainRequestBase<GetUserAccessTokenRequestParameters>, IGetUserAccessTokenRequest
 	{
 		protected IGetUserAccessTokenRequest Self => this;
@@ -618,7 +618,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</pre></summary>
+	///<summary>Request for GetUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html</para></summary>
 	public partial class GetUserRequest : PlainRequestBase<GetUserRequestParameters>, IGetUserRequest
 	{
 		protected IGetUserRequest Self => this;
@@ -645,7 +645,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GetUserPrivileges <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</pre></summary>
+	///<summary>Request for GetUserPrivileges <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html</para></summary>
 	public partial class GetUserPrivilegesRequest : PlainRequestBase<GetUserPrivilegesRequestParameters>, IGetUserPrivilegesRequest
 	{
 		protected IGetUserPrivilegesRequest Self => this;
@@ -664,7 +664,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for HasPrivileges <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</pre></summary>
+	///<summary>Request for HasPrivileges <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</para></summary>
 	public partial class HasPrivilegesRequest : PlainRequestBase<HasPrivilegesRequestParameters>, IHasPrivilegesRequest
 	{
 		protected IHasPrivilegesRequest Self => this;
@@ -692,7 +692,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for InvalidateApiKey <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</pre></summary>
+	///<summary>Request for InvalidateApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</para></summary>
 	public partial class InvalidateApiKeyRequest : PlainRequestBase<InvalidateApiKeyRequestParameters>, IInvalidateApiKeyRequest
 	{
 		protected IInvalidateApiKeyRequest Self => this;
@@ -706,7 +706,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for InvalidateUserAccessToken <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</pre></summary>
+	///<summary>Request for InvalidateUserAccessToken <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html</para></summary>
 	public partial class InvalidateUserAccessTokenRequest : PlainRequestBase<InvalidateUserAccessTokenRequestParameters>, IInvalidateUserAccessTokenRequest
 	{
 		protected IInvalidateUserAccessTokenRequest Self => this;
@@ -720,7 +720,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for PutPrivileges <pre>TODO</pre></summary>
+	///<summary>Request for PutPrivileges <para>TODO</para></summary>
 	public partial class PutPrivilegesRequest : PlainRequestBase<PutPrivilegesRequestParameters>, IPutPrivilegesRequest
 	{
 		protected IPutPrivilegesRequest Self => this;
@@ -748,7 +748,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutRole <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</pre></summary>
+	///<summary>Request for PutRole <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html</para></summary>
 	public partial class PutRoleRequest : PlainRequestBase<PutRoleRequestParameters>, IPutRoleRequest
 	{
 		protected IPutRoleRequest Self => this;
@@ -790,7 +790,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutRoleMapping <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</pre></summary>
+	///<summary>Request for PutRoleMapping <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html</para></summary>
 	public partial class PutRoleMappingRequest : PlainRequestBase<PutRoleMappingRequestParameters>, IPutRoleMappingRequest
 	{
 		protected IPutRoleMappingRequest Self => this;
@@ -832,7 +832,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for PutUser <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</pre></summary>
+	///<summary>Request for PutUser <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html</para></summary>
 	public partial class PutUserRequest : PlainRequestBase<PutUserRequestParameters>, IPutUserRequest
 	{
 		protected IPutUserRequest Self => this;
@@ -869,7 +869,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for GetCertificates <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</pre></summary>
+	///<summary>Request for GetCertificates <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html</para></summary>
 	public partial class GetCertificatesRequest : PlainRequestBase<GetCertificatesRequestParameters>, IGetCertificatesRequest
 	{
 		protected IGetCertificatesRequest Self => this;

--- a/src/Nest/Requests.Snapshot.cs
+++ b/src/Nest/Requests.Snapshot.cs
@@ -47,7 +47,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Snapshot <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for Snapshot <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class SnapshotRequest : PlainRequestBase<SnapshotRequestParameters>, ISnapshotRequest
 	{
 		protected ISnapshotRequest Self => this;
@@ -96,7 +96,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for CreateRepository <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for CreateRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class CreateRepositoryRequest : PlainRequestBase<CreateRepositoryRequestParameters>, ICreateRepositoryRequest
 	{
 		protected ICreateRepositoryRequest Self => this;
@@ -155,7 +155,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Delete <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class DeleteSnapshotRequest : PlainRequestBase<DeleteSnapshotRequestParameters>, IDeleteSnapshotRequest
 	{
 		protected IDeleteSnapshotRequest Self => this;
@@ -197,7 +197,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for DeleteRepository <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for DeleteRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class DeleteRepositoryRequest : PlainRequestBase<DeleteRepositoryRequestParameters>, IDeleteRepositoryRequest
 	{
 		protected IDeleteRepositoryRequest Self => this;
@@ -249,7 +249,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Get <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class GetSnapshotRequest : PlainRequestBase<GetSnapshotRequestParameters>, IGetSnapshotRequest
 	{
 		protected IGetSnapshotRequest Self => this;
@@ -305,7 +305,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetRepository <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for GetRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class GetRepositoryRequest : PlainRequestBase<GetRepositoryRequestParameters>, IGetRepositoryRequest
 	{
 		protected IGetRepositoryRequest Self => this;
@@ -356,7 +356,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Restore <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for Restore <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class RestoreRequest : PlainRequestBase<RestoreRequestParameters>, IRestoreRequest
 	{
 		protected IRestoreRequest Self => this;
@@ -411,7 +411,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Status <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for Status <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class SnapshotStatusRequest : PlainRequestBase<SnapshotStatusRequestParameters>, ISnapshotStatusRequest
 	{
 		protected ISnapshotStatusRequest Self => this;
@@ -465,7 +465,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for VerifyRepository <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</pre></summary>
+	///<summary>Request for VerifyRepository <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html</para></summary>
 	public partial class VerifyRepositoryRequest : PlainRequestBase<VerifyRepositoryRequestParameters>, IVerifyRepositoryRequest
 	{
 		protected IVerifyRepositoryRequest Self => this;

--- a/src/Nest/Requests.Sql.cs
+++ b/src/Nest/Requests.Sql.cs
@@ -36,7 +36,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for ClearCursor <pre>Clear SQL cursor</pre></summary>
+	///<summary>Request for ClearCursor <para>Clear SQL cursor</para></summary>
 	public partial class ClearSqlCursorRequest : PlainRequestBase<ClearSqlCursorRequestParameters>, IClearSqlCursorRequest
 	{
 		protected IClearSqlCursorRequest Self => this;
@@ -50,7 +50,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Query <pre>Execute SQL</pre></summary>
+	///<summary>Request for Query <para>Execute SQL</para></summary>
 	public partial class QuerySqlRequest : PlainRequestBase<QuerySqlRequestParameters>, IQuerySqlRequest
 	{
 		protected IQuerySqlRequest Self => this;
@@ -70,7 +70,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Translate <pre>Translate SQL into Elasticsearch queries</pre></summary>
+	///<summary>Request for Translate <para>Translate SQL into Elasticsearch queries</para></summary>
 	public partial class TranslateSqlRequest : PlainRequestBase<TranslateSqlRequestParameters>, ITranslateSqlRequest
 	{
 		protected ITranslateSqlRequest Self => this;

--- a/src/Nest/Requests.Tasks.cs
+++ b/src/Nest/Requests.Tasks.cs
@@ -41,7 +41,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Cancel <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>Request for Cancel <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public partial class CancelTasksRequest : PlainRequestBase<CancelTasksRequestParameters>, ICancelTasksRequest
 	{
 		protected ICancelTasksRequest Self => this;
@@ -96,7 +96,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for GetTask <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>Request for GetTask <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public partial class GetTaskRequest : PlainRequestBase<GetTaskRequestParameters>, IGetTaskRequest
 	{
 		protected IGetTaskRequest Self => this;
@@ -137,7 +137,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for List <pre>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</pre></summary>
+	///<summary>Request for List <para>http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html</para></summary>
 	public partial class ListTasksRequest : PlainRequestBase<ListTasksRequestParameters>, IListTasksRequest
 	{
 		protected IListTasksRequest Self => this;

--- a/src/Nest/Requests.Watcher.cs
+++ b/src/Nest/Requests.Watcher.cs
@@ -47,7 +47,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Acknowledge <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</pre></summary>
+	///<summary>Request for Acknowledge <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html</para></summary>
 	public partial class AcknowledgeWatchRequest : PlainRequestBase<AcknowledgeWatchRequestParameters>, IAcknowledgeWatchRequest
 	{
 		protected IAcknowledgeWatchRequest Self => this;
@@ -89,7 +89,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Activate <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</pre></summary>
+	///<summary>Request for Activate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html</para></summary>
 	public partial class ActivateWatchRequest : PlainRequestBase<ActivateWatchRequestParameters>, IActivateWatchRequest
 	{
 		protected IActivateWatchRequest Self => this;
@@ -122,7 +122,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Deactivate <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</pre></summary>
+	///<summary>Request for Deactivate <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html</para></summary>
 	public partial class DeactivateWatchRequest : PlainRequestBase<DeactivateWatchRequestParameters>, IDeactivateWatchRequest
 	{
 		protected IDeactivateWatchRequest Self => this;
@@ -155,7 +155,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Delete <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</pre></summary>
+	///<summary>Request for Delete <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html</para></summary>
 	public partial class DeleteWatchRequest : PlainRequestBase<DeleteWatchRequestParameters>, IDeleteWatchRequest
 	{
 		protected IDeleteWatchRequest Self => this;
@@ -188,7 +188,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Execute <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</pre></summary>
+	///<summary>Request for Execute <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html</para></summary>
 	public partial class ExecuteWatchRequest : PlainRequestBase<ExecuteWatchRequestParameters>, IExecuteWatchRequest
 	{
 		protected IExecuteWatchRequest Self => this;
@@ -226,7 +226,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Get <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</pre></summary>
+	///<summary>Request for Get <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html</para></summary>
 	public partial class GetWatchRequest : PlainRequestBase<GetWatchRequestParameters>, IGetWatchRequest
 	{
 		protected IGetWatchRequest Self => this;
@@ -259,7 +259,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Put <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</pre></summary>
+	///<summary>Request for Put <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html</para></summary>
 	public partial class PutWatchRequest : PlainRequestBase<PutWatchRequestParameters>, IPutWatchRequest
 	{
 		protected IPutWatchRequest Self => this;
@@ -314,7 +314,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Start <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</pre></summary>
+	///<summary>Request for Start <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html</para></summary>
 	public partial class StartWatcherRequest : PlainRequestBase<StartWatcherRequestParameters>, IStartWatcherRequest
 	{
 		protected IStartWatcherRequest Self => this;
@@ -333,7 +333,7 @@ namespace Nest
 		}
 	}
 
-	///<summary>Request for Stats <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</pre></summary>
+	///<summary>Request for Stats <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html</para></summary>
 	public partial class WatcherStatsRequest : PlainRequestBase<WatcherStatsRequestParameters>, IWatcherStatsRequest
 	{
 		protected IWatcherStatsRequest Self => this;
@@ -366,7 +366,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Stop <pre>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</pre></summary>
+	///<summary>Request for Stop <para>http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html</para></summary>
 	public partial class StopWatcherRequest : PlainRequestBase<StopWatcherRequestParameters>, IStopWatcherRequest
 	{
 		protected IStopWatcherRequest Self => this;

--- a/src/Nest/Requests.XPack.cs
+++ b/src/Nest/Requests.XPack.cs
@@ -36,7 +36,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Info <pre>https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</pre></summary>
+	///<summary>Request for Info <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html</para></summary>
 	public partial class XPackInfoRequest : PlainRequestBase<XPackInfoRequestParameters>, IXPackInfoRequest
 	{
 		protected IXPackInfoRequest Self => this;
@@ -56,7 +56,7 @@ namespace Nest
 	{
 	}
 
-	///<summary>Request for Usage <pre>Retrieve information about xpack features usage</pre></summary>
+	///<summary>Request for Usage <para>Retrieve information about xpack features usage</para></summary>
 	public partial class XPackUsageRequest : PlainRequestBase<XPackUsageRequestParameters>, IXPackUsageRequest
 	{
 		protected IXPackUsageRequest Self => this;

--- a/src/Nest/XPack/Watcher/Condition/ConditionContainer.cs
+++ b/src/Nest/XPack/Watcher/Condition/ConditionContainer.cs
@@ -42,17 +42,10 @@ namespace Nest
 
 		/// <summary>
 		/// A watch condition that evaluates a script.
-		/// The default scripting language is groovy.
 		/// You can use any of the scripting languages supported by Elasticsearch as long as the
 		/// language supports evaluating expressions to Boolean values.
 		/// Note that the mustache and expression languages are too limited to be used by this condition.
 		/// </summary>
-		/// <remarks>
-		/// For Groovy, you must explicitly enable dynamic scripts in elasticsearch.yml
-		/// to use inline or stored scripts.
-		/// To enable groovy scripting for watches only,
-		/// you can set script.engine.groovy.inline.xpack_watch: true.
-		/// </remarks>
 		[DataMember(Name = "script")]
 		IScriptCondition Script { get; set; }
 	}

--- a/src/Tests/Tests.Configuration/TestConfigurationBase.cs
+++ b/src/Tests/Tests.Configuration/TestConfigurationBase.cs
@@ -10,7 +10,7 @@ namespace Tests.Configuration
 		/// <summary> comma separated list of test method names to execute </summary>
 		public string TestFilter { get; protected set; }
 
-		/// <summary> The elasticsearch version to test against, defined for both unit and integration tests</summary>
+		/// <summary> The Elasticsearch version to test against, defined for both unit and integration tests</summary>
 		public string ElasticsearchVersion { get; protected set; }
 
 		/// <summary> Force a reseed (bootstrap) of the cluster even if checks indicate bootstrap already ran </summary>

--- a/src/Tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
@@ -57,7 +57,7 @@ namespace Tests.Core.ManagedElasticsearch.NodeSeeders
 			t.Wait(TimeSpan.FromSeconds(40));
 		}
 
-		// Sometimes we run against an manually started elasticsearch when
+		// Sometimes we run against an manually started Elasticsearch when
 		// writing tests to cut down on cluster startup times.
 		// If raw_fields exists assume this cluster is already seeded.
 		private bool AlreadySeeded() => Client.Indices.TemplateExists(TestsIndexTemplateName).Exists;

--- a/src/Tests/Tests/Analysis/AnalysisCrudTests.cs
+++ b/src/Tests/Tests/Analysis/AnalysisCrudTests.cs
@@ -19,7 +19,7 @@ namespace Tests.Analysis
 		*
 		* In this example we will create an index with analysis settings, read those settings back, update the analysis settings
 		* and do another read after the update to assert our new analysis setting is applied.
-		* There is NO mechanism to delete an analysis setting in elasticsearch.
+		* There is NO mechanism to delete an analysis setting in Elasticsearch.
 		*/
 		protected override bool SupportsDeletes => false;
 

--- a/src/Tests/Tests/XPack/MachineLearning/MachineLearningSeeder.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/MachineLearningSeeder.cs
@@ -26,7 +26,7 @@ namespace Tests.XPack.MachineLearning
 
 		private IElasticClient Client { get; }
 
-		// Sometimes we run against an manually started elasticsearch when
+		// Sometimes we run against an manually started Elasticsearch when
 		// writing tests to cut down on cluster startup times.
 		// If template exists assume this cluster is already seeded with the machine learning data.
 		private bool AlreadySeeded() => Client.Indices.TemplateExists(MachineLearningTestsIndexTemplateName).Exists;


### PR DESCRIPTION
This commit refines the code generated XML comments.

- For namespaces, split pascal cased names.
- Use `<para>` instead of `<pre>`
- Replace usage of elasticsearch with Elasticsearch