### PR TITLE
Generate APIs asynchronously

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Generator/ApiGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/ApiGenerator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ApiGenerator.Domain.Specification;
@@ -15,20 +16,20 @@ namespace ApiGenerator.Generator
 	{
 		public static List<string> Warnings { get; private set; }
 
-		public static void Generate(string downloadBranch, params string[] folders)
+		public static async Task Generate(string downloadBranch, params string[] folders)
 		{
 			Warnings = new List<string>();
 			var spec = CreateRestApiSpecModel(downloadBranch, folders);
 			var generators = new List<RazorGeneratorBase>
 			{
-				
+
 				//low level client
 				new LowLevelClientInterfaceGenerator(),
 				new LowLevelClientImplementationGenerator(),
 				new RequestParametersGenerator(),
 				new EnumsGenerator(),
-				
-				
+
+
 				//high level client
 				new HighLevelClientInterfaceGenerator(),
 				new HighLevelClientImplementationGenerator(),
@@ -42,7 +43,7 @@ namespace ApiGenerator.Generator
 				foreach (var generator in generators)
 				{
 					pbar.Message = "Generating " + generator.Title;
-					generator.Generate(spec, pbar);
+					await generator.Generate(spec, pbar);
 					pbar.Tick("Generated " + generator.Title);
 				}
 			}

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/ApiUrlsLookupsGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/ApiUrlsLookupsGenerator.cs
@@ -1,19 +1,20 @@
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor 
+namespace ApiGenerator.Generator.Razor
 {
 	public class ApiUrlsLookupsGenerator : RazorGeneratorBase
 	{
 		public override string Title => "NEST static url lookups";
 
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.HighLevel("Requests", "ApiUrlsLookup.cshtml");
 			var target = GeneratorLocations.HighLevel("_Generated", "ApiUrlsLookup.generated.cs");
-			
-			DoRazor(spec, view, target);
+
+			await DoRazor(spec, view, target);
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/DescriptorsGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/DescriptorsGenerator.cs
@@ -1,24 +1,25 @@
 using System.Linq;
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor 
+namespace ApiGenerator.Generator.Razor
 {
 	public class DescriptorsGenerator : RazorGeneratorBase
 	{
 		public override string Title => "NEST descriptors";
 
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.HighLevel("Descriptors", "RequestDescriptorBase.cshtml");
 			var target = GeneratorLocations.HighLevel("Descriptors.cs");
-			DoRazor(spec, view, target);
-			
+			await DoRazor(spec, view, target);
+
 			var dependantView = ViewLocations.HighLevel("Descriptors", "Descriptors.cshtml");
 			string Target(string id) => GeneratorLocations.HighLevel($"Descriptors.{id}.cs");
 			var namespaced = spec.EndpointsPerNamespace.ToList();
-			DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
+			await DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/EnumsGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/EnumsGenerator.cs
@@ -1,19 +1,20 @@
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor 
+namespace ApiGenerator.Generator.Razor
 {
 	public class EnumsGenerator : RazorGeneratorBase
 	{
 		public override string Title => "Elasticsearch.Net enums";
 
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.LowLevel("Enums.Generated.cshtml");
 			var target = GeneratorLocations.LowLevel("Api", "Enums.Generated.cs");
-			
-			DoRazor(spec, view, target);
+
+			await DoRazor(spec, view, target);
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/HighLevelClientImplementationGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/HighLevelClientImplementationGenerator.cs
@@ -1,27 +1,28 @@
 using System.Linq;
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ApiGenerator.Domain.Code;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor 
+namespace ApiGenerator.Generator.Razor
 {
 	public class HighLevelClientImplementationGenerator : RazorGeneratorBase
 	{
 		public override string Title => "NEST client implementation";
 
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.HighLevel("Client", "Implementation", "ElasticClient.cshtml");
 			var target = GeneratorLocations.HighLevel($"ElasticClient.{CsharpNames.RootNamespace}.cs");
-			DoRazor(spec, view, target);
-			
+			await DoRazor(spec, view, target);
+
 			string Target(string id) => GeneratorLocations.HighLevel($"ElasticClient.{id}.cs");
-			
+
 			var namespaced = spec.EndpointsPerNamespace.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
 			var dependantView = ViewLocations.HighLevel("Client", "Implementation", "ElasticClient.Namespace.cshtml");
-			DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
-			
+			await DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
+
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/HighLevelClientInterfaceGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/HighLevelClientInterfaceGenerator.cs
@@ -1,20 +1,20 @@
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor 
+namespace ApiGenerator.Generator.Razor
 {
 	public class HighLevelClientInterfaceGenerator : RazorGeneratorBase
 	{
 		public override string Title => "NEST client interface";
 
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.HighLevel("Client", "Interface", "IElasticClient.cshtml");
 			var target = GeneratorLocations.HighLevel("IElasticClient.Generated.cs");
-			
-			DoRazor(spec, view, target);
-			
+
+			await DoRazor(spec, view, target);
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
@@ -1,23 +1,26 @@
 using System.Linq;
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ApiGenerator.Domain.Code;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor {
+namespace ApiGenerator.Generator.Razor
+{
 	public class LowLevelClientImplementationGenerator : RazorGeneratorBase
 	{
 		public override string Title { get; } = "Elasticsearch.Net client implementation";
 
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.LowLevel("Client", "Implementation", "ElasticLowLevelClient.cshtml");
 			var target = GeneratorLocations.LowLevel($"ElasticLowLevelClient.{CsharpNames.RootNamespace}.cs");
-			DoRazor(spec, view, target);
-			
+			await DoRazor(spec, view, target);
+
 			var namespaced = spec.EndpointsPerNamespace.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
 			var namespacedView = ViewLocations.LowLevel("Client", "Implementation", "ElasticLowLevelClient.Namespace.cshtml");
-			DoRazorDependantFiles(progressBar, namespaced, namespacedView, kv => kv.Key, id => GeneratorLocations.LowLevel($"ElasticLowLevelClient.{id}.cs"));
+			await DoRazorDependantFiles(progressBar, namespaced, namespacedView, kv => kv.Key,
+				id => GeneratorLocations.LowLevel($"ElasticLowLevelClient.{id}.cs"));
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/LowLevelClientInterfaceGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/LowLevelClientInterfaceGenerator.cs
@@ -1,19 +1,20 @@
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor 
+namespace ApiGenerator.Generator.Razor
 {
 	public class LowLevelClientInterfaceGenerator : RazorGeneratorBase
 	{
 		public override string Title { get; } = "Elasticsearch.Net client interface";
-		
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.LowLevel("Client", "Interface", "IElasticLowLevelClient.cshtml");
 			var target = GeneratorLocations.LowLevel("IElasticLowLevelClient.Generated.cs");
-			
-			DoRazor(spec, view, target);
+
+			await DoRazor(spec, view, target);
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/RequestParametersGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/RequestParametersGenerator.cs
@@ -1,21 +1,22 @@
 using System.Linq;
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor 
+namespace ApiGenerator.Generator.Razor
 {
 	public class RequestParametersGenerator : RazorGeneratorBase
 	{
 		public override string Title { get; } = "Elasticsearch.Net request parameters";
 
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.LowLevel("RequestParameters", "RequestParameters.cshtml");
 			string Target(string id) => GeneratorLocations.LowLevel("Api", "RequestParameters", $"RequestParameters.{id}.cs");
-			
+
 			var namespaced = spec.EndpointsPerNamespace.ToList();
-			DoRazorDependantFiles(progressBar, namespaced, view, kv => kv.Key, id => Target(id));
+			await DoRazorDependantFiles(progressBar, namespaced, view, kv => kv.Key, id => Target(id));
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/Razor/RequestsGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/Razor/RequestsGenerator.cs
@@ -1,24 +1,25 @@
 using System.Linq;
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain;
 using ShellProgressBar;
 
-namespace ApiGenerator.Generator.Razor 
+namespace ApiGenerator.Generator.Razor
 {
 	public class RequestsGenerator : RazorGeneratorBase
 	{
 		public override string Title => "NEST requests";
 
-		public override void Generate(RestApiSpec spec, ProgressBar progressBar)
+		public override async Task Generate(RestApiSpec spec, ProgressBar progressBar)
 		{
 			var view = ViewLocations.HighLevel("Requests", "PlainRequestBase.cshtml");
 			var target = GeneratorLocations.HighLevel("Requests.cs");
-			DoRazor(spec, view, target);
-			
+			await DoRazor(spec, view, target);
+
 			var dependantView = ViewLocations.HighLevel("Requests", "Requests.cshtml");
 			string Target(string id) => GeneratorLocations.HighLevel($"Requests.{id}.cs");
 			var namespaced = spec.EndpointsPerNamespace.ToList();
-			DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
+			await DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Program.cs
+++ b/src/CodeGeneration/ApiGenerator/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using ApiGenerator.Configuration;
 
 namespace ApiGenerator
@@ -9,7 +10,7 @@ namespace ApiGenerator
 		private static readonly string DownloadBranch = "master";
 
 		// ReSharper disable once UnusedParameter.Local
-		private static void Main(string[] args)
+		private static async Task Main(string[] args)
 		{
 			var redownloadCoreSpecification = false;
 			var generateCode = false;
@@ -50,7 +51,7 @@ namespace ApiGenerator
 				generateCode = answer == "y" || answer == "";
 			}
 			if (generateCode)
-				Generator.ApiGenerator.Generate(downloadBranch, "Core", "XPack");
+				await Generator.ApiGenerator.Generate(downloadBranch, "Core", "XPack");
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentMethod.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/FluentSyntax/FluentMethod.cshtml
@@ -17,6 +17,6 @@
 	var selectorChained = syntax.SelectorChainedDefaults();
 	var cancellationToken = !Model.Async ? string.Empty : ", ct";
 }
-@{ IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", syntax); }
-public @{ IncludeAsync("HighLevel/Client/FluentSyntax/FluentMethodHeader.cshtml", Model);} @Raw("=>")
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", syntax); }
+public @{ await IncludeAsync("HighLevel/Client/FluentSyntax/FluentMethodHeader.cshtml", Model);} @Raw("=>")
 	@(method)@(Raw(requestMethodGenerics))(selector.InvokeOrDefault(new @(Raw(descriptor))(@Raw(selectorArgs))@(@selectorChained))@cancellationToken);

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.Namespace.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.Namespace.cshtml
@@ -13,7 +13,7 @@
 	string ns = model.Key;
 	var endpoints = model.Value;
 }
-@{ IncludeAsync("GeneratorNotice.cshtml", model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", model); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Threading;
@@ -35,7 +35,7 @@ namespace Nest.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNamespaceSuffix
 		internal @(CsharpNames.HighLevelClientNamespacePrefix)@(model.Key)@(CsharpNames.ClientNamespaceSuffix)(ElasticClient client) : base(client) {}
 		@foreach(var e in endpoints)
 		{
-			IncludeAsync("HighLevel/Client/Implementation/MethodImplementation.cshtml", e.HighLevelModel);
+			await IncludeAsync("HighLevel/Client/Implementation/MethodImplementation.cshtml", e.HighLevelModel);
 		}
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.cshtml
@@ -10,13 +10,13 @@
 @using ApiGenerator.Domain.Code
 @using CsQuery.StringScanner.Implementation
 @inherits CodeTemplatePage<RestApiSpec>
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nest;
-@{ IncludeAsync("HighLevel/Client/Usings.cshtml", Model);}
+@{ await IncludeAsync("HighLevel/Client/Usings.cshtml", Model);}
 
 @{
 	RestApiSpec model = Model;
@@ -61,7 +61,7 @@ namespace Nest
 		var models = endpoints.Select(e=>e.HighLevelModel).ToList();
 		foreach (var m in models)
 		{
-			IncludeAsync("HighLevel/Client/Implementation/MethodImplementation.cshtml", m);
+			await IncludeAsync("HighLevel/Client/Implementation/MethodImplementation.cshtml", m);
 		}
 	}
 	<text>

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/MethodImplementation.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Implementation/MethodImplementation.cshtml
@@ -13,14 +13,14 @@
 	var fluentPath = "HighLevel/Client/FluentSyntax/FluentMethod.cshtml";
 	var initializerPath = "HighLevel/Client/InitializerSyntax/InitializerMethod.cshtml";
 }
-@{ IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: false)); }
-@{ IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: true)); }
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: false)); }
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: true)); }
 @if (model.FluentBound != null)
 {
 <text>
-	@{ IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: false)); }
-	@{ IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: true)); }
+	@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: false)); }
+	@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: true)); }
 </text>
 }
-@{ IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: false)); }
-@{ IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: true)); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: false)); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: true)); }

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/InitializerSyntax/InitializerMethod.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/InitializerSyntax/InitializerMethod.cshtml
@@ -17,8 +17,8 @@
 		dispatchParameters += ", ct";
 	}
 }
