### PR TITLE
Use Marshal.SecureStringToGlobalAllocUnicode

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -513,6 +513,8 @@ namespace Elasticsearch.Net
 			_connectionPool?.Dispose();
 			_connection?.Dispose();
 			_semaphore?.Dispose();
+			_proxyPassword?.Dispose();
+			_basicAuthCredentials?.Dispose();
 		}
 	}
 }

--- a/src/Elasticsearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
+++ b/src/Elasticsearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
@@ -1,11 +1,12 @@
-﻿using System.Security;
+﻿using System;
+using System.Security;
 
 namespace Elasticsearch.Net
 {
 	/// <summary>
 	/// Credentials for Basic Authentication
 	/// </summary>
-	public class BasicAuthenticationCredentials
+	public class BasicAuthenticationCredentials : IDisposable
 	{
 		public BasicAuthenticationCredentials()
 		{
@@ -32,5 +33,7 @@ namespace Elasticsearch.Net
 		/// The username with which to authenticate
 		/// </summary>
 		public string Username { get; set; }
+
+		public void Dispose() => Password?.Dispose();
 	}
 }

--- a/src/Elasticsearch.Net/Connection/SecureStrings.cs
+++ b/src/Elasticsearch.Net/Connection/SecureStrings.cs
@@ -19,13 +19,13 @@ namespace Elasticsearch.Net
 			{
 				try
 				{
-					num = Marshal.SecureStringToBSTR(secureString);
-					return Marshal.PtrToStringBSTR(num);
+					num = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+					return Marshal.PtrToStringUni(num);
 				}
 				finally
 				{
 					if (num != IntPtr.Zero)
-						Marshal.ZeroFreeBSTR(num);
+						Marshal.ZeroFreeGlobalAllocUnicode(num);
 				}
 			}
 

--- a/src/Elasticsearch.Net/Connection/SecureStrings.cs
+++ b/src/Elasticsearch.Net/Connection/SecureStrings.cs
@@ -14,22 +14,21 @@ namespace Elasticsearch.Net
 		/// </summary>
 		public static string CreateString(this SecureString secureString)
 		{
-			var num = IntPtr.Zero;
-			if (secureString != null && secureString.Length != 0)
-			{
-				try
-				{
-					num = Marshal.SecureStringToGlobalAllocUnicode(secureString);
-					return Marshal.PtrToStringUni(num);
-				}
-				finally
-				{
-					if (num != IntPtr.Zero)
-						Marshal.ZeroFreeGlobalAllocUnicode(num);
-				}
-			}
+			if (secureString == null || secureString.Length == 0)
+				return string.Empty;
 
-			return string.Empty;
+			var num = IntPtr.Zero;
+
+			try
+			{
+				num = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+				return Marshal.PtrToStringUni(num);
+			}
+			finally
+			{
+				if (num != IntPtr.Zero)
+					Marshal.ZeroFreeGlobalAllocUnicode(num);
+			}
 		}
 
 		/// <summary>

--- a/src/Tests/Tests/ClientConcepts/Connection/SecureStringsTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/SecureStringsTests.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+
+namespace Tests.ClientConcepts.Connection
+{
+	public class SecureStringsTests
+	{
+		[U]
+		public void CreateStringMatchesOriginalString()
+		{
+			var password = "password";
+			var secureString = password.CreateSecureString();
+			var count = 100;
+			var tasks = new Task<string>[count];
+
+			for (var i = 0; i < count; i++)
+				tasks[i] = new Task<string>(() => secureString.CreateString());
+
+			for (var i = 0; i < count; i++)
+				tasks[i].Start();
+
+			Task.WaitAll(tasks);
+
+			for (var i = 0; i < count; i++)
+				tasks[i].Result.Should().Be(password);
+		}
+	}
+}


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch-net/pull/3806#issuecomment-502700127

This commit updates the SecureStrings implementation to use the cross platform
Marshal methods that deal with unmanaged unicode strings.

Implement IDisposable on BasicAuthenticationCredentials and dispose of SecureString
instances when ConnectionConfiguration is disposed.