### PR TITLE
Fix/7.x/compression dotnetcore

### DIFF
--- a/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
+++ b/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
@@ -37,6 +37,8 @@ namespace Elasticsearch.Net
 
 			Task OnStreamAvailable(PostData data, Stream stream, HttpContent content, TransportContext context)
 			{
+				if (_requestData.HttpCompression)
+					stream = new GZipStream(stream, CompressionMode.Compress, false);
 				using(stream)
 					data.Write(stream, requestData.ConnectionSettings);
 				return Task.CompletedTask;
@@ -52,6 +54,8 @@ namespace Elasticsearch.Net
 
 			async Task OnStreamAvailable(PostData data, Stream stream, HttpContent content, TransportContext context)
 			{
+				if (_requestData.HttpCompression)
+					stream = new GZipStream(stream, CompressionMode.Compress, false);
 				using (stream)
 					await data.WriteAsync(stream, requestData.ConnectionSettings, token).ConfigureAwait(false);
 			}
@@ -75,8 +79,6 @@ namespace Elasticsearch.Net
 
 			var serializeToStreamTask = new TaskCompletionSource<bool>();
 
-			if (_requestData.HttpCompression)
-				stream = new GZipStream(stream, CompressionMode.Compress, false);
 			var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
             await _onStreamAvailable(data, wrappedStream, this, context).ConfigureAwait(false);
             await serializeToStreamTask.Task.ConfigureAwait(false);

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -241,13 +241,7 @@ namespace Elasticsearch.Net
 
 			if (!requestData.RunAs.IsNullOrEmpty())
 				requestMessage.Headers.Add(RequestData.RunAsSecurityHeader, requestData.RunAs);
-
-			if (requestData.HttpCompression)
-			{
-				requestMessage.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
-				requestMessage.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("deflate"));
-			}
-
+			
 			return requestMessage;
 		}
 

--- a/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
+++ b/src/Tests/Tests.Configuration/EnvironmentConfiguration.cs
@@ -28,6 +28,7 @@ namespace Tests.Configuration
 			{
 				SourceSerializer = RandomBoolConfig("SOURCESERIALIZER", randomizer),
 				TypedKeys = RandomBoolConfig("TYPEDKEYS", randomizer),
+				HttpCompression = RandomBoolConfig("HTTPCOMPRESSION", randomizer),
 			};
 		}
 

--- a/src/Tests/Tests.Configuration/TestConfigurationBase.cs
+++ b/src/Tests/Tests.Configuration/TestConfigurationBase.cs
@@ -66,5 +66,8 @@ namespace Tests.Configuration
 
 		/// <summary> Randomly enable typed keys on searches (defaults to true) on NEST search requests</summary>
 		public bool TypedKeys { get; set; }
+		
+		/// <summary> Randomly enable compression on the http requests</summary>
+		public bool HttpCompression { get; set; }
 	}
 }

--- a/src/Tests/Tests.Configuration/TestConfigurationExtensions.cs
+++ b/src/Tests/Tests.Configuration/TestConfigurationExtensions.cs
@@ -24,6 +24,7 @@ namespace Tests.Configuration
 			Console.WriteLine($" - Random:");
 			Console.WriteLine($" \t- {nameof(config.Random.SourceSerializer)}: {config.Random.SourceSerializer}");
 			Console.WriteLine($" \t- {nameof(config.Random.TypedKeys)}: {config.Random.TypedKeys}");
+			Console.WriteLine($" \t- {nameof(config.Random.HttpCompression)}: {config.Random.HttpCompression}");
 			Console.WriteLine(new string('-', 20));
 		}
 	}

--- a/src/Tests/Tests.Configuration/YamlConfiguration.cs
+++ b/src/Tests/Tests.Configuration/YamlConfiguration.cs
@@ -34,6 +34,7 @@ namespace Tests.Configuration
 			{
 				SourceSerializer = RandomBool("source_serializer", randomizer),
 				TypedKeys = RandomBool("typed_keys", randomizer),
+				HttpCompression = RandomBool("http_compression", randomizer),
 			};
 		}
 

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -20,7 +20,8 @@ test_against_already_running_elasticsearch: true
 
 #random_source_serializer: true
 #random_old_connection: true
-seed: 74337
+#random_http_compresssion: true
+#seed: 74337
 
 # Can be helpful to speed up tests runs as setting this to true only randomly tests a single overload of the api rather than all 4.
 # Can also help keep the noise down in case of test failures

--- a/src/Tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
+++ b/src/Tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
@@ -43,8 +43,7 @@ namespace Tests.Core.Client.Settings
 		private void ApplyTestSettings() => 
 			RerouteToProxyIfNeeded()
 			.EnableDebugMode()
-				//TODO make this random
-			//.EnableHttpCompression()
+			.EnableHttpCompression(TestConfiguration.Instance.Random.HttpCompression)
 #if DEBUG
 			.EnableDebugMode()
 #endif

--- a/src/Tests/Tests.Core/Xunit/NestXunitRunOptions.cs
+++ b/src/Tests/Tests.Core/Xunit/NestXunitRunOptions.cs
@@ -96,6 +96,7 @@ namespace Tests.Core.Xunit
 
 			AppendExplictConfig(nameof(RandomConfiguration.SourceSerializer), sb);
 			AppendExplictConfig(nameof(RandomConfiguration.TypedKeys), sb);
+			AppendExplictConfig(nameof(RandomConfiguration.HttpCompression), sb);
 
 			if (runningIntegrations)
 				sb.Append("integrate ")


### PR DESCRIPTION
On .NET with our move to using non buffered writes to the stream I moved the `GzipStream` to wrap the stream passed to `CompleteTaskOnCloseStream` which was inadvertently breaking the stream becomming ready for writing resulting in no data being sent over the wire.

This PR also randomly enables `HttpCompression` on `ConnectionSettings` based on the test seed. Something I could have sworn was already in place but found only a `TODO` :crying_cat_face: 