-@{ IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", syntax); }
-public @{ IncludeAsync("HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml", Model); } @Raw("=>")
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", syntax); }
+public @{ await IncludeAsync("HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml", Model); } @Raw("=>")
 	@(dispatchMethod)@(Raw(dispatchGenerics))(@Raw(dispatchParameters));
 
 

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Interface/IElasticClient.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Interface/IElasticClient.cshtml
@@ -4,7 +4,7 @@
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using Nest;
-@{ IncludeAsync("HighLevel/Client/Usings.cshtml", Model);}
+@{ await IncludeAsync("HighLevel/Client/Usings.cshtml", Model);}
 
 namespace Nest
 {
@@ -34,7 +34,7 @@ namespace Nest
 			var models = endpoints.Select(e=>e.HighLevelModel).ToList();
 			foreach(var m in models)
 			{
-				IncludeAsync("HighLevel/Client/Interface/MethodInterface.cshtml", m);
+				await IncludeAsync("HighLevel/Client/Interface/MethodInterface.cshtml", m);
 			}
 		}
 	}

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Interface/MethodInterface.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Client/Interface/MethodInterface.cshtml
@@ -15,22 +15,22 @@
 	var initializerPath = "HighLevel/Client/InitializerSyntax/InitializerMethodHeader.cshtml";
 }
 
