### PR TITLE
Implement Api Key authorisation on requests

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -116,6 +116,7 @@ namespace Elasticsearch.Net
 		private readonly ElasticsearchUrlFormatter _urlFormatter;
 
 		private BasicAuthenticationCredentials _basicAuthCredentials;
+		private ApiKeyAuthenticationCredentials _apiKeyAuthentication;
 		private X509CertificateCollection _clientCertificates;
 		private Action<IApiCallDetails> _completedRequestHandler = DefaultCompletedRequestHandler;
 		private int _connectionLimit;
@@ -169,6 +170,7 @@ namespace Elasticsearch.Net
 
 		protected IElasticsearchSerializer UseThisRequestResponseSerializer { get; set; }
 		BasicAuthenticationCredentials IConnectionConfigurationValues.BasicAuthenticationCredentials => _basicAuthCredentials;
+		ApiKeyAuthenticationCredentials IConnectionConfigurationValues.ApiKeyAuthenticationCredentials => _apiKeyAuthentication;
 		SemaphoreSlim IConnectionConfigurationValues.BootstrapLock => _semaphore;
 		X509CertificateCollection IConnectionConfigurationValues.ClientCertificates => _clientCertificates;
 		IConnection IConnectionConfigurationValues.Connection => _connection;
@@ -433,6 +435,18 @@ namespace Elasticsearch.Net
 		/// </summary>
 		public T BasicAuthentication(string username, SecureString password) =>
 			Assign(new BasicAuthenticationCredentials(username, password), (a, v) => a._basicAuthCredentials = v);
+
+		/// <summary>
+		/// Api Key to send with all requests to Elasticsearch
+		/// </summary>
+		public T ApiKeyAuthentication(string id, SecureString apiKey) =>
+			Assign(new ApiKeyAuthenticationCredentials(id, apiKey), (a, v) => a._apiKeyAuthentication = v);
+
+		/// <summary>
+		/// Api Key to send with all requests to Elasticsearch
+		/// </summary>
+		public T ApiKeyAuthentication(string id, string apiKey) =>
+			Assign(new ApiKeyAuthenticationCredentials(id, apiKey), (a, v) => a._apiKeyAuthentication = v);
 
 		/// <summary>
 		/// Allows for requests to be pipelined. http://en.wikipedia.org/wiki/HTTP_pipelining

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -116,7 +116,7 @@ namespace Elasticsearch.Net
 		private readonly ElasticsearchUrlFormatter _urlFormatter;
 
 		private BasicAuthenticationCredentials _basicAuthCredentials;
-		private ApiKeyAuthenticationCredentials _apiKeyAuthentication;
+		private ApiKeyAuthenticationCredentials _apiKeyAuthCredentials;
 		private X509CertificateCollection _clientCertificates;
 		private Action<IApiCallDetails> _completedRequestHandler = DefaultCompletedRequestHandler;
 		private int _connectionLimit;
@@ -170,7 +170,7 @@ namespace Elasticsearch.Net
 
 		protected IElasticsearchSerializer UseThisRequestResponseSerializer { get; set; }
 		BasicAuthenticationCredentials IConnectionConfigurationValues.BasicAuthenticationCredentials => _basicAuthCredentials;
-		ApiKeyAuthenticationCredentials IConnectionConfigurationValues.ApiKeyAuthenticationCredentials => _apiKeyAuthentication;
+		ApiKeyAuthenticationCredentials IConnectionConfigurationValues.ApiKeyAuthenticationCredentials => _apiKeyAuthCredentials;
 		SemaphoreSlim IConnectionConfigurationValues.BootstrapLock => _semaphore;
 		X509CertificateCollection IConnectionConfigurationValues.ClientCertificates => _clientCertificates;
 		IConnection IConnectionConfigurationValues.Connection => _connection;
@@ -440,13 +440,13 @@ namespace Elasticsearch.Net
 		/// Api Key to send with all requests to Elasticsearch
 		/// </summary>
 		public T ApiKeyAuthentication(string id, SecureString apiKey) =>
-			Assign(new ApiKeyAuthenticationCredentials(id, apiKey), (a, v) => a._apiKeyAuthentication = v);
+			Assign(new ApiKeyAuthenticationCredentials(id, apiKey), (a, v) => a._apiKeyAuthCredentials = v);
 
 		/// <summary>
 		/// Api Key to send with all requests to Elasticsearch
 		/// </summary>
 		public T ApiKeyAuthentication(string id, string apiKey) =>
