### PR TITLE
Feature/7.x/warnings as errors

### DIFF
--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -5,7 +5,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <VersionSuffix>alpha</VersionSuffix>
-    <NoWarn>NU1701,NU1605</NoWarn>
+    <!-- CAC001: We dont need to set ConfigureAwait(false) here -->
+    <NoWarn>NU1701,NU1605,CAC001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha6" />

--- a/src/CodeGeneration/DocGenerator/Documentation/Files/DocumentationFile.cs
+++ b/src/CodeGeneration/DocGenerator/Documentation/Files/DocumentationFile.cs
@@ -59,7 +59,7 @@ namespace DocGenerator.Documentation.Files
 				FileOptions.Asynchronous | FileOptions.SequentialScan))
 			using (var destinationStream = new FileStream(destinationFile, FileMode.Create, FileAccess.Write, FileShare.None, 4096,
 				FileOptions.Asynchronous | FileOptions.SequentialScan))
-				await sourceStream.CopyToAsync(destinationStream);
+				await sourceStream.CopyToAsync(destinationStream).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
+++ b/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
@@ -52,7 +52,7 @@ namespace Elasticsearch.Net
 			async Task OnStreamAvailable(PostData data, Stream stream, HttpContent content, TransportContext context)
 			{
 				using (stream)
-					await data.WriteAsync(stream, requestData.ConnectionSettings, token);
+					await data.WriteAsync(stream, requestData.ConnectionSettings, token).ConfigureAwait(false);
 			}
 			_onStreamAvailable = OnStreamAvailable;
 		}
@@ -77,8 +77,8 @@ namespace Elasticsearch.Net
 			if (_requestData.HttpCompression)
 				stream = new GZipStream(stream, CompressionMode.Compress, false);
 			var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
-            await _onStreamAvailable(data, wrappedStream, this, context);
-            await serializeToStreamTask.Task;
+            await _onStreamAvailable(data, wrappedStream, this, context).ConfigureAwait(false);
+            await serializeToStreamTask.Task.ConfigureAwait(false);
 		}
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -9,6 +9,7 @@
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0" />
     <PackageReference Condition="'$(OS)' != 'Windows_NT'" Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2" /> 
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0-preview3.19128.7" />
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -133,7 +133,7 @@ namespace Elasticsearch.Net
 
 				var serializer = requestData.ConnectionSettings.RequestResponseSerializer;
 				if (requestData.CustomResponseBuilder != null)
-					return await requestData.CustomResponseBuilder.DeserializeResponseAsync(serializer, details, responseStream, cancellationToken) as TResponse;
+					return await requestData.CustomResponseBuilder.DeserializeResponseAsync(serializer, details, responseStream, cancellationToken).ConfigureAwait(false) as TResponse;
 
 				return mimeType == null || !mimeType.StartsWith(requestData.RequestMimeType, StringComparison.Ordinal)
 					? null

--- a/src/Elasticsearch.sln
+++ b/src/Elasticsearch.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RelatedFiles", "RelatedFile
 		..\src\Artifacts.build.props = ..\src\Artifacts.build.props
 		..\src\Library.build.props = ..\src\Library.build.props
 		Directory.Build.props = Directory.Build.props
+		Tests.build.props = Tests.build.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeGeneration", "CodeGeneration", "{93331BEE-0AA0-47B7-B1D2-BD5BD31634D1}"

--- a/src/Library.build.props
+++ b/src/Library.build.props
@@ -12,8 +12,9 @@
 		<AssemblyVersion>$(CurrentAssemblyVersion)</AssemblyVersion>
 		<!-- File version reflects actual version number without prelease since that not allowed in its struct -->
 		<FileVersion>$(CurrentAssemblyFileVersion)</FileVersion>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <DefineConstants Condition="'$(TargetFramework)'=='net461'">$(DefineConstants);FULLFRAMEWORK</DefineConstants>
+    	<DefineConstants Condition="'$(TargetFramework)'=='net461'">$(DefineConstants);FULLFRAMEWORK</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)'=='netstandard2.0'">$(DefineConstants);DOTNETCORE</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)'=='netcoreapp2.0'">$(DefineConstants);DOTNETCORE</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)'=='netcoreapp2.1'">$(DefineConstants);DOTNETCORE</DefineConstants>

