### PR TITLE
AuditTrail integration assertion fix

### DIFF
--- a/src/Tests/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs
@@ -87,7 +87,7 @@ namespace Tests.ClientConcepts.Troubleshooting
 			 * some understanding of how long it took
 			 */
 			response.ApiCall.AuditTrail
-				.Should().OnlyContain(a => a.Ended - a.Started > TimeSpan.Zero);
+				.Should().OnlyContain(a => a.Ended - a.Started >= TimeSpan.Zero);
 
 		}
 	}


### PR DESCRIPTION
Audit trail test assumed timespan is never TimeSpan.Zero but of course can be.

Needs to be cherry-picked to `7.2` as well