### PR TITLE
Add numeric_type sorting option.

### DIFF
--- a/src/Nest/Search/Search/Sort/NumericType.cs
+++ b/src/Nest/Search/Search/Sort/NumericType.cs
@@ -1,0 +1,25 @@
+using System.Runtime.Serialization;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	/// <summary>
+	/// For numeric fields it is also possible to cast the values from one type to another using this option. This can be useful for cross-index
+	/// search if the sort field is mapped differently on some indices.
+	/// </summary>
+	[StringEnum]
+	public enum NumericType
+	{
+		[EnumMember(Value = "long")]
+		Long,
+
+		[EnumMember(Value = "double")]
+		Double,
+
+		[EnumMember(Value = "date")]
+		Date,
+
+		[EnumMember(Value = "date_nanos")]
+		DateNanos
+	}
+}

--- a/src/Nest/Search/Search/Sort/SortBase.cs
+++ b/src/Nest/Search/Search/Sort/SortBase.cs
@@ -23,6 +23,12 @@ namespace Nest
 		SortMode? Mode { get; set; }
 
 		/// <summary>
+		/// Set a single resolution for the sort
+		/// </summary>
+		[DataMember(Name ="numeric_type")]
+		NumericType? NumericType { get; set; }
+
+		/// <summary>
 		/// Specifies the path and filter to apply when sorting on a nested field
 		/// </summary>
 		[DataMember(Name ="nested")]
@@ -48,6 +54,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public SortMode? Mode { get; set; }
+
+		/// <inheritdoc />
+		public NumericType? NumericType { get; set; }
 
 		/// <inheritdoc />
 		public INestedSort Nested { get; set; }
@@ -76,6 +85,7 @@ namespace Nest
 
 		object ISort.Missing { get; set; }
 		SortMode? ISort.Mode { get; set; }
+		NumericType? ISort.NumericType { get; set; }
 		INestedSort ISort.Nested { get; set; }
 		SortOrder? ISort.Order { get; set; }
 		Field ISort.SortKey => SortKey;
@@ -92,6 +102,9 @@ namespace Nest
 
 		/// <inheritdoc cref="ISort.Order" />
 		public virtual TDescriptor Order(SortOrder? order) => Assign(order, (a, v) => a.Order = v);
+
+		/// <inheritdoc cref="ISort.NumericType" />
+		public virtual TDescriptor NumericType(NumericType? numericType) => Assign(numericType, (a, v) => a.NumericType = v);
 
 		/// <inheritdoc cref="ISort.Mode" />
 		public virtual TDescriptor Mode(SortMode? mode) => Assign(mode, (a, v) => a.Mode = v);

--- a/src/Tests/Tests/Search/Request/SortUsageTests.cs
+++ b/src/Tests/Tests/Search/Request/SortUsageTests.cs
@@ -333,7 +333,7 @@ namespace Tests.Search.Request
 	}
 
 	//hide
-	[SkipVersion("<7..0", "numeric_type added in 7.2.0")]
+	[SkipVersion("<7.2.0", "numeric_type added in 7.2.0")]
 	public class NumericTypeUsageTests : SearchUsageTestBase
 	{
 		public NumericTypeUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }

--- a/src/Tests/Tests/Search/Request/SortUsageTests.cs
+++ b/src/Tests/Tests/Search/Request/SortUsageTests.cs
@@ -331,4 +331,38 @@ namespace Tests.Search.Request
 				}
 			};
 	}
+
+	//hide
+	[SkipVersion("<7..0", "numeric_type added in 7.2.0")]
+	public class NumericTypeUsageTests : SearchUsageTestBase
+	{
+		public NumericTypeUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson =>
+			new
+			{
+				sort = new object[]
+				{
+					new { startedOn = new { numeric_type = "date", order = "asc" } }
+				}
+			};
+
+		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
+			.Sort(ss => ss
+				.Field(g => g
+					.Field(p => p.StartedOn)
+					.NumericType(NumericType.Date)
+					.Ascending()
+				)
+			);
+
+		protected override SearchRequest<Project> Initializer =>
+			new SearchRequest<Project>
+			{
+				Sort = new List<ISort>
+				{
+					new FieldSort { Field = "startedOn", NumericType = NumericType.Date, Order = SortOrder.Ascending },
+				}
+			};
+	}
 }


### PR DESCRIPTION
For numeric fields it is also possible to cast the values from one type to another using this option. This can be useful for cross-index search if the sort field is mapped differently on some indices.