-@{ IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Fluent); }
-@{ IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: false)); };
-@{ IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Fluent); }
-@{ IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: true)); };
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Fluent); }
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: false)); };
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Fluent); }
+@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.Fluent, async: true)); };
 
 @if (model.FluentBound != null)
 {
 <text>
-	@{ IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.FluentBound); }
-	@{ IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: false)); };
-	@{ IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.FluentBound); }
-	@{ IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: true)); };
+	@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.FluentBound); }
+	@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: false)); };
+	@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.FluentBound); }
+	@{ await IncludeAsync(fluentPath, new FluentSyntaxView(model.FluentBound, async: true)); };
 </text>
 }
-@{ IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Initializer); }
-@{ IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: false)); };
-@{ IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Initializer); }
-@{ IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: true)); };
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Initializer); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: false)); };
+@{ await IncludeAsync("HighLevel/Client/MethodXmlDocs.cshtml", model.Initializer); }
+@{ await IncludeAsync(initializerPath, new InitializerSyntaxView(model.Initializer, async: true)); };
 

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/Descriptor.cshtml
@@ -57,7 +57,7 @@
 	var g = typed ? names.GenericsDeclaredOnDescriptor.Replace("<", "").Replace(">", "") : "T";
 	var desc = param.DescriptionHighLevel.ToList();
 	
