### PR TITLE
Fix 7.x documentation

### DIFF
--- a/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
@@ -41,6 +41,29 @@ new ScriptedMetricAggregation("sum_the_hard_way")
 }
 ----
 
+[source,javascript]
+.Example json output
+----
+{
+  "sum_the_hard_way": {
+    "scripted_metric": {
+      "init_script": {
+        "source": "state.commits = []"
+      },
+      "map_script": {
+        "source": "if (doc['state'].value == \"Stable\") { state.commits.add(doc['numberOfCommits'].value) }"
+      },
+      "combine_script": {
+        "source": "def sum = 0.0; for (c in state.commits) { sum += c } return sum"
+      },
+      "reduce_script": {
+        "source": "def sum = 0.0; for (a in states) { sum += a } return sum"
+      }
+    }
+  }
+}
+----
+
 ==== Handling Responses
 
 [source,csharp]
@@ -100,6 +123,53 @@ new ScriptedMetricAggregation("by_state_total")
     MapScript = new InlineScript(_second.Map) { Lang = _second.Language },
     CombineScript = new InlineScript(_second.Combine) { Lang = _second.Language },
     ReduceScript = new InlineScript(_second.Reduce) { Lang = _second.Language }
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "by_state_total": {
+    "scripted_metric": {
+      "init_script": {
+        "source": "state.map = [:]",
+        "lang": "painless"
+      },
+      "combine_script": {
+        "source": "return state.map;",
+        "lang": "painless"
+      },
+      "map_script": {
+        "source": "if (state.map.containsKey(doc['state'].value)) state.map[doc['state'].value] += 1; else state.map[doc['state'].value] = 1;",
+        "lang": "painless"
+      },
+      "reduce_script": {
+        "source": "def reduce = [:]; for (map in states){ for (entry in map.entrySet()) { if (reduce.containsKey(entry.getKey())) reduce[entry.getKey()] += entry.getValue(); else reduce[entry.getKey()] = entry.getValue(); }} return reduce;",
+        "lang": "painless"
+      }
+    }
+  },
+  "total_commits": {
+    "scripted_metric": {
+      "init_script": {
+        "source": "state.commits = []",
+        "lang": "painless"
+      },
+      "map_script": {
+        "source": "if (doc['state'].value == \"Stable\") { state.commits.add(doc['numberOfCommits'].value) }",
+        "lang": "painless"
+      },
+      "combine_script": {
+        "source": "def sum = 0.0; for (c in state.commits) { sum += c } return sum",
+        "lang": "painless"
+      },
+      "reduce_script": {
+        "source": "def sum = 0.0; for (a in states) { sum += a } return sum",
+        "lang": "painless"
+      }
+    }
+  }
 }
 ----
 

