### PR TITLE
Improve Index name inference docs

### DIFF
--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -152,6 +152,10 @@ NOTE: You can set this to a high value here, and specify a timeout on Elasticsea
 
 Register a ServerCertificateValidationCallback, this is called per endpoint until it returns true. After this callback returns true that endpoint is validated for the lifetime of the ServiceEndpoint for that host.
 
+`SkipDeserializationForStatusCodes`::
+
+Configure the client to skip deserialization of certain status codes e.g: you run elasticsearch behind a proxy that returns a HTML for 401, 500
+
 `SniffLifeSpan`::
 
 Set the duration after which a cluster state is considered stale and a sniff should be performed again. An `IConnectionPool` has to signal it supports reseeding, otherwise sniffing will never happen.             Defaults to 1 hour.             Set to null to disable completely. Sniffing will only ever happen on ConnectionPools that return true for SupportsReseeding

--- a/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
@@ -23,35 +23,29 @@ NEST has a number of ways in which the index name(s) can be specified
 ==== Default Index name on Connection Settings
 
 A default index name can be specified on `ConnectionSettings` using `.DefaultIndex()`.
-This is the default index name to use when no other index name can be resolved for a request
+This is the default index name to use, when no other index name can be resolved for a request
 
 [source,csharp]
 ----
 var settings = new ConnectionSettings()
-    .DefaultIndex("defaultindex");
-var resolver = new IndexNameResolver(settings);
-var index = resolver.Resolve<Project>();
-index.Should().Be("defaultindex");
+    .DefaultIndex("defaultindex"); <1>
+
+var client = new ElasticClient(settings);
+var searchResponse = client.Search<Project>();
+----
+<1> set the default index
+
+will send a search request to the API endpoint
+
+[source,javascript]
+----
+"http://localhost:9200/defaultindex/project/_search"
 ----
 
 [[index-name-type-mapping]]
-==== Mapping an Index name for a .NET type
+==== Index name for a .NET type
 
-A index name can be mapped for CLR types using `.MapDefaultTypeIndices()` on `ConnectionSettings`.
-
-[source,csharp]
-----
-var settings = new ConnectionSettings()
-    .DefaultMappingFor<Project>(m => m
-        .IndexName("projects")
-    );
-var resolver = new IndexNameResolver(settings);
-var index = resolver.Resolve<Project>();
-index.Should().Be("projects");
-----
-
-`.DefaultMappingFor<T>()` can also be used to specify the index name, as well as be used
-to specify the type name and POCO property that should be used as the id for the document
+An index name can be mapped for a _Plain Old CLR Object_ (POCO) using `.DefaultMappingFor<T>()` on `ConnectionSettings`
 
 [source,csharp]
 ----
@@ -59,67 +53,117 @@ var settings = new ConnectionSettings()
     .DefaultMappingFor<Project>(m => m
         .IndexName("projects")
     );
-var resolver = new IndexNameResolver(settings);
-var index = resolver.Resolve<Project>();
-index.Should().Be("projects");
+
+var client = new ElasticClient(settings);
+var searchResponse = client.Search<Project>();
 ----
 
-An index name for a POCO provided using `.MapDefaultTypeIndices()` or `.DefaultMappingFor<T>()` **will take precedence** over
+will send a search request to the API endpoint
+
+[source,javascript]
+----
+"http://localhost:9200/projects/project/_search"
+----
+
+`.DefaultMappingFor<T>()` can also be used to specify other defaults for a POCO, including
+property names, property to use for the document id, amongst others.
+
+An index name for a POCO provided using `.DefaultMappingFor<T>()` **will take precedence** over
 the default index name set on `ConnectionSettings`. This way, the client can be configured with a default index to use if no
 index is specified, and a specific index to use for different POCO types.
 
 [source,csharp]
 ----
 var settings = new ConnectionSettings()
-    .DefaultIndex("defaultindex")
+    .DefaultIndex("defaultindex") <1>
     .DefaultMappingFor<Project>(m => m
-        .IndexName("projects")
+        .IndexName("projects") <2>
     );
-var resolver = new IndexNameResolver(settings);
-var index = resolver.Resolve<Project>();
-index.Should().Be("projects");
+
+var client = new ElasticClient(settings);
+
+var projectSearchResponse = client.Search<Project>();
+----
+<1> a default index to use, when no other index can be inferred
+
+<2> a index to use when `Project` is the target POCO type
+
+will send a search request to the API endpoint
+
+[source,javascript]
+----
+"http://localhost:9200/projects/project/_search"
+----
+
+but
+
+[source,csharp]
+----
+var objectSearchResponse = client.Search<object>();
+----
+
+will send a search request to the API endpoint
+
+[source,javascript]
+----
+"http://localhost:9200/defaultindex/object/_search"
 ----
 
 ==== Explicitly specifying Index name on the request
 