-	IncludeAsync("HighLevel/Descriptors/XmlDocs.cshtml", desc);
+	await IncludeAsync("HighLevel/Descriptors/XmlDocs.cshtml", desc);
 	if(!string.IsNullOrWhiteSpace(param.Obsolete))
 	{
 <text>		[Obsolete("Scheduled to be removed in 7.0, @param.Obsolete")]

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/Descriptors.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/Descriptors.cshtml
@@ -13,7 +13,7 @@
 	string ns = model.Key != CsharpNames.RootNamespace ? "."+CsharpNames.ApiNamespace+"." + model.Key + CsharpNames.ApiNamespaceSuffix : null;
 	var endpoints = model.Value;
 }
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -37,6 +37,6 @@ namespace Nest
 {
 @foreach (var endpoint in endpoints)
 {
-	IncludeAsync("HighLevel/Descriptors/Descriptor.cshtml", endpoint.DescriptorPartialImplementation);
+	await IncludeAsync("HighLevel/Descriptors/Descriptor.cshtml", endpoint.DescriptorPartialImplementation);
 }
 }

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
@@ -11,7 +11,7 @@
 @{
 	RestApiSpec m = Model;
 }
-@{ IncludeAsync("GeneratorNotice.cshtml", m); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", m); }
 namespace Nest
 {
 	internal static class ApiUrlsLookups 

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/PlainRequestBase.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/PlainRequestBase.cshtml
@@ -7,7 +7,7 @@
 @{
 	RestApiSpec m = Model;
 }
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -17,7 +17,7 @@ using System.Linq.Expressions;
 using System.Runtime.Serialization;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Utf8Json;
-@{ IncludeAsync("LowLevel/Client/Usings.cshtml", Model);}
+@{ await IncludeAsync("LowLevel/Client/Usings.cshtml", Model);}
 
 // ReSharper disable UnusedTypeParameter
 namespace Nest

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/Requests.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/Requests.cshtml
@@ -16,7 +16,7 @@
 	string ns = model.Key != CsharpNames.RootNamespace ? "."+CsharpNames.ApiNamespace+"." + model.Key + CsharpNames.ApiNamespaceSuffix : null;
 	var endpoints = model.Value;
 }
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -40,7 +40,7 @@ namespace Nest
 {
 @foreach (var endpoint in endpoints)
 {
-	IncludeAsync("HighLevel/Requests/RequestInterface.cshtml", endpoint.RequestInterface);
-	IncludeAsync("HighLevel/Requests/RequestImplementations.cshtml", endpoint.RequestPartialImplementation);
+	await IncludeAsync("HighLevel/Requests/RequestInterface.cshtml", endpoint.RequestInterface);
+	await IncludeAsync("HighLevel/Requests/RequestImplementations.cshtml", endpoint.RequestPartialImplementation);
 }
 }

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.Namespace.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.Namespace.cshtml
@@ -11,7 +11,7 @@
 @using CsQuery.StringScanner.Implementation
 @using ApiGenerator.Domain.Specification
 @inherits CodeTemplatePage<KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>>>
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 @{
 	KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>> model = Model;
 	string ns = model.Key;
@@ -51,7 +51,7 @@ namespace Elasticsearch.Net.@(CsharpNames.ApiNamespace).@(ns)@(CsharpNames.ApiNa
 		var methods = endpoints.SelectMany(e=>e.LowLevelClientMethods).ToList();
 		foreach (var method in methods)
 		{
-			IncludeAsync("LowLevel/Client/Methods/MethodImplementation.cshtml", method);
+			await IncludeAsync("LowLevel/Client/Methods/MethodImplementation.cshtml", method);
 		}
 	}
 	}

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.cshtml
@@ -9,7 +9,7 @@
 @using ApiGenerator.Domain.Code
 @using CsQuery.StringScanner.Implementation
 @inherits CodeTemplatePage<RestApiSpec>
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -19,7 +19,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
-@{ IncludeAsync("LowLevel/Client/Usings.cshtml", Model);}
+@{ await IncludeAsync("LowLevel/Client/Usings.cshtml", Model);}
 using static Elasticsearch.Net.HttpMethod;
 
 @{
@@ -65,7 +65,7 @@ namespace Elasticsearch.Net
 		var methods = endpoints.SelectMany(e=>e.LowLevelClientMethods).ToList();
 		foreach (var method in methods)
 		{
-			IncludeAsync("LowLevel/Client/Methods/MethodImplementation.cshtml", method);
+			await IncludeAsync("LowLevel/Client/Methods/MethodImplementation.cshtml", method);
 		}
 	}
 	<text>

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Interface/IElasticLowLevelClient.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Interface/IElasticLowLevelClient.cshtml
@@ -4,7 +4,7 @@
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
@@ -14,7 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
-@{ IncludeAsync("LowLevel/Client/Usings.cshtml", Model);}
+@{ await IncludeAsync("LowLevel/Client/Usings.cshtml", Model);}
 
 namespace Elasticsearch.Net
 {
@@ -37,7 +37,7 @@ namespace Elasticsearch.Net
 			var methods = endpoints.SelectMany(e=>e.LowLevelClientMethods).ToList();
 			foreach(var method in methods)
 			{
-				IncludeAsync("LowLevel/Client/Methods/MethodInterface.cshtml", method);
+				await IncludeAsync("LowLevel/Client/Methods/MethodInterface.cshtml", method);
 			}
 		}
 	}

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Methods/MethodImplementation.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Methods/MethodImplementation.cshtml
@@ -9,10 +9,10 @@
 @{
 	LowLevelClientMethod method = Model;
 }