--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -26,11 +26,181 @@ The following is a list of available connection configuration options on `Connec
 `ConnectionSettings` derives from `ConnectionConfiguration`, these options are available for both
 Elasticsearch.Net and NEST:
 
+`BasicAuthentication`::
+
+Basic Authentication credentials to send with all requests to Elasticsearch
+
+`BasicAuthentication`::
+
+Basic Authentication credentials to send with all requests to Elasticsearch
+
+`ClientCertificate`::
+
+Use a `X509Certificate` to authenticate all HTTP requests. You can also set them on individual request using `ClientCertificates`
+
+`ClientCertificate`::
+
+Use a file path to a certificate to authenticate all HTTP requests. You can also set them on individual request using `ClientCertificates`
+
+`ClientCertificates`::
+
+Use the following certificates to authenticate all HTTP requests. You can also set them on individual request using `ClientCertificates`
+
+`ConnectionLimit`::
+
+Limits the number of concurrent connections that can be opened to an endpoint. Defaults to `80` .
++
+For Desktop CLR, this setting applies to the DefaultConnectionLimit property on the  ServicePointManager object when creating ServicePoint objects, affecting the default `IConnection` implementation.
++
+For Core CLR, this setting applies to the MaxConnectionsPerServer property on the HttpClientHandler instances used by the HttpClient inside the default `IConnection` implementation
+
+`DeadTimeout`::
+
+Sets the default dead timeout factor when a node has been marked dead. Some connection pools may use a flat timeout whilst others take this factor and increase it exponentially
+
+`DisableAutomaticProxyDetection`::
+
+Disables the automatic detection of a proxy
+
+`DisableDirectStreaming`::
+
+Ensures the response bytes are always available on the `ElasticsearchResponse<T>`
++
+IMPORTANT: Depending on the registered serializer, this may cause the response to be buffered in memory first, potentially affecting performance.
+
+`DisablePing`::
+
+When a node is used for the very first time or when it's used for the first time after it has been marked dead a ping with a very low timeout is send to the node to make sure that when it's still dead it reports it as fast as possible. You can disable these pings globally here if you rather have it fail on the possible slower original request
+
+`EnableDebugMode`::
+
+Turns on settings that aid in debugging like DisableDirectStreaming() and PrettyJson() so that the original request and response JSON can be inspected. It also always asks the server for the full stack trace on errors
+
+`EnableHttpCompression`::
+
+Enables gzip compressed requests and responses.
++
+IMPORTANT: You need to configure http compression on Elasticsearch to be able to use this
++
+http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html
+
+`EnableHttpPipelining`::
+
+Allows for requests to be pipelined. http://en.wikipedia.org/wiki/HTTP_pipelining
++
+NOTE: HTTP pipelining must also be enabled in Elasticsearch for this to work properly.
+
+`EnableTcpKeepAlive`::
+
+Sets the keep-alive option on a TCP connection.
++
+For Desktop CLR, sets ServicePointManager.SetTcpKeepAlive
+
+`GlobalHeaders`::
+
+A collection of headers that will be sent with every request. Useful in situations where you always need to pass a header e.g. a custom auth header
+
+`GlobalQueryStringParameters`::
+
+A collection of query string parameters that will be sent with every request. Useful in situations where you always need to pass a parameter e.g. an API key.
+
+`IncludeServerStackTraceOnError`::
+
+Forces all requests to have ?error_trace=true querystring parameter appended, causing Elasticsearch to return stack traces as part of serialized exceptions Defaults to `false`
+
+`MaxDeadTimeout`::
+
+Sets the maximum time a node can be marked dead. Different implementations of `IConnectionPool` may choose a different default.
+
+`MaximumRetries`::
+
+The maximum number of retries for a given request
+
+`MaxRetryTimeout`::
+
+Limits the total runtime, including retries, separately from `RequestTimeout`
++
+When not specified, defaults to `RequestTimeout` , which itself defaults to `60` seconds
+
+`NodePredicate`::
+
+Register a predicate to select which nodes that you want to execute API calls on. Note that sniffing requests omit this predicate and always execute on all nodes. When using an `IConnectionPool` implementation that supports reseeding of nodes, this will default to omitting master only             node from regular API calls.             When using static or single node connection pooling it is assumed the list of node you instantiate the client with should be taken             verbatim.
+
+`OnRequestCompleted`::
+
+Registers an `Action<T>` that is called when a response is received from Elasticsearch.             This can be useful for implementing custom logging.             Multiple callbacks can be registered by calling this multiple times
+
+`OnRequestDataCreated`::
+
+Registers an `Action<T>` that is called when `RequestData` is created.             Multiple callbacks can be registered by calling this multiple times
+
+`PingTimeout`::
+
+Sets the default ping timeout in milliseconds for ping requests, which are used to determine whether a node is alive. Pings should fail as fast as possible.
+
+`PrettyJson`::
+
+Forces all requests to have ?pretty=true querystring parameter appended, causing Elasticsearch to return formatted JSON. Also forces the client to send out formatted JSON. Defaults to `false`
+
+`Proxy`::
+
+If your connection has to go through proxy, use this method to specify the proxy url
+
+`Proxy`::
+
+If your connection has to go through proxy, use this method to specify the proxy url
+
+`RequestTimeout`::
+
+Sets the default timeout in milliseconds for each request to Elasticsearch. Defaults to `60` seconds.
++
+NOTE: You can set this to a high value here, and specify a timeout on Elasticsearch's side.
+
+`ServerCertificateValidationCallback`::
+
+Register a ServerCertificateValidationCallback, this is called per endpoint until it returns true. After this callback returns true that endpoint is validated for the lifetime of the ServiceEndpoint for that host.
+
+`SkipDeserializationForStatusCodes`::
+
+Configure the client to skip deserialization of certain status codes e.g: you run Elasticsearch behind a proxy that returns a HTML for 401, 500
+
+`SniffLifeSpan`::
+
+Set the duration after which a cluster state is considered stale and a sniff should be performed again. An `IConnectionPool` has to signal it supports reseeding, otherwise sniffing will never happen.             Defaults to 1 hour.             Set to null to disable completely. Sniffing will only ever happen on ConnectionPools that return true for SupportsReseeding
+
+`SniffOnConnectionFault`::
+
+Enables resniffing of the cluster when a call fails, if the connection pool supports reseeding. Defaults to `true`
+
+`SniffOnStartup`::
+
+Enables sniffing on first usage of a connection pool if that pool supports reseeding. Defaults to `true`
+
+`ThrowExceptions`::
+
+Instead of following a c/go like error checking on response.IsValid do throw an exception (except when `SuccessOrKnownError` is false)             on the client when a call resulted in an exception on either the client or the Elasticsearch server.
++
+Reasons for such exceptions could be search parser errors, index missing exceptions, etc...
+
 :xml-docs: Elasticsearch.Net:ConnectionConfiguration`1
 
 ==== Options on ConnectionSettings
 
 The following is a list of available connection configuration options on `ConnectionSettings`:
