### PR TITLE
Add track_total_hits to search request body

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
@@ -40,7 +40,8 @@ namespace ApiGenerator.Configuration.Overrides
 			"copy_settings", //this still needs a PR?
 			"source", // allows the body to be specified as a request param, we do not want to advertise this with a strongly typed method
 			"timestamp",
-			"_source_include", "_source_exclude" // can be removed once https://github.com/elastic/elasticsearch/pull/41439 is in
+			"_source_include", "_source_exclude", // can be removed once https://github.com/elastic/elasticsearch/pull/41439 is in
+			"track_total_hits"
 		};
 	}
 }

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
@@ -1712,13 +1712,6 @@ namespace Elasticsearch.Net
 			set => Q("rest_total_hits_as_int", value);
 		}
 
-		///<summary>Indicate if the number of documents that match the query should be tracked</summary>
-		public bool? TrackTotalHits
-		{
-			get => Q<bool? >("track_total_hits");
-			set => Q("track_total_hits", value);
-		}
-
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public bool? TypedKeys
 		{

--- a/src/Nest/Descriptors.NoNamespace.cs
+++ b/src/Nest/Descriptors.NoNamespace.cs
@@ -1300,8 +1300,6 @@ namespace Nest
 		public SearchDescriptor<TInferDocument> SuggestText(string suggesttext) => Qs("suggest_text", suggesttext);
 		///<summary>Indicates whether hits.total should be rendered as an integer or an object in the rest search response</summary>
 		public SearchDescriptor<TInferDocument> TotalHitsAsInteger(bool? totalhitsasinteger = true) => Qs("rest_total_hits_as_int", totalhitsasinteger);
-		///<summary>Indicate if the number of documents that match the query should be tracked</summary>
-		public SearchDescriptor<TInferDocument> TrackTotalHits(bool? tracktotalhits = true) => Qs("track_total_hits", tracktotalhits);
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public SearchDescriptor<TInferDocument> TypedKeys(bool? typedkeys = true) => Qs("typed_keys", typedkeys);
 	}

--- a/src/Nest/Requests.NoNamespace.cs
+++ b/src/Nest/Requests.NoNamespace.cs
@@ -2809,13 +2809,6 @@ namespace Nest
 			set => Q("rest_total_hits_as_int", value);
 		}
 
