### PR TITLE
Fix CatHelp NodeHotThreads integ tests due to mimetype mismatch 

### DIFF
--- a/build/scripts/Tooling.fs
+++ b/build/scripts/Tooling.fs
@@ -16,7 +16,7 @@ module Tooling =
         let startArgs = StartArguments(bin, args |> List.toArray)
         if (Option.isSome workinDir) then
             startArgs.WorkingDirectory <- Option.defaultValue "" workinDir
-        startArgs.WaitForStreamReadersTimeout <- Nullable<TimeSpan>()
+        if Commandline.isMono then startArgs.WaitForStreamReadersTimeout <- Nullable<TimeSpan>()
         let result = Proc.StartRedirected(startArgs, timeout, LineHighlightWriter())
         if not result.Completed then failwithf "process failed to complete within %O: %s" timeout bin
         if not result.ExitCode.HasValue then failwithf "process yielded no exit code: %s" bin

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -69,7 +69,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="2.4.0-alpha.1" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190621T072151" />
+    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190626T161237" />
     <PackageReference Include="Fake.Core.Environment" Version="5.15.0" />
     <PackageReference Include="Fake.Core.SemVer" Version="5.15.0" />
     <PackageReference Include="Fake.IO.FileSystem" Version="5.15.0" />

--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -20,6 +20,8 @@ namespace Elasticsearch.Net
 		{
 			//Not available under mono
 			if (!IsMono) HttpWebRequest.DefaultMaximumErrorResponseLength = -1;
+
+
 		}
 
 		internal static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
@@ -244,10 +246,13 @@ namespace Elasticsearch.Net
 			// 2 - Specified at the global IConnectionSettings level
 			// 3 - Specified with the URI (lowest precedence)
 
-			var userInfo = Uri.UnescapeDataString(requestData.Uri.UserInfo);
+			string userInfo = null;
+			if (!string.IsNullOrEmpty(requestData.Uri.UserInfo))
+				userInfo = Uri.UnescapeDataString(requestData.Uri.UserInfo);
+			else if (requestData.BasicAuthorizationCredentials != null)
+				userInfo =
+					$"{requestData.BasicAuthorizationCredentials.Username}:{requestData.BasicAuthorizationCredentials.Password.CreateString()}";
 
-			if (requestData.BasicAuthorizationCredentials != null)
-				userInfo = requestData.BasicAuthorizationCredentials.ToString();
 
 			if (!string.IsNullOrWhiteSpace(userInfo))
 				request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userInfo));

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -12,6 +12,7 @@ namespace Elasticsearch.Net
 	public class RequestData
 	{
 		public const string MimeType = "application/json";
+		public const string MimeTypeTextPlain = "text/plain";
 		public const string OpaqueIdHeader = "X-Opaque-Id";
 		public const string RunAsSecurityHeader = "es-security-runas-user";
 

--- a/src/Nest/Cluster/NodesHotThreads/NodesHotThreadsRequest.cs
+++ b/src/Nest/Cluster/NodesHotThreads/NodesHotThreadsRequest.cs
@@ -1,4 +1,5 @@
-﻿using Elasticsearch.Net.Specification.NodesApi;
+﻿using Elasticsearch.Net;
+using Elasticsearch.Net.Specification.NodesApi;
 
 namespace Nest
 {
@@ -7,12 +8,16 @@ namespace Nest
 
 	public partial class NodesHotThreadsRequest
 	{
+		protected override string ContentType => RequestData.MimeTypeTextPlain;
+
 		protected sealed override void RequestDefaults(NodesHotThreadsRequestParameters parameters) =>
 			parameters.CustomResponseBuilder = NodeHotThreadsResponseBuilder.Instance;
 	}
 
 	public partial class NodesHotThreadsDescriptor
 	{
+		protected override string ContentType => RequestData.MimeTypeTextPlain;
+		
 		protected sealed override void RequestDefaults(NodesHotThreadsRequestParameters parameters) =>
 			parameters.CustomResponseBuilder = NodeHotThreadsResponseBuilder.Instance;
 	}

--- a/src/Nest/CommonAbstractions/Request/RequestBase.cs
+++ b/src/Nest/CommonAbstractions/Request/RequestBase.cs
@@ -10,6 +10,9 @@ namespace Nest
 	public interface IRequest
 	{
 		[IgnoreDataMember]
+		string ContentType { get; }
+
+		[IgnoreDataMember]
 		HttpMethod HttpMethod { get; }
 
 		[IgnoreDataMember]
@@ -57,6 +60,10 @@ namespace Nest
 
 		[IgnoreDataMember]
 		HttpMethod IRequest.HttpMethod => HttpMethod;
+
+		[IgnoreDataMember]
+		string IRequest.ContentType => ContentType;
+		protected virtual string ContentType { get; } = null;
 
 		private readonly TParameters _parameters;
 

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20190621T072151" />
+    <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20190626T161237" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Core/Tests.Core.csproj
+++ b/src/Tests/Tests.Core/Tests.Core.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20190621T072151" />
+    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20190626T161237" />
     <PackageReference Include="Proc" Version="0.6.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
     <PackageReference Include="DiffPlex" Version="1.4.1" />
   </ItemGroup>

--- a/src/Tests/Tests.Domain/Tests.Domain.csproj
+++ b/src/Tests/Tests.Domain/Tests.Domain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190621T072151" />
+    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190626T161237" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="..\Tests.Configuration\Tests.Configuration.csproj" />
   </ItemGroup>

--- a/src/Tests/Tests/Framework/EndpointTests/CoordinatedIntegrationTestBase.cs
+++ b/src/Tests/Tests/Framework/EndpointTests/CoordinatedIntegrationTestBase.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Elastic.Managed.Ephemeral;
 using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
 using Nest;
+using Tests.Core.Client;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Framework.EndpointTests.TestState;
 using Tests.Framework.Extensions;
@@ -53,7 +57,23 @@ namespace Tests.Framework.EndpointTests
 				if (!_coordinatedUsage.MethodIsolatedValues.TryGetValue(key, out var isolatedValue))
 					throw new Exception($"{name} is not a request observed and so no call isolated values could be located for it");
 
-				assert(isolatedValue, response);
+				var r = response;
+				if (TestClient.Configuration.RunIntegrationTests && !r.IsValid && r.ApiCall.OriginalException != null
+					&& !(r.ApiCall.OriginalException is ElasticsearchClientException))
+				{
+					var e = ExceptionDispatchInfo.Capture(r.ApiCall.OriginalException.Demystify());
+					throw new ResponseAssertionException(e.SourceException, r).Demystify();
+				}
+
+				try
+				{
+					assert(isolatedValue, response);
+				}
+				catch (Exception e)
+				{
+					var ex = ExceptionDispatchInfo.Capture(e.Demystify());
+					throw new ResponseAssertionException(ex.SourceException, r).Demystify();
+				}
 			}
 		}
 

--- a/src/Tests/Tests/Indices/IndexManagement/RolloverIndex/RolloverIndexApiTests.cs
+++ b/src/Tests/Tests/Indices/IndexManagement/RolloverIndex/RolloverIndexApiTests.cs
@@ -55,7 +55,7 @@ namespace Tests.Indices.IndexManagement.RolloverIndex
 			},
 			aliases = new Dictionary<string, object>
 			{
-				{ CallIsolatedValue + "new_projects",  new { } }
+				{ CallIsolatedValue + "-new_projects",  new { } }
 			}
 		};
 
