### PR TITLE
Fix default chunked transfer encoding and expose as configurable

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -145,6 +145,7 @@ namespace Elasticsearch.Net
 		private bool _sniffOnConnectionFault;
 		private bool _sniffOnStartup;
 		private bool _throwExceptions;
+		private bool _transferEncodingChunked;
 
 		private string _userAgent = ConnectionConfiguration.DefaultUserAgent;
 		private Func<HttpMethod, int, bool> _statusCodeToResponseSuccess;
@@ -213,6 +214,7 @@ namespace Elasticsearch.Net
 		ElasticsearchUrlFormatter IConnectionConfigurationValues.UrlFormatter => _urlFormatter;
 		string IConnectionConfigurationValues.UserAgent => _userAgent;
 		Func<HttpMethod, int, bool> IConnectionConfigurationValues.StatusCodeToResponseSuccess => _statusCodeToResponseSuccess;
+		bool IConnectionConfigurationValues.TransferEncodingChunked => _transferEncodingChunked;
 
 		void IDisposable.Dispose() => DisposeManagedResources();
 
@@ -529,6 +531,11 @@ namespace Elasticsearch.Net
 		/// versions that initiate requests to Elasticsearch
 		/// </summary>
 		public T UserAgent(string userAgent) => Assign(userAgent, (a, v) => a._userAgent = v);
+
+		/// <summary>
+		/// Whether the request should be sent with chunked Transfer-Encoding. Default is <c>true</c>
+		/// </summary>
+		public T TransferEncodingChunked(bool transferEncodingChunked = true) => Assign(transferEncodingChunked, (a, v) => a._transferEncodingChunked = v);
 
 		protected virtual void DisposeManagedResources()
 		{

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -533,7 +533,7 @@ namespace Elasticsearch.Net
 		public T UserAgent(string userAgent) => Assign(userAgent, (a, v) => a._userAgent = v);
 
 		/// <summary>
-		/// Whether the request should be sent with chunked Transfer-Encoding. Default is <c>true</c>
+		/// Whether the request should be sent with chunked Transfer-Encoding. Default is <c>false</c>
 		/// </summary>
 		public T TransferEncodingChunked(bool transferEncodingChunked = true) => Assign(transferEncodingChunked, (a, v) => a._transferEncodingChunked = v);
 

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -244,5 +244,10 @@ namespace Elasticsearch.Net
 		/// <para>NOTE: if a request specifies <see cref="IRequestConfiguration.AllowedStatusCodes"/> this takes precedence</para>
 		/// </summary>
 		Func<HttpMethod, int, bool> StatusCodeToResponseSuccess { get; }
+
+		/// <summary>
+		/// Whether the request should be sent with chunked Transfer-Encoding.
+		/// </summary>
+		bool TransferEncodingChunked { get; }
 	}
 }

--- a/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/RequestConfiguration.cs
@@ -106,35 +106,51 @@ namespace Elasticsearch.Net
 		/// <para>Reasons for such exceptions could be search parser errors, index missing exceptions, etc...</para>
 		/// </summary>
 		bool? ThrowExceptions { get; set; }
+
+		/// <summary>
+		/// Whether the request should be sent with chunked Transfer-Encoding.
+		/// </summary>
+		bool? TransferEncodingChunked { get; set; }
 	}
 
 	public class RequestConfiguration : IRequestConfiguration
 	{
+		/// <inheritdoc />
 		public string Accept { get; set; }
+		/// <inheritdoc />
 		public IReadOnlyCollection<int> AllowedStatusCodes { get; set; }
+		/// <inheritdoc />
 		public BasicAuthenticationCredentials BasicAuthenticationCredentials { get; set; }
-
+		/// <inheritdoc />
 		public ApiKeyAuthenticationCredentials ApiKeyAuthenticationCredentials { get; set; }
-
+		/// <inheritdoc />
 		public X509CertificateCollection ClientCertificates { get; set; }
+		/// <inheritdoc />
 		public string ContentType { get; set; }
+		/// <inheritdoc />
 		public bool? DisableDirectStreaming { get; set; }
+		/// <inheritdoc />
 		public bool? DisablePing { get; set; }
+		/// <inheritdoc />
 		public bool? DisableSniff { get; set; }
+		/// <inheritdoc />
 		public bool? EnableHttpPipelining { get; set; } = true;
+		/// <inheritdoc />
 		public Uri ForceNode { get; set; }
+		/// <inheritdoc />
 		public int? MaxRetries { get; set; }
+		/// <inheritdoc />
 		public string OpaqueId { get; set; }
+		/// <inheritdoc />
 		public TimeSpan? PingTimeout { get; set; }
+		/// <inheritdoc />
 		public TimeSpan? RequestTimeout { get; set; }
-
-		/// <summary>
-		/// Submit the request on behalf in the context of a different user
-		/// https://www.elastic.co/guide/en/shield/current/submitting-requests-for-other-users.html
-		/// </summary>
+		/// <inheritdoc />
 		public string RunAs { get; set; }
-
+		/// <inheritdoc />
 		public bool? ThrowExceptions { get; set; }
+		/// <inheritdoc />
+		public bool? TransferEncodingChunked { get; set; }
 	}
 
 	public class RequestConfigurationDescriptor : IRequestConfiguration
