### PR TITLE
Add rank_feature, rank_feature fields and rank_feature query

### DIFF
--- a/docs/code-standards/descriptors.asciidoc
+++ b/docs/code-standards/descriptors.asciidoc
@@ -204,6 +204,9 @@ var methods = from d in YieldAllDescriptors()
     where !(m.Name == nameof(RuleConditionDescriptor.AppliesTo) && dt == typeof(RuleConditionDescriptor))
     where !(m.Name == nameof(RuleConditionDescriptor.Operator) && dt == typeof(RuleConditionDescriptor))
     where !(m.Name == nameof(RuleConditionDescriptor.Value) && dt == typeof(RuleConditionDescriptor))
+    where !(m.Name == nameof(RankFeatureLogarithmFunctionDescriptor.ScalingFactor) && dt == typeof(RankFeatureLogarithmFunctionDescriptor))
+    where !(m.Name == nameof(RankFeatureSigmoidFunctionDescriptor.Exponent) && dt == typeof(RankFeatureSigmoidFunctionDescriptor))
+    where !(m.Name == nameof(RankFeatureSigmoidFunctionDescriptor.Pivot) && dt == typeof(RankFeatureSigmoidFunctionDescriptor))
 
     select new {m, d, p};
 

--- a/docs/query-dsl.asciidoc
+++ b/docs/query-dsl.asciidoc
@@ -273,6 +273,8 @@ Specialized types of queries that do not fit into other groups
 
 * <<percolate-query-usage,Percolate Query Usage>>
 
+* <<rank-feature-query-usage,Rank Feature Query Usage>>
+
 * <<script-query-usage,Script Query Usage>>
 
 * <<script-score-query-usage,Script Score Query Usage>>
@@ -286,6 +288,8 @@ include::query-dsl/specialized/more-like-this/more-like-this-full-document-query
 include::query-dsl/specialized/more-like-this/more-like-this-query-usage.asciidoc[]
 
 include::query-dsl/specialized/percolate/percolate-query-usage.asciidoc[]
+
+include::query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc[]
 
 include::query-dsl/specialized/script/script-query-usage.asciidoc[]
 

--- a/docs/query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc
@@ -1,0 +1,65 @@
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.0
+
+:github: https://github.com/elastic/elasticsearch-net
+
+:nuget: https://www.nuget.org/packages
+
+////
+IMPORTANT NOTE
+==============
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs. 
+If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
+please modify the original csharp file found at the link and submit the PR with that change. Thanks!
+////
+
+[[rank-feature-query-usage]]
+=== Rank Feature Query Usage
+
+The rank_feature query is a specialized query that only works on `rank_feature` fields and `rank_features` fields.
+Its goal is to boost the score of documents based on the values of numeric features. It is typically put in a should clause of a bool query
+so that its score is added to the score of the query.
+
+Compared to using `function_score` or other ways to modify the score, this query has the benefit of being able to efficiently
+skip non-competitive hits when track_total_hits is not set to true. Speedups may be spectacular.
+
+See the Elasticsearch documentation on {ref_current}/query-dsl-rank-feature-query.html[rank feature query] for more details.
+
+==== Fluent DSL example
+
+[source,csharp]
+----
+q
+.RankFeature(rf => rf
+    .Name("named_query")
+    .Boost(1.1)
+    .Field(f => f.Rank)
+    .Saturation()
+)
+----
+
+==== Object Initializer syntax example
+
+[source,csharp]
+----
+new RankFeatureQuery()
+{
+    Name = "named_query",
+    Boost = 1.1, 
+    Field = Infer.Field<Project>(f => f.Rank),
+    Function = new RankFeatureSaturationFunction()
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "rank_feature": {
+    "_name": "named_query",
+    "boost": 1.1,
+    "field": "rank",
+    "saturation": {}
+  }
+}
+----
+

--- a/src/Nest/Mapping/Types/Core/RankFeature/RankFeatureAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/RankFeature/RankFeatureAttribute.cs
@@ -1,0 +1,19 @@
+namespace Nest
+{
+	/// <inheritdoc cref="IRankFeatureProperty"/>
+	public class RankFeatureAttribute : ElasticsearchPropertyAttributeBase, IRankFeatureProperty
+	{
+		public RankFeatureAttribute() : base(FieldType.RankFeature) { }
+
+		private IRankFeatureProperty Self => this;
+
+		/// <inheritdoc cref="IRankFeatureProperty.PositiveScoreImpact"/>
+		public bool PositiveScoreImpact
+		{
+			get => Self.PositiveScoreImpact.GetValueOrDefault(true);
+			set => Self.PositiveScoreImpact = value;
+		}
+
+		bool? IRankFeatureProperty.PositiveScoreImpact { get; set; }
+	}
+}

