### PR TITLE
Support deprecated delimited_payload_filter name in deserialization

### DIFF
--- a/src/Nest/Analysis/TokenFilters/TokenFilterFormatter.cs
+++ b/src/Nest/Analysis/TokenFilters/TokenFilterFormatter.cs
@@ -16,6 +16,7 @@ namespace Nest
 			{ "asciifolding", 0 },
 			{ "common_grams", 1 },
 			{ "delimited_payload", 2 },
+			{ "delimited_payload_filter", 2 },
 			{ "dictionary_decompounder", 3 },
 			{ "edge_ngram", 4 },
 			{ "elision", 5 },


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/pull/27705

This commit adds support for the deprecated delimited_payload_filter
name when deserializing token filters in a 6.x index within a 7.x cluster.

When serializing, the new name delimited_payload will be used.