### PR TITLE
Sum on stats aggregation always returns a value

### DIFF
--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -416,7 +416,7 @@ namespace Nest
 			reader.ReadNext(); // ,
 			reader.ReadNext(); // sum
 			reader.ReadNext(); // :
-			var sum = reader.ReadNullableDouble();
+			var sum = reader.ReadDouble();
 
 			var statsMetric = new StatsAggregate
 			{

--- a/src/Nest/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregate.cs
+++ b/src/Nest/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregate.cs
@@ -1,14 +1,9 @@
 ﻿namespace Nest
 {
-	public class ExtendedStatsAggregate : MetricAggregateBase
+	public class ExtendedStatsAggregate : StatsAggregate
 	{
-		public double? Average { get; set; }
-		public long Count { get; set; }
-		public double? Max { get; set; }
-		public double? Min { get; set; }
 		public double? StdDeviation { get; set; }
 		public StandardDeviationBounds StdDeviationBounds { get; set; }
-		public double? Sum { get; set; }
 		public double? SumOfSquares { get; set; }
 		public double? Variance { get; set; }
 	}

--- a/src/Nest/Aggregations/Metric/Stats/StatsAggregate.cs
+++ b/src/Nest/Aggregations/Metric/Stats/StatsAggregate.cs
@@ -6,6 +6,6 @@
 		public long Count { get; set; }
 		public double? Max { get; set; }
 		public double? Min { get; set; }
-		public double? Sum { get; set; }
+		public double Sum { get; set; }
 	}
 }

--- a/src/Tests/Tests/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregationUsageTests.cs
@@ -54,4 +54,71 @@ namespace Tests.Aggregations.Metric.ExtendedStats
 			commitStats.StdDeviationBounds.Lower.Should().NotBe(0);
 		}
 	}
+
+	/// <summary>
+	/// Asserts that stats sum is 0 (and not null) when matching document count is 0
+	/// </summary>
+	// hide
+	public class ExtendedStatsAggregationUsageDocCountZeroTests : AggregationUsageTestBase
+	{
+		public ExtendedStatsAggregationUsageDocCountZeroTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// a query that no docs will match
+		protected override QueryContainer QueryScope => base.QueryScope &&
+			new TermQuery { Field = Field<Project>(f => f.Branches), Value = "non-existent branch name" };
+
+		protected override object QueryScopeJson { get; } = new
+		{
+			@bool = new
+			{
+				must = new object[]
+				{
+					new { term = new { type = new { value = Project.TypeName } } },
+					new { term = new { branches = new { value = "non-existent branch name" } } },
+				}
+			}
+
+		};
+
+		protected override object AggregationJson => new
+		{
+			commit_stats = new
+			{
+				extended_stats = new
+				{
+					field = "numberOfCommits",
+					sigma = 1d
+				}
+			}
+		};
+
+		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
+			.ExtendedStats("commit_stats", es => es
+				.Field(p => p.NumberOfCommits)
+				.Sigma(1)
+			);
+
+		protected override AggregationDictionary InitializerAggs =>
+			new ExtendedStatsAggregation("commit_stats", Field<Project>(p => p.NumberOfCommits))
+			{
+				Sigma = 1
+			};
+
+		protected override void ExpectResponse(SearchResponse<Project> response)
+		{
+			response.ShouldBeValid();
+			var commitStats = response.Aggregations.ExtendedStats("commit_stats");
+			commitStats.Count.Should().Be(0);
+			commitStats.Sum.Should().Be(0);
+			commitStats.Should().NotBeNull();
+			commitStats.Average.Should().BeNull();
+			commitStats.Max.Should().BeNull();
+			commitStats.Min.Should().BeNull();
+			commitStats.SumOfSquares.Should().BeNull();
+			commitStats.Variance.Should().BeNull();
+			commitStats.StdDeviation.Should().BeNull();
+			commitStats.StdDeviationBounds.Upper.Should().BeNull();
+			commitStats.StdDeviationBounds.Lower.Should().BeNull();
+		}
+	}
 }


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/pull/27193

This commit updates Sum property on StatsAggregate to be modelled as non-nullable and to derive ExtendedStatsAggregate from StatsAggregate. Adds integration test to assert deserialization behaviour.