### PR TITLE
Remove Scalar Nanos implementation

### DIFF
--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -250,30 +250,6 @@ namespace Nest
 		) =>
 			selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field));
 
-		public IProperty ScalarNanos(Expression<Func<T, DateTime>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null) =>
-			selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field));
-
-		public IProperty ScalarNanos(Expression<Func<T, DateTime?>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null) =>
-			selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field));
-
-		public IProperty ScalarNanos(Expression<Func<T, IEnumerable<DateTime>>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null) =>
-			selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field));
-
-		public IProperty ScalarNanos(Expression<Func<T, IEnumerable<DateTime?>>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null) =>
-			selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field));
-
-		public IProperty ScalarNanos(Expression<Func<T,DateTimeOffset>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null) =>
-			selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field));
-
-		public IProperty ScalarNanos(Expression<Func<T, DateTimeOffset?>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null) =>
-			selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field));
-
-		public IProperty ScalarNanos(Expression<Func<T, IEnumerable<DateTimeOffset>>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null
-		) => selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field));
-
-		public IProperty ScalarNanos(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null
-		) => selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field));
-
 		public IProperty Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector = null) =>
 			selector.InvokeOrDefault(new BooleanPropertyDescriptor<T>().Name(field));
 

--- a/src/Nest/Mapping/Types/Properties-Scalar.cs
+++ b/src/Nest/Mapping/Types/Properties-Scalar.cs
@@ -115,22 +115,6 @@ namespace Nest
 
 		TReturnType Scalar(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field, Func<DatePropertyDescriptor<T>, IDateProperty> selector = null);
 
-		TReturnType ScalarNanos(Expression<Func<T, DateTime>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null);
-
-		TReturnType ScalarNanos(Expression<Func<T, DateTime?>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null);
-
-		TReturnType ScalarNanos(Expression<Func<T, IEnumerable<DateTime>>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null);
-
-		TReturnType ScalarNanos(Expression<Func<T, IEnumerable<DateTime?>>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null);
-
-		TReturnType ScalarNanos(Expression<Func<T, DateTimeOffset>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null);
-
-		TReturnType ScalarNanos(Expression<Func<T, DateTimeOffset?>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null);
-
-		TReturnType ScalarNanos(Expression<Func<T, IEnumerable<DateTimeOffset>>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null);
-
-		TReturnType ScalarNanos(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null);
-
 		TReturnType Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector = null);
 
 		TReturnType Scalar(Expression<Func<T, bool?>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector = null);
@@ -403,42 +387,6 @@ namespace Nest
 			Func<DatePropertyDescriptor<T>, IDateProperty> selector = null
 		) =>
 			SetProperty(selector.InvokeOrDefault(new DatePropertyDescriptor<T>().Name(field)));
-
-		public PropertiesDescriptor<T> ScalarNanos(Expression<Func<T, DateTime>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null) =>
-			SetProperty(selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field)));
-
-		public PropertiesDescriptor<T> ScalarNanos(Expression<Func<T, DateTime?>> field, Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null) =>
-			SetProperty(selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field)));
-
-		public PropertiesDescriptor<T> ScalarNanos(Expression<Func<T, IEnumerable<DateTime>>> field,
-			Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null
-		) =>
-			SetProperty(selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field)));
-
-		public PropertiesDescriptor<T> ScalarNanos(Expression<Func<T, IEnumerable<DateTime?>>> field,
-			Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null
-		) =>
-			SetProperty(selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field)));
-
-		public PropertiesDescriptor<T> ScalarNanos(Expression<Func<T, DateTimeOffset>> field,
-			Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null
-		) =>
-			SetProperty(selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field)));
-
-		public PropertiesDescriptor<T> ScalarNanos(Expression<Func<T, DateTimeOffset?>> field,
-			Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null
-		) =>
-			SetProperty(selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field)));
-
-		public PropertiesDescriptor<T> ScalarNanos(Expression<Func<T, IEnumerable<DateTimeOffset>>> field,
-			Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null
-		) =>
-			SetProperty(selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field)));
-
-		public PropertiesDescriptor<T> ScalarNanos(Expression<Func<T, IEnumerable<DateTimeOffset?>>> field,
-			Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector = null
-		) =>
-			SetProperty(selector.InvokeOrDefault(new DateNanosPropertyDescriptor<T>().Name(field)));
 
 		public PropertiesDescriptor<T> Scalar(Expression<Func<T, bool>> field, Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector = null
 		) =>

