### PR TITLE
Serialize GeoLocation with internal serializer

### DIFF
--- a/src/Serializers/Nest.JsonNetSerializer/Converters/HandleNestTypesOnSourceJsonConverter.cs
+++ b/src/Serializers/Nest.JsonNetSerializer/Converters/HandleNestTypesOnSourceJsonConverter.cs
@@ -16,7 +16,8 @@ namespace Nest.JsonNetSerializer.Converters
 			typeof(CompletionField),
 			typeof(Attachment),
 			typeof(ILazyDocument),
-			typeof(GeoCoordinate)
+			typeof(GeoCoordinate),
+			typeof(GeoLocation)
 		};
 
 		private readonly IElasticsearchSerializer _builtInSerializer;

--- a/src/Tests/Tests.Reproduce/GitHubIssue3981.cs
+++ b/src/Tests/Tests.Reproduce/GitHubIssue3981.cs
@@ -1,0 +1,31 @@
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue3981
+	{
+		// This test always passes because the JsonPropertyAttribute on
+		// the GeoLocation type are recognized by the JsonNetSerializer when used in tests, because the
+		// IL rewriting to internalize Json.NET in the client happens *after* tests are run.
+		[U]
+		public void JsonNetSerializerSerializesGeoLocation()
+		{
+			var document = new Document
+			{
+				Location = new GeoLocation(45, 45)
+			};
+
+			var indexResponse = TestClient.InMemoryWithJsonNetSerializer.IndexDocument(document);
+			Encoding.UTF8.GetString(indexResponse.ApiCall.RequestBodyInBytes).Should().Contain("\"lat\"").And.Contain("\"lon\"");
+		}
+
+		private class Document
+		{
+			public GeoLocation Location { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
This commit adds GeoLocation to types handled by the internal serializer so that
a property on a document POCO of type GeoLocation is serialized by the internal serializer.

It's not possible with the current test configuration to test this scenario, because
IL rewriting happens after unit tests are run, so the Json.NET constructs used on Nest types
are recognised by the JsonNetSerializer. Have added test that _would_ test behaviour, should
tests be run after IL-merging in the future.

Fixes #3981