--- a/src/Nest/Mapping/Types/Core/RankFeature/RankFeatureProperty.cs
+++ b/src/Nest/Mapping/Types/Core/RankFeature/RankFeatureProperty.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A field that can index numbers so that they can later be used
+	/// to boost documents in queries with a rank_feature query.
+	/// </summary>
+	[InterfaceDataContract]
+	public interface IRankFeatureProperty : IProperty
+	{
+		/// <summary>
+		/// Rank features that correlate negatively with the score should set <see cref="PositiveScoreImpact"/>
+		/// to false (defaults to true). This will be used by the rank_feature query to modify the scoring
+		/// formula in such a way that the score decreases with the value of the feature instead of
+		/// increasing. For instance in web search, the url length is a commonly used feature
+		/// which correlates negatively with scores.
+		/// </summary>
+		[DataMember(Name = "positive_score_impact")]
+		bool? PositiveScoreImpact { get; set; }
+	}
+
+	/// <inheritdoc cref="IRankFeatureProperty" />
+	public class RankFeatureProperty : PropertyBase, IRankFeatureProperty
+	{
+		public RankFeatureProperty() : base(FieldType.RankFeature) { }
+
+		/// <inheritdoc />
+		public bool? PositiveScoreImpact { get; set; }
+	}
+
+	/// <inheritdoc cref="IRankFeatureProperty" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class RankFeaturePropertyDescriptor<T>
+		: PropertyDescriptorBase<RankFeaturePropertyDescriptor<T>, IRankFeatureProperty, T>, IRankFeatureProperty
+		where T : class
+	{
+		public RankFeaturePropertyDescriptor() : base(FieldType.RankFeature) { }
+
+		bool? IRankFeatureProperty.PositiveScoreImpact { get; set; }
+
+		/// <inheritdoc cref="IRankFeatureProperty.PositiveScoreImpact" />
+		public RankFeaturePropertyDescriptor<T> PositiveScoreImpact(bool? positiveScoreImpact = true) =>
+			Assign(positiveScoreImpact, (a, v) => a.PositiveScoreImpact = v);
+	}
+}

--- a/src/Nest/Mapping/Types/Core/RankFeatures/RankFeaturesAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/RankFeatures/RankFeaturesAttribute.cs
@@ -1,0 +1,8 @@
+namespace Nest
+{
+	/// <inheritdoc cref="IRankFeaturesProperty"/>
+	public class RankFeaturesAttribute : ElasticsearchPropertyAttributeBase, IRankFeaturesProperty
+	{
+		public RankFeaturesAttribute() : base(FieldType.RankFeatures) { }
+	}
+}

--- a/src/Nest/Mapping/Types/Core/RankFeatures/RankFeaturesProperty.cs
+++ b/src/Nest/Mapping/Types/Core/RankFeatures/RankFeaturesProperty.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A field that can index numeric feature vectors, so that they can later be used to boost documents in queries with a rank_feature query.
+	/// It is analogous to the <see cref="IRankFeatureProperty"/> datatype, but is better suited when the list of features is sparse so that it
+	/// wouldn't be reasonable to add one field to the mappings for each of them.
+	/// </summary>
+	[InterfaceDataContract]
+	public interface IRankFeaturesProperty : IProperty
+	{
+	}
+
+	/// <inheritdoc cref="IRankFeaturesProperty" />
+	public class RankFeaturesProperty : PropertyBase, IRankFeaturesProperty
+	{
+		public RankFeaturesProperty() : base(FieldType.RankFeatures) { }
+	}
+
+	/// <inheritdoc cref="IRankFeaturesProperty" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class RankFeaturesPropertyDescriptor<T>
+		: PropertyDescriptorBase<RankFeaturesPropertyDescriptor<T>, IRankFeaturesProperty, T>, IRankFeaturesProperty
+		where T : class
+	{
+		public RankFeaturesPropertyDescriptor() : base(FieldType.RankFeatures) { }
+	}
+}

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -118,5 +118,8 @@ namespace Nest
 
 		[EnumMember(Value = "join")]
 		Join,
+
+		[EnumMember(Value = "rank_feature")]
+		RankFeature
 	}
 }

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -120,6 +120,9 @@ namespace Nest
 		Join,
 
 		[EnumMember(Value = "rank_feature")]