-For API calls that expect an index name, the index name can be explicitly provided
+For API calls that expect an index name, an index name can be explicitly provided
 on the request
 
 [source,csharp]
 ----
-var client = TestClient.Default;
-var response = client.Search<Project>(s => s.Index("some-other-index")); <1>
-var requestUri = response.ApiCall.Uri;
+var settings = new ConnectionSettings();
+var client = new ElasticClient(settings);
 
-requestUri.Should().NotBeNull();
-requestUri.LocalPath.Should().StartWith("/some-other-index/");
+var response = client.Search<Project>(s => s
+    .Index("some-other-index") <1>
+);
 ----
 <1> Provide the index name on the request
 
+will send a search request to the API endpoint
+
+[source,javascript]
+----
+"http://localhost:9200/some-other-index/project/_search"
+----
+
 When an index name is provided on a request, it **will take precedence** over the default
-index name and any index name specified for the POCO type using `.MapDefaultTypeIndices()` or
-`.DefaultMappingFor<T>()`
+index name specified on `ConnectionSettings`, _and_ any index name specified for the POCO
+using `.DefaultMappingFor<T>()`. The following example will send a search request
+to the same API endpoint as the previous example
 
 [source,csharp]
 ----
-var client = new ElasticClient(new AlwaysInMemoryConnectionSettings()
+var settings = new ConnectionSettings()
     .DefaultIndex("defaultindex")
     .DefaultMappingFor<Project>(m => m
         .IndexName("projects")
-    ));
+    );
 
-var response = client.Search<Project>(s => s.Index("some-other-index")); <1>
+var client = new ElasticClient(settings);
 
-response.ApiCall.Uri.Should().NotBeNull();
-response.ApiCall.Uri.LocalPath.Should().StartWith("/some-other-index/");
+var response = client.Search<Project>(s => s
+    .Index("some-other-index")
+);
 ----
-<1> Provide the index name on the request
 
 In summary, the order of precedence for determining the index name for a request is
 
 . Index name specified  on the request
 
-. Index name specified for the generic type parameter in the request using `.MapDefaultTypeIndices()` or `.DefaultMappingFor<T>()`
+. Index name specified for the generic type parameter in the request using `.DefaultMappingFor<T>()`
 
 . Default index name specified on `ConnectionSettings`
+
+[IMPORTANT]
+--
+If no index can be determined for a request that requires an index, the client will throw
+an exception to indicate that this is the case.
+
+--
 

--- a/src/CodeGeneration/DocGenerator/StringExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/StringExtensions.cs
@@ -218,7 +218,7 @@ namespace DocGenerator
 
 		public static string[] SplitOnNewLines(this string input, StringSplitOptions options) => input.Split(new[] { "\r\n", "\n" }, options);
 
-		public static bool TryGetJsonForAnonymousType(this string anonymousTypeString, out string json)
+		public static bool TryGetJsonForExpressionSyntax(this string anonymousTypeString, out string json)
 		{
 			json = null;
 

--- a/src/CodeGeneration/DocGenerator/SyntaxNodeExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/SyntaxNodeExtensions.cs
@@ -71,12 +71,11 @@ namespace DocGenerator
 		{
 			json = null;
 
-			// find the first anonymous object or new object expression
-			var creationExpressionSyntax = node.DescendantNodes()
-				.FirstOrDefault(n => n is AnonymousObjectCreationExpressionSyntax || n is ObjectCreationExpressionSyntax);
+			// find the first anonymous object, new object expression, or literal expression
+			var syntax = node.DescendantNodes()
+				.FirstOrDefault(n => n is AnonymousObjectCreationExpressionSyntax || n is ObjectCreationExpressionSyntax || n is LiteralExpressionSyntax);
 
-			return creationExpressionSyntax != null &&
-				creationExpressionSyntax.ToFullString().TryGetJsonForAnonymousType(out json);
+			return syntax != null && syntax.ToFullString().TryGetJsonForExpressionSyntax(out json);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This commit improves the readability of the index name inference documentation,
and updates paragraphs in line with client changes.

Closes #3914