-			Assign(new ApiKeyAuthenticationCredentials(id, apiKey), (a, v) => a._apiKeyAuthentication = v);
+			Assign(new ApiKeyAuthenticationCredentials(id, apiKey), (a, v) => a._apiKeyAuthCredentials = v);
 
 		/// <summary>
 		/// Allows for requests to be pipelined. http://en.wikipedia.org/wiki/HTTP_pipelining
@@ -537,6 +537,7 @@ namespace Elasticsearch.Net
 			_semaphore?.Dispose();
 			_proxyPassword?.Dispose();
 			_basicAuthCredentials?.Dispose();
+			_apiKeyAuthCredentials?.Dispose();
 		}
 
 		protected virtual bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) =>

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -13,7 +13,18 @@ namespace Elasticsearch.Net
 		/// <summary>
 		/// Basic access authorization credentials to specify with all requests.
 		/// </summary>
+		/// <remarks>
+		/// Cannot be used in conjuction with <see cref="ApiKeyAuthenticationCredentials"/>
+		/// </remarks>
 		BasicAuthenticationCredentials BasicAuthenticationCredentials { get; }
+
+		/// <summary>
+		/// Api Key authorization credentials to specify with all requests.
+		/// </summary>
+		/// <remarks>
+		/// Cannot be used in conjuction with <see cref="BasicAuthenticationCredentials"/>
+		/// </remarks>
+		ApiKeyAuthenticationCredentials ApiKeyAuthenticationCredentials { get; }
 
 		/// <summary> Provides a semaphoreslim to transport implementations that need to limit access to a resource</summary>
 		SemaphoreSlim BootstrapLock { get; }

--- a/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
@@ -290,12 +290,27 @@ namespace Elasticsearch.Net
 			return this;
 		}
 
+		public RequestConfigurationDescriptor ApiKeyAuthentication(string id, string apiKey)
+		{
+			Self.ApiKeyAuthenticationCredentials = new ApiKeyAuthenticationCredentials(id, apiKey);
+			return this;
+		}
+
 		public RequestConfigurationDescriptor ApiKeyAuthentication(string id, SecureString apiKey)
 		{
-			if (Self.ApiKeyAuthenticationCredentials == null)
-				Self.ApiKeyAuthenticationCredentials = new ApiKeyAuthenticationCredentials();
-			Self.ApiKeyAuthenticationCredentials.Id = id;
-			Self.ApiKeyAuthenticationCredentials.ApiKey = apiKey;
+			Self.ApiKeyAuthenticationCredentials = new ApiKeyAuthenticationCredentials(id, apiKey);
+			return this;
+		}
+
+		public RequestConfigurationDescriptor ApiKeyAuthentication(string base64EncodedApiKey)
+		{
+			Self.ApiKeyAuthenticationCredentials = new ApiKeyAuthenticationCredentials(base64EncodedApiKey);
+			return this;
+		}
+
+		public RequestConfigurationDescriptor ApiKeyAuthentication(SecureString base64EncodedApiKey)
+		{
+			Self.ApiKeyAuthenticationCredentials = new ApiKeyAuthenticationCredentials(base64EncodedApiKey);
 			return this;
 		}
 

--- a/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
@@ -22,7 +22,19 @@ namespace Elasticsearch.Net
 		/// Basic access authorization credentials to specify with this request.
 		/// Overrides any credentials that are set at the global IConnectionSettings level.
 		/// </summary>
+		/// <remarks>
+		///	Cannot be used in conjunction with <see cref="ApiKeyAuthenticationCredentials"/>
+		/// </remarks>
 		BasicAuthenticationCredentials BasicAuthenticationCredentials { get; set; }
+
+		/// <summary>
+		/// An API-key authorization credentials to specify with this request.
+		/// Overrides any credentials that are set at the global IConnectionSettings level.
+		/// </summary>
+		/// <remarks>
+		///	Cannot be used in conjunction with <see cref="BasicAuthenticationCredentials"/>
+		/// </remarks>
+		ApiKeyAuthenticationCredentials ApiKeyAuthenticationCredentials { get; set; }
 
 		/// <summary>
 		/// Use the following client certificates to authenticate this single request
