### PR TITLE
Fix/7.x/unmapped

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -59,9 +59,11 @@ namespace ApiGenerator.Configuration
 
 		public static readonly Dictionary<string, string> DescriptorGenericsLookup =
 			(from f in new DirectoryInfo(GeneratorLocations.NestFolder).GetFiles("*Request.cs", SearchOption.AllDirectories)
+				let name = Path.GetFileNameWithoutExtension(f.Name).Replace("Request", "")
 				let contents = File.ReadAllText(f.FullName)
-				let c = Regex.Replace(contents, @"^.+class ([^ \r\n]+Descriptor(?:<[^>\r\n]+>)?[^ \r\n]*).*$", "$1", RegexOptions.Singleline)
-				select new { Key = Regex.Replace(c, "<.*$", ""), Value = Regex.Replace(c, @"^.*?(?:(\<.+>).*?)?$", "$1") })
+				let c = Regex.Replace(contents, $@"^.+class ({name}Descriptor(?:<[^>\r\n]+>)?[^ \r\n]*).*$", "$1", RegexOptions.Singleline)
+				let key = $"{name}Descriptor"
+				select new { Key = key, Value = Regex.Replace(c, @"^.*?(?:(\<.+>).*?)?$", "$1") })
 			.DistinctBy(v => v.Key)
 			.OrderBy(v => v.Key)
 			.ToDictionary(k => k.Key, v => v.Value);

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
@@ -83,8 +83,9 @@
 }
 	@if (names.DescriptorNotFoundInCodebase)
 	{<text>
-		 [Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement @names.DescriptorName and @names.RequestName in a file called @(names.RequestName).cs in NEST's codebase", true)]
-		 public bool IsUnmapped => true;
+		[Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement @names.DescriptorName and @names.RequestName in a file called @(names.RequestName).cs in NEST's codebase", true)]
+		public bool IsUnmapped => true;
+		public bool UseIsUnmapped => IsUnmapped;
 	 </text>
 	}	
 	}

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
@@ -51,8 +51,9 @@
 }
 @if (names.DescriptorNotFoundInCodebase)
 {<text>
-		 [Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement @names.DescriptorName and @names.RequestName in a file called @(names.RequestName).cs in NEST's codebase", true)]
-		 public bool IsUnmapped => true;
+		[Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement @names.DescriptorName and @names.RequestName in a file called @(names.RequestName).cs in NEST's codebase", true)]
+		public bool IsUnmapped => true;
+		public bool UseIsUnmapped => IsUnmapped;
  </text>
 }
 	}

--- a/src/Nest/Descriptors.IndexLifecycleManagement.cs
+++ b/src/Nest/Descriptors.IndexLifecycleManagement.cs
@@ -130,9 +130,7 @@ namespace Nest
 		///<summary>a shortcut into calling Index(typeof(TOther))</summary>
 		public MoveToStepDescriptor Index<TOther>()
 			where TOther : class => Assign(typeof(TOther), (a, v) => a.RouteValues.Required("index", (IndexName)v));
-		// Request parameters
-		[Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement MoveToStepDescriptor and MoveToStepRequest in a file called MoveToStepRequest.cs in NEST's codebase", true)]
-		public bool IsUnmapped => true;
+	// Request parameters
 	}
 
 	///<summary>descriptor for PutLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html</para></summary>

--- a/src/Nest/Descriptors.Security.cs
+++ b/src/Nest/Descriptors.Security.cs
@@ -405,9 +405,7 @@ namespace Nest
 		Name IHasPrivilegesRequest.User => Self.RouteValues.Get<Name>("user");
 		///<summary>Username</summary>
 		public HasPrivilegesDescriptor User(Name user) => Assign(user, (a, v) => a.RouteValues.Optional("user", v));
-		// Request parameters
-		[Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement HasPrivilegesDescriptor and HasPrivilegesRequest in a file called HasPrivilegesRequest.cs in NEST's codebase", true)]
-		public bool IsUnmapped => true;
+	// Request parameters
 	}
 
 	///<summary>descriptor for InvalidateApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html</para></summary>

--- a/src/Nest/Requests.IndexLifecycleManagement.cs
+++ b/src/Nest/Requests.IndexLifecycleManagement.cs
@@ -173,9 +173,7 @@ namespace Nest
 		// values part of the url path
 		[IgnoreDataMember]
 		IndexName IMoveToStepRequest.Index => Self.RouteValues.Get<IndexName>("index");
-		// Request parameters
-		[Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement MoveToStepDescriptor and MoveToStepRequest in a file called MoveToStepRequest.cs in NEST's codebase", true)]
-		public bool IsUnmapped => true;
+	// Request parameters
 	}
 
 	[InterfaceDataContract]

--- a/src/Nest/Requests.Security.cs
+++ b/src/Nest/Requests.Security.cs
@@ -683,9 +683,7 @@ namespace Nest
 		// values part of the url path
 		[IgnoreDataMember]
 		Name IHasPrivilegesRequest.User => Self.RouteValues.Get<Name>("user");
-		// Request parameters
-		[Obsolete("Unmapped, blacklist this API in CodeConfiguration.cs or implement HasPrivilegesDescriptor and HasPrivilegesRequest in a file called HasPrivilegesRequest.cs in NEST's codebase", true)]
-		public bool IsUnmapped => true;
+	// Request parameters
 	}
 
 	[InterfaceDataContract]


### PR DESCRIPTION
This updates the check for unmapped API's which was broken as a result of all the clean up that happened in the code generator.

If a file contained more descriptors then just the request descriptor the lookup yielded true.

This also makes the code generation use the `[Obsolete("", true)]` property so that the compiler emits a nice error message if an API is unmapped after code generation runs.