### PR TITLE
Remove IAggregate Meta property setter

### DIFF
--- a/src/Nest/Aggregations/Aggregate.cs
+++ b/src/Nest/Aggregations/Aggregate.cs
@@ -9,10 +9,9 @@ namespace Nest
 	[JsonFormatter(typeof(AggregateFormatter))]
 	public interface IAggregate
 	{
-		//TODO this public set is problematic
 		/// <summary>
 		/// Metadata for the aggregation
 		/// </summary>
-		IReadOnlyDictionary<string, object> Meta { get; set; }
+		IReadOnlyDictionary<string, object> Meta { get; }
 	}
 }

--- a/src/Nest/Aggregations/AggregateDictionary.cs
+++ b/src/Nest/Aggregations/AggregateDictionary.cs
@@ -212,12 +212,8 @@ namespace Nest
 
 		public ValueAggregate MedianAbsoluteDeviation(string key) => TryGet<ValueAggregate>(key);
 
-		private TAggregate TryGet<TAggregate>(string key)
-			where TAggregate : class, IAggregate
-		{
-			IAggregate agg;
-			return BackingDictionary.TryGetValue(key, out agg) ? agg as TAggregate : null;
-		}
+		private TAggregate TryGet<TAggregate>(string key) where TAggregate : class, IAggregate =>
+			BackingDictionary.TryGetValue(key, out var agg) ? agg as TAggregate : null;
 
 		private MultiBucketAggregate<TBucket> GetMultiBucketAggregate<TBucket>(string key)
 			where TBucket : IBucket
@@ -228,7 +224,7 @@ namespace Nest
 			return new MultiBucketAggregate<TBucket>
 			{
 				Buckets = bucket.Items.OfType<TBucket>().ToList(),
-				Meta = bucket.Meta,
+				Meta = bucket.Meta
 			};
 		}
 
@@ -240,7 +236,7 @@ namespace Nest
 			return new MultiBucketAggregate<KeyedBucket<TKey>>
 			{
 				Buckets = GetKeyedBuckets<TKey>(bucket.Items).ToList(),
-				Meta = bucket.Meta,
+				Meta = bucket.Meta
 			};
 		}
 

--- a/src/Nest/Aggregations/Bucket/BucketAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/BucketAggregate.cs
@@ -32,7 +32,7 @@ namespace Nest
 		public IReadOnlyCollection<TBucket> Buckets { get; set; } = EmptyReadOnly<TBucket>.Collection;
 
 		/// <inheritdoc />
-		public IReadOnlyDictionary<string, object> Meta { get; set; }
+		public IReadOnlyDictionary<string, object> Meta { get; set; } = EmptyReadOnly<string, object>.Dictionary;
 	}
 
 	/// <summary>
@@ -50,7 +50,10 @@ namespace Nest
 		public CompositeKey AfterKey { get; set; }
 	}
 
-	// Intermediate object used for deserialization
+	/// <summary>
+	/// Intermediate Aggregation response, transformed to a more specific
+	/// aggregation response when requested.
+	/// </summary>
 	public class BucketAggregate : IAggregate
 	{
 		public CompositeKey AfterKey { get; set; }

--- a/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregate.cs
@@ -2,7 +2,14 @@
 {
 	public class SignificantTermsAggregate : MultiBucketAggregate<SignificantTermsBucket>
 	{
+		/// <summary>
+		/// The background count
+		/// </summary>
 		public long? BgCount { get; set; }
+
+		/// <summary>
+		/// The document count
+		/// </summary>
 		public long DocCount { get; set; }
 	}
 }

--- a/src/Nest/Aggregations/Matrix/MatrixAggregate.cs
+++ b/src/Nest/Aggregations/Matrix/MatrixAggregate.cs
@@ -4,6 +4,7 @@ namespace Nest
 {
 	public abstract class MatrixAggregateBase : IAggregate
 	{
+		/// <inheritdoc />
 		public IReadOnlyDictionary<string, object> Meta { get; set; } = EmptyReadOnly<string, object>.Dictionary;
 	}
 }

--- a/src/Nest/Aggregations/Matrix/MatrixStats/MatrixStatsAggregate.cs
+++ b/src/Nest/Aggregations/Matrix/MatrixStats/MatrixStatsAggregate.cs
@@ -6,28 +6,28 @@ namespace Nest
 	[DataContract]
 	public class MatrixStatsField
 	{
-		[DataMember(Name ="correlation")]
+		[DataMember(Name = "correlation")]
 		public Dictionary<string, double> Correlation { get; set; }
 
-		[DataMember(Name ="count")]
+		[DataMember(Name = "count")]
 		public int Count { get; set; }
 
-		[DataMember(Name ="covariance")]
+		[DataMember(Name = "covariance")]
 		public Dictionary<string, double> Covariance { get; set; }
 
-		[DataMember(Name ="kurtosis")]
+		[DataMember(Name = "kurtosis")]
 		public double Kurtosis { get; set; }
 
-		[DataMember(Name ="mean")]
+		[DataMember(Name = "mean")]
 		public double Mean { get; set; }
 
-		[DataMember(Name ="name")]
+		[DataMember(Name = "name")]
 		public string Name { get; set; }
 
-		[DataMember(Name ="skewness")]
+		[DataMember(Name = "skewness")]
 		public double Skewness { get; set; }
 
-		[DataMember(Name ="variance")]
+		[DataMember(Name = "variance")]
 		public double Variance { get; set; }
 	}
 
@@ -35,10 +35,10 @@ namespace Nest
 	public class MatrixStatsAggregate : MatrixAggregateBase
 	{
 		//TODO non nullable in 6.0
-		[DataMember(Name ="fields")]
+		[DataMember(Name = "fields")]
 		public long? DocCount { get; set; }
 
-		[DataMember(Name ="fields")]
+		[DataMember(Name = "fields")]
 		public List<MatrixStatsField> Fields { get; set; }
 	}
 }

--- a/src/Nest/Aggregations/Metric/TopHits/TopHitsAggregate.cs
+++ b/src/Nest/Aggregations/Metric/TopHits/TopHitsAggregate.cs
@@ -6,8 +6,8 @@ namespace Nest
 {
 	public class TopHitsAggregate : MetricAggregateBase
 	{
-		private readonly IList<LazyDocument> _hits;
 		private readonly IJsonFormatterResolver _formatterResolver;
+		private readonly IList<LazyDocument> _hits;
 
 		public TopHitsAggregate() { }
 


### PR DESCRIPTION
This commit removes the Meta property setter on IAggregate, setting the meta dictionary on concrete IAggregate implementations inside AggregateFormatter