+
+`DefaultDisableIdInference`::
+
+`DefaultFieldNameInferrer`::
+
+`DefaultIndex`::
+
+`DefaultMappingFor`::
+
+Specify how the mapping is inferred for a given CLR type. The mapping can infer the index, id and relation name for a given CLR type, as well as control serialization behaviour for CLR properties.
+
+`DefaultMappingFor`::
+
+Specify how the mapping is inferred for a given CLR type. The mapping can infer the index and relation name for a given CLR type.
 
 :xml-docs: Nest:ConnectionSettingsBase`1
 

--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -17,14 +17,14 @@ please modify the original csharp file found at the link and submit the PR with 
 
 Connecting to Elasticsearch with <<elasticsearch-net-getting-started,Elasticsearch.Net>> and <<nest-getting-started,NEST>> is easy, but
 it's entirely possible that you'd like to change the default connection behaviour. There are a number of configuration options available
-on `ConnectionSettings` (and `ConnectionConfiguration` for Elasticsearch.Net) that can be used to control
+on `ConnectionConfiguration` for the low level client and `ConnectionSettings` for the high level client that can be used to control
 how the clients interact with Elasticsearch.
 
 ==== Options on ConnectionConfiguration
 
 The following is a list of available connection configuration options on `ConnectionConfiguration`; since
 `ConnectionSettings` derives from `ConnectionConfiguration`, these options are available for both
-Elasticsearch.Net and NEST:
+the low level and high level client:
 
 `BasicAuthentication`::
 
@@ -48,7 +48,7 @@ Use the following certificates to authenticate all HTTP requests. You can also s
 
 `ConnectionLimit`::
 
-Limits the number of concurrent connections that can be opened to an endpoint. Defaults to `80` .
+Limits the number of concurrent connections that can be opened to an endpoint. Defaults to `80` for all IConnection             implementations that are not based on `System.Net.Http.CurlHandler` . For those based on System.Net.Http.CurlHandler, defaults             to `Environment.ProcessorCount` .
 +
 For Desktop CLR, this setting applies to the DefaultConnectionLimit property on the  ServicePointManager object when creating ServicePoint objects, affecting the default `IConnection` implementation.
 +
@@ -184,25 +184,7 @@ Reasons for such exceptions could be search parser errors, index missing excepti
 
 :xml-docs: Elasticsearch.Net:ConnectionConfiguration`1
 