-		///<summary>Indicate if the number of documents that match the query should be tracked</summary>
-		public bool? TrackTotalHits
-		{
-			get => Q<bool? >("track_total_hits");
-			set => Q("track_total_hits", value);
-		}
-
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public bool? TypedKeys
 		{

--- a/src/Nest/Search/MultiSearch/MultiSearchFormatter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchFormatter.cs
@@ -4,7 +4,7 @@ using Elasticsearch.Net.Utf8Json.Resolvers;
 
 namespace Nest
 {
-	internal class MultiSearchJsonConverter : IJsonFormatter<IMultiSearchRequest>
+	internal class MultiSearchFormatter : IJsonFormatter<IMultiSearchRequest>
 	{
 		private const byte Newline = (byte)'\n';
 

--- a/src/Nest/Search/MultiSearch/MultiSearchRequest.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchRequest.cs
@@ -6,7 +6,7 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	[MapsApi("msearch.json")]
-	[JsonFormatter(typeof(MultiSearchJsonConverter))]
+	[JsonFormatter(typeof(MultiSearchFormatter))]
 	public partial interface IMultiSearchRequest
 	{
 		IDictionary<string, ISearchRequest> Operations { get; set; }

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -9,70 +9,162 @@ namespace Nest
 	[ReadAs(typeof(SearchRequest))]
 	public partial interface ISearchRequest : ITypedSearchRequest
 	{
+		/// <summary>
+		/// Specifies the aggregations to perform
+		/// </summary>
 		[DataMember(Name = "aggs")]
 		AggregationDictionary Aggregations { get; set; }
 
+		/// <summary>
+		/// Allows to collapse search results based on field values.
+		/// The collapsing is done by selecting only the top sorted document per collapse key.
+		/// For instance the query below retrieves the best tweet for each user and sorts them by number of likes.
+		/// <para>
+		/// NOTE: The collapsing is applied to the top hits only and does not affect aggregations.
+		/// You can only collapse to a depth of 2.
+		/// </para>
+		/// </summary>
 		[DataMember(Name = "collapse")]
 		IFieldCollapse Collapse { get; set; }
 
+		/// <summary>
+		/// Enables explanation for each hit on how its score was computed
+		/// </summary>
 		[DataMember(Name = "explain")]
 		bool? Explain { get; set; }
 
+		/// <summary>
+		/// The starting from index of the hits to return. Defaults to 0.
+		/// </summary>
 		[DataMember(Name = "from")]
 		int? From { get; set; }
 
+		/// <summary>
+		/// Allow to highlight search results on one or more fields. The implementation uses the either lucene
+		/// fast-vector-highlighter or highlighter.
+		/// </summary>
 		[DataMember(Name = "highlight")]
 		IHighlight Highlight { get; set; }
 
+		/// <summary>
+		/// Allows to configure different boost level per index when searching across
+		/// more than one indices. This is very handy when hits coming from one index
+		/// matter more than hits coming from another index (think social graph where each user has an index).
+		/// </summary>
 		[DataMember(Name = "indices_boost")]
 		[JsonFormatter(typeof(IndicesBoostFormatter))]
 		IDictionary<IndexName, double> IndicesBoost { get; set; }
 
+		/// <summary>
+		/// Allows to filter out documents based on a minimum score
+		/// </summary>
 		[DataMember(Name = "min_score")]
 		double? MinScore { get; set; }
 
+		/// <summary>
+		/// Specify a query to apply to the search hits at the very end of a search request,
+		/// after aggregations have already been calculated. Useful when both search hits and aggregations
+		/// will be returned in the response, and a filter should only be applied to the search hits.
+		/// </summary>
 		[DataMember(Name = "post_filter")]
 		QueryContainer PostFilter { get; set; }
 
+		/// <summary>
+		/// The Profile API provides detailed timing information about the execution of individual components in a query.
+		/// It gives the user insight into how queries are executed at a low level so that the user can understand
+		/// why certain queries are slow, and take steps to improve their slow queries.
+		/// </summary>
 		[DataMember(Name = "profile")]
 		bool? Profile { get; set; }
 
+		/// <summary>
+		/// Specify the search query to perform
+		/// </summary>
 		[DataMember(Name = "query")]
 		QueryContainer Query { get; set; }
 
+		/// <summary>
+		/// Specify one or more queries to use for rescoring
+		/// </summary>
 		[DataMember(Name = "rescore")]
 		IList<IRescore> Rescore { get; set; }
 
+		/// <summary>
+		/// Allows to return a script evaluation (based on different fields) for each hit
+		/// </summary>
 		[DataMember(Name = "script_fields")]
 		IScriptFields ScriptFields { get; set; }
 
+		/// <summary>
+		///  Sort values that can be used to start returning results "after" any document in the result list.
+		/// </summary>
 		[DataMember(Name = "search_after")]
 		IList<object> SearchAfter { get; set; }
 
+		/// <summary> The number of hits to return. Defaults to 10. </summary>
 		[DataMember(Name = "size")]
 		int? Size { get; set; }
 
+		/// <summary>
+		/// For scroll queries that return a lot of documents it is possible to split the scroll in multiple slices which can be
+		/// consumed independently
+		/// </summary>
 		[DataMember(Name = "slice")]
 		ISlicedScroll Slice { get; set; }
 
+		/// <summary>
+		/// Specifies how to sort the search hits
+		/// </summary>
 		[DataMember(Name = "sort")]
 		IList<ISort> Sort { get; set; }
 
+		/// <summary>
+		/// Specify how the _source field is returned for each search hit.
+		/// <para>When <c>true</c>, _source retrieval is enabled (default)</para>
+		/// <para>When <c>false</c>, _source retrieval is disabled, and no _source will be returned for each hit</para>
+		/// <para>When <see cref="ISourceFilter"/> is specified, fields to include/exclude can be controlled</para>
+		/// </summary>
 		[DataMember(Name = "_source")]
 		Union<bool, ISourceFilter> Source { get; set; }
 
+		/// <summary>
+		///  The suggest feature suggests similar looking terms based on a provided text by using a suggester
+		/// </summary>
 		[DataMember(Name = "suggest")]
 		ISuggestContainer Suggest { get; set; }
 
+		/// <summary>
+		/// The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate
+		/// early.
+		/// If set, the response will have a boolean field terminated_early to indicate whether the query execution has actually
+		/// terminated_early.
+		/// </summary>
 		[DataMember(Name = "terminate_after")]
 		long? TerminateAfter { get; set; }
 
+		/// <summary>
+		/// A search timeout, bounding the search request to be executed within the
+		/// specified time value and bail with the hits accumulated up
+		/// to that point, when expired. Defaults to no timeout.
+		/// </summary>
 		[DataMember(Name = "timeout")]
 		string Timeout { get; set; }
 
+		/// <summary>
+		/// Make sure we keep calculating score even if we are sorting on a field.
+		/// </summary>
 		[DataMember(Name = "track_scores")]
 		bool? TrackScores { get; set; }
 
+		/// <summary>
+		/// Indicate if the number of documents that match the query should be tracked.
+		/// </summary>
+		[DataMember(Name = "track_total_hits")]
+		bool? TrackTotalHits { get; set; }
+
+		/// <summary>
+		/// Return a version for each search hit
+		/// </summary>
 		[DataMember(Name = "version")]
 		bool? Version { get; set; }
 	}
@@ -85,33 +177,56 @@ namespace Nest
 	[DataContract]
 	public partial class SearchRequest
 	{
-		public Fields StoredFields { get; set; }
-		public Fields DocValueFields { get; set; }
+		/// <inheritdoc />
 		public AggregationDictionary Aggregations { get; set; }
+		/// <inheritdoc />
 		public IFieldCollapse Collapse { get; set; }
+		/// <inheritdoc />
+		public Fields DocValueFields { get; set; }
+		/// <inheritdoc />
 		public bool? Explain { get; set; }
+		/// <inheritdoc />
 		public int? From { get; set; }
-
+		/// <inheritdoc />
 		public IHighlight Highlight { get; set; }
-
+		/// <inheritdoc />
 		[JsonFormatter(typeof(IndicesBoostFormatter))]
 		public IDictionary<IndexName, double> IndicesBoost { get; set; }
-
+		/// <inheritdoc />
 		public double? MinScore { get; set; }
+		/// <inheritdoc />
 		public QueryContainer PostFilter { get; set; }
+		/// <inheritdoc />
 		public bool? Profile { get; set; }
+		/// <inheritdoc />
 		public QueryContainer Query { get; set; }
+		/// <inheritdoc />
 		public IList<IRescore> Rescore { get; set; }
+		/// <inheritdoc />
 		public IScriptFields ScriptFields { get; set; }
+		/// <inheritdoc />
 		public IList<object> SearchAfter { get; set; }
+		/// <inheritdoc />
 		public int? Size { get; set; }
+		/// <inheritdoc />
 		public ISlicedScroll Slice { get; set; }
+		/// <inheritdoc />
 		public IList<ISort> Sort { get; set; }
+		/// <inheritdoc />
 		public Union<bool, ISourceFilter> Source { get; set; }
+		/// <inheritdoc />
+		public Fields StoredFields { get; set; }
+		/// <inheritdoc />
 		public ISuggestContainer Suggest { get; set; }
+		/// <inheritdoc />
 		public long? TerminateAfter { get; set; }
+		/// <inheritdoc />
 		public string Timeout { get; set; }
+		/// <inheritdoc />
 		public bool? TrackScores { get; set; }
+		/// <inheritdoc />
+		public bool? TrackTotalHits { get; set; }
+		/// <inheritdoc />
 		public bool? Version { get; set; }
 
 		protected override HttpMethod HttpMethod =>
@@ -148,7 +263,6 @@ namespace Nest
 		bool? ISearchRequest.Explain { get; set; }
 		int? ISearchRequest.From { get; set; }
 		IHighlight ISearchRequest.Highlight { get; set; }
-
 		IDictionary<IndexName, double> ISearchRequest.IndicesBoost { get; set; }
 		double? ISearchRequest.MinScore { get; set; }
 		QueryContainer ISearchRequest.PostFilter { get; set; }
@@ -164,83 +278,61 @@ namespace Nest
 		Fields ISearchRequest.StoredFields { get; set; }
 		ISuggestContainer ISearchRequest.Suggest { get; set; }
 		long? ISearchRequest.TerminateAfter { get; set; }
-
 		string ISearchRequest.Timeout { get; set; }
 		bool? ISearchRequest.TrackScores { get; set; }
+		bool? ISearchRequest.TrackTotalHits { get; set; }
 		bool? ISearchRequest.Version { get; set; }
 
 		protected sealed override void RequestDefaults(SearchRequestParameters parameters) => TypedKeys();
 
-		public SearchDescriptor<TInferDocument> Aggregations(Func<AggregationContainerDescriptor<TInferDocument>, IAggregationContainer> aggregationsSelector) =>
+		/// <inheritdoc cref="ISearchRequest.Aggregations" />
+		public SearchDescriptor<TInferDocument> Aggregations(
+			Func<AggregationContainerDescriptor<TInferDocument>, IAggregationContainer> aggregationsSelector
+		) =>
 			Assign(aggregationsSelector(new AggregationContainerDescriptor<TInferDocument>())?.Aggregations, (a, v) => a.Aggregations = v);
 
+		/// <inheritdoc cref="ISearchRequest.Aggregations" />
 		public SearchDescriptor<TInferDocument> Aggregations(AggregationDictionary aggregations) =>
 			Assign(aggregations, (a, v) => a.Aggregations = v);
 
+		/// <inheritdoc cref="ISearchRequest.Source" />
 		public SearchDescriptor<TInferDocument> Source(bool enabled = true) => Assign(enabled, (a, v) => a.Source = v);
 
+		/// <inheritdoc cref="ISearchRequest.Source" />
 		public SearchDescriptor<TInferDocument> Source(Func<SourceFilterDescriptor<TInferDocument>, ISourceFilter> selector) =>
 			Assign(selector, (a, v) => a.Source = new Union<bool, ISourceFilter>(v?.Invoke(new SourceFilterDescriptor<TInferDocument>())));
 
-		/// <summary> The number of hits to return. Defaults to 10. </summary>
+		/// <inheritdoc cref="ISearchRequest.Size" />
 		public SearchDescriptor<TInferDocument> Size(int? size) => Assign(size, (a, v) => a.Size = v);
 
-		/// <summary>
-		/// The number of hits to return. Alias for <see cref="Size" />. Defaults to 10.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Size" />
 		public SearchDescriptor<TInferDocument> Take(int? take) => Size(take);
 
-		/// <summary>
-		/// The starting from index of the hits to return. Defaults to 0.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.From" />
 		public SearchDescriptor<TInferDocument> From(int? from) => Assign(from, (a, v) => a.From = v);
 
-		/// <summary>
-		/// The starting from index of the hits to return. Alias for <see cref="From" />. Defaults to 0.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.From" />
 		public SearchDescriptor<TInferDocument> Skip(int? skip) => From(skip);
 
-		/// <summary>
-		/// A search timeout, bounding the search request to be executed within the
-		/// specified time value and bail with the hits accumulated up
-		/// to that point when expired. Defaults to no timeout.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Timeout" />
 		public SearchDescriptor<TInferDocument> Timeout(string timeout) => Assign(timeout, (a, v) => a.Timeout = v);
 
-		/// <summary>
-		/// Enables explanation for each hit on how its score was computed.
-		/// (Use .DocumentsWithMetadata on the return results)
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Explain" />
 		public SearchDescriptor<TInferDocument> Explain(bool? explain = true) => Assign(explain, (a, v) => a.Explain = v);
 
-		/// <summary>
-		/// Returns a version for each search hit. (Use .DocumentsWithMetadata on the return results)
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Version" />
 		public SearchDescriptor<TInferDocument> Version(bool? version = true) => Assign(version, (a, v) => a.Version = v);
 
-		/// <summary>
-		/// Make sure we keep calculating score even if we are sorting on a field.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.TrackScores" />
 		public SearchDescriptor<TInferDocument> TrackScores(bool? trackscores = true) => Assign(trackscores, (a, v) => a.TrackScores = v);
 
-		/// <summary>
-		/// The Profile API provides detailed timing information about the execution of individual components in a query.
-		/// It gives the user insight into how queries are executed at a low level so that the user can understand
-		/// why certain queries are slow, and take steps to improve their slow queries.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Profile" />
 		public SearchDescriptor<TInferDocument> Profile(bool? profile = true) => Assign(profile, (a, v) => a.Profile = v);
 
-		/// <summary>
-		/// Allows to filter out documents based on a minimum score:
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.MinScore" />
 		public SearchDescriptor<TInferDocument> MinScore(double? minScore) => Assign(minScore, (a, v) => a.MinScore = v);
 
-		/// <summary>
-		/// The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate
-		/// early.
-		/// If set, the response will have a boolean field terminated_early to indicate whether the query execution has actually
-		/// terminated_early.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.TerminateAfter" />
 		public SearchDescriptor<TInferDocument> TerminateAfter(long? terminateAfter) => Assign(terminateAfter, (a, v) => a.TerminateAfter = v);
 
 		/// <summary>
@@ -274,102 +366,76 @@ namespace Nest
 		/// Prefers execution on the node with the provided node id if applicable.
 		/// </para>
 		/// </summary>
-		public SearchDescriptor<TInferDocument> ExecuteOnPreferredNode(string node) => Preference(node.IsNullOrEmpty() ? null : $"_prefer_node:{node}");
+		public SearchDescriptor<TInferDocument> ExecuteOnPreferredNode(string node) =>
+			Preference(node.IsNullOrEmpty() ? null : $"_prefer_node:{node}");
 
-		/// <summary>
-		/// Allows to configure different boost level per index when searching across
-		/// more than one indices. This is very handy when hits coming from one index
-		/// matter more than hits coming from another index (think social graph where each user has an index).
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.IndicesBoost" />
 		public SearchDescriptor<TInferDocument> IndicesBoost(Func<FluentDictionary<IndexName, double>, FluentDictionary<IndexName, double>> boost) =>
 			Assign(boost, (a, v) => a.IndicesBoost = v?.Invoke(new FluentDictionary<IndexName, double>()));
 
-		/// <summary>
-		/// Allows to selectively load specific fields for each document
-		/// represented by a search hit. Defaults to load the internal _source field.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.StoredFields" />
 		public SearchDescriptor<TInferDocument> StoredFields(Func<FieldsDescriptor<TInferDocument>, IPromise<Fields>> fields) =>
 			Assign(fields, (a, v) => a.StoredFields = v?.Invoke(new FieldsDescriptor<TInferDocument>())?.Value);
 
+		/// <inheritdoc cref="ISearchRequest.StoredFields" />
 		public SearchDescriptor<TInferDocument> StoredFields(Fields fields) => Assign(fields, (a, v) => a.StoredFields = v);
 
+		/// <inheritdoc cref="ISearchRequest.ScriptFields" />
 		public SearchDescriptor<TInferDocument> ScriptFields(Func<ScriptFieldsDescriptor, IPromise<IScriptFields>> selector) =>
 			Assign(selector, (a, v) => a.ScriptFields = v?.Invoke(new ScriptFieldsDescriptor())?.Value);
 
+		/// <inheritdoc cref="ISearchRequest.ScriptFields" />
 		public SearchDescriptor<TInferDocument> DocValueFields(Func<FieldsDescriptor<TInferDocument>, IPromise<Fields>> fields) =>
 			Assign(fields, (a, v) => a.DocValueFields = v?.Invoke(new FieldsDescriptor<TInferDocument>())?.Value);
 
+		/// <inheritdoc cref="ISearchRequest.DocValueFields" />
 		public SearchDescriptor<TInferDocument> DocValueFields(Fields fields) => Assign(fields, (a, v) => a.DocValueFields = v);
 
-		/// <summary>
-		/// A comma-separated list of fields to return as the field data representation of a field for each hit
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Sort" />
 		public SearchDescriptor<TInferDocument> Sort(Func<SortDescriptor<TInferDocument>, IPromise<IList<ISort>>> selector) =>
 			Assign(selector, (a, v) => a.Sort = v?.Invoke(new SortDescriptor<TInferDocument>())?.Value);
 
-		/// <summary>
-		///  Sort values that can be used to start returning results "after" any document in the result list.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.SearchAfter" />
 		public SearchDescriptor<TInferDocument> SearchAfter(IList<object> searchAfter) => Assign(searchAfter, (a, v) => a.SearchAfter = v);
 
-		/// <summary>
-		///  Sort values that can be used to start returning results "after" any document in the result list.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.SearchAfter" />
 		public SearchDescriptor<TInferDocument> SearchAfter(params object[] searchAfter) => Assign(searchAfter, (a, v) => a.SearchAfter = v);
 
-		/// <summary>
-		///  The suggest feature suggests similar looking terms based on a provided text by using a suggester
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Suggest" />
 		public SearchDescriptor<TInferDocument> Suggest(Func<SuggestContainerDescriptor<TInferDocument>, IPromise<ISuggestContainer>> selector) =>
 			Assign(selector, (a, v) => a.Suggest = v?.Invoke(new SuggestContainerDescriptor<TInferDocument>())?.Value);
 
-		/// <summary>
-		/// Describe the query to perform using a query descriptor lambda
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Query" />
 		public SearchDescriptor<TInferDocument> Query(Func<QueryContainerDescriptor<TInferDocument>, QueryContainer> query) =>
 			Assign(query, (a, v) => a.Query = v?.Invoke(new QueryContainerDescriptor<TInferDocument>()));
 
-		/// <summary>
-		/// For scroll queries that return a lot of documents it is possible to split the scroll in multiple slices which can be
-		/// consumed independently
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Slice" />
 		public SearchDescriptor<TInferDocument> Slice(Func<SlicedScrollDescriptor<TInferDocument>, ISlicedScroll> selector) =>
 			Assign(selector, (a, v) => a.Slice = v?.Invoke(new SlicedScrollDescriptor<TInferDocument>()));
 
 		/// <summary>
 		/// Shortcut to default to a match all query
 		/// </summary>
-		public SearchDescriptor<TInferDocument> MatchAll(Func<MatchAllQueryDescriptor, IMatchAllQuery> selector = null) => Query(q => q.MatchAll(selector));
+		public SearchDescriptor<TInferDocument> MatchAll(Func<MatchAllQueryDescriptor, IMatchAllQuery> selector = null) =>
+			Query(q => q.MatchAll(selector));
 
-		/// <summary>
-		/// Filter search using a filter descriptor lambda
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.PostFilter" />
 		public SearchDescriptor<TInferDocument> PostFilter(Func<QueryContainerDescriptor<TInferDocument>, QueryContainer> filter) =>
 			Assign(filter, (a, v) => a.PostFilter = v?.Invoke(new QueryContainerDescriptor<TInferDocument>()));
 
-		/// <summary>
-		/// Allow to highlight search results on one or more fields. The implementation uses the either lucene
-		/// fast-vector-highlighter or highlighter.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Highlight" />
 		public SearchDescriptor<TInferDocument> Highlight(Func<HighlightDescriptor<TInferDocument>, IHighlight> highlightSelector) =>
 			Assign(highlightSelector, (a, v) => a.Highlight = v?.Invoke(new HighlightDescriptor<TInferDocument>()));
 
-		/// <summary>
-		/// Allows to collapse search results based on field values.
-		/// The collapsing is done by selecting only the top sorted document per collapse key.
-		/// For instance the query below retrieves the best tweet for each user and sorts them by number of likes.
-		/// <para>
-		/// NOTE: The collapsing is applied to the top hits only and does not affect aggregations.
-		/// You can only collapse to a depth of 2.
-		/// </para>
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Collapse" />
 		public SearchDescriptor<TInferDocument> Collapse(Func<FieldCollapseDescriptor<TInferDocument>, IFieldCollapse> collapseSelector) =>
 			Assign(collapseSelector, (a, v) => a.Collapse = v?.Invoke(new FieldCollapseDescriptor<TInferDocument>()));
 
-		/// <summary>
-		/// Allows you to specify one or more queries to use for rescoring
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Rescore" />
 		public SearchDescriptor<TInferDocument> Rescore(Func<RescoringDescriptor<TInferDocument>, IPromise<IList<IRescore>>> rescoreSelector) =>
 			Assign(rescoreSelector, (a, v) => a.Rescore = v?.Invoke(new RescoringDescriptor<TInferDocument>()).Value);
+
+		/// <inheritdoc cref="ISearchRequest.TrackTotalHits" />
+		public SearchDescriptor<TInferDocument> TrackTotalHits(bool? trackTotalHits = true) => Assign(trackTotalHits, (a, v) => a.TrackTotalHits = v);
 	}
 }


### PR DESCRIPTION
This commit removes track_total_hits as a query string parameter on a search request and instead defines it in the body, allowing track_total_hits to work with individual search requests in multi search API.

Closes #3906