@@ -120,7 +120,7 @@ namespace Tests.Indices.IndexManagement.RolloverIndex
 			},
 			Aliases = new Aliases
 			{
-				{ CallIsolatedValue + "new_projects", new Alias() }
+				{ CallIsolatedValue + "-new_projects", new Alias() }
 			}
 		};
 
@@ -138,7 +138,7 @@ namespace Tests.Indices.IndexManagement.RolloverIndex
 				.IndexMany(Project.Generator.Generate(1200))
 			);
 			someDocs.ShouldBeValid();
-			
+
 		}
 
 		protected override LazyResponses ClientUsage() => Calls(

--- a/src/Tests/Tests/Indices/IndexManagement/RolloverIndex/RolloverIndexApiTests.cs
+++ b/src/Tests/Tests/Indices/IndexManagement/RolloverIndex/RolloverIndexApiTests.cs
@@ -53,9 +53,9 @@ namespace Tests.Indices.IndexManagement.RolloverIndex
 					}
 				}
 			},
-			aliases = new
+			aliases = new Dictionary<string, object>
 			{
-				new_projects = new { }
+				{ CallIsolatedValue + "new_projects",  new { } }
 			}
 		};
 
@@ -83,7 +83,7 @@ namespace Tests.Indices.IndexManagement.RolloverIndex
 				)
 			)
 			.Aliases(a => a
-				.Alias("new_projects")
+				.Alias(CallIsolatedValue + "-new_projects")
 			);
 
 		protected override RolloverIndexRequest Initializer => new RolloverIndexRequest(CallIsolatedValue + "-alias", CallIsolatedValue + "-new")
@@ -120,7 +120,7 @@ namespace Tests.Indices.IndexManagement.RolloverIndex
 			},
 			Aliases = new Aliases
 			{
-				{ "new_projects", new Alias() }
+				{ CallIsolatedValue + "new_projects", new Alias() }
 			}
 		};
 

--- a/src/Tests/Tests/XPack/Security/User/PutUser/PutUserApiTests.cs
+++ b/src/Tests/Tests/XPack/Security/User/PutUser/PutUserApiTests.cs
@@ -72,7 +72,8 @@ namespace Tests.XPack.Security.User.PutUser
 
 		protected override PutUserDescriptor NewDescriptor() => new PutUserDescriptor(CallIsolatedValue);
 
-		protected override void ExpectResponse(PutUserResponse response) => response.Created.Should().BeTrue();
+		protected override void ExpectResponse(PutUserResponse response) => 
+			response.Created.Should().BeTrue("{0}", response.DebugInformation);
 	}
 
 	public class PutUserRunAsApiTests : PutUserApiTests


### PR DESCRIPTION
Fixes cathelp and nodehotthreads now being unsuccesful in the low level client due to mimetype mismatch.

Also improves SSL generation which was failing on my windows partition due to warnings emitted about forbidden API usage. 