--- a/src/Nest/Cat/CatHelpResponseBuilder.cs
+++ b/src/Nest/Cat/CatHelpResponseBuilder.cs
@@ -39,7 +39,7 @@ namespace Nest
 			using (stream)
 			using (var ms = response.ConnectionConfiguration.MemoryStreamFactory.Create())
 			{
-				await stream.CopyToAsync(ms, 81920, ctx);
+				await stream.CopyToAsync(ms, 81920, ctx).ConfigureAwait(false);
 				var body = ms.ToArray().Utf8String();
 				Parse(catResponse, body);
 			}

--- a/src/Nest/Cat/CatResponseBuilder.cs
+++ b/src/Nest/Cat/CatResponseBuilder.cs
@@ -29,7 +29,7 @@ namespace Nest
 			if (!response.Success)
 				return catResponse;
 
-			var records = await builtInSerializer.DeserializeAsync<IReadOnlyCollection<TCatRecord>>(stream, ctx);
+			var records = await builtInSerializer.DeserializeAsync<IReadOnlyCollection<TCatRecord>>(stream, ctx).ConfigureAwait(false);
 			catResponse.Records = records;
 			return catResponse;
 		}

--- a/src/Nest/Cluster/NodesHotThreads/NodeHotThreadsResponseBuilder.cs
+++ b/src/Nest/Cluster/NodesHotThreads/NodeHotThreadsResponseBuilder.cs
@@ -75,7 +75,7 @@ namespace Nest
 			using (stream)
 			using (var sr = new StreamReader(stream, Encoding.UTF8))
 			{
-				var plainTextResponse = await sr.ReadToEndAsync();
+				var plainTextResponse = await sr.ReadToEndAsync().ConfigureAwait(false);
 				return Parse(plainTextResponse);
 			}
 		}

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -127,7 +127,7 @@ namespace Nest
 			_compositeCancelToken.ThrowIfCancellationRequested();
 
 			if (!response.ApiCall.Success)
-				return await HandleBulkRequest(buffer, page, backOffRetries, response);
+				return await HandleBulkRequest(buffer, page, backOffRetries, response).ConfigureAwait(false);
 
 			var retryableDocuments = new List<T>();
 			var droppedDocuments = new List<Tuple<BulkResponseItemBase, T>>();
@@ -174,7 +174,7 @@ namespace Nest
 					if (response.ApiCall.AuditTrail.Last().Event == AuditEvent.FailedOverAllNodes)
 						throw ThrowOnBadBulk(response, $"BulkAll halted after attempted bulk failed over all the active nodes");
 
-					return await RetryDocuments(page, ++backOffRetries, buffer);
+					return await RetryDocuments(page, ++backOffRetries, buffer).ConfigureAwait(false);
 				case PipelineFailure.CouldNotStartSniffOnStartup:
 				case PipelineFailure.BadAuthentication:
 				case PipelineFailure.NoNodesAttempted:

--- a/src/Nest/Document/Multiple/MultiGet/Request/MultiGetResponseBuilder.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Request/MultiGetResponseBuilder.cs
@@ -11,23 +11,21 @@ namespace Nest
 
 		private MultiGetResponseFormatter Formatter { get; }
 
-		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
-		{
-			return response.Success
+		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
+			response.Success
 				? builtInSerializer.CreateStateful(Formatter).Deserialize<MultiGetResponse>(stream)
 				: new MultiGetResponse();
-		}
 
 		public override async Task<object> DeserializeResponseAsync(
 			IElasticsearchSerializer builtInSerializer,
 			IApiCallDetails response,
 			Stream stream,
 			CancellationToken ctx = default
-		)
-		{
-			return response.Success
-				? await builtInSerializer.CreateStateful(Formatter).DeserializeAsync<MultiGetResponse>(stream, ctx)
+		) =>
+			response.Success
+				? await builtInSerializer.CreateStateful(Formatter)
+					.DeserializeAsync<MultiGetResponse>(stream, ctx)
+					.ConfigureAwait(false)
 				: new MultiGetResponse();
-		}
 	}
 }