-		RankFeature
+		RankFeature,
+
+		[EnumMember(Value = "rank_features")]
+		RankFeatures
 	}
 }

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -157,6 +157,9 @@ namespace Nest
 		/// <inheritdoc cref="IRankFeatureProperty"/>
 		public PropertiesDescriptor<T> RankFeature(Func<RankFeaturePropertyDescriptor<T>, IRankFeatureProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IRankFeaturesProperty"/>
+		public PropertiesDescriptor<T> RankFeatures(Func<RankFeaturesPropertyDescriptor<T>, IRankFeaturesProperty> selector) => SetProperty(selector);
+
 		public PropertiesDescriptor<T> Custom(IProperty customType) => SetProperty(customType);
 
 		private PropertiesDescriptor<T> SetProperty<TDescriptor, TInterface>(Func<TDescriptor, TInterface> selector)

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -154,6 +154,9 @@ namespace Nest
 
 		public PropertiesDescriptor<T> FieldAlias(Func<FieldAliasPropertyDescriptor<T>, IFieldAliasProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IRankFeatureProperty"/>
+		public PropertiesDescriptor<T> RankFeature(Func<RankFeaturePropertyDescriptor<T>, IRankFeatureProperty> selector) => SetProperty(selector);
+
 		public PropertiesDescriptor<T> Custom(IProperty customType) => SetProperty(customType);
 
 		private PropertiesDescriptor<T> SetProperty<TDescriptor, TInterface>(Func<TDescriptor, TInterface> selector)

--- a/src/Nest/Mapping/Types/PropertyBase.cs
+++ b/src/Nest/Mapping/Types/PropertyBase.cs
@@ -23,7 +23,7 @@ namespace Nest
 		/// <summary>
 		/// The name of the property
 		/// </summary>
-		//[DataMember(Name = "name")]
+		[IgnoreDataMember]
 		PropertyName Name { get; set; }
 
 		/// <summary>

--- a/src/Nest/Mapping/Types/PropertyFormatter.cs
+++ b/src/Nest/Mapping/Types/PropertyFormatter.cs
@@ -87,6 +87,7 @@ namespace Nest
 				case FieldType.IpRange: return Deserialize<IpRangeProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Join: return Deserialize<JoinProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Alias: return Deserialize<FieldAliasProperty>(ref segmentReader, formatterResolver);
+				case FieldType.RankFeature: return Deserialize<RankFeatureProperty>(ref segmentReader, formatterResolver);
 				case FieldType.None:
 					// no "type" field in the property mapping
 					return Deserialize<ObjectProperty>(ref segmentReader, formatterResolver);
@@ -180,6 +181,9 @@ namespace Nest
 					break;
 				case "alias":
 					Serialize<IFieldAliasProperty>(ref writer, value, formatterResolver);
+					break;
+				case "rank_feature":
+					Serialize<IRankFeatureProperty>(ref writer, value, formatterResolver);
 					break;
 				default:
 					if (value is IGenericProperty genericProperty)

--- a/src/Nest/Mapping/Types/PropertyFormatter.cs
+++ b/src/Nest/Mapping/Types/PropertyFormatter.cs
@@ -88,6 +88,7 @@ namespace Nest
 				case FieldType.Join: return Deserialize<JoinProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Alias: return Deserialize<FieldAliasProperty>(ref segmentReader, formatterResolver);
 				case FieldType.RankFeature: return Deserialize<RankFeatureProperty>(ref segmentReader, formatterResolver);
+				case FieldType.RankFeatures: return Deserialize<RankFeaturesProperty>(ref segmentReader, formatterResolver);
 				case FieldType.None:
 					// no "type" field in the property mapping
 					return Deserialize<ObjectProperty>(ref segmentReader, formatterResolver);
@@ -184,6 +185,9 @@ namespace Nest
 					break;
 				case "rank_feature":
 					Serialize<IRankFeatureProperty>(ref writer, value, formatterResolver);
+					break;
+				case "rank_features":
+					Serialize<IRankFeaturesProperty>(ref writer, value, formatterResolver);
 					break;
 				default:
 					if (value is IGenericProperty genericProperty)

--- a/src/Nest/Mapping/Visitor/IMappingVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IMappingVisitor.cs
@@ -49,6 +49,10 @@
 		void Visit(IIpRangeProperty property);
 
 		void Visit(IJoinProperty property);
+
+		void Visit(IRankFeatureProperty property);
+
+		void Visit(IRankFeaturesProperty property);
 	}
 
 	public class NoopMappingVisitor : IMappingVisitor
@@ -100,5 +104,9 @@
 		public virtual void Visit(IIpRangeProperty property) { }
 
 		public virtual void Visit(IJoinProperty property) { }
+
+		public virtual void Visit(IRankFeatureProperty property) { }
+
+		public virtual void Visit(IRankFeaturesProperty property) { }
 	}
 }

