### PR TITLE
Handle cat API 404 responses

### DIFF
--- a/src/Nest/Cat/CatResponse.cs
+++ b/src/Nest/Cat/CatResponse.cs
@@ -8,6 +8,7 @@ namespace Nest
 	public class CatResponse<TCatRecord> : ResponseBase
 		where TCatRecord : ICatRecord
 	{
+		[IgnoreDataMember]
 		public IReadOnlyCollection<TCatRecord> Records { get; internal set; } = EmptyReadOnly<TCatRecord>.Collection;
 	}
 }

--- a/src/Nest/Cat/CatResponseBuilder.cs
+++ b/src/Nest/Cat/CatResponseBuilder.cs
@@ -12,11 +12,13 @@ namespace Nest
 
 		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
 		{
-			var catResponse = new CatResponse<TCatRecord>();
-
 			if (!response.Success)
-				return catResponse;
+				return new CatResponse<TCatRecord>();
 
+			if (response.HttpStatusCode == 404)
+				return builtInSerializer.Deserialize<CatResponse<TCatRecord>>(stream);
+
+			var catResponse = new CatResponse<TCatRecord>();
 			var records = builtInSerializer.Deserialize<IReadOnlyCollection<TCatRecord>>(stream);
 			catResponse.Records = records;
 			return catResponse;
@@ -24,11 +26,13 @@ namespace Nest
 
 		public override async Task<object> DeserializeResponseAsync(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream, CancellationToken ctx = default)
 		{
-			var catResponse = new CatResponse<TCatRecord>();
-
 			if (!response.Success)
-				return catResponse;
+				return new CatResponse<TCatRecord>();
 
+			if (response.HttpStatusCode == 404)
+				return await builtInSerializer.DeserializeAsync<CatResponse<TCatRecord>>(stream, ctx).ConfigureAwait(false);
+
+			var catResponse = new CatResponse<TCatRecord>();
 			var records = await builtInSerializer.DeserializeAsync<IReadOnlyCollection<TCatRecord>>(stream, ctx).ConfigureAwait(false);
 			catResponse.Records = records;
 			return catResponse;


### PR DESCRIPTION
This commit adds handling for 404 responses for cat APIs. When a 404 is returned, NEST's HttpStatusCodeClassifier deems it to be successful, which the CatResponseBuilder tries to then deserialize the response to a collection of TCatRecord. When a 404 is returned however, the response is a JSON object with an error and status. The CatResponse<TRecord> should be deserialized from this when a 404 is returned.

Fixes #3936