### PR TITLE
Implement adjust_offsets on word delimiter graph token filter

### DIFF
--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -83,14 +83,28 @@ anchor will be an actual `DateTime`, even after a serialization/deserialization 
 [source,csharp]
 ----
 var date = new DateTime(2015, 05, 05);
-Expect("2015-05-05T00:00:00")
-    .WhenSerializing<Nest.DateMath>(date)
-    .AssertSubject(dateMath => ((IDateMath)dateMath)
-        .Anchor.Match(
-            d => d.Should().Be(date),
-            s => s.Should().BeNull()
-        )
-    );
+----
+
+will serialize to
+
+[source,javascript]
+----
+"2015-05-05T00:00:00"
+----
+
+When the `DateTime` is local or UTC, the time zone information is included.
+For example, for a UTC `DateTime`
+
+[source,csharp]
+----
+var utcDate = new DateTime(2015, 05, 05, 0, 0, 0, DateTimeKind.Utc);
+----
+
+will serialize to
+
+[source,javascript]
+----
+"2015-05-05T00:00:00Z"
 ----
 
 ==== Complex expressions

--- a/docs/query-dsl.asciidoc
+++ b/docs/query-dsl.asciidoc
@@ -275,6 +275,8 @@ Specialized types of queries that do not fit into other groups
 
 * <<script-query-usage,Script Query Usage>>
 
+* <<script-score-query-usage,Script Score Query Usage>>
+
 See the Elasticsearch documentation on {ref_current}/specialized-queries.html[Specialized queries] for more details.
 
 :includes-from-dirs: query-dsl/specialized
@@ -286,6 +288,8 @@ include::query-dsl/specialized/more-like-this/more-like-this-query-usage.asciido
 include::query-dsl/specialized/percolate/percolate-query-usage.asciidoc[]
 
 include::query-dsl/specialized/script/script-query-usage.asciidoc[]
+
+include::query-dsl/specialized/script-score/script-score-query-usage.asciidoc[]
 
 [[span-queries]]
 == Span queries

--- a/docs/query-dsl/compound/function-score/function-score-query-usage.asciidoc
+++ b/docs/query-dsl/compound/function-score/function-score-query-usage.asciidoc
@@ -29,15 +29,36 @@ q
     .MaxBoost(20.0)
     .MinScore(1.0)
     .Functions(f => f
-        .Exponential(b => b.Field(p => p.NumberOfCommits).Decay(0.5).Origin(1.0).Scale(0.1).Weight(2.1))
+        .Exponential(b => b
+            .Field(p => p.NumberOfCommits)
+            .Decay(0.5)
+            .Origin(1.0)
+            .Scale(0.1)
+            .Weight(2.1)
+            .Filter(fi => fi
+                .Range(r => r
+                    .Field(p => p.NumberOfContributors)
+                    .GreaterThan(10)
+                )
+            )
+        )
         .GaussDate(b => b.Field(p => p.LastActivity).Origin(DateMath.Now).Decay(0.5).Scale("1d"))
-        .LinearGeoLocation(b =>
-            b.Field(p => p.LocationPoint).Origin(new GeoLocation(70, -70)).Scale(Distance.Miles(1)).MultiValueMode(MultiValueMode.Average))
+        .LinearGeoLocation(b => b
+            .Field(p => p.LocationPoint)
+            .Origin(new GeoLocation(70, -70))
+            .Scale(Distance.Miles(1))
+            .MultiValueMode(MultiValueMode.Average)
+        )
         .FieldValueFactor(b => b.Field(p => p.NumberOfContributors).Factor(1.1).Missing(0.1).Modifier(FieldValueFactorModifier.Square))
         .RandomScore(r => r.Seed(1337).Field("_seq_no"))
         .RandomScore(r => r.Seed("randomstring").Field("_seq_no"))
         .Weight(1.0)
-        .ScriptScore(s => s.Script(ss => ss.Source("Math.log(2 + doc['numberOfCommits'].value)")))
+        .ScriptScore(s => s
+            .Script(ss => ss
+                .Source("Math.log(2 + doc['numberOfCommits'].value)")
+            )
+            .Weight(2)
+        )
     )
 )
 ----
@@ -57,7 +78,19 @@ new FunctionScoreQuery()
     MinScore = 1.0,
     Functions = new List<IScoreFunction>
     {
-        new ExponentialDecayFunction { Origin = 1.0, Decay = 0.5, Field = Field<Project>(p => p.NumberOfCommits), Scale = 0.1, Weight = 2.1 },
+        new ExponentialDecayFunction
+        {
+            Origin = 1.0,
+            Decay = 0.5,
+            Field = Field<Project>(p => p.NumberOfCommits),
+            Scale = 0.1,
+            Weight = 2.1,
+            Filter = new NumericRangeQuery
+            {
+                Field = Field<Project>(f => f.NumberOfContributors),
+                GreaterThan = 10
+            }
+        },
         new GaussDateDecayFunction
             { Origin = DateMath.Now, Field = Field<Project>(p => p.LastActivity), Decay = 0.5, Scale = TimeSpan.FromDays(1) },
         new LinearGeoDecayFunction
@@ -72,7 +105,7 @@ new FunctionScoreQuery()
         new RandomScoreFunction { Seed = 1337, Field = "_seq_no" },
         new RandomScoreFunction { Seed = "randomstring", Field = "_seq_no" },
         new WeightFunction { Weight = 1.0 },
-        new ScriptScoreFunction { Script = new InlineScript("Math.log(2 + doc['numberOfCommits'].value)") }
+        new ScriptScoreFunction { Script = new InlineScript("Math.log(2 + doc['numberOfCommits'].value)"), Weight = 2.0 }
     }
 }
 ----
@@ -94,7 +127,14 @@ new FunctionScoreQuery()
             "decay": 0.5
           }
         },
-        "weight": 2.1
+        "weight": 2.1,
+        "filter": {
+          "range": {
+            "numberOfContributors": {
+              "gt": 10.0
+            }
+          }
+        }
       },
       {
         "gauss": {
@@ -145,7 +185,8 @@ new FunctionScoreQuery()
           "script": {
             "source": "Math.log(2 + doc['numberOfCommits'].value)"
           }
-        }
+        },
+        "weight": 2.0
       }
     ],
     "max_boost": 20.0,