--- a/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
@@ -48,6 +48,10 @@ namespace Nest
 
 		void Visit(IJoinProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
+		void Visit(IRankFeatureProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+
+		void Visit(IRankFeaturesProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+
 		void Visit(IProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);

--- a/src/Nest/Mapping/Visitor/MappingWalker.cs
+++ b/src/Nest/Mapping/Visitor/MappingWalker.cs
@@ -211,6 +211,18 @@ namespace Nest
 					case FieldType.Join:
 						Visit<IJoinProperty>(field, t => { _visitor.Visit(t); });
 						break;
+					case FieldType.RankFeature:
+						Visit<IRankFeatureProperty>(field, t =>
+						{
+							_visitor.Visit(t);
+						});
+						break;
+					case FieldType.RankFeatures:
+						Visit<IRankFeaturesProperty>(field, t =>
+						{
+							_visitor.Visit(t);
+						});
+						break;
 				}
 			}
 		}

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -36,6 +36,10 @@ namespace Nest
 
 		public void Visit(IJoinProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
+		public virtual void Visit(IRankFeatureProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+
+		public virtual void Visit(IRankFeaturesProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+
 		public virtual void Visit(IIpProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
 		public virtual void Visit(IGeoPointProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
@@ -121,6 +125,12 @@ namespace Nest
 					break;
 				case IIpRangeProperty ipRangeType:
 					Visit(ipRangeType, propertyInfo, attribute);
+					break;
+				case IRankFeatureProperty rankFeature:
+					Visit(rankFeature, propertyInfo, attribute);
+					break;
+				case IRankFeaturesProperty rankFeatures:
+					Visit(rankFeatures, propertyInfo, attribute);
 					break;
 			}
 		}

--- a/src/Nest/QueryDsl/Abstractions/Container/IQueryContainer.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/IQueryContainer.cs
@@ -161,6 +161,10 @@ namespace Nest
 		[DataMember(Name = "wildcard")]
 		IWildcardQuery Wildcard { get; set; }
 
+		/// <inheritdoc cref="IRankFeatureQuery"/>
+		[DataMember(Name = "rank_feature")]
+		IRankFeatureQuery RankFeature { get; set; }
+
 		void Accept(IQueryVisitor visitor);
 	}
 }

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainer-Assignments.cs
@@ -53,6 +53,7 @@ namespace Nest
 		private ITermsQuery _terms;
 		private ITermsSetQuery _termsSet;
 		private IWildcardQuery _wildcard;
+		private IRankFeatureQuery _rankFeature;
 
 		[IgnoreDataMember]
 		private IQueryContainer Self => this;
@@ -340,6 +341,12 @@ namespace Nest
 		{
 			get => _wildcard;
 			set => _wildcard = Set(value);
+		}
+
+		IRankFeatureQuery IQueryContainer.RankFeature
+		{
+			get => _rankFeature;
+			set => _rankFeature = Set(value);
 		}
 
 		private T Set<T>(T value) where T : IQuery

--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -353,6 +353,10 @@ namespace Nest
 		public QueryContainer Intervals(Func<IntervalsQueryDescriptor<T>, IIntervalsQuery> selector) =>
 			WrapInContainer(selector, (query, container) => container.Intervals = query);
 
+		/// <inheritdoc cref="IRankFeatureQuery"/>
+		public QueryContainer RankFeature(Func<RankFeatureQueryDescriptor<T>, IRankFeatureQuery> selector) =>
+			WrapInContainer(selector, (query, container) => container.RankFeature = query);
+
 		/// <summary>
 		/// Matches spans containing a term. The span term query maps to Lucene SpanTermQuery.
 		/// </summary>

--- a/src/Nest/QueryDsl/Query.cs
+++ b/src/Nest/QueryDsl/Query.cs
@@ -114,6 +114,10 @@ namespace Nest
 		public static QueryContainer Regexp(Func<RegexpQueryDescriptor<T>, IRegexpQuery> selector) =>
 			new QueryContainerDescriptor<T>().Regexp(selector);
 
+		/// <inheritdoc cref="IRankFeatureQuery"/>
+		public static QueryContainer RankFeature(Func<RankFeatureQueryDescriptor<T>, IRankFeatureQuery> selector) =>
+			new QueryContainerDescriptor<T>().RankFeature(selector);
+
 		public static QueryContainer Script(Func<ScriptQueryDescriptor<T>, IScriptQuery> selector) =>
 			new QueryContainerDescriptor<T>().Script(selector);
 

--- a/src/Nest/QueryDsl/Specialized/RankFeature/RankFeatureQuery.cs
+++ b/src/Nest/QueryDsl/Specialized/RankFeature/RankFeatureQuery.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+using Elasticsearch.Net.Utf8Json.Internal;
+
+namespace Nest
+{
+	/// <summary>
+	/// A query that only works on rank_feature fields and rank_features fields. Its goal is to boost the score of documents
+	/// based on the values of numeric features. It is typically put in a should clause of a bool query so that its score
+	/// is added to the score of the query.
+	///
+	/// Compared to using function_score or other ways to modify the score, this query has the benefit of being able to efficiently
+	/// skip non-competitive hits when track_total_hits is not set to true. Speedups may be spectacular.
+	/// </summary>
+	[JsonFormatter(typeof(RankFeatureQueryFormatter))]
+	[InterfaceDataContract]
+	public interface IRankFeatureQuery : IFieldNameQuery
+	{
+		/// <inheritdoc cref="IRankFeatureFunction"/>
+		IRankFeatureFunction Function { get; set; }
+	}
+
+	public class RankFeatureQuery : FieldNameQueryBase, IRankFeatureQuery
+	{
+		protected override bool Conditionless => IsConditionless(this);
+
+		internal static bool IsConditionless(IRankFeatureQuery q) => q.Field.IsConditionless() || q.Function == null;
+
+		internal override void InternalWrapInContainer(IQueryContainer container) => container.RankFeature = this;
+
+		/// <inheritdoc />
+		public IRankFeatureFunction Function { get; set; }
+	}
+
+	public class RankFeatureQueryDescriptor<T>
+		: FieldNameQueryDescriptorBase<RankFeatureQueryDescriptor<T>, IRankFeatureQuery, T>
+			, IRankFeatureQuery where T : class
+	{
+		IRankFeatureFunction IRankFeatureQuery.Function { get; set; }
+
+		protected override bool Conditionless => RankFeatureQuery.IsConditionless(this);
+
+		/// <inheritdoc cref="IRankFeatureSaturationFunction"/>
+		public RankFeatureQueryDescriptor<T> Saturation(Func<RankFeatureSaturationFunctionDescriptor, IRankFeatureSaturationFunction> selector = null) =>
+			Assign(selector, (a, v) => a.Function = v.InvokeOrDefault(new RankFeatureSaturationFunctionDescriptor()));
+
+		/// <inheritdoc cref="IRankFeatureLogarithmFunction"/>
+		public RankFeatureQueryDescriptor<T> Logarithm(Func<RankFeatureLogarithmFunctionDescriptor, IRankFeatureLogarithmFunction> selector) =>
+			Assign(selector, (a, v) => a.Function = v?.Invoke(new RankFeatureLogarithmFunctionDescriptor()));
+
+		/// <inheritdoc cref="IRankFeatureSigmoidFunction"/>
+		public RankFeatureQueryDescriptor<T> Sigmoid(Func<RankFeatureSigmoidFunctionDescriptor, IRankFeatureSigmoidFunction> selector) =>
+			Assign(selector, (a, v) => a.Function = v?.Invoke(new RankFeatureSigmoidFunctionDescriptor()));
+	}
+
+	/// <summary>
+	/// A function to boost scores in a rank_feature query, using the values of rank features.
+	/// </summary>
+	public interface IRankFeatureFunction { }
+
+	/// <summary>
+	/// Gives a score that is equal to log(scaling_factor + S) where S is the value of the rank feature and scaling_factor is a configurable
+	/// scaling factor. Scores are unbounded.
+	/// This function only supports rank features that have a positive score impact.
+	/// </summary>
+	public interface IRankFeatureLogarithmFunction : IRankFeatureFunction
+	{
+		/// <summary>
+		/// The scaling factor
+		/// </summary>
+		[DataMember(Name = "scaling_factor")]
+		float ScalingFactor { get; set; }
+	}
+
+	/// <inheritdoc />
+	public class RankFeatureLogarithmFunction : IRankFeatureLogarithmFunction
+	{
+		/// <inheritdoc />
+		public float ScalingFactor { get; set; }
+	}
+
+	/// <inheritdoc cref="IRankFeatureLogarithmFunction" />
+	public class RankFeatureLogarithmFunctionDescriptor
+		: DescriptorBase<RankFeatureLogarithmFunctionDescriptor, IRankFeatureLogarithmFunction>, IRankFeatureLogarithmFunction
+	{
+		float IRankFeatureLogarithmFunction.ScalingFactor { get; set; }
+
+		/// <inheritdoc cref="IRankFeatureLogarithmFunction.ScalingFactor" />
+		public RankFeatureLogarithmFunctionDescriptor ScalingFactor(float scalingFactor) =>
+			Assign(scalingFactor, (a, v) => a.ScalingFactor = v);
+	}
+
+	/// <summary>
+	/// Gives a score that is equal to S / (S + pivot) where S is the value of the rank feature and pivot is a configurable pivot value
+	/// so that the result will be less than 0.5 if S is less than pivot and greater than 0.5 otherwise. Scores are always is (0, 1).
+	/// If the rank feature has a negative score impact then the function will be computed as pivot / (S + pivot), which decreases when S increases.
+	/// </summary>
+	public interface IRankFeatureSaturationFunction : IRankFeatureFunction
+	{
+		[DataMember(Name = "pivot")]
+		float? Pivot { get; set; }
+	}
+
+	/// <inheritdoc />
+	public class RankFeatureSaturationFunction : IRankFeatureSaturationFunction
+	{
+		public float? Pivot { get; set; }
+	}
+
+	/// <inheritdoc cref="IRankFeatureSaturationFunction" />
+	public class RankFeatureSaturationFunctionDescriptor
+		: DescriptorBase<RankFeatureSaturationFunctionDescriptor, IRankFeatureSaturationFunction>, IRankFeatureSaturationFunction
+	{
+		float? IRankFeatureSaturationFunction.Pivot { get; set; }
+
+		/// <inheritdoc cref="IRankFeatureSaturationFunction.Pivot" />
+		public RankFeatureSaturationFunctionDescriptor Pivot(float? pivot) => Assign(pivot, (a, v) => a.Pivot = v);
+	}
+
+	/// <summary>
+	/// is an extension of saturation which adds a configurable exponent. Scores are computed as S^exp^ / (S^exp^ + pivot^exp^).
+	/// Like for the saturation function, pivot is the value of S that gives a score of 0.5 and scores are in (0, 1).
+	///
+	/// exponent must be positive, but is typically in [0.5, 1]. A good value should be computed via training. If you don’t have the opportunity
+	/// to do so, we recommend that you stick to the saturation function instead.
+	/// </summary>
+	public interface IRankFeatureSigmoidFunction : IRankFeatureFunction
+	{
+		[DataMember(Name = "pivot")]
+		float Pivot { get; set; }
+
+		/// <summary>
+		/// The exponent. Must be positive
+		/// </summary>
+		[DataMember(Name = "exponent")]
+		float Exponent { get; set; }
+	}
+
+	/// <inheritdoc cref="IRankFeatureSigmoidFunction" />
+	public class RankFeatureSigmoidFunction : IRankFeatureSigmoidFunction
+	{
+		public float Pivot { get; set; }
+
+		/// <inheritdoc cref="IRankFeatureSigmoidFunction.Exponent" />
+		public float Exponent { get; set; }
+	}
+
+	/// <inheritdoc cref="IRankFeatureSigmoidFunction" />
+	public class RankFeatureSigmoidFunctionDescriptor
+		: DescriptorBase<RankFeatureSigmoidFunctionDescriptor, IRankFeatureSigmoidFunction>, IRankFeatureSigmoidFunction
+	{
+		float IRankFeatureSigmoidFunction.Exponent { get; set; }
+		float IRankFeatureSigmoidFunction.Pivot { get; set; }
+
+		/// <inheritdoc cref="IRankFeatureSigmoidFunction.Exponent" />
+		public RankFeatureSigmoidFunctionDescriptor Exponent(float exponent) => Assign(exponent, (a, v) => a.Exponent = v);
+
+		/// <inheritdoc cref="IRankFeatureSigmoidFunction.Pivot" />
+		public RankFeatureSigmoidFunctionDescriptor Pivot(float pivot) => Assign(pivot, (a, v) => a.Pivot = v);
+	}
+
+	internal class RankFeatureQueryFormatter : IJsonFormatter<IRankFeatureQuery>
+	{
+		public void Serialize(ref JsonWriter writer, IRankFeatureQuery value, IJsonFormatterResolver formatterResolver)
+		{
+			if (value == null)
+			{
+				writer.WriteNull();
+				return;
+			}
+
+			writer.WriteBeginObject();
+
+			if (!string.IsNullOrEmpty(value.Name))
+			{
+				writer.WritePropertyName("_name");
+				writer.WriteString(value.Name);
+				writer.WriteValueSeparator();
+			}
+
+			if (value.Boost.HasValue)
+			{
+				writer.WritePropertyName("boost");
+				writer.WriteDouble(value.Boost.Value);
+				writer.WriteValueSeparator();
+			}
+
+			writer.WritePropertyName("field");
+			var fieldFormatter = formatterResolver.GetFormatter<Field>();
+			fieldFormatter.Serialize(ref writer, value.Field, formatterResolver);
+			writer.WriteValueSeparator();
+			switch (value.Function)
+			{
+				case IRankFeatureSigmoidFunction sigmoid:
+					SerializeScoreFunction(ref writer, "sigmoid", sigmoid, formatterResolver);
+					break;
+				case IRankFeatureSaturationFunction saturation:
+					SerializeScoreFunction(ref writer, "saturation", saturation, formatterResolver);
+					break;
+				case IRankFeatureLogarithmFunction log:
+					SerializeScoreFunction(ref writer, "log", log, formatterResolver);
+					break;
+			}
+
+			writer.WriteEndObject();
+		}
+
+		private static void SerializeScoreFunction<TScoreFunction>(ref JsonWriter writer, string name, TScoreFunction scoreFunction,
+			IJsonFormatterResolver formatterResolver
+		) where TScoreFunction : IRankFeatureFunction
+		{
+			writer.WritePropertyName(name);
+			formatterResolver.GetFormatter<TScoreFunction>()
+				.Serialize(ref writer, scoreFunction, formatterResolver);
+		}
+
+		private static IRankFeatureFunction DeserializeScoreFunction<TScoreFunction>(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
+			where TScoreFunction : IRankFeatureFunction =>
+			formatterResolver.GetFormatter<TScoreFunction>().Deserialize(ref reader, formatterResolver);
+
+		private static readonly AutomataDictionary Fields = new AutomataDictionary
+		{
+			{ "_name", 0 },
+			{ "boost", 1 },
+			{ "field", 2 },
+			{ "saturation", 3 },
+			{ "log", 4 },
+			{ "sigmoid", 5 }
+		};
+
+		public IRankFeatureQuery Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
+		{
+			if (reader.ReadIsNull())
+				return null;
+
+			var query = new RankFeatureQuery();
+			var count = 0;
+			while (reader.ReadIsInObject(ref count))
+			{
+				if (Fields.TryGetValue(reader.ReadPropertyNameSegmentRaw(), out var value))
+				{
+					switch (value)
+					{
+						case 0:
+							query.Name = reader.ReadString();
+							break;
+						case 1:
+							query.Boost = reader.ReadDouble();
+							break;
+						case 2:
+							query.Field = formatterResolver.GetFormatter<Field>().Deserialize(ref reader, formatterResolver);
+							break;
+						case 3:
+							query.Function = DeserializeScoreFunction<RankFeatureSaturationFunction>(ref reader, formatterResolver);
+							break;
+						case 4:
+							query.Function = DeserializeScoreFunction<RankFeatureLogarithmFunction>(ref reader, formatterResolver);
+							break;
+						case 5:
+							query.Function = DeserializeScoreFunction<RankFeatureSigmoidFunction>(ref reader, formatterResolver);
+							break;
+					}
+				}
+				else
+					reader.ReadNextBlock();
+			}
+
+			return query;
+		}
+	}
+}

--- a/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/DslPrettyPrintVisitor.cs
@@ -147,6 +147,8 @@ namespace Nest
 
 		public virtual void Visit(IQueryStringQuery query) => Write("query_string");
 
+		public virtual void Visit(IRankFeatureQuery query) => Write("rank_feature");
+
 		public virtual void Visit(IRangeQuery query) => Write("range");
 
 		public virtual void Visit(IRegexpQuery query) => Write("regexp");

--- a/src/Nest/QueryDsl/Visitor/QueryVisitor.cs
+++ b/src/Nest/QueryDsl/Visitor/QueryVisitor.cs
@@ -72,6 +72,8 @@
 
 		void Visit(IQueryStringQuery query);
 
+		void Visit(IRankFeatureQuery query);
+
 		void Visit(IRangeQuery query);
 
 		void Visit(IRegexpQuery query);
@@ -208,6 +210,8 @@
 		public virtual void Visit(IPrefixQuery query) { }
 
 		public virtual void Visit(IQueryStringQuery query) { }
+
+		public virtual void Visit(IRankFeatureQuery query) { }
 
 		public virtual void Visit(IRangeQuery query) { }
 

--- a/src/Nest/QueryDsl/Visitor/QueryWalker.cs
+++ b/src/Nest/QueryDsl/Visitor/QueryWalker.cs
@@ -35,6 +35,7 @@ namespace Nest
 			VisitQuery(qd.Prefix, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.QueryString, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.Range, visitor, (v, d) => v.Visit(d));
+			VisitQuery(qd.RankFeature, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.Regexp, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.SimpleQueryString, visitor, (v, d) => v.Visit(d));
 			VisitQuery(qd.Term, visitor, (v, d) => v.Visit(d));

--- a/src/Tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
@@ -346,6 +346,10 @@ namespace Tests.Core.ManagedElasticsearch.NodeSeeders
 			.Scalar(p => p.NumberOfContributors, n => n.Store())
 			.Object<Dictionary<string, Metadata>>(o => o
 				.Name(p => p.Metadata)
+			)
+			.RankFeature(rf => rf
+				.Name(p => p.Rank)
+				.PositiveScoreImpact()
 			);
 
 		private static PropertiesDescriptor<Tag> TagProperties(PropertiesDescriptor<Tag> props) => props

--- a/src/Tests/Tests.Domain/Project.cs
+++ b/src/Tests/Tests.Domain/Project.cs
@@ -34,6 +34,7 @@ namespace Tests.Domain
 		public int NumberOfContributors { get; set; }
 
 		public Ranges Ranges { get; set; }
+		public int? Rank { get; set; }
 		public int? RequiredBranches => Branches?.Count();
 
 		public SourceOnlyObject SourceOnly { get; set; }
@@ -65,6 +66,7 @@ namespace Tests.Domain
 				.RuleFor(p => p.NumberOfCommits, f => Gimme.Random.Number(1, 1000))
 				.RuleFor(p => p.NumberOfContributors, f => Gimme.Random.Number(1, 50))
 				.RuleFor(p => p.Ranges, f => Ranges.Generator.Generate())
+				.RuleFor(p => p.Rank, f => Gimme.Random.Number(1, 100))
 				.RuleFor(p => p.Branches, f => Gimme.Random.ListItems(new List<string> { "master", "dev", "release", "qa", "test" }))
 				.RuleFor(p => p.SourceOnly, f =>
 					TestConfiguration.Instance.Random.SourceSerializer ? new SourceOnlyObject() : null

--- a/src/Tests/Tests/CodeStandards/Descriptors.doc.cs
+++ b/src/Tests/Tests/CodeStandards/Descriptors.doc.cs
@@ -216,6 +216,9 @@ namespace Tests.CodeStandards
 				where !(m.Name == nameof(RuleConditionDescriptor.AppliesTo) && dt == typeof(RuleConditionDescriptor))
 				where !(m.Name == nameof(RuleConditionDescriptor.Operator) && dt == typeof(RuleConditionDescriptor))
 				where !(m.Name == nameof(RuleConditionDescriptor.Value) && dt == typeof(RuleConditionDescriptor))
+				where !(m.Name == nameof(RankFeatureLogarithmFunctionDescriptor.ScalingFactor) && dt == typeof(RankFeatureLogarithmFunctionDescriptor))
+				where !(m.Name == nameof(RankFeatureSigmoidFunctionDescriptor.Exponent) && dt == typeof(RankFeatureSigmoidFunctionDescriptor))
+				where !(m.Name == nameof(RankFeatureSigmoidFunctionDescriptor.Pivot) && dt == typeof(RankFeatureSigmoidFunctionDescriptor))
 
 				select new {m, d, p};
 

--- a/src/Tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/src/Tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -102,6 +102,7 @@ namespace Tests.Indices.MappingManagement.GetMapping
 			visitor.CountsShouldContainKeyAndCountBe("long_range", 1);
 			visitor.CountsShouldContainKeyAndCountBe("ip_range", 1);
 			visitor.CountsShouldContainKeyAndCountBe("nested", 1);
+			visitor.CountsShouldContainKeyAndCountBe("rank_feature", 1);
 		}
 	}
 
@@ -190,6 +191,10 @@ namespace Tests.Indices.MappingManagement.GetMapping
 		public void Visit(IKeywordProperty mapping) => Increment("keyword");
 
 		public void Visit(ITypeMapping mapping) => Increment("type");
+
+		public void Visit(IRankFeatureProperty mapping) => Increment("rank_feature");
+
+		public void Visit(IRankFeaturesProperty mapping) => Increment("rank_features");
 
 		private void Increment(string key)
 		{

--- a/src/Tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
+++ b/src/Tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
@@ -119,6 +119,10 @@ namespace Tests.Indices.MappingManagement.PutMapping
 						name = new { type = "text" }
 					},
 					type = "object"
+				},
+				rank = new
+				{
+					type = "rank_feature"
 				}
 			}
 		};