-@{IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
+@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
 		public TResponse @(method.PerPathMethodName)@(Raw("<TResponse>"))(@Raw(method.Arguments))
 			where TResponse : class, IElasticsearchResponse, new() => DoRequest@(Raw("<TResponse>"))(@method.HttpMethod, @Raw(method.UrlInCode), @(method.HasBody ? "body" : "null"), RequestParams(requestParameters));
 
-@{IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
+@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
 		public Task@(Raw("<TResponse>")) @(method.PerPathMethodName)Async@(Raw("<TResponse>"))(@Raw(method.Arguments), CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync@(Raw("<TResponse>"))(@method.HttpMethod, @Raw(method.UrlInCode), ctx, @(method.HasBody ? "body" : "null"), RequestParams(requestParameters));

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Methods/MethodInterface.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Client/Methods/MethodInterface.cshtml
@@ -9,8 +9,8 @@
 @{
 	LowLevelClientMethod method = Model;
 }
-@{IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
+@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
 		TResponse @(method.PerPathMethodName)@(Raw("<TResponse>"))(@Raw(method.Arguments)) where TResponse : class, IElasticsearchResponse, new();
 
-@{IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
+@{await IncludeAsync("LowLevel/Client/Methods/MethodDocs.cshtml", method); }
 		Task@(Raw("<TResponse>")) @(method.PerPathMethodName)Async@(Raw("<TResponse>"))(@Raw(method.Arguments), CancellationToken ctx = default) where TResponse : class, IElasticsearchResponse, new();

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Enums.Generated.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Enums.Generated.cshtml
@@ -6,7 +6,7 @@
 @using ApiGenerator
 @using ApiGenerator.Configuration.Overrides
 @inherits CodeTemplatePage<RestApiSpec>
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 @functions {
 	private const string RawSize = "Raw";
 	private const string SizeEnum = "Size";

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
@@ -6,7 +6,7 @@
 @using ApiGenerator.Domain.Code
 @using ApiGenerator.Domain.Specification
 @inherits CodeTemplatePage<KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>>>
-@{ IncludeAsync("GeneratorNotice.cshtml", Model); }
+@{ await IncludeAsync("GeneratorNotice.cshtml", Model); }
 @{
 	KeyValuePair<string, ReadOnlyCollection<ApiEndpoint>> model = Model;
 	string ns = model.Key != CsharpNames.RootNamespace ? "."+CsharpNames.ApiNamespace+"." + model.Key + CsharpNames.ApiNamespaceSuffix : null;


### PR DESCRIPTION
This commit updates the API generator to generate APIs asynchronously
and to await all IncludeAsync calls. Not await'ing these calls results in
Razorlight template compilation errors, as the RoslynCompilationService
used by the RazorLightEngine type flags these as warnings, which are
treated as errors.