--- a/src/Nest/Document/Single/Source/SourceRequestResponseBuilder.cs
+++ b/src/Nest/Document/Single/Source/SourceRequestResponseBuilder.cs
@@ -9,18 +9,17 @@ namespace Nest
 	{
 		public static SourceRequestResponseBuilder<TDocument> Instance { get; } = new SourceRequestResponseBuilder<TDocument>();
 
-		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
-		{
-			return response.Success
+		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
+			response.Success
 				? new SourceResponse<TDocument> { Body = builtInSerializer.Deserialize<TDocument>(stream) }
 				: new SourceResponse<TDocument>();
-		}
 
-		public override async Task<object> DeserializeResponseAsync(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream, CancellationToken ctx = default)
-		{
-			return response.Success
-				? new SourceResponse<TDocument> { Body = await builtInSerializer.DeserializeAsync<TDocument>(stream) }
+		public override async Task<object> DeserializeResponseAsync(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream, CancellationToken ctx = default) =>
+			response.Success
+				? new SourceResponse<TDocument>
+				{
+					Body = await builtInSerializer.DeserializeAsync<TDocument>(stream, ctx).ConfigureAwait(false)
+				}
 				: new SourceResponse<TDocument>();
-		}
 	}
 }

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elasticsearch.Net\Elasticsearch.Net.csproj" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0" />
     <PackageReference Condition="'$(OS)' != 'Windows_NT'" Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2" /> 
   </ItemGroup>
   <ItemGroup>

--- a/src/Nest/Search/MultiSearch/MultiSearchResponseBuilder.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchResponseBuilder.cs
@@ -11,23 +11,21 @@ namespace Nest
 
 		private MultiSearchResponseFormatter Formatter { get; }
 
-		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
-		{
-			return response.Success
+		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
+			response.Success
 				? builtInSerializer.CreateStateful(Formatter).Deserialize<MultiSearchResponse>(stream)
 				: new MultiSearchResponse();
-		}
 
 		public override async Task<object> DeserializeResponseAsync(
 			IElasticsearchSerializer builtInSerializer,
 			IApiCallDetails response,
 			Stream stream,
 			CancellationToken ctx = default
-		)
-		{
-			return response.Success
-				? await builtInSerializer.CreateStateful(Formatter).DeserializeAsync<MultiSearchResponse>(stream, ctx)
+		) =>
+			response.Success
+				? await builtInSerializer.CreateStateful(Formatter)
+					.DeserializeAsync<MultiSearchResponse>(stream, ctx)
+					.ConfigureAwait(false)
 				: new MultiSearchResponse();
-		}
 	}
 }

--- a/src/Nest/XPack/MachineLearning/PreviewDatafeed/PreviewDatafeedResponseBuilder.cs
+++ b/src/Nest/XPack/MachineLearning/PreviewDatafeed/PreviewDatafeedResponseBuilder.cs
@@ -10,23 +10,22 @@ namespace Nest
 	{
 		public static PreviewDatafeedResponseBuilder<TDocument> Instance { get; } = new PreviewDatafeedResponseBuilder<TDocument>();
 
-		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
-		{
-			return response.Success
+		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
+			response.Success
 				? new PreviewDatafeedResponse<TDocument> { Data = builtInSerializer.Deserialize<IReadOnlyCollection<TDocument>>(stream) }
 				: new PreviewDatafeedResponse<TDocument>();
-		}
 
 		public override async Task<object> DeserializeResponseAsync(
 			IElasticsearchSerializer builtInSerializer,
 			IApiCallDetails response,
 			Stream stream,
 			CancellationToken ctx = default
-		)
-		{
-			return response.Success
-				? new PreviewDatafeedResponse<TDocument> { Data = await builtInSerializer.DeserializeAsync<IReadOnlyCollection<TDocument>>(stream) }
+		) =>
+			response.Success
+				? new PreviewDatafeedResponse<TDocument>
+				{
+					Data = await builtInSerializer.DeserializeAsync<IReadOnlyCollection<TDocument>>(stream, ctx).ConfigureAwait(false)
+				}
 				: new PreviewDatafeedResponse<TDocument>();
-		}
 	}
 }

