### PR TITLE
Add index name to ICreateIndexResponse

### DIFF
--- a/src/Nest/Indices/IndexManagement/CreateIndex/CreateIndexResponse.cs
+++ b/src/Nest/Indices/IndexManagement/CreateIndex/CreateIndexResponse.cs
@@ -7,10 +7,15 @@ namespace Nest
 	{
 		[JsonProperty("shards_acknowledged")]
 		bool ShardsAcknowledged { get; }
+
+		[JsonProperty("index")]
+		string Index { get; }
 	}
 
 	public class CreateIndexResponse : AcknowledgedResponseBase, ICreateIndexResponse
 	{
 		public bool ShardsAcknowledged { get; set; }
+
+		public string Index { get; set; }
 	}
 }

--- a/src/Tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
+++ b/src/Tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
@@ -205,9 +205,7 @@ namespace Tests.Indices.IndexManagement.CreateIndex
 			response.ShouldBeValid();
 			response.Acknowledged.Should().BeTrue();
 			response.ShardsAcknowledged.Should().BeTrue();
-
-			if (Cluster.ClusterConfiguration.Version >= "6.8.0")
-				response.Index.Should().Be(CallIsolatedValue);
+			response.Index.Should().Be(CallIsolatedValue);
 
 			var indexSettings = Client.GetIndexSettings(g => g.Index(CallIsolatedValue));
 

--- a/src/Tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
+++ b/src/Tests/Tests/Indices/IndexManagement/CreateIndex/CreateIndexApiTests.cs
@@ -206,6 +206,9 @@ namespace Tests.Indices.IndexManagement.CreateIndex
 			response.Acknowledged.Should().BeTrue();
 			response.ShardsAcknowledged.Should().BeTrue();
 
+			if (Cluster.ClusterConfiguration.Version >= "6.8.0")
+				response.Index.Should().Be(CallIsolatedValue);
+
 			var indexSettings = Client.GetIndexSettings(g => g.Index(CallIsolatedValue));
 
 			indexSettings.ShouldBeValid();


### PR DESCRIPTION
Fixes #3823

Port to `7.x` requires attention to new serialiser attributes.