### PR TITLE
make SignificantTermsBucket generic on key type

### DIFF
--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -864,9 +864,9 @@ namespace Nest
 				subAggregates = GetSubAggregates(ref reader, propertyName, formatterResolver);
 			}
 
-			return new SignificantTermsBucket(subAggregates)
+			return new SignificantTermsBucket<object>(subAggregates)
 			{
-				Key = (string)key,
+				Key = key,
 				DocCount = docCount.GetValueOrDefault(0),
 				BgCount = bgCount,
 				Score = score

--- a/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregate.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nest
 {
-	public class SignificantTermsAggregate : MultiBucketAggregate<SignificantTermsBucket>
+	public class SignificantTermsAggregate<TKey> : MultiBucketAggregate<SignificantTermsBucket<TKey>>
 	{
 		/// <summary>
 		/// The background count

--- a/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsBucket.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantTerms/SignificantTermsBucket.cs
@@ -2,14 +2,14 @@
 
 namespace Nest
 {
-	public class SignificantTermsBucket : BucketBase, IBucket
+	public class SignificantTermsBucket<TKey> : BucketBase, IBucket
 	{
 		public SignificantTermsBucket(IReadOnlyDictionary<string, IAggregate> dict) : base(dict) { }
 
 		public long BgCount { get; set; }
 		public long DocCount { get; set; }
 
-		public string Key { get; set; }
+		public TKey Key { get; set; }
 		public double Score { get; set; }
 	}
 }

--- a/src/Tests/Tests.Domain/Project.cs
+++ b/src/Tests/Tests.Domain/Project.cs
@@ -63,7 +63,7 @@ namespace Tests.Domain
 				.RuleFor(p => p.LocationPoint, f => SimpleGeoPoint.Generator.Generate())
 				.RuleFor(p => p.LocationShape, f => new PointGeoShape(new GeoCoordinate(f.Address.Latitude(), f.Address.Latitude())))
 				.RuleFor(p => p.NumberOfCommits, f => Gimme.Random.Number(1, 1000))
-				.RuleFor(p => p.NumberOfContributors, f => Gimme.Random.Number(1, 200))
+				.RuleFor(p => p.NumberOfContributors, f => Gimme.Random.Number(1, 50))
 				.RuleFor(p => p.Ranges, f => Ranges.Generator.Generate())
 				.RuleFor(p => p.Branches, f => Gimme.Random.ListItems(new List<string> { "master", "dev", "release", "qa", "test" }))
 				.RuleFor(p => p.SourceOnly, f =>

--- a/src/Tests/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs
@@ -196,4 +196,52 @@ namespace Tests.Aggregations.Bucket.SignificantTerms
 			sigNames.DocCount.Should().BeGreaterThan(0);
 		}
 	}
+
+	/**
+	 * [float]
+	 * [[significant-terms-numeric-field]]
+	 * == Numeric fields
+	 *
+	 * A significant terms aggregation on a numeric field
+	 */
+	public class NumericSignificantTermsAggregationUsageTests : AggregationUsageTestBase
+	{
+		public NumericSignificantTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object AggregationJson => new
+		{
+			commits = new
+			{
+				significant_terms = new
+				{
+					field = "numberOfContributors"
+				}
+			}
+		};
+
+		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
+			.SignificantTerms("commits", st => st
+				.Field(p => p.NumberOfContributors)
+			);
+
+		protected override AggregationDictionary InitializerAggs =>
+			new SignificantTermsAggregation("commits")
+			{
+				Field = Field<Project, int>(p => p.NumberOfContributors)
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.ShouldBeValid();
+			var commits = response.Aggregations.SignificantTerms<int>("commits");
+			commits.Should().NotBeNull();
+			commits.Buckets.Should().NotBeNull();
+			commits.Buckets.Count.Should().BeGreaterThan(0);
+			foreach (var item in commits.Buckets)
+			{
+				item.Key.Should().BeGreaterThan(0);
+				item.DocCount.Should().BeGreaterOrEqualTo(1);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Supersedes: #3795

Key of SignificantTermsBucket is generic to allow for returning both string and numeric key values.