### PR TITLE
Ephemeral Cluster for tests now uses a SHA has for its cached folder

### DIFF
--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -69,7 +69,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="2.4.0-alpha.1" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190626T161237" />
+    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190627T121416" />
     <PackageReference Include="Fake.Core.Environment" Version="5.15.0" />
     <PackageReference Include="Fake.Core.SemVer" Version="5.15.0" />
     <PackageReference Include="Fake.IO.FileSystem" Version="5.15.0" />

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20190626T161237" />
+    <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20190627T121416" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Core/Tests.Core.csproj
+++ b/src/Tests/Tests.Core/Tests.Core.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20190626T161237" />
+    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20190627T121416" />
     <PackageReference Include="Proc" Version="0.6.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />

--- a/src/Tests/Tests.Domain/Tests.Domain.csproj
+++ b/src/Tests/Tests.Domain/Tests.Domain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190626T161237" />
+    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190627T121416" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="..\Tests.Configuration\Tests.Configuration.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch-net-abstractions/commit/f75189735cb6d23dd685a2ad0003dea68bafc6dd


The ephemeral cluster generates a cached folder name based on the options including the chosen plugins which can be a very long list and cause max file path issues down the line.