### PR TITLE
Connection pool ping honours relative path

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -561,7 +561,7 @@ namespace Elasticsearch.Net
 			IRequestParameters requestParameters = new RootNodeInfoRequestParameters();
 			requestParameters.RequestConfiguration = requestOverrides;
 
-			var data = new RequestData(HttpMethod.HEAD, "/", null, _settings, requestParameters, _memoryStreamFactory) { Node = node };
+			var data = new RequestData(HttpMethod.HEAD, string.Empty, null, _settings, requestParameters, _memoryStreamFactory) { Node = node };
 			return data;
 		}
 

--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/Pinging/PingTests.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/Pinging/PingTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.ClientConcepts.Connection;
+using Tests.Core.ManagedElasticsearch.Clusters;
+
+
+namespace Tests.ClientConcepts.ConnectionPooling.Pinging
+{
+	public class PingTests : IClusterFixture<ReadOnlyCluster>
+	{
+		private readonly ReadOnlyCluster _cluster;
+
+		public PingTests(ReadOnlyCluster cluster) => _cluster = cluster;
+
+#if DOTNETCORE
+		[I]
+		public void UsesRelativePathForPing()
+		{
+			var pool = new StaticConnectionPool(new[] { new Uri("http://localhost:9200/elasticsearch/") });
+			var settings = new ConnectionSettings(pool,
+				new HttpConnectionTests.TestableHttpConnection(response =>
+				{
+					response.RequestMessage.RequestUri.AbsolutePath.Should().StartWith("/elasticsearch/");
+				}));
+
+			var client = new ElasticClient(settings);
+			var healthResponse = client.Ping();
+		}
+#else
+		[I]
+		public void UsesRelativePathForPing()
+		{
+			var pool = new StaticConnectionPool(new[] { new Uri("http://localhost:9200/elasticsearch/") });
+			var connection = new HttpWebRequestConnectionTests.TestableHttpWebRequestConnection();
+			var settings = new ConnectionSettings(pool, connection);
+
+			var client = new ElasticClient(settings);
+			var healthResponse = client.Ping();
+
+			connection.LastRequest.Address.AbsolutePath.Should().StartWith("/elasticsearch/");
+		}
+#endif
+	}
+}
+

--- a/src/Tests/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
+++ b/src/Tests/Tests/Framework/VirtualClustering/VirtualClusterConnection.cs
@@ -67,7 +67,7 @@ namespace Tests.Framework.VirtualClustering
 		public bool IsSniffRequest(RequestData requestData) =>
 			requestData.PathAndQuery.StartsWith(RequestPipeline.SniffPath, StringComparison.Ordinal);
 
-		public bool IsPingRequest(RequestData requestData) => requestData.PathAndQuery == "/" && requestData.Method == HttpMethod.HEAD;
+		public bool IsPingRequest(RequestData requestData) => requestData.PathAndQuery == string.Empty && requestData.Method == HttpMethod.HEAD;
 
 		public override TResponse Request<TResponse>(RequestData requestData)
 		{


### PR DESCRIPTION
This commit updates the RequestPipeline ping operation to use an empty string for the ping relative path. Using a relative
path that starts with "/" will overwrite any base path when combined with the node URI.

Fixes #3970