-==== Options on ConnectionSettings
-
-The following is a list of available connection configuration options on `ConnectionSettings`:
-
-`DefaultDisableIdInference`::
-
-`DefaultFieldNameInferrer`::
-
-`DefaultIndex`::
-
-`DefaultMappingFor`::
-
-Specify how the mapping is inferred for a given CLR type. The mapping can infer the index, id and relation name for a given CLR type, as well as control serialization behaviour for CLR properties.
-
-`DefaultMappingFor`::
-
-Specify how the mapping is inferred for a given CLR type. The mapping can infer the index and relation name for a given CLR type.
-
-:xml-docs: Nest:ConnectionSettingsBase`1
+==== ConnectionConfiguration with ElasticLowLevelClient
 
 Here's an example to demonstrate setting several configuration options using the low level client
 
@@ -218,13 +200,46 @@ var connectionConfiguration = new ConnectionConfiguration()
 var lowLevelClient = new ElasticLowLevelClient(connectionConfiguration);
 ----
 
-And with the high level client
+==== Options on ConnectionSettings
+
+The following is a list of available connection configuration options on `ConnectionSettings`:
+
+`DefaultDisableIdInference`::
+
+Disables automatic Id inference for given CLR types.
++
+NEST by default will use the value of a property named Id on a CLR type as the _id to send to Elasticsearch. Adding a type will disable this behaviour for that CLR type. If Id inference should be disabled for all CLR types, use `DefaultDisableIdInference`
+
+`DefaultFieldNameInferrer`::
+
+Specifies how field names are inferred from CLR property names.
++
+By default, NEST camel cases property names. For example, CLR property EmailAddress will be inferred as "emailAddress" Elasticsearch document field name
+
+`DefaultIndex`::
+
+The default index to use for a request when no index has been explicitly specified and no default indices are specified for the given CLR type specified for the request.
+
+`DefaultMappingFor`::
+
+Specify how the mapping is inferred for a given CLR type. The mapping can infer the index, id and relation name for a given CLR type, as well as control serialization behaviour for CLR properties.
+
+`DefaultMappingFor`::
+
+Specify how the mapping is inferred for a given CLR type. The mapping can infer the index and relation name for a given CLR type.
+
+:xml-docs: Nest:ConnectionSettingsBase`1
+
+==== ConnectionSettings with ElasticClient
+
+Here's an example to demonstrate setting several configuration options using the high level client
 
 [source,csharp]
 ----
 var connectionSettings = new ConnectionSettings()
     .DefaultMappingFor<Project>(i => i
         .IndexName("my-projects")
+        .IdProperty(p => p.Name)
     )
     .EnableDebugMode()
     .PrettyJson()

--- a/docs/query-dsl/compound/bool/bool-dsl-complex-query-usage.asciidoc
+++ b/docs/query-dsl/compound/bool/bool-dsl-complex-query-usage.asciidoc
@@ -45,3 +45,145 @@ Query && Query
 && base.QueryInitializer
 ----
 