@@ -158,6 +174,7 @@ namespace Elasticsearch.Net
 			Self.ClientCertificates = config?.ClientCertificates;
 			Self.ThrowExceptions = config?.ThrowExceptions;
 			Self.OpaqueId = config?.OpaqueId;
+			Self.TransferEncodingChunked = config?.TransferEncodingChunked;
 		}
 
 		string IRequestConfiguration.Accept { get; set; }
@@ -171,7 +188,6 @@ namespace Elasticsearch.Net
 		bool? IRequestConfiguration.DisableSniff { get; set; }
 		bool? IRequestConfiguration.EnableHttpPipelining { get; set; } = true;
 		Uri IRequestConfiguration.ForceNode { get; set; }
-
 		int? IRequestConfiguration.MaxRetries { get; set; }
 		string IRequestConfiguration.OpaqueId { get; set; }
 		TimeSpan? IRequestConfiguration.PingTimeout { get; set; }
@@ -179,6 +195,7 @@ namespace Elasticsearch.Net
 		string IRequestConfiguration.RunAs { get; set; }
 		private IRequestConfiguration Self => this;
 		bool? IRequestConfiguration.ThrowExceptions { get; set; }
+		bool? IRequestConfiguration.TransferEncodingChunked { get; set; }
 
 		/// <summary>
 		/// Submit the request on behalf in the context of a different shield user
@@ -334,5 +351,12 @@ namespace Elasticsearch.Net
 		/// <summary> Use the following client certificate to authenticate this request to Elasticsearch </summary>
 		public RequestConfigurationDescriptor ClientCertificate(string certificatePath) =>
 			ClientCertificates(new X509Certificate2Collection { new X509Certificate(certificatePath) });
+
+		/// <inheritdoc cref="IRequestConfiguration.TransferEncodingChunked" />
+		public RequestConfigurationDescriptor TransferEncodingChunked(bool? transferEncodingChunked = true)
+		{
+			Self.TransferEncodingChunked = transferEncodingChunked;
+			return this;
+		}
 	}
 }

--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -181,6 +181,9 @@ namespace Elasticsearch.Net
 #endif
 			request.Pipelined = requestData.Pipelined;
 
+			if (requestData.TransferEncodingChunked)
+				request.SendChunked = true;
+
 			if (requestData.HttpCompression)
 			{
 				request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.IO;
-using System.Linq;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Elasticsearch.Net.Extensions;
@@ -80,6 +78,7 @@ namespace Elasticsearch.Net
 			AllowedStatusCodes = local?.AllowedStatusCodes ?? EmptyReadOnly<int>.Collection;
 			ClientCertificates = local?.ClientCertificates ?? global.ClientCertificates;
 			UserAgent = global.UserAgent;
+			TransferEncodingChunked = local?.TransferEncodingChunked ?? global.TransferEncodingChunked;
 		}
 		
 		private readonly string _path;
@@ -122,6 +121,7 @@ namespace Elasticsearch.Net
 		public IReadOnlyCollection<int> SkipDeserializationForStatusCodes { get; }
 		public bool ThrowExceptions { get; }
 		public string UserAgent { get; }
+		public bool TransferEncodingChunked { get; }
 
 		public Uri Uri => Node != null ? new Uri(Node.Uri, PathAndQuery) : null;
 

--- a/src/Tests/Tests/ClientConcepts/Connection/HttpWebRequestConnectionTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/HttpWebRequestConnectionTests.cs
@@ -45,7 +45,7 @@ namespace Tests.ClientConcepts.Connection
 			return requestData;
 		}
 
-		[I] public async Task HttpClientUseTransferEncodingChunkedWhenTransferEncodingChunkedTrue()
+		[I] public async Task HttpWebRequestUseTransferEncodingChunkedWhenTransferEncodingChunkedTrue()
 		{
 			var connection = new TestableHttpWebRequestConnection();
 			var requestData = CreateRequestData(transferEncodingChunked: true);

--- a/src/Tests/Tests/ClientConcepts/Connection/HttpWebRequestConnectionTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/HttpWebRequestConnectionTests.cs
@@ -59,7 +59,7 @@ namespace Tests.ClientConcepts.Connection
 			connection.LastRequest.ContentLength.Should().Be(-1);
 		}
 