--- a/docs/query-dsl/specialized/script-score/script-score-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/script-score/script-score-query-usage.asciidoc
@@ -1,0 +1,102 @@
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.0
+
+:github: https://github.com/elastic/elasticsearch-net
+
+:nuget: https://www.nuget.org/packages
+
+////
+IMPORTANT NOTE
+==============
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs. 
+If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
+please modify the original csharp file found at the link and submit the PR with that change. Thanks!
+////
+
+[[script-score-query-usage]]
+=== Script Score Query Usage
+
+A query allowing you to modify the score of documents that are retrieved by a query.
+This can be useful if, for example, a score function is computationally expensive and
+it is sufficient to compute the score on a filtered set of documents.
+
+See the Elasticsearch documentation on {ref_current}/query-dsl-script-score-query.html[script_score query] for more details.
+
+==== Fluent DSL example
+
+[source,csharp]
+----
+q
+.ScriptScore(sn => sn
+    .Name("named_query")
+    .Boost(1.1)
+    .Query(qq => qq
+        .Range(r => r
+            .Field(f => f.NumberOfCommits)
+            .GreaterThan(50)
+        )
+    )
+    .Script(s => s
+        .Source(_scriptScoreSource)
+        .Params(p => p
+            .Add("origin", 100)
+            .Add("scale", 10)
+            .Add("decay", 0.5)
+            .Add("offset", 0)
+        )
+    )
+)
+----
+
+==== Object Initializer syntax example
+
+[source,csharp]
+----
+new ScriptScoreQuery
+{
+    Name = "named_query",
+    Boost = 1.1,
+    Query = new NumericRangeQuery
+    {
+        Field = Infer.Field<Project>(f => f.NumberOfCommits),
+        GreaterThan = 50
+    },
+    Script = new InlineScript(_scriptScoreSource)
+    {
+        Params = new Dictionary<string, object>
+        {
+            { "origin", 100 },
+            { "scale", 10 },
+            { "decay", 0.5 },
+            { "offset", 0 }
+        }
+    },
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "script_score": {
+    "_name": "named_query",
+    "boost": 1.1,
+    "query": {
+      "range": {
+        "numberOfCommits": {
+          "gt": 50.0
+        }
+      }
+    },
+    "script": {
+      "source": "decayNumericLinear(params.origin, params.scale, params.offset, params.decay, doc['numberOfCommits'].value)",
+      "params": {
+        "origin": 100,
+        "scale": 10,
+        "decay": 0.5,
+        "offset": 0
+      }
+    }
+  }
+}
+----
+

--- a/src/CodeGeneration/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
@@ -40,7 +40,8 @@ namespace ApiGenerator.Configuration.Overrides
 			"copy_settings", //this still needs a PR?
 			"source", // allows the body to be specified as a request param, we do not want to advertise this with a strongly typed method
 			"timestamp",
-			"_source_include", "_source_exclude" // can be removed once https://github.com/elastic/elasticsearch/pull/41439 is in
+			"_source_include", "_source_exclude", // can be removed once https://github.com/elastic/elasticsearch/pull/41439 is in
+			"track_total_hits"
 		};
 	}
 }

--- a/src/CodeGeneration/DocGenerator/StringExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/StringExtensions.cs
@@ -114,7 +114,8 @@ namespace DocGenerator
 										new []{ new [] {8.2, 18.2}, new [] {8.2, -18.8}, new [] {-8.8, -10.8}, new [] {8.8, 18.2}}
 									}"
 			},
-			{ "ProjectFilterExpectedJson", "new {term = new {type = new {value = \"project\"}}}" }
+			{ "ProjectFilterExpectedJson", "new {term = new {type = new {value = \"project\"}}}" },
+			{ "_scriptScoreSource", "\"decayNumericLinear(params.origin, params.scale, params.offset, params.decay, doc['numberOfCommits'].value)\""}
 		};
 
 		private static readonly Regex LeadingSpacesAndAsterisk = new Regex(@"^(?<value>[ \t]*\*\s?).*", RegexOptions.Compiled);

--- a/src/CodeGeneration/DocGenerator/StringExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/StringExtensions.cs
@@ -213,7 +213,7 @@ namespace DocGenerator
 
 		public static string[] SplitOnNewLines(this string input, StringSplitOptions options) => input.Split(new[] { "\r\n", "\n" }, options);
 
-		public static bool TryGetJsonForAnonymousType(this string anonymousTypeString, out string json)
+		public static bool TryGetJsonForExpressionSyntax(this string anonymousTypeString, out string json)
 		{
 			json = null;
 

--- a/src/CodeGeneration/DocGenerator/SyntaxNodeExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/SyntaxNodeExtensions.cs
@@ -72,11 +72,10 @@ namespace DocGenerator
 			json = null;
 
 			// find the first anonymous object or new object expression
-			var creationExpressionSyntax = node.DescendantNodes()
-				.FirstOrDefault(n => n is AnonymousObjectCreationExpressionSyntax || n is ObjectCreationExpressionSyntax);
+			var syntax = node.DescendantNodes()
+				.FirstOrDefault(n => n is AnonymousObjectCreationExpressionSyntax || n is ObjectCreationExpressionSyntax || n is LiteralExpressionSyntax);
 
-			return creationExpressionSyntax != null &&
-				creationExpressionSyntax.ToFullString().TryGetJsonForAnonymousType(out json);
+			return syntax != null && syntax.ToFullString().TryGetJsonForExpressionSyntax(out json);
 		}
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
@@ -1712,13 +1712,6 @@ namespace Elasticsearch.Net
 			set => Q("rest_total_hits_as_int", value);
 		}
 
