### PR TITLE
Fix for #3971, change check for mimeType to include empty string

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -67,7 +67,7 @@ namespace Elasticsearch.Net
 						.StatusCodeToResponseSuccess(requestData.Method, statusCode.Value);
 			}
 			//mimeType can include charset information on .NET full framework
-			if (mimeType != null && !mimeType.StartsWith(requestData.RequestMimeType))
+			if (!string.IsNullOrEmpty(mimeType) && !mimeType.StartsWith(requestData.RequestMimeType))
 				success = false;
 
 			var details = new ApiCallDetails


### PR DESCRIPTION
Check if mimeType is empty string, or null, as this is different in .NET Core vs FULL .NET.