### PR TITLE
Honour IPropertyMappingProvider on custom IElastisearchSerializer

### DIFF
--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -87,14 +87,13 @@ namespace Nest
 			var formatterResolver = new NestFormatterResolver(this);
 			var defaultSerializer = new DefaultHighLevelSerializer(formatterResolver);
 			var sourceSerializer = sourceSerializerFactory?.Invoke(defaultSerializer, this) ?? defaultSerializer;
-			
-			//We wrap these in an internal proxy to facilitate diagnostics
-			_sourceSerializer = new DiagnosticsSerializerProxy(sourceSerializer, "source"); 
-			UseThisRequestResponseSerializer = new DiagnosticsSerializerProxy(defaultSerializer);
-			
-			var serializerAsMappingProvider = _sourceSerializer as IPropertyMappingProvider;
+			var serializerAsMappingProvider = sourceSerializer as IPropertyMappingProvider;
+
 			_propertyMappingProvider = propertyMappingProvider ?? serializerAsMappingProvider ?? new PropertyMappingProvider();
 
+			//We wrap these in an internal proxy to facilitate serialization diagnostics
+			_sourceSerializer = new DiagnosticsSerializerProxy(sourceSerializer, "source");
+			UseThisRequestResponseSerializer = new DiagnosticsSerializerProxy(defaultSerializer);
 			_defaultFieldNameInferrer = p => p.ToCamelCase();
 			_defaultIndices = new FluentDictionary<Type, string>();
 			_defaultRelationNames = new FluentDictionary<Type, string>();
@@ -294,14 +293,14 @@ namespace Nest
 
 			return (TConnectionSettings)this;
 		}
-		
+
 		/// <summary>
 		/// NEST handles 404 in its <see cref="ResponseBase.IsValid"/>, we do not want the low level client throwing exceptions
 		/// when <see cref="IConnectionConfigurationValues.ThrowExceptions"/> is enabled for 404's. The client is in charge of composing paths
 		/// so a 404 never signals a wrong url but a missing entity.
 		/// </summary>
-		protected override bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) => 
+		protected override bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) =>
 			statusCode >= 200 && statusCode < 300
-			|| statusCode == 404; 
+			|| statusCode == 404;
 	}
 }

--- a/src/Tests/Tests.Reproduce/GitHubIssue3926.cs
+++ b/src/Tests/Tests.Reproduce/GitHubIssue3926.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue3926
+	{
+		public class DocumentModel
+		{
+			[JsonProperty("@timestamp")]
+			public DateTime Timestamp { get; set; }
+
+			[JsonProperty("document_name")]
+			public string DocumentName { get; set; }
+		}
+
+		[U]
+		public void FieldInferenceUsesJsonPropertyName()
+		{
+			var client = TestClient.InMemoryWithJsonNetSerializer;
+
+			var searchResponse = client.Search<DocumentModel>(descriptor => descriptor
+				.Index("my-index")
+				.Query(q => q
+					.DateRange(range => range
+						.Field(model => model.Timestamp)
+						.GreaterThan("1970-01-01"))
+				)
+			);
+
+			Encoding.UTF8.GetString(searchResponse.ApiCall.RequestBodyInBytes).Should().Contain("@timestamp");
+		}
+	}
+}


### PR DESCRIPTION
This commit fixes a bug introduced with Diagnostics Source support. DiagnosticsSerializerProxy does not implement IPropertyMappingProvider, so if it wraps and delegates to a serializer that does implement IPropertyMappingProvider, such as JsonNetSerialzer, this is not honoured when assigning to _propertyMappingProvider. This commit uses the sourceSerializer when determining _propertyMappingProvider, and not the DiagnosticsSerializerProxy.

Fixes #3926