+[source,javascript]
+.Example json output
+----
+{
+  "bool": {
+    "should": [
+      {
+        "bool": {
+          "must": [
+            {
+              "term": {
+                "x": {
+                  "value": "y"
+                }
+              }
+            },
+            {
+              "term": {
+                "x": {
+                  "value": "y"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "term": {
+                            "x": {
+                              "value": "y"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "term": {
+                            "x": {
+                              "value": "y"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must_not": [
+                        {
+                          "term": {
+                            "x": {
+                              "value": "y"
+                            }
+                          }
+                        },
+                        {
+                          "term": {
+                            "x": {
+                              "value": "y"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "x": {
+                        "value": "y"
+                      }
+                    }
+                  },
+                  {
+                    "term": {
+                      "x": {
+                        "value": "y"
+                      }
+                    }
+                  },
+                  {
+                    "term": {
+                      "x": {
+                        "value": "y"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "bool": {
+                "must": [
+                  {
+                    "match_all": {}
+                  }
+                ],
+                "must_not": [
+                  {
+                    "match_all": {}
+                  }
+                ],
+                "should": [
+                  {
+                    "match_all": {}
+                  }
+                ],
+                "filter": [
+                  {
+                    "match_all": {}
+                  }
+                ],
+                "minimum_should_match": 1,
+                "boost": 2.0
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+----
+

--- a/src/CodeGeneration/DocGenerator/StringExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/StringExtensions.cs
@@ -15,10 +15,7 @@ namespace DocGenerator
 	public static class StringExtensions
 	{
 		private static readonly Regex LeadingMultiLineComment = new Regex(@"^(?<value>[ \t]*\/\*)", RegexOptions.Compiled);
-		private static readonly Regex LeadingSpacesAndAsterisk = new Regex(@"^(?<value>[ \t]*\*\s?).*", RegexOptions.Compiled);
 
-		// TODO: Total Hack of replacements in anonymous types that represent json. This can be resolved by referencing tests assembly when building the dynamic assembly,
-		// but might want to put doc generation at same directory level as Tests to reference project directly.
 		private static readonly Dictionary<string, string> Substitutions = new Dictionary<string, string>
 		{
 			{ "FixedDate", "new DateTime(2015, 06, 06, 12, 01, 02, 123)" },
@@ -42,26 +39,20 @@ namespace DocGenerator
 			{ "Project.First.Name", "\"Lesch Group\"" },
 			{ "Project.First.NumberOfCommits", "775" },
 			{ "LastNameSearch", "\"Stokes\"" },
-			{ "First.Language", "\"painless\"" },
-			{ "First.Init", "\"params._agg.map = [:]\"" },
-			{
-				"First.Map",
-				"\"if (params._agg.map.containsKey(doc['state'].value)) params._agg.map[doc['state'].value] += 1 else params._agg.map[doc['state'].value] = 1;\""
-			},
-			{
-				"First.Reduce",
-				"\"def reduce = [:]; for (agg in params._aggs) { for (entry in agg.map.entrySet()) { if (reduce.containsKey(entry.getKey())) reduce[entry.getKey()] += entry.getValue(); else reduce[entry.getKey()] = entry.getValue(); } } return reduce;\""
-			},
-			{ "Second.Language", "\"painless\"" },
-			{ "Second.Combine", "\"def sum = 0.0; for (c in params._agg.commits) { sum += c } return sum\"" },
-			{ "Second.Init", "\"params._agg.commits = []\"" },
-			{ "Second.Map", "\"if (doc['state'].value == \\\"Stable\\\") { params._agg.commits.add(doc['numberOfCommits'].value) }\"" },
-			{ "Second.Reduce", "\"def sum = 0.0; for (a in params._aggs) { sum += a } return sum\"" },
-			{ "Script.Lang", "\"painless\"" },
-			{ "Script.Init", "\"params._agg.commits = []\"" },
-			{ "Script.Map", "\"if (doc['state'].value == \\\"Stable\\\") { params._agg.commits.add(doc['numberOfCommits'].value) }\"" },
-			{ "Script.Combine", "\"def sum = 0.0; for (c in params._agg.commits) { sum += c } return sum\"" },
-			{ "Script.Reduce", "\"def sum = 0.0; for (a in params._aggs) { sum += a } return sum\"" },
+			{ "_first.Language", "\"painless\"" },
+			{ "_first.Init", "\"state.map = [:]\"" },
+			{ "_first.Map", "\"if (state.map.containsKey(doc['state'].value)) state.map[doc['state'].value] += 1; else state.map[doc['state'].value] = 1;\"" },
+			{ "_first.Reduce", "\"def reduce = [:]; for (map in states){ for (entry in map.entrySet()) { if (reduce.containsKey(entry.getKey())) reduce[entry.getKey()] += entry.getValue(); else reduce[entry.getKey()] = entry.getValue(); }} return reduce;\"" },
+			{ "_first.Combine", "\"return state.map;\"" },
+			{ "_second.Language", "\"painless\"" },
+			{ "_second.Init", "\"state.commits = []\"" },
+			{ "_second.Combine", "\"def sum = 0.0; for (c in state.commits) { sum += c } return sum\"" },
+			{ "_second.Map", "\"if (doc['state'].value == \\\"Stable\\\") { state.commits.add(doc['numberOfCommits'].value) }\"" },
+			{ "_second.Reduce", "\"def sum = 0.0; for (a in states) { sum += a } return sum\"" },
+			{ "_script.Init", "\"state.commits = []\"" },
+			{ "_script.Map", "\"if (doc['state'].value == \\\"Stable\\\") { state.commits.add(doc['numberOfCommits'].value) }\"" },
+			{ "_script.Combine", "\"def sum = 0.0; for (c in state.commits) { sum += c } return sum\"" },
+			{ "_script.Reduce", "\"def sum = 0.0; for (a in states) { sum += a } return sum\"" },
 			{ "EnvelopeCoordinates", @"new [] { new [] { -45.0, 45.0 }, new [] { 45.0, -45.0 }}" },
 			{ "CircleCoordinates", @"new [] { 45.0, -45.0 }" },
 			{ "MultiPointCoordinates", @"new [] { new [] {38.897676, -77.03653}, new [] {38.889939, -77.009051} }" },
@@ -125,6 +116,12 @@ namespace DocGenerator
 			},
 			{ "ProjectFilterExpectedJson", "new {term = new {type = new {value = \"project\"}}}" }
 		};
+
+		private static readonly Regex LeadingSpacesAndAsterisk = new Regex(@"^(?<value>[ \t]*\*\s?).*", RegexOptions.Compiled);
+
+		// TODO: Total Hack of replacements in anonymous types that represent json. This can be resolved by referencing tests assembly when building the dynamic assembly,
+
+		// but might want to put doc generation at same directory level as Tests to reference project directly.
 
 		private static readonly Regex TrailingMultiLineComment = new Regex(@"(?<value>\*\/[ \t]*)$", RegexOptions.Compiled);
 

--- a/src/CodeGeneration/DocGenerator/XmlDocs/XmlDocsVisitor.cs
+++ b/src/CodeGeneration/DocGenerator/XmlDocs/XmlDocsVisitor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using AsciiDocNet;
 using NuDoq;
+using Example = NuDoq.Example;
 
 namespace DocGenerator.XmlDocs
 {
@@ -45,6 +46,15 @@ namespace DocGenerator.XmlDocs
 						paragraph.Add(new TextLiteral(" " + content));
 				}
 			}
+		}
+
+		public override void VisitExample(Example example)
+		{
+			var elements = new List<Element> { new Text ("For example, " )};
+			elements.AddRange(example.Elements);
+			example = new Example(elements);
+
+			base.VisitExample(example);
 		}
 
 		public override void VisitParam(Param param)

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -238,7 +238,9 @@ namespace Elasticsearch.Net
 		public T MaximumRetries(int maxRetries) => Assign(maxRetries, (a, v) => a._maxRetries = v);
 
 		/// <summary>
-		/// Limits the number of concurrent connections that can be opened to an endpoint. Defaults to <c>80</c>.
+		/// Limits the number of concurrent connections that can be opened to an endpoint. Defaults to <c>80</c> for all IConnection
+		/// implementations that are not based on <c>System.Net.Http.CurlHandler</c>. For those based on System.Net.Http.CurlHandler, defaults
+		/// to <c>Environment.ProcessorCount</c>.
 		/// <para>
 		/// For Desktop CLR, this setting applies to the DefaultConnectionLimit property on the  ServicePointManager object when creating
 		/// ServicePoint objects, affecting the default <see cref="IConnection" /> implementation.

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -105,8 +105,8 @@ namespace Nest
 
 			UserAgent(ConnectionSettings.DefaultUserAgent);
 		}
-		bool IConnectionSettingsValues.DefaultDisableIdInference => _defaultDisableAllInference;
 
+		bool IConnectionSettingsValues.DefaultDisableIdInference => _defaultDisableAllInference;
 		Func<string, string> IConnectionSettingsValues.DefaultFieldNameInferrer => _defaultFieldNameInferrer;
 		string IConnectionSettingsValues.DefaultIndex => _defaultIndex;
 		FluentDictionary<Type, string> IConnectionSettingsValues.DefaultIndices => _defaultIndices;
@@ -213,7 +213,7 @@ namespace Nest
 
 		/// <summary>
 		/// Specify how the mapping is inferred for a given CLR type.
-		/// The mapping can infer the index, type, id and relation name for a given CLR type, as well as control
+		/// The mapping can infer the index, id and relation name for a given CLR type, as well as control
 		/// serialization behaviour for CLR properties.
 		/// </summary>
 		public TConnectionSettings DefaultMappingFor<TDocument>(Func<ClrTypeMappingDescriptor<TDocument>, IClrTypeMapping<TDocument>> selector)
@@ -246,7 +246,7 @@ namespace Nest
 
 		/// <summary>
 		/// Specify how the mapping is inferred for a given CLR type.
-		/// The mapping can infer the index, type and relation name for a given CLR type.
+		/// The mapping can infer the index and relation name for a given CLR type.
 		/// </summary>
 		public TConnectionSettings DefaultMappingFor(Type documentType, Func<ClrTypeMappingDescriptor, IClrTypeMapping> selector)
 		{

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -63,23 +63,16 @@ namespace Nest
 		where TConnectionSettings : ConnectionSettingsBase<TConnectionSettings>, IConnectionSettingsValues
 	{
 		private readonly FluentDictionary<Type, string> _defaultIndices;
-
 		private readonly FluentDictionary<Type, string> _defaultRelationNames;
 		private readonly HashSet<Type> _disableIdInference = new HashSet<Type>();
-
 		private readonly FluentDictionary<Type, string> _idProperties = new FluentDictionary<Type, string>();
-
 		private readonly Inferrer _inferrer;
-
 		private readonly IPropertyMappingProvider _propertyMappingProvider;
-
 		private readonly FluentDictionary<MemberInfo, IPropertyMapping> _propertyMappings = new FluentDictionary<MemberInfo, IPropertyMapping>();
-
 		private readonly FluentDictionary<Type, string> _routeProperties = new FluentDictionary<Type, string>();
-
 		private readonly IElasticsearchSerializer _sourceSerializer;
-		private bool _defaultDisableAllInference;
 
+		private bool _defaultDisableAllInference;
 		private Func<string, string> _defaultFieldNameInferrer;
 		private string _defaultIndex;
 
@@ -119,17 +112,32 @@ namespace Nest
 		FluentDictionary<Type, string> IConnectionSettingsValues.RouteProperties => _routeProperties;
 		IElasticsearchSerializer IConnectionSettingsValues.SourceSerializer => _sourceSerializer;
 
-		/// <inheritdoc cref="IConnectionSettingsValues.DefaultIndex"/>
+		/// <summary>
+		/// The default index to use for a request when no index has been explicitly specified
+		/// and no default indices are specified for the given CLR type specified for the request.
+		/// </summary>
 		public TConnectionSettings DefaultIndex(string defaultIndex) => Assign(defaultIndex, (a, v) => a._defaultIndex = v);
 
-		/// <inheritdoc cref="IConnectionSettingsValues.DefaultFieldNameInferrer"/>
+		/// <summary>
+		/// Specifies how field names are inferred from CLR property names.
+		/// <para></para>
+		/// By default, NEST camel cases property names.
+		/// </summary>
+		/// <example>
+		/// CLR property EmailAddress will be inferred as "emailAddress" Elasticsearch document field name
+		/// </example>
 		public TConnectionSettings DefaultFieldNameInferrer(Func<string, string> fieldNameInferrer) =>
 			Assign(fieldNameInferrer, (a, v) => a._defaultFieldNameInferrer = v);
 
-		/// <inheritdoc cref="IConnectionSettingsValues.DefaultDisableIdInference" />
+		/// <summary>
+		/// Disables automatic Id inference for given CLR types.
+		/// <para></para>
+		/// NEST by default will use the value of a property named Id on a CLR type as the _id to send to Elasticsearch. Adding a type
+		/// will disable this behaviour for that CLR type. If Id inference should be disabled for all CLR types, use
+		/// <see cref="DefaultDisableIdInference"/>
+		/// </summary>
 		public TConnectionSettings DefaultDisableIdInference(bool disable = true) => Assign(disable, (a, v) => a._defaultDisableAllInference = v);
 
-		/// <inheritdoc cref="IConnectionSettingsValues.IdProperties"/>
 		private void MapIdPropertyFor<TDocument>(Expression<Func<TDocument, object>> objectPath)
 		{
 			objectPath.ThrowIfNull(nameof(objectPath));
@@ -263,7 +271,10 @@ namespace Nest
 			return (TConnectionSettings)this;
 		}
 
-		/// <inheritdoc cref="DefaultMappingFor(Type, Func{ClrTypeMappingDescriptor,IClrTypeMapping})" />
+		/// <summary>
+		/// Specify how the mapping is inferred for a given CLR type.
+		/// The mapping can infer the index and relation name for a given CLR type.
+		/// </summary>
 		public TConnectionSettings DefaultMappingFor(IEnumerable<IClrTypeMapping> typeMappings)
 		{
 			if (typeMappings == null) return (TConnectionSettings)this;

--- a/src/Nest/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/IConnectionSettingsValues.cs
@@ -13,7 +13,7 @@ namespace Nest
 		/// <summary>
 		/// Specifies how field names are inferred from CLR property names.
 		/// <para></para>
-		/// By default, NEST camel cases property names
+		/// By default, NEST camel cases property names.
 		/// </summary>
 		/// <example>
 		/// CLR property EmailAddress will be inferred as "emailAddress" Elasticsearch document field name

--- a/src/Nest/IndexModules/IndexSettings/Settings/AutoExpandReplicas.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/AutoExpandReplicas.cs
@@ -85,7 +85,7 @@ namespace Nest
 		}
 
 		/// <summary>
-		/// Creates an <see cref="AutoExpandReplicas" /> with the specified lower and upper bounds of replicas
+		/// Creates an <see cref="AutoExpandReplicas" /> with the specified lower and upper bounds of replicas.
 		/// </summary>
 		/// <example>0-5</example>
 		/// <example>0-all</example>

--- a/src/Tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
@@ -12,22 +12,18 @@ namespace Tests.ClientConcepts.Connection
 		 *
 		 * Connecting to Elasticsearch with <<elasticsearch-net-getting-started,Elasticsearch.Net>> and <<nest-getting-started,NEST>> is easy, but
 		 * it's entirely possible that you'd like to change the default connection behaviour. There are a number of configuration options available
-		 * on `ConnectionSettings` (and `ConnectionConfiguration` for Elasticsearch.Net) that can be used to control
+		 * on `ConnectionConfiguration` for the low level client and `ConnectionSettings` for the high level client that can be used to control
 		 * how the clients interact with Elasticsearch.
 		 *
 		 * ==== Options on ConnectionConfiguration
 		 *
 		 * The following is a list of available connection configuration options on `ConnectionConfiguration`; since
 		 * `ConnectionSettings` derives from `ConnectionConfiguration`, these options are available for both
-		 * Elasticsearch.Net and NEST:
+		 * the low level and high level client:
 		 *
 		 * :xml-docs: Elasticsearch.Net:ConnectionConfiguration`1
 		 *
-		 * ==== Options on ConnectionSettings
-		 *
-		 * The following is a list of available connection configuration options on `ConnectionSettings`:
-		 *
-		 * :xml-docs: Nest:ConnectionSettingsBase`1
+		 * ==== ConnectionConfiguration with ElasticLowLevelClient
 		 *
 		 * Here's an example to demonstrate setting several configuration options using the low level client
 		 */
@@ -42,13 +38,21 @@ namespace Tests.ClientConcepts.Connection
 
 			var lowLevelClient = new ElasticLowLevelClient(connectionConfiguration);
 
-
 			/**
-			 * And with the high level client
+			 * ==== Options on ConnectionSettings
+			 *
+			 * The following is a list of available connection configuration options on `ConnectionSettings`:
+			 *
+			 * :xml-docs: Nest:ConnectionSettingsBase`1
+			 *
+			 * ==== ConnectionSettings with ElasticClient
+			 *
+			 * Here's an example to demonstrate setting several configuration options using the high level client
 			 */
 			var connectionSettings = new ConnectionSettings()
 				.DefaultMappingFor<Project>(i => i
 					.IndexName("my-projects")
+					.IdProperty(p => p.Name)
 				)
 				.EnableDebugMode()
 				.PrettyJson()

--- a/src/Tests/Tests/QueryDsl/Compound/Bool/BoolDslComplexQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Compound/Bool/BoolDslComplexQueryUsageTests.cs
@@ -50,7 +50,8 @@ namespace Tests.QueryDsl.Compound.Bool
 					{
 						@bool = new
 						{
-							must = new[]
+							// must be typed to object[] for documentation
+							must = new object[]
 							{
 								new
 								{


### PR DESCRIPTION
This PR fixes 7.x documentation in preparation for GA. Once this is merged, https://github.com/elastic/docs/pull/876 can be merged to bring 7.x documentation onto elastic.co site.