@@ -102,6 +114,8 @@ namespace Elasticsearch.Net
 		public IReadOnlyCollection<int> AllowedStatusCodes { get; set; }
 		public BasicAuthenticationCredentials BasicAuthenticationCredentials { get; set; }
 
+		public ApiKeyAuthenticationCredentials ApiKeyAuthenticationCredentials { get; set; }
+
 		public X509CertificateCollection ClientCertificates { get; set; }
 		public string ContentType { get; set; }
 		public bool? DisableDirectStreaming { get; set; }
@@ -138,6 +152,7 @@ namespace Elasticsearch.Net
 			Self.DisableDirectStreaming = config?.DisableDirectStreaming;
 			Self.AllowedStatusCodes = config?.AllowedStatusCodes;
 			Self.BasicAuthenticationCredentials = config?.BasicAuthenticationCredentials;
+			Self.ApiKeyAuthenticationCredentials = config?.ApiKeyAuthenticationCredentials;
 			Self.EnableHttpPipelining = config?.EnableHttpPipelining ?? true;
 			Self.RunAs = config?.RunAs;
 			Self.ClientCertificates = config?.ClientCertificates;
@@ -148,6 +163,7 @@ namespace Elasticsearch.Net
 		string IRequestConfiguration.Accept { get; set; }
 		IReadOnlyCollection<int> IRequestConfiguration.AllowedStatusCodes { get; set; }
 		BasicAuthenticationCredentials IRequestConfiguration.BasicAuthenticationCredentials { get; set; }
+		ApiKeyAuthenticationCredentials IRequestConfiguration.ApiKeyAuthenticationCredentials { get; set; }
 		X509CertificateCollection IRequestConfiguration.ClientCertificates { get; set; }
 		string IRequestConfiguration.ContentType { get; set; }
 		bool? IRequestConfiguration.DisableDirectStreaming { get; set; }
@@ -271,6 +287,15 @@ namespace Elasticsearch.Net
 				Self.BasicAuthenticationCredentials = new BasicAuthenticationCredentials();
 			Self.BasicAuthenticationCredentials.Username = userName;
 			Self.BasicAuthenticationCredentials.Password = password;
+			return this;
+		}
+
+		public RequestConfigurationDescriptor ApiKeyAuthentication(string id, SecureString apiKey)
+		{
+			if (Self.ApiKeyAuthenticationCredentials == null)
+				Self.ApiKeyAuthenticationCredentials = new ApiKeyAuthenticationCredentials();
+			Self.ApiKeyAuthenticationCredentials.Id = id;
+			Self.ApiKeyAuthenticationCredentials.ApiKey = apiKey;
 			return this;
 		}
 

--- a/src/Elasticsearch.Net/Configuration/Security/ApiKeyAuthenticationCredentials.cs
+++ b/src/Elasticsearch.Net/Configuration/Security/ApiKeyAuthenticationCredentials.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security;
+using System.Text;
 
 namespace Elasticsearch.Net
 {
@@ -14,26 +15,30 @@ namespace Elasticsearch.Net
 
 		public ApiKeyAuthenticationCredentials(string id, SecureString apiKey)
 		{
-			Id = id;
-			ApiKey = apiKey;
+			Base64EncodedApiKey = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{id}:{apiKey.CreateString()}")).CreateSecureString();
 		}
 
 		public ApiKeyAuthenticationCredentials(string id, string apiKey)
 		{
-			Id = id;
-			ApiKey = apiKey.CreateSecureString();
+			Base64EncodedApiKey = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{id}:{apiKey}")).CreateSecureString();
+		}
+
+		public ApiKeyAuthenticationCredentials(string base64EncodedApiKey)
+		{
+			Base64EncodedApiKey = base64EncodedApiKey.CreateSecureString();
+		}
+
+		public ApiKeyAuthenticationCredentials(SecureString base64EncodedApiKey)
+		{
+			Base64EncodedApiKey = base64EncodedApiKey;
 		}
 
 		/// <summary>
-		/// The api_key with which to authenticate
+		/// The Base64 encoded api key with which to authenticate
+		/// Take the form, id:api_key, which is then base 64 encoded
 		/// </summary>
-		public SecureString ApiKey { get; set; }
+		public SecureString Base64EncodedApiKey { get; }
 
-		/// <summary>
-		/// The id with which to authenticate
-		/// </summary>
-		public string Id { get; set; }
-
-		public void Dispose() => ApiKey?.Dispose();
+		public void Dispose() => Base64EncodedApiKey?.Dispose();
 	}
 }