-		///<summary>Indicate if the number of documents that match the query should be tracked</summary>
-		public bool? TrackTotalHits
-		{
-			get => Q<bool? >("track_total_hits");
-			set => Q("track_total_hits", value);
-		}
-
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public bool? TypedKeys
 		{

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -57,7 +57,10 @@ namespace Elasticsearch.Net
 			try
 			{
 				var requestMessage = CreateHttpRequestMessage(requestData);
-				SetContent(requestMessage, requestData);
+
+				if (requestData.PostData != null)
+					SetContent(requestMessage, requestData);
+
 				using(requestMessage?.Content ?? (IDisposable)Stream.Null)
 				using (var d = DiagnosticSource.Diagnose<RequestData, int?>(DiagnosticSources.HttpConnection.SendAndReceiveHeaders, requestData))
 				{
@@ -107,8 +110,11 @@ namespace Elasticsearch.Net
 			try
 			{
 				var requestMessage = CreateHttpRequestMessage(requestData);
-				SetAsyncContent(requestMessage, requestData, cancellationToken);
-				using(requestMessage?.Content ?? (IDisposable)Stream.Null) 
+
+				if (requestData.PostData != null)
+					SetAsyncContent(requestMessage, requestData, cancellationToken);
+
+				using(requestMessage?.Content ?? (IDisposable)Stream.Null)
 				using (var d = DiagnosticSource.Diagnose<RequestData, int?>(DiagnosticSources.HttpConnection.SendAndReceiveHeaders, requestData))
 				{
 					responseMessage = await client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);

--- a/src/Elasticsearch.Net/Extensions/StringBuilderCache.cs
+++ b/src/Elasticsearch.Net/Extensions/StringBuilderCache.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+namespace Elasticsearch.Net.Extensions
+{
+	/// <summary>Provide a cached reusable instance of stringbuilder per thread.</summary>
+	internal static class StringBuilderCache
+	{
+		private const int DefaultCapacity = 16; // == StringBuilder.DefaultCapacity
+
+		// The value 360 was chosen in discussion with performance experts as a compromise between using
+		// as little memory per thread as possible and still covering a large part of short-lived
+		// StringBuilder creations on the startup path of VS designers.
+		private const int MaxBuilderSize = 360;
+
+		// WARNING: We allow diagnostic tools to directly inspect this member (t_cachedInstance).
+		// See https://github.com/dotnet/corert/blob/master/Documentation/design-docs/diagnostics/diagnostics-tools-contract.md for more details.
+		// Please do not change the type, the name, or the semantic usage of this member without understanding the implication for tools.
+		// Get in touch with the diagnostics team if you have questions.
+		[ThreadStatic]
+		private static StringBuilder _cachedInstance;
+
+		/// <summary>Get a StringBuilder for the specified capacity.</summary>
+		/// <remarks>If a StringBuilder of an appropriate size is cached, it will be returned and the cache emptied.</remarks>
+		public static StringBuilder Acquire(int capacity = DefaultCapacity)
+		{
+			if (capacity <= MaxBuilderSize)
+			{
+				var sb = _cachedInstance;
+				if (sb != null)
+				{
+					// Avoid stringbuilder block fragmentation by getting a new StringBuilder
+					// when the requested size is larger than the current capacity
+					if (capacity <= sb.Capacity)
+					{
+						_cachedInstance = null;
+						sb.Clear();
+						return sb;
+					}
+				}
+			}
+
+			return new StringBuilder(capacity);
+		}
+
+		/// <summary>Place the specified builder in the cache if it is not too big.</summary>
+		public static void Release(StringBuilder sb)
+		{
+			if (sb.Capacity <= MaxBuilderSize) _cachedInstance = sb;
+		}
+
+		/// <summary>ToString() the stringbuilder, Release it to the cache, and return the resulting string.</summary>
+		public static string GetStringAndRelease(StringBuilder sb)
+		{
+			var result = sb.ToString();
+			Release(sb);
+			return result;
+		}
+	}
+}

--- a/src/Nest/Analysis/TokenFilters/WordDelimiterGraph/WordDelimiterGraphTokenFilter.cs
+++ b/src/Nest/Analysis/TokenFilters/WordDelimiterGraph/WordDelimiterGraphTokenFilter.cs
@@ -11,6 +11,13 @@ namespace Nest
 	public interface IWordDelimiterGraphTokenFilter : ITokenFilter
 	{
 		/// <summary>
+		/// By default, the filter tries to output subtokens with adjusted offsets to reflect their actual position in the token stream. However, when used in combination with other filters that alter the length or starting position of tokens without changing their offsets (e.g. <see cref="TrimTokenFilter"/>) this can cause tokens with illegal offsets to be emitted. Setting <see cref="AdjustOffsets"/> to false will stop <see cref="WordDelimiterGraphTokenFilter"/> from adjusting these internal offsets.
+		/// </summary>
+		[DataMember(Name ="adjust_offsets")]
+		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
+		bool? AdjustOffsets { get; set; }
+
+		/// <summary>
 		/// If true causes all subword parts to be catenated: "wi-fi-4000" ⇒ "wifi4000". Defaults to false.
 		/// </summary>
 		[DataMember(Name ="catenate_all")]
@@ -105,6 +112,9 @@ namespace Nest
 		public WordDelimiterGraphTokenFilter() : base("word_delimiter_graph") { }
 
 		/// <inheritdoc />
+		public bool? AdjustOffsets { get; set; }
+
+		/// <inheritdoc />
 		public bool? CatenateAll { get; set; }
 
 		/// <inheritdoc />
@@ -149,6 +159,7 @@ namespace Nest
 		: TokenFilterDescriptorBase<WordDelimiterGraphTokenFilterDescriptor, IWordDelimiterGraphTokenFilter>, IWordDelimiterGraphTokenFilter
 	{
 		protected override string Type => "word_delimiter_graph";
+		bool? IWordDelimiterGraphTokenFilter.AdjustOffsets { get; set; }
 		bool? IWordDelimiterGraphTokenFilter.CatenateAll { get; set; }
 		bool? IWordDelimiterGraphTokenFilter.CatenateNumbers { get; set; }
 		bool? IWordDelimiterGraphTokenFilter.CatenateWords { get; set; }
@@ -178,6 +189,9 @@ namespace Nest
 		/// <inheritdoc />
 		public WordDelimiterGraphTokenFilterDescriptor CatenateNumbers(bool? catenateNumbers = true) =>
 			Assign(catenateNumbers, (a, v) => a.CatenateNumbers = v);
+
+		/// <inheritdoc />
+		public WordDelimiterGraphTokenFilterDescriptor AdjustOffsets(bool? adjustOffsets = true) => Assign(adjustOffsets, (a, v) => a.AdjustOffsets = v);
 
 		/// <inheritdoc />
 		public WordDelimiterGraphTokenFilterDescriptor CatenateAll(bool? catenateAll = true) => Assign(catenateAll, (a, v) => a.CatenateAll = v);

--- a/src/Nest/Descriptors.NoNamespace.cs
+++ b/src/Nest/Descriptors.NoNamespace.cs
@@ -1300,8 +1300,6 @@ namespace Nest
 		public SearchDescriptor<TInferDocument> SuggestText(string suggesttext) => Qs("suggest_text", suggesttext);
 		///<summary>Indicates whether hits.total should be rendered as an integer or an object in the rest search response</summary>
 		public SearchDescriptor<TInferDocument> TotalHitsAsInteger(bool? totalhitsasinteger = true) => Qs("rest_total_hits_as_int", totalhitsasinteger);
-		///<summary>Indicate if the number of documents that match the query should be tracked</summary>
-		public SearchDescriptor<TInferDocument> TrackTotalHits(bool? tracktotalhits = true) => Qs("track_total_hits", tracktotalhits);
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public SearchDescriptor<TInferDocument> TypedKeys(bool? typedkeys = true) => Qs("typed_keys", typedkeys);
 	}

--- a/src/Nest/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusResponse.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Snapshot/SnapshotStatus/SnapshotStatusResponse.cs
@@ -85,10 +85,25 @@ namespace Nest
 
 	public class SnapshotStats
 	{
+		[DataMember(Name ="incremental")]
+		public FileCountSnapshotStats Incremental { get; internal set; }
+
+		[DataMember(Name ="total")]
+		public FileCountSnapshotStats Total { get; internal set; }
+
 		[DataMember(Name ="start_time_in_millis")]
 		public long StartTimeInMilliseconds { get; internal set; }
 
 		[DataMember(Name ="time_in_millis")]
 		public long TimeInMilliseconds { get; internal set; }
+	}
+
+	public class FileCountSnapshotStats
+	{
+		[DataMember(Name ="file_count")]
+		public int FileCount { get; internal set; }
+
+		[DataMember(Name ="size_in_bytes")]
+		public long SizeInBytes { get; internal set; }
 	}
 }

--- a/src/Nest/QueryDsl/Abstractions/Container/IQueryContainer.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/IQueryContainer.cs
@@ -115,6 +115,10 @@ namespace Nest
 		[DataMember(Name ="script")]
 		IScriptQuery Script { get; set; }
 
+		/// <inheritdoc cref="IScriptScoreQuery"/>
+		[DataMember(Name ="script_score")]
+		IScriptScoreQuery ScriptScore { get; set; }
+
 		[DataMember(Name ="simple_query_string")]
 		ISimpleQueryStringQuery SimpleQueryString { get; set; }
 

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
@@ -38,6 +38,7 @@ namespace Nest
 		private IRawQuery _raw;
 		private IRegexpQuery _regexp;
 		private IScriptQuery _script;
+		private IScriptScoreQuery _scriptScore;
 		private ISimpleQueryStringQuery _simpleQueryString;
 		private ISpanContainingQuery _spanContaining;
 		private ISpanFieldMaskingQuery _spanFieldMasking;
@@ -249,6 +250,12 @@ namespace Nest
 		{
 			get => _script;
 			set => _script = Set(value);
+		}
+
+		IScriptScoreQuery IQueryContainer.ScriptScore
+		{
+			get => _scriptScore;
+			set => _scriptScore = Set(value);
 		}
 
 		ISimpleQueryStringQuery IQueryContainer.SimpleQueryString

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -437,6 +437,9 @@ namespace Nest
 		public QueryContainer Script(Func<ScriptQueryDescriptor<T>, IScriptQuery> selector) =>
 			WrapInContainer(selector, (query, container) => container.Script = query);
 
+		public QueryContainer ScriptScore(Func<ScriptScoreQueryDescriptor<T>, IScriptScoreQuery> selector) =>
+			WrapInContainer(selector, (query, container) => container.ScriptScore = query);
+
 		public QueryContainer Exists(Func<ExistsQueryDescriptor<T>, IExistsQuery> selector) =>
 			WrapInContainer(selector, (query, container) => container.Exists = query);
 

--- a/src/Nest/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctionJsonFormatter.cs
+++ b/src/Nest/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctionJsonFormatter.cs
@@ -158,8 +158,11 @@ namespace Nest
 		private static void WriteScriptScore(ref JsonWriter writer, IScriptScoreFunction value, IJsonFormatterResolver formatterResolver)
 		{
 			writer.WritePropertyName("script_score");
-			var scriptFormatter = formatterResolver.GetFormatter<IScriptScoreFunction>();
-			scriptFormatter.Serialize(ref writer, value, formatterResolver);
+			writer.WriteBeginObject();
+			writer.WritePropertyName("script");
+			var scriptFormatter = formatterResolver.GetFormatter<IScript>();
+			scriptFormatter.Serialize(ref writer, value?.Script, formatterResolver);
+			writer.WriteEndObject();
 		}
 
 		private static void WriteRandomScore(ref JsonWriter writer, IRandomScoreFunction value, IJsonFormatterResolver formatterResolver)

--- a/src/Nest/QueryDsl/Query.cs
+++ b/src/Nest/QueryDsl/Query.cs
@@ -117,6 +117,10 @@ namespace Nest
 		public static QueryContainer Script(Func<ScriptQueryDescriptor<T>, IScriptQuery> selector) =>
 			new QueryContainerDescriptor<T>().Script(selector);
 
+		/// <inheritdoc cref="IScriptScoreQuery"/>
+		public static QueryContainer ScriptScore(Func<ScriptScoreQueryDescriptor<T>, IScriptScoreQuery> selector) =>
+			new QueryContainerDescriptor<T>().ScriptScore(selector);
+
 		public static QueryContainer SimpleQueryString(Func<SimpleQueryStringQueryDescriptor<T>, ISimpleQueryStringQuery> selector) =>
 			new QueryContainerDescriptor<T>().SimpleQueryString(selector);
 

--- a/src/Nest/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
+++ b/src/Nest/QueryDsl/Specialized/ScriptScore/ScriptScoreQuery.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A query allowing you to modify the score of documents that are retrieved by a query.
+	/// This can be useful if, for example, a score function is computationally expensive and it is sufficient to
+	/// compute the score on a filtered set of documents.
+	/// </summary>
+	[ReadAs(typeof(ScriptScoreQuery))]
+	[InterfaceDataContract]
+	public interface IScriptScoreQuery : IQuery
+	{
+		/// <summary>
+		/// The query to execute
+		/// </summary>
+		[DataMember(Name = "query")]
+		QueryContainer Query { get; set; }
+
+		/// <summary>
+		/// The script to execute
+		/// </summary>
+		[DataMember(Name = "script")]
+		IScript Script { get; set; }
+	}
+
+	/// <inheritdoc cref="IScriptScoreQuery" />
+	public class ScriptScoreQuery : QueryBase, IScriptScoreQuery
+	{
+		/// <inheritdoc />
+		public QueryContainer Query { get; set; }
+
+		/// <inheritdoc />
+		public IScript Script { get; set; }
+
+		protected override bool Conditionless => IsConditionless(this);
+
+		internal override void InternalWrapInContainer(IQueryContainer c) => c.ScriptScore = this;
+
+		internal static bool IsConditionless(IScriptScoreQuery q)
+		{
+			if (q.Script == null || q.Query.IsConditionless())
+				return true;
+
+			switch (q.Script)
+			{
+				case IInlineScript inlineScript:
+					return inlineScript.Source.IsNullOrEmpty();
+				case IIndexedScript indexedScript:
+					return indexedScript.Id.IsNullOrEmpty();
+			}
+
+			return false;
+		}
+	}
+
+	/// <inheritdoc cref="IScriptScoreQuery" />
+	public class ScriptScoreQueryDescriptor<T>
+		: QueryDescriptorBase<ScriptScoreQueryDescriptor<T>, IScriptScoreQuery>
+			, IScriptScoreQuery where T : class
+	{
+		protected override bool Conditionless => ScriptScoreQuery.IsConditionless(this);
+		QueryContainer IScriptScoreQuery.Query { get; set; }
+
+		IScript IScriptScoreQuery.Script { get; set; }
+
+		/// <inheritdoc cref="IScriptScoreQuery.Query" />
+		public ScriptScoreQueryDescriptor<T> Query(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
+			Assign(selector, (a, v) => a.Query = v?.Invoke(new QueryContainerDescriptor<T>()));
+
+		/// <inheritdoc cref="IScriptScoreQuery.Script" />
+		public ScriptScoreQueryDescriptor<T> Script(Func<ScriptDescriptor, IScript> selector) =>
+			Assign(selector, (a, v) => a.Script = v?.Invoke(new ScriptDescriptor()));
+	}
+}

--- a/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
@@ -187,6 +187,8 @@ namespace Nest
 
 		public virtual void Visit(IScriptQuery query) => Write("script");
 
+		public virtual void Visit(IScriptScoreQuery query) => Write("script_score");
+
 		public virtual void Visit(IRawQuery query) => Write("raw");
 
 		public virtual void Visit(IPercolateQuery query) => Write("percolate");

--- a/src/Nest/QueryDsl/Visitor/QueryVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/QueryVisitor.cs
@@ -86,6 +86,8 @@
 
 		void Visit(IScriptQuery query);
 
+		void Visit(IScriptScoreQuery query);
+
 		void Visit(IGeoPolygonQuery query);
 
 		void Visit(IGeoDistanceQuery query);
@@ -236,6 +238,8 @@
 		public virtual void Visit(ITermsQuery query) { }
 
 		public virtual void Visit(IScriptQuery query) { }
+
+		public virtual void Visit(IScriptScoreQuery query) { }
 
 		public virtual void Visit(IGeoPolygonQuery query) { }
 

--- a/src/Nest/QueryDsl/Visitor/QueryWalker.cs
+++ b/src/Nest/QueryDsl/Visitor/QueryWalker.cs
@@ -44,6 +44,7 @@ namespace Nest
 			VisitQuery(qd.MatchPhrase, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.MatchPhrasePrefix, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.Script, visitor, (v, d) => v.Visit(d));
+			VisitQuery(qd.ScriptScore, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.Exists, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.GeoPolygon, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.GeoDistance, visitor, (v, d) => v.Visit(d));

--- a/src/Nest/Requests.NoNamespace.cs
+++ b/src/Nest/Requests.NoNamespace.cs
@@ -2809,13 +2809,6 @@ namespace Nest
 			set => Q("rest_total_hits_as_int", value);
 		}
 
-		///<summary>Indicate if the number of documents that match the query should be tracked</summary>
-		public bool? TrackTotalHits
-		{
-			get => Q<bool? >("track_total_hits");
-			set => Q("track_total_hits", value);
-		}
-
 		///<summary>Specify whether aggregation and suggester names should be prefixed by their respective types in the response</summary>
 		public bool? TypedKeys
 		{

--- a/src/Nest/Search/MultiSearch/MultiSearchFormatter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchFormatter.cs
@@ -4,7 +4,7 @@ using Elasticsearch.Net.Utf8Json.Resolvers;
 
 namespace Nest
 {
-	internal class MultiSearchJsonConverter : IJsonFormatter<IMultiSearchRequest>
+	internal class MultiSearchFormatter : IJsonFormatter<IMultiSearchRequest>
 	{
 		private const byte Newline = (byte)'\n';
 

--- a/src/Nest/Search/MultiSearch/MultiSearchRequest.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchRequest.cs
@@ -6,7 +6,7 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	[MapsApi("msearch.json")]
-	[JsonFormatter(typeof(MultiSearchJsonConverter))]
+	[JsonFormatter(typeof(MultiSearchFormatter))]
 	public partial interface IMultiSearchRequest
 	{
 		IDictionary<string, ISearchRequest> Operations { get; set; }

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -9,70 +9,162 @@ namespace Nest
 	[ReadAs(typeof(SearchRequest))]
 	public partial interface ISearchRequest : ITypedSearchRequest
 	{
+		/// <summary>
+		/// Specifies the aggregations to perform
+		/// </summary>
 		[DataMember(Name = "aggs")]
 		AggregationDictionary Aggregations { get; set; }
 
+		/// <summary>
+		/// Allows to collapse search results based on field values.
+		/// The collapsing is done by selecting only the top sorted document per collapse key.
+		/// For instance the query below retrieves the best tweet for each user and sorts them by number of likes.
+		/// <para>
+		/// NOTE: The collapsing is applied to the top hits only and does not affect aggregations.
+		/// You can only collapse to a depth of 2.
+		/// </para>
+		/// </summary>
 		[DataMember(Name = "collapse")]
 		IFieldCollapse Collapse { get; set; }
 
+		/// <summary>
+		/// Enables explanation for each hit on how its score was computed
+		/// </summary>
 		[DataMember(Name = "explain")]
 		bool? Explain { get; set; }
 
+		/// <summary>
+		/// The starting from index of the hits to return. Defaults to 0.
+		/// </summary>
 		[DataMember(Name = "from")]
 		int? From { get; set; }
 
+		/// <summary>
+		/// Allow to highlight search results on one or more fields. The implementation uses the either lucene
+		/// fast-vector-highlighter or highlighter.
+		/// </summary>
 		[DataMember(Name = "highlight")]
 		IHighlight Highlight { get; set; }
 
+		/// <summary>
+		/// Allows to configure different boost level per index when searching across
+		/// more than one indices. This is very handy when hits coming from one index
+		/// matter more than hits coming from another index (think social graph where each user has an index).
+		/// </summary>
 		[DataMember(Name = "indices_boost")]
 		[JsonFormatter(typeof(IndicesBoostFormatter))]
 		IDictionary<IndexName, double> IndicesBoost { get; set; }
 
+		/// <summary>
+		/// Allows to filter out documents based on a minimum score
+		/// </summary>
 		[DataMember(Name = "min_score")]
 		double? MinScore { get; set; }
 
+		/// <summary>
+		/// Specify a query to apply to the search hits at the very end of a search request,
+		/// after aggregations have already been calculated. Useful when both search hits and aggregations
+		/// will be returned in the response, and a filter should only be applied to the search hits.
+		/// </summary>
 		[DataMember(Name = "post_filter")]
 		QueryContainer PostFilter { get; set; }
 
+		/// <summary>
+		/// The Profile API provides detailed timing information about the execution of individual components in a query.
+		/// It gives the user insight into how queries are executed at a low level so that the user can understand
+		/// why certain queries are slow, and take steps to improve their slow queries.
+		/// </summary>
 		[DataMember(Name = "profile")]
 		bool? Profile { get; set; }
 
+		/// <summary>
+		/// Specify the search query to perform
+		/// </summary>
 		[DataMember(Name = "query")]
 		QueryContainer Query { get; set; }
 
+		/// <summary>
+		/// Specify one or more queries to use for rescoring
+		/// </summary>
 		[DataMember(Name = "rescore")]
 		IList<IRescore> Rescore { get; set; }
 
+		/// <summary>
+		/// Allows to return a script evaluation (based on different fields) for each hit
+		/// </summary>
 		[DataMember(Name = "script_fields")]
 		IScriptFields ScriptFields { get; set; }
 
+		/// <summary>
+		///  Sort values that can be used to start returning results "after" any document in the result list.
+		/// </summary>
 		[DataMember(Name = "search_after")]
 		IList<object> SearchAfter { get; set; }
 
+		/// <summary> The number of hits to return. Defaults to 10. </summary>
 		[DataMember(Name = "size")]
 		int? Size { get; set; }
 
+		/// <summary>
+		/// For scroll queries that return a lot of documents it is possible to split the scroll in multiple slices which can be
+		/// consumed independently
+		/// </summary>
 		[DataMember(Name = "slice")]
 		ISlicedScroll Slice { get; set; }
 
+		/// <summary>
+		/// Specifies how to sort the search hits
+		/// </summary>
 		[DataMember(Name = "sort")]
 		IList<ISort> Sort { get; set; }
 
+		/// <summary>
+		/// Specify how the _source field is returned for each search hit.
+		/// <para>When <c>true</c>, _source retrieval is enabled (default)</para>
+		/// <para>When <c>false</c>, _source retrieval is disabled, and no _source will be returned for each hit</para>
+		/// <para>When <see cref="ISourceFilter"/> is specified, fields to include/exclude can be controlled</para>
+		/// </summary>
 		[DataMember(Name = "_source")]
 		Union<bool, ISourceFilter> Source { get; set; }
 
+		/// <summary>
+		///  The suggest feature suggests similar looking terms based on a provided text by using a suggester
+		/// </summary>
 		[DataMember(Name = "suggest")]
 		ISuggestContainer Suggest { get; set; }
 
+		/// <summary>
+		/// The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate
+		/// early.
+		/// If set, the response will have a boolean field terminated_early to indicate whether the query execution has actually
+		/// terminated_early.
+		/// </summary>
 		[DataMember(Name = "terminate_after")]
 		long? TerminateAfter { get; set; }
 
+		/// <summary>
+		/// A search timeout, bounding the search request to be executed within the
+		/// specified time value and bail with the hits accumulated up
+		/// to that point, when expired. Defaults to no timeout.
+		/// </summary>
 		[DataMember(Name = "timeout")]
 		string Timeout { get; set; }
 
+		/// <summary>
+		/// Make sure we keep calculating score even if we are sorting on a field.
+		/// </summary>
 		[DataMember(Name = "track_scores")]
 		bool? TrackScores { get; set; }
 
+		/// <summary>
+		/// Indicate if the number of documents that match the query should be tracked.
+		/// </summary>
+		[DataMember(Name = "track_total_hits")]
+		bool? TrackTotalHits { get; set; }
+
+		/// <summary>
+		/// Return a version for each search hit
+		/// </summary>
 		[DataMember(Name = "version")]
 		bool? Version { get; set; }
 	}
@@ -85,33 +177,56 @@ namespace Nest
 	[DataContract]
 	public partial class SearchRequest
 	{
-		public Fields StoredFields { get; set; }
-		public Fields DocValueFields { get; set; }
+		/// <inheritdoc />
 		public AggregationDictionary Aggregations { get; set; }
+		/// <inheritdoc />
 		public IFieldCollapse Collapse { get; set; }
+		/// <inheritdoc />
+		public Fields DocValueFields { get; set; }
+		/// <inheritdoc />
 		public bool? Explain { get; set; }
+		/// <inheritdoc />
 		public int? From { get; set; }
-
+		/// <inheritdoc />
 		public IHighlight Highlight { get; set; }
-
+		/// <inheritdoc />
 		[JsonFormatter(typeof(IndicesBoostFormatter))]
 		public IDictionary<IndexName, double> IndicesBoost { get; set; }
-
+		/// <inheritdoc />
 		public double? MinScore { get; set; }
+		/// <inheritdoc />
 		public QueryContainer PostFilter { get; set; }
+		/// <inheritdoc />
 		public bool? Profile { get; set; }
+		/// <inheritdoc />
 		public QueryContainer Query { get; set; }
+		/// <inheritdoc />
 		public IList<IRescore> Rescore { get; set; }
+		/// <inheritdoc />
 		public IScriptFields ScriptFields { get; set; }
+		/// <inheritdoc />
 		public IList<object> SearchAfter { get; set; }
+		/// <inheritdoc />
 		public int? Size { get; set; }
+		/// <inheritdoc />
 		public ISlicedScroll Slice { get; set; }
+		/// <inheritdoc />
 		public IList<ISort> Sort { get; set; }
+		/// <inheritdoc />
 		public Union<bool, ISourceFilter> Source { get; set; }
+		/// <inheritdoc />
+		public Fields StoredFields { get; set; }
+		/// <inheritdoc />
 		public ISuggestContainer Suggest { get; set; }
+		/// <inheritdoc />
 		public long? TerminateAfter { get; set; }
+		/// <inheritdoc />
 		public string Timeout { get; set; }
+		/// <inheritdoc />
 		public bool? TrackScores { get; set; }
+		/// <inheritdoc />
+		public bool? TrackTotalHits { get; set; }
+		/// <inheritdoc />
 		public bool? Version { get; set; }
 
 		protected override HttpMethod HttpMethod =>
@@ -148,7 +263,6 @@ namespace Nest
 		bool? ISearchRequest.Explain { get; set; }
 		int? ISearchRequest.From { get; set; }
 		IHighlight ISearchRequest.Highlight { get; set; }
-
 		IDictionary<IndexName, double> ISearchRequest.IndicesBoost { get; set; }
 		double? ISearchRequest.MinScore { get; set; }
 		QueryContainer ISearchRequest.PostFilter { get; set; }
@@ -164,83 +278,61 @@ namespace Nest
 		Fields ISearchRequest.StoredFields { get; set; }
 		ISuggestContainer ISearchRequest.Suggest { get; set; }
 		long? ISearchRequest.TerminateAfter { get; set; }
-
 		string ISearchRequest.Timeout { get; set; }
 		bool? ISearchRequest.TrackScores { get; set; }
+		bool? ISearchRequest.TrackTotalHits { get; set; }
 		bool? ISearchRequest.Version { get; set; }
 
 		protected sealed override void RequestDefaults(SearchRequestParameters parameters) => TypedKeys();
 
-		public SearchDescriptor<TInferDocument> Aggregations(Func<AggregationContainerDescriptor<TInferDocument>, IAggregationContainer> aggregationsSelector) =>
+		/// <inheritdoc cref="ISearchRequest.Aggregations" />
+		public SearchDescriptor<TInferDocument> Aggregations(
+			Func<AggregationContainerDescriptor<TInferDocument>, IAggregationContainer> aggregationsSelector
+		) =>
 			Assign(aggregationsSelector(new AggregationContainerDescriptor<TInferDocument>())?.Aggregations, (a, v) => a.Aggregations = v);
 
+		/// <inheritdoc cref="ISearchRequest.Aggregations" />
 		public SearchDescriptor<TInferDocument> Aggregations(AggregationDictionary aggregations) =>
 			Assign(aggregations, (a, v) => a.Aggregations = v);
 
+		/// <inheritdoc cref="ISearchRequest.Source" />
 		public SearchDescriptor<TInferDocument> Source(bool enabled = true) => Assign(enabled, (a, v) => a.Source = v);
 
+		/// <inheritdoc cref="ISearchRequest.Source" />
 		public SearchDescriptor<TInferDocument> Source(Func<SourceFilterDescriptor<TInferDocument>, ISourceFilter> selector) =>
 			Assign(selector, (a, v) => a.Source = new Union<bool, ISourceFilter>(v?.Invoke(new SourceFilterDescriptor<TInferDocument>())));
 
-		/// <summary> The number of hits to return. Defaults to 10. </summary>
+		/// <inheritdoc cref="ISearchRequest.Size" />
 		public SearchDescriptor<TInferDocument> Size(int? size) => Assign(size, (a, v) => a.Size = v);
 
-		/// <summary>
-		/// The number of hits to return. Alias for <see cref="Size" />. Defaults to 10.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Size" />
 		public SearchDescriptor<TInferDocument> Take(int? take) => Size(take);
 
-		/// <summary>
-		/// The starting from index of the hits to return. Defaults to 0.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.From" />
 		public SearchDescriptor<TInferDocument> From(int? from) => Assign(from, (a, v) => a.From = v);
 
-		/// <summary>
-		/// The starting from index of the hits to return. Alias for <see cref="From" />. Defaults to 0.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.From" />
 		public SearchDescriptor<TInferDocument> Skip(int? skip) => From(skip);
 
-		/// <summary>
-		/// A search timeout, bounding the search request to be executed within the
-		/// specified time value and bail with the hits accumulated up
-		/// to that point when expired. Defaults to no timeout.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Timeout" />
 		public SearchDescriptor<TInferDocument> Timeout(string timeout) => Assign(timeout, (a, v) => a.Timeout = v);
 
-		/// <summary>
-		/// Enables explanation for each hit on how its score was computed.
-		/// (Use .DocumentsWithMetadata on the return results)
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Explain" />
 		public SearchDescriptor<TInferDocument> Explain(bool? explain = true) => Assign(explain, (a, v) => a.Explain = v);
 
-		/// <summary>
-		/// Returns a version for each search hit. (Use .DocumentsWithMetadata on the return results)
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Version" />
 		public SearchDescriptor<TInferDocument> Version(bool? version = true) => Assign(version, (a, v) => a.Version = v);
 
-		/// <summary>
-		/// Make sure we keep calculating score even if we are sorting on a field.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.TrackScores" />
 		public SearchDescriptor<TInferDocument> TrackScores(bool? trackscores = true) => Assign(trackscores, (a, v) => a.TrackScores = v);
 
-		/// <summary>
-		/// The Profile API provides detailed timing information about the execution of individual components in a query.
-		/// It gives the user insight into how queries are executed at a low level so that the user can understand
-		/// why certain queries are slow, and take steps to improve their slow queries.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Profile" />
 		public SearchDescriptor<TInferDocument> Profile(bool? profile = true) => Assign(profile, (a, v) => a.Profile = v);
 
-		/// <summary>
-		/// Allows to filter out documents based on a minimum score:
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.MinScore" />
 		public SearchDescriptor<TInferDocument> MinScore(double? minScore) => Assign(minScore, (a, v) => a.MinScore = v);
 
-		/// <summary>
-		/// The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate
-		/// early.
-		/// If set, the response will have a boolean field terminated_early to indicate whether the query execution has actually
-		/// terminated_early.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.TerminateAfter" />
 		public SearchDescriptor<TInferDocument> TerminateAfter(long? terminateAfter) => Assign(terminateAfter, (a, v) => a.TerminateAfter = v);
 
 		/// <summary>
@@ -274,102 +366,76 @@ namespace Nest
 		/// Prefers execution on the node with the provided node id if applicable.
 		/// </para>
 		/// </summary>
-		public SearchDescriptor<TInferDocument> ExecuteOnPreferredNode(string node) => Preference(node.IsNullOrEmpty() ? null : $"_prefer_node:{node}");
+		public SearchDescriptor<TInferDocument> ExecuteOnPreferredNode(string node) =>
+			Preference(node.IsNullOrEmpty() ? null : $"_prefer_node:{node}");
 
-		/// <summary>
-		/// Allows to configure different boost level per index when searching across
-		/// more than one indices. This is very handy when hits coming from one index
-		/// matter more than hits coming from another index (think social graph where each user has an index).
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.IndicesBoost" />
 		public SearchDescriptor<TInferDocument> IndicesBoost(Func<FluentDictionary<IndexName, double>, FluentDictionary<IndexName, double>> boost) =>
 			Assign(boost, (a, v) => a.IndicesBoost = v?.Invoke(new FluentDictionary<IndexName, double>()));
 
-		/// <summary>
-		/// Allows to selectively load specific fields for each document
-		/// represented by a search hit. Defaults to load the internal _source field.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.StoredFields" />
 		public SearchDescriptor<TInferDocument> StoredFields(Func<FieldsDescriptor<TInferDocument>, IPromise<Fields>> fields) =>
 			Assign(fields, (a, v) => a.StoredFields = v?.Invoke(new FieldsDescriptor<TInferDocument>())?.Value);
 
+		/// <inheritdoc cref="ISearchRequest.StoredFields" />
 		public SearchDescriptor<TInferDocument> StoredFields(Fields fields) => Assign(fields, (a, v) => a.StoredFields = v);
 
+		/// <inheritdoc cref="ISearchRequest.ScriptFields" />
 		public SearchDescriptor<TInferDocument> ScriptFields(Func<ScriptFieldsDescriptor, IPromise<IScriptFields>> selector) =>
 			Assign(selector, (a, v) => a.ScriptFields = v?.Invoke(new ScriptFieldsDescriptor())?.Value);
 
+		/// <inheritdoc cref="ISearchRequest.ScriptFields" />
 		public SearchDescriptor<TInferDocument> DocValueFields(Func<FieldsDescriptor<TInferDocument>, IPromise<Fields>> fields) =>
 			Assign(fields, (a, v) => a.DocValueFields = v?.Invoke(new FieldsDescriptor<TInferDocument>())?.Value);
 
+		/// <inheritdoc cref="ISearchRequest.DocValueFields" />
 		public SearchDescriptor<TInferDocument> DocValueFields(Fields fields) => Assign(fields, (a, v) => a.DocValueFields = v);
 
-		/// <summary>
-		/// A comma-separated list of fields to return as the field data representation of a field for each hit
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Sort" />
 		public SearchDescriptor<TInferDocument> Sort(Func<SortDescriptor<TInferDocument>, IPromise<IList<ISort>>> selector) =>
 			Assign(selector, (a, v) => a.Sort = v?.Invoke(new SortDescriptor<TInferDocument>())?.Value);
 
-		/// <summary>
-		///  Sort values that can be used to start returning results "after" any document in the result list.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.SearchAfter" />
 		public SearchDescriptor<TInferDocument> SearchAfter(IList<object> searchAfter) => Assign(searchAfter, (a, v) => a.SearchAfter = v);
 
-		/// <summary>
-		///  Sort values that can be used to start returning results "after" any document in the result list.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.SearchAfter" />
 		public SearchDescriptor<TInferDocument> SearchAfter(params object[] searchAfter) => Assign(searchAfter, (a, v) => a.SearchAfter = v);
 
-		/// <summary>
-		///  The suggest feature suggests similar looking terms based on a provided text by using a suggester
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Suggest" />
 		public SearchDescriptor<TInferDocument> Suggest(Func<SuggestContainerDescriptor<TInferDocument>, IPromise<ISuggestContainer>> selector) =>
 			Assign(selector, (a, v) => a.Suggest = v?.Invoke(new SuggestContainerDescriptor<TInferDocument>())?.Value);
 
-		/// <summary>
-		/// Describe the query to perform using a query descriptor lambda
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Query" />
 		public SearchDescriptor<TInferDocument> Query(Func<QueryContainerDescriptor<TInferDocument>, QueryContainer> query) =>
 			Assign(query, (a, v) => a.Query = v?.Invoke(new QueryContainerDescriptor<TInferDocument>()));
 
-		/// <summary>
-		/// For scroll queries that return a lot of documents it is possible to split the scroll in multiple slices which can be
-		/// consumed independently
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Slice" />
 		public SearchDescriptor<TInferDocument> Slice(Func<SlicedScrollDescriptor<TInferDocument>, ISlicedScroll> selector) =>
 			Assign(selector, (a, v) => a.Slice = v?.Invoke(new SlicedScrollDescriptor<TInferDocument>()));
 
 		/// <summary>
 		/// Shortcut to default to a match all query
 		/// </summary>
-		public SearchDescriptor<TInferDocument> MatchAll(Func<MatchAllQueryDescriptor, IMatchAllQuery> selector = null) => Query(q => q.MatchAll(selector));
+		public SearchDescriptor<TInferDocument> MatchAll(Func<MatchAllQueryDescriptor, IMatchAllQuery> selector = null) =>
+			Query(q => q.MatchAll(selector));
 
-		/// <summary>
-		/// Filter search using a filter descriptor lambda
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.PostFilter" />
 		public SearchDescriptor<TInferDocument> PostFilter(Func<QueryContainerDescriptor<TInferDocument>, QueryContainer> filter) =>
 			Assign(filter, (a, v) => a.PostFilter = v?.Invoke(new QueryContainerDescriptor<TInferDocument>()));
 
-		/// <summary>
-		/// Allow to highlight search results on one or more fields. The implementation uses the either lucene
-		/// fast-vector-highlighter or highlighter.
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Highlight" />
 		public SearchDescriptor<TInferDocument> Highlight(Func<HighlightDescriptor<TInferDocument>, IHighlight> highlightSelector) =>
 			Assign(highlightSelector, (a, v) => a.Highlight = v?.Invoke(new HighlightDescriptor<TInferDocument>()));
 
-		/// <summary>
-		/// Allows to collapse search results based on field values.
-		/// The collapsing is done by selecting only the top sorted document per collapse key.
-		/// For instance the query below retrieves the best tweet for each user and sorts them by number of likes.
-		/// <para>
-		/// NOTE: The collapsing is applied to the top hits only and does not affect aggregations.
-		/// You can only collapse to a depth of 2.
-		/// </para>
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Collapse" />
 		public SearchDescriptor<TInferDocument> Collapse(Func<FieldCollapseDescriptor<TInferDocument>, IFieldCollapse> collapseSelector) =>
 			Assign(collapseSelector, (a, v) => a.Collapse = v?.Invoke(new FieldCollapseDescriptor<TInferDocument>()));
 
-		/// <summary>
-		/// Allows you to specify one or more queries to use for rescoring
-		/// </summary>
+		/// <inheritdoc cref="ISearchRequest.Rescore" />
 		public SearchDescriptor<TInferDocument> Rescore(Func<RescoringDescriptor<TInferDocument>, IPromise<IList<IRescore>>> rescoreSelector) =>
 			Assign(rescoreSelector, (a, v) => a.Rescore = v?.Invoke(new RescoringDescriptor<TInferDocument>()).Value);
+
+		/// <inheritdoc cref="ISearchRequest.TrackTotalHits" />
+		public SearchDescriptor<TInferDocument> TrackTotalHits(bool? trackTotalHits = true) => Assign(trackTotalHits, (a, v) => a.TrackTotalHits = v);
 	}
 }

--- a/src/Tests/Tests.Reproduce/GithubIssue3907.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue3907.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Net;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3907 : IClusterFixture<ReadOnlyCluster>
+	{
+		private readonly IntrusiveOperationCluster _cluster;
+
+		// use intrusive operation cluster because we're changing the underlying http handler
+		// and this cluster runs with a max concurrency of 1, so changing http handler
+		// will not affect other integration tests
+		public GithubIssue3907(IntrusiveOperationCluster cluster) => _cluster = cluster;
+
+		[I]
+		public void NotUsingSocketsHttpHandlerDoesNotCauseException()
+		{
+			AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
+
+			var response = _cluster.Client.Indices.Exists("non_existent_index");
+			response.ApiCall.HttpStatusCode.Should().Be(404);
+			response.OriginalException.Should().BeNull();
+
+			AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", true);
+		}
+	}
+}

--- a/src/Tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
+++ b/src/Tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
@@ -833,6 +833,7 @@ namespace Tests.Analysis.TokenFilters
 		{
 			public override FuncTokenFilters Fluent => (n, tf) => tf
 				.WordDelimiterGraph(n, t => t
+					.AdjustOffsets()
 					.CatenateAll()
 					.CatenateNumbers()
 					.CatenateWords()
@@ -848,6 +849,7 @@ namespace Tests.Analysis.TokenFilters
 			public override ITokenFilter Initializer =>
 				new WordDelimiterGraphTokenFilter
 				{
+					AdjustOffsets = true,
 					CatenateAll = true,
 					CatenateNumbers = true,
 					CatenateWords = true,
@@ -863,6 +865,7 @@ namespace Tests.Analysis.TokenFilters
 			public override object Json => new
 			{
 				type = "word_delimiter_graph",
+				adjust_offsets = true,
 				generate_word_parts = true,
 				generate_number_parts = true,
 				catenate_words = true,

--- a/src/Tests/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
+++ b/src/Tests/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs
@@ -61,11 +61,41 @@ namespace Tests.CommonOptions.DateMath
 			 * anchor will be an actual `DateTime`, even after a serialization/deserialization round trip
 			 */
 			var date = new DateTime(2015, 05, 05);
-			Expect("2015-05-05T00:00:00")
+
+			/**
+			 * will serialize to
+			 */
+			//json
+			var expected = "2015-05-05T00:00:00";
+
+			// hide
+			Expect(expected)
 				.WhenSerializing<Nest.DateMath>(date)
 				.AssertSubject(dateMath => ((IDateMath)dateMath)
 					.Anchor.Match(
 						d => d.Should().Be(date),
+						s => s.Should().BeNull()
+					)
+				);
+
+			/**
+			 * When the `DateTime` is local or UTC, the time zone information is included.
+			 * For example, for a UTC `DateTime`
+			 */
+			var utcDate = new DateTime(2015, 05, 05, 0, 0, 0, DateTimeKind.Utc);
+
+			/**
+			 * will serialize to
+			 */
+			//json
+			expected = "2015-05-05T00:00:00Z";
+
+			// hide
+			Expect(expected)
+				.WhenSerializing<Nest.DateMath>(utcDate)
+				.AssertSubject(dateMath => ((IDateMath)dateMath)
+					.Anchor.Match(
+						d => d.Should().Be(utcDate),
 						s => s.Should().BeNull()
 					)
 				);

--- a/src/Tests/Tests/QueryDsl/Geo/Shape/GeoWKTTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/Shape/GeoWKTTests.cs
@@ -24,6 +24,22 @@ namespace Tests.QueryDsl.Geo.Shape
 		}
 
 		[U]
+		public void ReadAndWritePointWithExponent()
+		{
+			var wkt = "POINT (1.2E2 -2.5E-05)";
+			var shape = GeoWKTReader.Read(wkt);
+
+			shape.Should().BeOfType<PointGeoShape>();
+			var point = (PointGeoShape)shape;
+
+			point.Coordinates.Latitude.Should().Be(-0.000025);
+			point.Coordinates.Longitude.Should().Be(120);
+
+			// 1.2E2 will be expanded
+			GeoWKTWriter.Write(point).Should().Be("POINT (120 -2.5E-05)");
+		}
+
+		[U]
 		public void ReadAndWriteMultiPoint()
 		{
 			var wkt = "MULTIPOINT (102.0 2.0, 103.0 2.0)";

--- a/src/Tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs
@@ -1,0 +1,122 @@
+﻿using System.Collections.Generic;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.QueryDsl.Specialized.ScriptScore
+{
+	/**
+	* A query allowing you to modify the score of documents that are retrieved by a query.
+	* This can be useful if, for example, a score function is computationally expensive and
+	* it is sufficient to compute the score on a filtered set of documents.
+	*
+	* See the Elasticsearch documentation on {ref_current}/query-dsl-script-score-query.html[script_score query] for more details.
+	*/
+	public class ScriptScoreQueryUsageTests : QueryDslUsageTestsBase
+	{
+		private static readonly string _scriptScoreSource = "decayNumericLinear(params.origin, params.scale, params.offset, params.decay, doc['numberOfCommits'].value)";
+
+		public ScriptScoreQueryUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IScriptScoreQuery>(a => a.ScriptScore)
+		{
+			q =>
+			{
+				q.Query = null;
+			},
+			q =>
+			{
+				q.Script = null;
+			},
+			q =>
+			{
+				q.Script = new InlineScript(null);
+			},
+			q =>
+			{
+				q.Script = new InlineScript("");
+			},
+			q =>
+			{
+				q.Script = new IndexedScript(null);
+			},
+			q =>
+			{
+				q.Script = new IndexedScript("");
+			}
+		};
+
+		protected override QueryContainer QueryInitializer => new ScriptScoreQuery
+		{
+			Name = "named_query",
+			Boost = 1.1,
+			Query = new NumericRangeQuery
+			{
+				Field = Infer.Field<Project>(f => f.NumberOfCommits),
+				GreaterThan = 50
+			},
+			Script = new InlineScript(_scriptScoreSource)
+			{
+				Params = new Dictionary<string, object>
+				{
+					{ "origin", 100 },
+					{ "scale", 10 },
+					{ "decay", 0.5 },
+					{ "offset", 0 }
+				}
+			},
+		};
+
+		protected override object QueryJson => new
+		{
+			script_score = new
+			{
+				_name = "named_query",
+				boost = 1.1,
+				query = new
+				{
+					range = new
+					{
+						numberOfCommits = new
+						{
+							gt = 50.0
+						}
+					}
+				},
+				script = new
+				{
+					source = _scriptScoreSource,
+					@params = new
+					{
+						origin = 100,
+						scale = 10,
+						decay = 0.5,
+						offset = 0
+					}
+				}
+			}
+		};
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.ScriptScore(sn => sn
+				.Name("named_query")
+				.Boost(1.1)
+				.Query(qq => qq
+					.Range(r => r
+						.Field(f => f.NumberOfCommits)
+						.GreaterThan(50)
+					)
+				)
+				.Script(s => s
+					.Source(_scriptScoreSource)
+					.Params(p => p
+						.Add("origin", 100)
+						.Add("scale", 10)
+						.Add("decay", 0.5)
+						.Add("offset", 0)
+					)
+				)
+			);
+	}
+}


### PR DESCRIPTION
 Allow word_delimiter_graph_filter to not adjust internal offsets

https://github.com/elastic/elasticsearch/issues/36699