--- a/src/Tests/Tests/Mapping/Scalar/ScalarUsageTests.cs
+++ b/src/Tests/Tests/Mapping/Scalar/ScalarUsageTests.cs
@@ -36,14 +36,6 @@ namespace Tests.Mapping.Scalar
 				dateTimeOffsets = new { type = "date" },
 				dateTimeOffsetNullable = new { type = "date" },
 				dateTimeOffsetNullables = new { type = "date" },
-				dateTimeNanos = new { type = "date_nanos" },
-				dateTimeNanoss = new { type = "date_nanos" },
-				dateTimeNanosNullable = new { type = "date_nanos" },
-				dateTimeNanosNullables = new { type = "date_nanos" },
-				dateTimeNanosOffset = new { type = "date_nanos" },
-				dateTimeNanosOffsets = new { type = "date_nanos" },
-				dateTimeNanosOffsetNullable = new { type = "date_nanos" },
-				dateTimeNanosOffsetNullables = new { type = "date_nanos" },
 				@decimal = new { type = "double" },
 				decimals = new { type = "double" },
 				decimalNullable = new { type = "double" },
@@ -153,14 +145,6 @@ namespace Tests.Mapping.Scalar
 				.Scalar(p => p.DateTimeOffsets, m => m)
 				.Scalar(p => p.DateTimeOffsetNullable, m => m)
 				.Scalar(p => p.DateTimeOffsetNullables, m => m)
-				.ScalarNanos(p => p.DateTimeNanos, m => m)
-				.ScalarNanos(p => p.DateTimeNanoss, m => m)
-				.ScalarNanos(p => p.DateTimeNanosNullable, m => m)
-				.ScalarNanos(p => p.DateTimeNanosNullables, m => m)
-				.ScalarNanos(p => p.DateTimeNanosOffset, m => m)
-				.ScalarNanos(p => p.DateTimeNanosOffsets, m => m)
-				.ScalarNanos(p => p.DateTimeNanosOffsetNullable, m => m)
-				.ScalarNanos(p => p.DateTimeNanosOffsetNullables, m => m)
 				.Scalar(p => p.Bool, m => m)
 				.Scalar(p => p.Bools, m => m)
 				.Scalar(p => p.BoolNullable, m => m)
@@ -215,16 +199,6 @@ namespace Tests.Mapping.Scalar
 			public IEnumerable<DateTimeOffset?> DateTimeOffsetNullables { get; set; }
 			public IEnumerable<DateTimeOffset> DateTimeOffsets { get; set; }
 			public IEnumerable<DateTime> DateTimes { get; set; }
-
-			public DateTime DateTimeNanos { get; set; }
-			public DateTime? DateTimeNanosNullable { get; set; }
-			public IEnumerable<DateTime?> DateTimeNanosNullables { get; set; }
-
-			public DateTimeOffset DateTimeNanosOffset { get; set; }
-			public DateTimeOffset? DateTimeNanosOffsetNullable { get; set; }
-			public IEnumerable<DateTimeOffset?> DateTimeNanosOffsetNullables { get; set; }
-			public IEnumerable<DateTimeOffset> DateTimeNanosOffsets { get; set; }
-			public IEnumerable<DateTime> DateTimeNanoss { get; set; }
 
 			public decimal Decimal { get; set; }
 			public decimal? DecimalNullable { get; set; }


### PR DESCRIPTION
Remove Scalar Nanos implementation.

Will look at removing `Scalar()` methods in `8.0`.