--- a/src/Elasticsearch.Net/Configuration/Security/ApiKeyAuthenticationCredentials.cs
+++ b/src/Elasticsearch.Net/Configuration/Security/ApiKeyAuthenticationCredentials.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Security;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// Credentials for Api Key Authentication
+	/// </summary>
+	public class ApiKeyAuthenticationCredentials : IDisposable
+	{
+		public ApiKeyAuthenticationCredentials()
+		{
+		}
+
+		public ApiKeyAuthenticationCredentials(string id, SecureString apiKey)
+		{
+			Id = id;
+			ApiKey = apiKey;
+		}
+
+		public ApiKeyAuthenticationCredentials(string id, string apiKey)
+		{
+			Id = id;
+			ApiKey = apiKey.CreateSecureString();
+		}
+
+		/// <summary>
+		/// The api_key with which to authenticate
+		/// </summary>
+		public SecureString ApiKey { get; set; }
+
+		/// <summary>
+		/// The id with which to authenticate
+		/// </summary>
+		public string Id { get; set; }
+
+		public void Dispose() => ApiKey?.Dispose();
+	}
+}

--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -239,7 +239,7 @@ namespace Elasticsearch.Net
 				request.Proxy = null;
 		}
 
-		private void SetAuthenticationIfNeeded(RequestData requestData, HttpWebRequest request)
+		protected virtual void SetAuthenticationIfNeeded(RequestData requestData, HttpWebRequest request)
 		{
 			// Api Key authentication takes precedence
 			var apiKeySet = SetApiKeyAuthenticationIfNeeded(request, requestData);
@@ -248,6 +248,7 @@ namespace Elasticsearch.Net
 				SetBasicAuthenticationIfNeeded(request, requestData);
 		}
 
+		// TODO - make private in 8.0 and only expose SetAuthenticationIfNeeded
 		protected virtual void SetBasicAuthenticationIfNeeded(HttpWebRequest request, RequestData requestData)
 		{
 			// Basic auth credentials take the following precedence (highest -> lowest):
@@ -268,6 +269,7 @@ namespace Elasticsearch.Net
 			request.Headers["Authorization"] = $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes(userInfo))}";
 		}
 
+		// TODO - make private in 8.0 and only expose SetAuthenticationIfNeeded
 		protected virtual bool SetApiKeyAuthenticationIfNeeded(HttpWebRequest request, RequestData requestData)
 		{
 			// ApiKey auth credentials take the following precedence (highest -> lowest):

--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -257,7 +257,7 @@ namespace Elasticsearch.Net
 
 
 			if (!string.IsNullOrWhiteSpace(userInfo))
-				request.Headers["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userInfo));
+				request.Headers["Authorization"] = $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes(userInfo))}";
 		}
 
 		protected virtual void SetApiKeyAuthenticationIfNeeded(HttpWebRequest request, RequestData requestData)
@@ -268,10 +268,10 @@ namespace Elasticsearch.Net
 
 			string apiKey = null;
 			if (requestData.ApiKeyAuthenticationCredentials != null)
-				apiKey = $"{requestData.ApiKeyAuthenticationCredentials.Id}:{requestData.ApiKeyAuthenticationCredentials.ApiKey.CreateString()}";
+				apiKey = requestData.ApiKeyAuthenticationCredentials.Base64EncodedApiKey.CreateString();
 
 			if (!string.IsNullOrWhiteSpace(apiKey))
-				request.Headers["Authorization"] = "ApiKey " + Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey));
+				request.Headers["Authorization"] = $"ApiKey {apiKey}";
 		}
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -142,7 +142,6 @@ namespace Elasticsearch.Net
 		protected virtual HttpWebRequest CreateHttpWebRequest(RequestData requestData)
 		{
 			var request = CreateWebRequest(requestData);
-			// TODO: Do we need some kind of precedence here?
 			SetAuthenticationIfNeeded(requestData, request);
 			SetProxyIfNeeded(request, requestData);
 			SetServerCertificateValidationCallBackIfNeeded(request, requestData);
@@ -249,7 +248,7 @@ namespace Elasticsearch.Net
 				SetBasicAuthenticationIfNeeded(request, requestData);
 		}
 