--- a/src/Nest/XPack/Sql/TranslateSql/TranslateSqlResponseBuilder.cs
+++ b/src/Nest/XPack/Sql/TranslateSql/TranslateSqlResponseBuilder.cs
@@ -9,23 +9,22 @@ namespace Nest
 	{
 		public static TranslateSqlResponseBuilder Instance { get; } = new TranslateSqlResponseBuilder();
 
-		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
-		{
-			return response.Success
+		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
+			response.Success
 				? new TranslateSqlResponse { Result = builtInSerializer.Deserialize<ISearchRequest>(stream) }
 				: new TranslateSqlResponse();
-		}
 
 		public override async Task<object> DeserializeResponseAsync(
 			IElasticsearchSerializer builtInSerializer,
 			IApiCallDetails response,
 			Stream stream,
 			CancellationToken ctx = default
-		)
-		{
-			return response.Success
-				? new TranslateSqlResponse { Result = await builtInSerializer.DeserializeAsync<ISearchRequest>(stream) }
+		) =>
+			response.Success
+				? new TranslateSqlResponse
+				{
+					Result = await builtInSerializer.DeserializeAsync<ISearchRequest>(stream, ctx).ConfigureAwait(false)
+				}
 				: new TranslateSqlResponse();
-		}
 	}
 }

--- a/src/Nest/XPack/Ssl/GetCertificates/GetCertificatesResponseBuilder.cs
+++ b/src/Nest/XPack/Ssl/GetCertificates/GetCertificatesResponseBuilder.cs
@@ -9,23 +9,22 @@ namespace Nest
 	{
 		public static GetCertificatesResponseBuilder Instance { get; } = new GetCertificatesResponseBuilder();
 
-		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
-		{
-			return response.Success
+		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
+			response.Success
 				? new GetCertificatesResponse { Certificates = builtInSerializer.Deserialize<ClusterCertificateInformation[]>(stream) }
 				: new GetCertificatesResponse();
-		}
 
 		public override async Task<object> DeserializeResponseAsync(
 			IElasticsearchSerializer builtInSerializer,
 			IApiCallDetails response,
 			Stream stream,
 			CancellationToken ctx = default
-		)
-		{
-			return response.Success
-				? new GetCertificatesResponse { Certificates = await builtInSerializer.DeserializeAsync<ClusterCertificateInformation[]>(stream) }
+		) =>
+			response.Success
+				? new GetCertificatesResponse
+				{
+					Certificates = await builtInSerializer.DeserializeAsync<ClusterCertificateInformation[]>(stream, ctx).ConfigureAwait(false)
+				}
 				: new GetCertificatesResponse();
-		}
 	}
 }

--- a/src/Serializers/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
+++ b/src/Serializers/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0" />
     <PackageReference Condition="'$(OS)' != 'Windows_NT'" Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2" /> 
   </ItemGroup>
   <ItemGroup>

--- a/src/Tests.build.props
+++ b/src/Tests.build.props
@@ -1,0 +1,7 @@
+<Project>
+  <!-- Sets up the common properties for all Elastic assemblies -->
+	<PropertyGroup>
+        <!-- CAC001: We dont want to set ConfigureAwait() in tests, assume who evers calling our lib doesn't do this either.-->
+        <NoWarn>CAC001</NoWarn>
+	</PropertyGroup>
+</Project>

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -6,5 +6,7 @@
 	<PropertyGroup>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\build\keys\keypair.snk</AssemblyOriginatorKeyFile>
+		<!-- CAC001: We dont want to set ConfigureAwait() in tests, assume who evers calling our lib doesn't do this either.-->
+		<NoWarn>CAC001</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Tests/Tests.Core/Tests.Core.csproj
+++ b/src/Tests/Tests.Core/Tests.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugSymbols>True</DebugSymbols>
+    <NoWarn>CAC001</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(TestPackageVersion)'!=''">
     <PackageReference Include="NEST.JsonNetSerializer" Version="$(TestPackageVersion)" />


### PR DESCRIPTION
We now finally treat warnings as errors in the solution. 

We now also add a `ConfigureAwait(false)` roslyn Analyzer, the one we evaluated in the past has been updated and now works a treat!

Fixed the places we weren't calling `ConfigureAwait(false)`