@@ -175,6 +179,9 @@ namespace Tests.Indices.MappingManagement.PutMapping
 							.Name(tag => tag.Name)
 						)
 					)
+				)
+				.RankFeature(rf => rf
+					.Name(p => p.Rank)
 				)
 			);
 
@@ -288,6 +295,7 @@ namespace Tests.Indices.MappingManagement.PutMapping
 						}
 					}
 				},
+				{ p => p.Rank, new RankFeatureProperty() },
 			}
 		};
 

--- a/src/Tests/Tests/Mapping/Types/Core/RankFeature/RankFeatureAttributeTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/RankFeature/RankFeatureAttributeTests.cs
@@ -1,0 +1,25 @@
+﻿using Nest;
+
+namespace Tests.Mapping.Types.Core.RankFeature
+{
+	public class RankFeatureTest
+	{
+		[RankFeature(PositiveScoreImpact = true)]
+		public int RankFeature { get; set; }
+	}
+
+	public class RankFeatureAttributeTests : AttributeTestsBase<RankFeatureTest>
+	{
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				rankFeature = new
+				{
+					type = "rank_feature",
+					positive_score_impact = true
+				}
+			}
+		};
+	}
+}

--- a/src/Tests/Tests/Mapping/Types/Core/RankFeature/RankFeaturePropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/RankFeature/RankFeaturePropertyTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Core.RankFeature
+{
+	public class RankFeaturePropertyTests : PropertyTestsBase
+	{
+		public RankFeaturePropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				name = new
+				{
+					type = "rank_feature",
+					positive_score_impact = true
+				}
+			}
+		};
+
+
+		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.RankFeature(s => s
+				.Name(p => p.Name)
+				.PositiveScoreImpact()
+			);
+
+
+		protected override IProperties InitializerProperties => new Properties
+		{
+			{
+				"name", new RankFeatureProperty
+				{
+					PositiveScoreImpact = true
+				}
+			}
+		};
+	}
+}