-		protected virtual bool SetBasicAuthenticationIfNeeded(HttpWebRequest request, RequestData requestData)
+		protected virtual void SetBasicAuthenticationIfNeeded(HttpWebRequest request, RequestData requestData)
 		{
 			// Basic auth credentials take the following precedence (highest -> lowest):
 			// 1 - Specified on the request (highest precedence)
@@ -264,11 +263,9 @@ namespace Elasticsearch.Net
 					$"{requestData.BasicAuthorizationCredentials.Username}:{requestData.BasicAuthorizationCredentials.Password.CreateString()}";
 
 			if (string.IsNullOrWhiteSpace(userInfo))
-				return false;
+				return;
 
 			request.Headers["Authorization"] = $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes(userInfo))}";
-			return true;
-
 		}
 
 		protected virtual bool SetApiKeyAuthenticationIfNeeded(HttpWebRequest request, RequestData requestData)

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -76,6 +76,7 @@ namespace Elasticsearch.Net
 			ProxyPassword = global.ProxyPassword;
 			DisableAutomaticProxyDetection = global.DisableAutomaticProxyDetection;
 			BasicAuthorizationCredentials = local?.BasicAuthenticationCredentials ?? global.BasicAuthenticationCredentials;
+			ApiKeyAuthenticationCredentials = local?.ApiKeyAuthenticationCredentials ?? global.ApiKeyAuthenticationCredentials;
 			AllowedStatusCodes = local?.AllowedStatusCodes ?? EmptyReadOnly<int>.Collection;
 			ClientCertificates = local?.ClientCertificates ?? global.ClientCertificates;
 			UserAgent = global.UserAgent;
@@ -85,6 +86,8 @@ namespace Elasticsearch.Net
 		
 		public string Accept { get; }
 		public IReadOnlyCollection<int> AllowedStatusCodes { get; }
+
+		public ApiKeyAuthenticationCredentials ApiKeyAuthenticationCredentials { get; }
 
 		public BasicAuthenticationCredentials BasicAuthorizationCredentials { get; }
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -22,7 +22,7 @@ namespace Elasticsearch.Net
 		private readonly IDateTimeProvider _dateTimeProvider;
 		private readonly IMemoryStreamFactory _memoryStreamFactory;
 		private readonly IConnectionConfigurationValues _settings;
-		
+
 		private static DiagnosticSource DiagnosticSource { get; } = new DiagnosticListener(DiagnosticSources.RequestPipeline.SourceName);
 
 		public RequestPipeline(
@@ -392,7 +392,7 @@ namespace Elasticsearch.Net
 		public async Task PingAsync(Node node, CancellationToken cancellationToken)
 		{
 			if (PingDisabled(node)) return;
-			
+
 			var pingData = CreatePingRequestData(node);
 			using (var audit = Audit(PingSuccess, node))
 			using (var d = DiagnosticSource.Diagnose<RequestData, IApiCallDetails>(DiagnosticSources.RequestPipeline.Ping, pingData))
@@ -432,7 +432,7 @@ namespace Elasticsearch.Net
 						audit.Path = requestData.PathAndQuery;
 						var response = _connection.Request<SniffResponse>(requestData);
 						d.EndState = response;
-						
+
 						ThrowBadAuthPipelineExceptionWhenNeeded(response);
 						//sniff should not silently accept bad but valid http responses
 						if (!response.Success)
@@ -469,7 +469,7 @@ namespace Elasticsearch.Net
 						audit.Path = requestData.PathAndQuery;
 						var response = await _connection.RequestAsync<SniffResponse>(requestData, cancellationToken).ConfigureAwait(false);
 						d.EndState = response;
-						
+
 						ThrowBadAuthPipelineExceptionWhenNeeded(response);
 						//sniff should not silently accept bad but valid http responses
 						if (!response.Success)
@@ -554,6 +554,7 @@ namespace Elasticsearch.Net
 				PingTimeout = PingTimeout,
 				RequestTimeout = PingTimeout,
 				BasicAuthenticationCredentials = _settings.BasicAuthenticationCredentials,
+				ApiKeyAuthenticationCredentials = _settings.ApiKeyAuthenticationCredentials,
 				EnableHttpPipelining = RequestConfiguration?.EnableHttpPipelining ?? _settings.HttpPipeliningEnabled,
 				ForceNode = RequestConfiguration?.ForceNode
 			};

--- a/src/Tests/Tests.Core/Extensions/EphemeralClusterExtensions.cs
+++ b/src/Tests/Tests.Core/Extensions/EphemeralClusterExtensions.cs
@@ -30,7 +30,10 @@ namespace Tests.Core.Extensions
 				var settings = modifySettings(cluster.CreateConnectionSettings());
 
 				var current = (IConnectionConfigurationValues)settings;
-				var notAlreadyAuthenticated = current.BasicAuthenticationCredentials == null && current.ClientCertificates == null;
+				var notAlreadyAuthenticated = current.BasicAuthenticationCredentials == null
+					&& current.ApiKeyAuthenticationCredentials == null
+					&& current.ClientCertificates == null;
+
 				var noCertValidation = current.ServerCertificateValidationCallback == null;
 
 				if (cluster.ClusterConfiguration.EnableSecurity && notAlreadyAuthenticated)

--- a/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 using Elastic.Xunit.Sdk;
@@ -58,6 +59,23 @@ namespace Tests.ClientConcepts.Troubleshooting
 			);
 
 			response.DebugInformation.Should().NotContain("pass2");
