### PR TITLE
Do not set HttpRequestMessage content when no PostData

### DIFF
--- a/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
+++ b/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
@@ -91,7 +91,7 @@ namespace Elasticsearch.Net
 		protected override bool TryComputeLength(out long length)
 		{
 			// We can't know the length of the content being pushed to the output stream.
-			length = default;
+			length = -1;
 			return false;
 		}
 
@@ -112,11 +112,7 @@ namespace Elasticsearch.Net
 				base.Dispose();
 			}
 
-			public override void Close()
-			{
-				_serializeToStreamTask.TrySetResult(true);
-				base.Close();
-			}
+			public override void Close() => _serializeToStreamTask.TrySetResult(true);
 		}
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
+++ b/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
@@ -25,8 +25,7 @@ namespace Elasticsearch.Net
 	internal class RequestDataContent : HttpContent
 	{
 		private readonly RequestData _requestData;
-		private readonly Func<PostData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext, Task> _onStreamAvailable;
-
+		private readonly Func<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext, Task> _onStreamAvailable;
 
 		public RequestDataContent(RequestData requestData)
 		{
@@ -35,14 +34,17 @@ namespace Elasticsearch.Net
 			if (requestData.HttpCompression)
 				Headers.ContentEncoding.Add("gzip");
 
-			Task OnStreamAvailable(PostData data, Stream stream, HttpContent content, TransportContext context)
+			Task OnStreamAvailable(RequestData data, Stream stream, HttpContent content, TransportContext context)
 			{
-				if (_requestData.HttpCompression)
+				if (data.HttpCompression)
 					stream = new GZipStream(stream, CompressionMode.Compress, false);
+
 				using(stream)
-					data.Write(stream, requestData.ConnectionSettings);
+					data.PostData.Write(stream, data.ConnectionSettings);
+
 				return Task.CompletedTask;
 			}
+
 			_onStreamAvailable = OnStreamAvailable;
 		}
 		public RequestDataContent(RequestData requestData, CancellationToken token)
@@ -52,13 +54,15 @@ namespace Elasticsearch.Net
 			if (requestData.HttpCompression)
 				Headers.ContentEncoding.Add("gzip");
 
-			async Task OnStreamAvailable(PostData data, Stream stream, HttpContent content, TransportContext context)
+			async Task OnStreamAvailable(RequestData data, Stream stream, HttpContent content, TransportContext context)
 			{
-				if (_requestData.HttpCompression)
+				if (data.HttpCompression)
 					stream = new GZipStream(stream, CompressionMode.Compress, false);
+
 				using (stream)
-					await data.WriteAsync(stream, requestData.ConnectionSettings, token).ConfigureAwait(false);
+					await data.PostData.WriteAsync(stream, data.ConnectionSettings, token).ConfigureAwait(false);
 			}
+
 			_onStreamAvailable = OnStreamAvailable;
 		}
 
@@ -73,14 +77,9 @@ namespace Elasticsearch.Net
 		[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exception is passed as task result.")]
 		protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
 		{
-
-			var data = _requestData.PostData;
-			if (data == null) return;
-
 			var serializeToStreamTask = new TaskCompletionSource<bool>();
-
 			var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
-            await _onStreamAvailable(data, wrappedStream, this, context).ConfigureAwait(false);
+            await _onStreamAvailable(_requestData, wrappedStream, this, context).ConfigureAwait(false);
             await serializeToStreamTask.Task.ConfigureAwait(false);
 		}
 
@@ -92,7 +91,7 @@ namespace Elasticsearch.Net
 		protected override bool TryComputeLength(out long length)
 		{
 			// We can't know the length of the content being pushed to the output stream.
-			length = -1;
+			length = default;
 			return false;
 		}
 
@@ -113,8 +112,11 @@ namespace Elasticsearch.Net
 				base.Dispose();
 			}
 
-
-			public override void Close() => _serializeToStreamTask.TrySetResult(true);
+			public override void Close()
+			{
+				_serializeToStreamTask.TrySetResult(true);
+				base.Close();
+			}
 		}
 
 		/// <summary>
@@ -195,6 +197,8 @@ namespace Elasticsearch.Net
 			public override void EndWrite(IAsyncResult asyncResult) => _innerStream.EndWrite(asyncResult);
 
 			public override void WriteByte(byte value) => _innerStream.WriteByte(value);
+
+			public override void Close() => _innerStream.Close();
 		}
 	}
 }

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -57,7 +57,10 @@ namespace Elasticsearch.Net
 			try
 			{
 				var requestMessage = CreateHttpRequestMessage(requestData);
-				SetContent(requestMessage, requestData);
+
+				if (requestData.PostData != null)
+					SetContent(requestMessage, requestData);
+
 				using(requestMessage?.Content ?? (IDisposable)Stream.Null)
 				using (var d = DiagnosticSource.Diagnose<RequestData, int?>(DiagnosticSources.HttpConnection.SendAndReceiveHeaders, requestData))
 				{
@@ -107,8 +110,11 @@ namespace Elasticsearch.Net
 			try
 			{
 				var requestMessage = CreateHttpRequestMessage(requestData);
-				SetAsyncContent(requestMessage, requestData, cancellationToken);
-				using(requestMessage?.Content ?? (IDisposable)Stream.Null) 
+
+				if (requestData.PostData != null)
+					SetAsyncContent(requestMessage, requestData, cancellationToken);
+
+				using(requestMessage?.Content ?? (IDisposable)Stream.Null)
 				using (var d = DiagnosticSource.Diagnose<RequestData, int?>(DiagnosticSources.HttpConnection.SendAndReceiveHeaders, requestData))
 				{
 					responseMessage = await client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);

--- a/src/Tests/Tests.Reproduce/GithubIssue3907.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue3907.cs
@@ -12,7 +12,9 @@ namespace Tests.Reproduce
 	{
 		private readonly IntrusiveOperationCluster _cluster;
 
-		// use intrusive operation because we're changing the underlying http handler
+		// use intrusive operation cluster because we're changing the underlying http handler
+		// and this cluster runs with a max concurrency of 1, so changing http handler
+		// will not affect other integration tests
 		public GithubIssue3907(IntrusiveOperationCluster cluster) => _cluster = cluster;
 
 		[I]

--- a/src/Tests/Tests.Reproduce/GithubIssue3907.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue3907.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3907 : IClusterFixture<ReadOnlyCluster>
+	{
+		private readonly IntrusiveOperationCluster _cluster;
+
+		// use intrusive operation because we're changing the underlying http handler
+		public GithubIssue3907(IntrusiveOperationCluster cluster) => _cluster = cluster;
+
+		[I]
+		public void NotUsingSocketsHttpHandlerDoesNotCauseException()
+		{
+			AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
+
+			var response = _cluster.Client.Indices.Exists("non_existent_index");
+			response.ApiCall.HttpStatusCode.Should().Be(404);
+			response.OriginalException.Should().BeNull();
+
+			AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", true);
+		}
+	}
+}


### PR DESCRIPTION
This commit changes the HttpConnection to not set Content on HttpRequestMessage when there is no PostData. The check is performed inside of Request and RequestAsync to avoid creating any content instance and allocations.

Change length to default in TryComputeLength to match HttpContent implementation.

Pass RequestData through to _onStreamAvailable delegates so that HttpCompression, ConnectionSettings and PostData can be accessed on the passed instance.

Fixes #3907