--- a/src/Tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesAttributeTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesAttributeTests.cs
@@ -1,0 +1,24 @@
+﻿using Nest;
+
+namespace Tests.Mapping.Types.Core.RankFeatures
+{
+	public class RankFeaturesTest
+	{
+		[RankFeatures]
+		public int RankFeatures { get; set; }
+	}
+
+	public class RankFeaturesAttributeTests : AttributeTestsBase<RankFeaturesTest>
+	{
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				rankFeatures = new
+				{
+					type = "rank_features"
+				}
+			}
+		};
+	}
+}

--- a/src/Tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesAttributeTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesAttributeTests.cs
@@ -1,11 +1,12 @@
-﻿using Nest;
+﻿using System.Collections.Generic;
+using Nest;
 
 namespace Tests.Mapping.Types.Core.RankFeatures
 {
 	public class RankFeaturesTest
 	{
 		[RankFeatures]
-		public int RankFeatures { get; set; }
+		public Dictionary<string, int> RankFeatures { get; set; }
 	}
 
 	public class RankFeaturesAttributeTests : AttributeTestsBase<RankFeaturesTest>

--- a/src/Tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesPropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/RankFeatures/RankFeaturesPropertyTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Core.RankFeatures
+{
+	public class RankFeaturesPropertyTests : PropertyTestsBase
+	{
+		public RankFeaturesPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				name = new
+				{
+					type = "rank_features"
+				}
+			}
+		};
+
+		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.RankFeatures(s => s
+				.Name(p => p.Name)
+			);
+
+		protected override IProperties InitializerProperties => new Properties
+		{
+			{ "name", new RankFeaturesProperty() }
+		};
+	}
+}