-		[I] public async Task HttpClientSetsContentLengthWhenTransferEncodingChunkedFalse()
+		[I] public async Task HttpWebRequestSetsContentLengthWhenTransferEncodingChunkedFalse()
 		{
 			var connection = new TestableHttpWebRequestConnection();
 			var requestData = CreateRequestData(transferEncodingChunked: false);

--- a/src/Tests/Tests/ClientConcepts/Connection/HttpWebRequestConnectionTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/HttpWebRequestConnectionTests.cs
@@ -1,0 +1,106 @@
+﻿#if !DOTNETCORE
+using System.Linq;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.ManagedElasticsearch;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using HttpMethod = Elasticsearch.Net.HttpMethod;
+
+namespace Tests.ClientConcepts.Connection
+{
+	public class HttpWebRequestConnectionTests : ClusterTestClassBase<ReadOnlyCluster>
+	{
+		public HttpWebRequestConnectionTests(ReadOnlyCluster cluster) : base(cluster) { }
+
+		private RequestData CreateRequestData(
+			TimeSpan requestTimeout = default,
+			Uri proxyAddress = null,
+			bool disableAutomaticProxyDetection = false,
+			bool httpCompression = false,
+			bool transferEncodingChunked = false
+		)
+		{
+			if (requestTimeout == default) requestTimeout = TimeSpan.FromSeconds(10);
+
+			var node = Client.ConnectionSettings.ConnectionPool.Nodes.First();
+			var connectionSettings = new ConnectionSettings(node.Uri)
+				.RequestTimeout(requestTimeout)
+				.DisableAutomaticProxyDetection(disableAutomaticProxyDetection)
+				.TransferEncodingChunked(transferEncodingChunked)
+				.EnableHttpCompression(httpCompression);
+
+			if (proxyAddress != null)
+				connectionSettings.Proxy(proxyAddress, null, (string)null);
+
+			var requestData = new RequestData(HttpMethod.POST, "/_search", "{ \"query\": { \"match_all\" : { } } }", connectionSettings,
+				new SearchRequestParameters(),
+				new MemoryStreamFactory()) { Node = node };
+
+			return requestData;
+		}
+
+		[I] public async Task HttpClientUseTransferEncodingChunkedWhenTransferEncodingChunkedTrue()
+		{
+			var connection = new TestableHttpWebRequestConnection();
+			var requestData = CreateRequestData(transferEncodingChunked: true);
+
+			connection.Request<StringResponse>(requestData);
+			connection.LastRequest.SendChunked.Should().BeTrue();
+			connection.LastRequest.ContentLength.Should().Be(-1);
+
+			await connection.RequestAsync<StringResponse>(requestData, CancellationToken.None).ConfigureAwait(false);
+			connection.LastRequest.SendChunked.Should().BeTrue();
+			connection.LastRequest.ContentLength.Should().Be(-1);
+		}
+
+		[I] public async Task HttpClientSetsContentLengthWhenTransferEncodingChunkedFalse()
+		{
+			var connection = new TestableHttpWebRequestConnection();
+			var requestData = CreateRequestData(transferEncodingChunked: false);
+
+			connection.Request<StringResponse>(requestData);
+			connection.LastRequest.SendChunked.Should().BeFalse();
+			connection.LastRequest.ContentLength.Should().BeGreaterThan(0);
+
+			await connection.RequestAsync<StringResponse>(requestData, CancellationToken.None).ConfigureAwait(false);
+			connection.LastRequest.SendChunked.Should().BeFalse();
+			connection.LastRequest.ContentLength.Should().BeGreaterThan(0);
+		}
+
+		public class TestableHttpWebRequestConnection : HttpWebRequestConnection
+		{
+			public int CallCount { get; private set; }
+
+			public HttpWebRequest LastRequest { get; private set; }
+
+			public HttpWebResponse LastResponse => LastRequest != null && LastRequest.HaveResponse
+				? (HttpWebResponse)LastRequest?.GetResponse()
+				: null;
+
+			public override TResponse Request<TResponse>(RequestData requestData)
+			{
+				CallCount++;
+				return base.Request<TResponse>(requestData);
+			}
+
+			public override Task<TResponse> RequestAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+			{
+				CallCount++;
+				return base.RequestAsync<TResponse>(requestData, cancellationToken);
+			}
+
+			protected override HttpWebRequest CreateHttpWebRequest(RequestData requestData)
+			{
+				LastRequest = base.CreateHttpWebRequest(requestData);
+				return LastRequest;
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
This PR reverts the behaviour of the client to not use chunked tranfer encoding by default, and exposes chunked transfer encoding as a configuration value on IConnectionConfigurationValues and RequestConfiguration.

With the introduction of the pull based streaming model in RequestDataContent, a ContentLength value cannot be computed for what will be written to the request stream; a ContentLength value is attempted to be determined, and TryComputeLength() executed, _before_ PostData is serialized to the request stream, making it not possible to provide a ContentLength value in the implementation, and falling into the HttpClient behaviour of using chunked transfer encoding.

A potential fix could have been applied in RequestDataContent, to serialize PostData ahead of time and store in a byte array or stream field, and the logical place to do this would have been the ctor. It was determined however that this would be less than optimal to do because

1. It starts to overcomplicate the RequestDataContent implementation
2. An implementation in the RequestDataContent ctor would not have been able to use aynchronous methods for the RequestAsync<T> asynchronous path.

Instead, the serialization of PostData happens in sync and async paths in HttpConnection, using ByteArrayContent and the written request bytes when DisabledDirectStreaming is enabled to avoid keeping two copies of the request bytes around.

Additional integration tests added for HttpConnection and HttpWebRequestConnection to assert behaviour.

Fixes #3952