+		}
+		//hide
+		[U] public void ApiKeyIsNotExposedInDebugInformation()
+		{
+			// hide
+			var client = new ElasticClient(new AlwaysInMemoryConnectionSettings()
+				.DefaultIndex("index")
+				.ApiKeyAuthentication("id1", "api_key1")
+			);
+
+			var response = client.Search<Project>(s => s
+				.Query(q => q
+					.MatchAll()
+				)
+			);
+
+			response.DebugInformation.Should().NotContain("api_key1");
 		}
 
 		//hide

--- a/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyUsageTests.cs
+++ b/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyUsageTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Framework.EndpointTests;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.XPack.Security.ApiKey
+{
+	[SkipVersion("<7.0.0", "Implemented in version 7.0.0")]
+	public class SecurityApiKeyUsageTests
+		: ApiIntegrationTestBase<XPackCluster, NodesInfoResponse, INodesInfoRequest,
+			NodesInfoDescriptor, NodesInfoRequest>
+	{
+		public SecurityApiKeyUsageTests(XPackCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void OnBeforeCall(IElasticClient client)
+		{
+			var r = client.Security.CreateApiKey(o => o.Name(CallIsolatedValue));
+			r.ShouldBeValid();
+			ExtendedValue("response", r);
+		}
+
+		protected override bool ExpectIsValid => true;
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<NodesInfoDescriptor, INodesInfoRequest> Fluent
+		{
+			get
+			{
+				TryGetExtendedValue<CreateApiKeyResponse>("response", out var response);
+				return d => d.RequestConfiguration(r => r.ApiKeyAuthentication(response.Id, response.ApiKey));
+			}
+		}
+
+		protected override HttpMethod HttpMethod => HttpMethod.GET;
+
+		protected override NodesInfoDescriptor NewDescriptor() => new NodesInfoDescriptor();
+
+		protected override NodesInfoRequest Initializer
+		{
+			get
+			{
+				TryGetExtendedValue<CreateApiKeyResponse>("response", out var response);
+				return new NodesInfoRequest
+				{
+					RequestConfiguration = new RequestConfiguration
+					{
+						ApiKeyAuthenticationCredentials = new ApiKeyAuthenticationCredentials(response.Id, response.ApiKey)
+					}
+				};
+			}
+		}
+
+		protected override bool SupportsDeserialization => false;
+
+		protected override string UrlPath => "/_nodes";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.Nodes.Info(f),
+			(client, f) => client.Nodes.InfoAsync(f),
+			(client, r) => client.Nodes.Info(r),
+			(client, r) => client.Nodes.InfoAsync(r)
+		);
+
+		protected override void ExpectResponse(NodesInfoResponse response)
+		{
+			response.IsValid.Should().BeTrue();
+			response.Nodes.Should().NotBeEmpty();
+		}
+	}
+}


### PR DESCRIPTION
It is possible to set both the `Basic` auth and `ApiKey` auth together.

Clearly this doesn't make sense to do, and to me this feels like an exception.

Should we throw an exception in the client? (which would only surface at runtime), or do we apply some kind of precedence in which auth to apply if both are set?

I also left in the `string` override as I think this might be a little easier for someone to use, if they are unable to find our `.CreateSecureString()` extension method.