--- a/src/Tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs
+++ b/src/Tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs
@@ -1,0 +1,50 @@
+﻿using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.QueryDsl.Specialized.RankFeature
+{
+	/**
+	 * The rank_feature query is a specialized query that only works on `rank_feature` fields and `rank_features` fields.
+	 * Its goal is to boost the score of documents based on the values of numeric features. It is typically put in a should clause of a bool query
+	 * so that its score is added to the score of the query.
+	 *
+     * Compared to using `function_score` or other ways to modify the score, this query has the benefit of being able to efficiently
+	 * skip non-competitive hits when track_total_hits is not set to true. Speedups may be spectacular.
+	 *
+	 * See the Elasticsearch documentation on {ref_current}/query-dsl-rank-feature-query.html[rank feature query] for more details.
+	*/
+	public class RankFeatureQueryUsageTests : QueryDslUsageTestsBase
+	{
+		public RankFeatureQueryUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IRankFeatureQuery>(a => a.RankFeature)
+		{
+			q =>
+			{
+				q.Field = null;
+				q.Function = null;
+			}
+		};
+
+		protected override QueryContainer QueryInitializer => new RankFeatureQuery()
+		{
+			Name = "named_query",
+			Boost = 1.1, 
+			Field = Infer.Field<Project>(f => f.Rank),
+			Function = new RankFeatureSaturationFunction()
+		};
+
+		protected override object QueryJson =>
+			new { rank_feature = new { _name = "named_query", boost = 1.1, field = "rank", saturation = new { } } };
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.RankFeature(rf => rf
+				.Name("named_query")
+				.Boost(1.1)
+				.Field(f => f.Rank)
+				.Saturation()
+			);
+	}
+}

