### PR TITLE
Lazy document now uses source serializer and has async overloads

### DIFF
--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamFactory.cs
@@ -16,7 +16,7 @@ namespace Elasticsearch.Net
 
 		public MemoryStream Create() => _manager.GetStream();
 
-		public MemoryStream Create(byte[] bytes) => _manager.GetStream(string.Empty, bytes, 0, bytes.Length);
+		public MemoryStream Create(byte[] bytes) => new MemoryStream(bytes);
 
 		public MemoryStream Create(byte[] bytes, int index, int count) => _manager.GetStream(string.Empty, bytes, index, count);
 	}

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
@@ -393,7 +393,6 @@ namespace Elasticsearch.Net
 		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
 		public MemoryStream GetStream(string tag, byte[] buffer, int offset, int count)
 		{
-			// TODO wouldn't it be better to just wrap
 			var stream = new RecyclableMemoryStream(this, tag, count);
 			stream.Write(buffer, offset, count);
 			stream.Position = 0;

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
@@ -393,6 +393,7 @@ namespace Elasticsearch.Net
 		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
 		public MemoryStream GetStream(string tag, byte[] buffer, int offset, int count)
 		{
+			// TODO wouldn't it be better to just wrap
 			var stream = new RecyclableMemoryStream(this, tag, count);
 			stream.Write(buffer, offset, count);
 			stream.Position = 0;

--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -634,7 +634,9 @@ namespace Nest
 			}
 
 			var scriptedMetric = reader.ReadNextBlockSegment();
-			return new ScriptedMetricAggregate(new LazyDocument(BinaryUtil.ToArray(ref scriptedMetric), formatterResolver))
+			var bytes = BinaryUtil.ToArray(ref scriptedMetric);
+			var doc = new LazyDocument(bytes, formatterResolver);
+			return new ScriptedMetricAggregate(doc)
 			{
 				Meta = meta
 			};

--- a/src/Nest/CommonAbstractions/LazyDocument/LazyDocument.cs
+++ b/src/Nest/CommonAbstractions/LazyDocument/LazyDocument.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
 using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
@@ -22,36 +25,71 @@ namespace Nest
 		/// </summary>
 		/// <param name="objectType">The type</param>
 		object As(Type objectType);
+
+		/// <summary>
+		/// Creates an instance of <typeparamref name="T" /> from this
+		/// <see cref="ILazyDocument" /> instance
+		/// </summary>
+		/// <typeparam name="T">The type</typeparam>
+		Task<T> AsAsync<T>(CancellationToken ct = default);
+		
+		/// <summary>
+		/// Creates an instance of <paramref name="objectType" /> from this
+		/// <see cref="ILazyDocument" /> instance
+		/// </summary>
+		/// <param name="objectType">The type</param>
+		Task<object> AsAsync(Type objectType, CancellationToken ct = default);
 	}
 
 	/// <inheritdoc />
 	[JsonFormatter(typeof(LazyDocumentFormatter))]
 	public class LazyDocument : ILazyDocument
 	{
-		private readonly IJsonFormatterResolver _formatterResolver;
+		private readonly IElasticsearchSerializer _serializer;
+		private readonly IMemoryStreamFactory _memoryStreamFactory;
 
-		internal LazyDocument(byte[] bytes, IJsonFormatterResolver formatterResolver)
+		internal LazyDocument(byte[] bytes, IJsonFormatterResolver formatterResolver) 
+			: this(bytes, formatterResolver.GetConnectionSettings()) { }
+
+		private LazyDocument(byte[] bytes, IConnectionSettingsValues settings) :
+			this(bytes, settings.SourceSerializer, settings.MemoryStreamFactory) { }
+		
+		private LazyDocument(byte[] bytes, IElasticsearchSerializer serializer, IMemoryStreamFactory memoryStreamFactory)
 		{
 			Bytes = bytes;
-			_formatterResolver = formatterResolver;
+			_serializer = serializer;
+			_memoryStreamFactory = memoryStreamFactory;
 		}
+
 
 		internal byte[] Bytes { get; }
 
 		/// <inheritdoc />
 		public T As<T>()
 		{
-			var reader = new JsonReader(Bytes);
-			var formatter = new SourceFormatter<T>();
-			return formatter.Deserialize(ref reader, _formatterResolver);
+			using (var ms = _memoryStreamFactory.Create(Bytes))
+				return _serializer.Deserialize<T>(ms);
 		}
 
 		/// <inheritdoc />
 		public object As(Type objectType)
 		{
-			var reader = new JsonReader(Bytes);
-			// TODO: Non generic SourceFormatter equivalent
-			return JsonSerializer.NonGeneric.Deserialize(objectType, ref reader, _formatterResolver);
+			using (var ms = _memoryStreamFactory.Create(Bytes))
+				return _serializer.Deserialize(objectType, ms);
+		}
+		
+		/// <inheritdoc />
+		public Task<T> AsAsync<T>(CancellationToken ct = default)
+		{
+			using (var ms = _memoryStreamFactory.Create(Bytes))
+				return _serializer.DeserializeAsync<T>(ms, ct);
+		}
+
+		/// <inheritdoc />
+		public Task<object> AsAsync(Type objectType, CancellationToken ct = default)
+		{
+			using (var ms = _memoryStreamFactory.Create(Bytes))
+				return _serializer.DeserializeAsync(objectType, ms, ct);
 		}
 	}
 }


### PR DESCRIPTION
This normalizes `LazyDocument` a bit and makes it flow through the source serializer rather than sidestepping it through a formatter (a path source serializer will also take). 

Also added `async` overloads to `ILazyDocument`, since its currently backed a `byte[]` not immediately needed but good to have as part of the interface in`7.x` going forward.

This also updates `RecyclableStreamFactory` to simply return ` MemoryStream(bytes)` rather then going through the hoops in `RecyclableStream(bytes)` which ends up doing a copy which seems unnecessary.