--- a/src/Tests/Tests/Search/FieldCapabilities/FieldCapabilitiesApiTests.cs
+++ b/src/Tests/Tests/Search/FieldCapabilities/FieldCapabilitiesApiTests.cs
@@ -55,14 +55,14 @@ namespace Tests.Search.FieldCapabilities
 			indexField.Aggregatable.Should().BeTrue();
 			indexField.Searchable.Should().BeTrue();
 
-			response.Fields.Should().ContainKey("state");
-			var stateCapabilities = response.Fields["state"].Keyword;
-			stateCapabilities.Aggregatable.Should().BeTrue();
-			stateCapabilities.Searchable.Should().BeTrue();
+			response.Fields.Should().ContainKey("jobTitle.keyword");
+			var jobTitleCapabilities = response.Fields["jobTitle.keyword"].Keyword;
+			jobTitleCapabilities.Aggregatable.Should().BeTrue();
+			jobTitleCapabilities.Searchable.Should().BeTrue();
 
-			stateCapabilities = response.Fields[Field<Project>(p => p.State)].Keyword;
-			stateCapabilities.Aggregatable.Should().BeTrue();
-			stateCapabilities.Searchable.Should().BeTrue();
+			jobTitleCapabilities = response.Fields[Field<Developer>(p => p.JobTitle.Suffix("keyword"))].Keyword;
+			jobTitleCapabilities.Aggregatable.Should().BeTrue();
+			jobTitleCapabilities.Searchable.Should().BeTrue();
 		}
 	}
 }


### PR DESCRIPTION
This PR provides support for

- the new [`rank_feature`](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rank-feature.html), [`rank_features`](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rank-features.html) field datatypes
- [the new `rank_feature` query](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/query-dsl-rank-feature-query.html)

Closes #3938
