### PR TITLE
Add a CloudConnectionPool

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -66,6 +66,18 @@ namespace Elasticsearch.Net
 		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
 		public ConnectionConfiguration(Uri uri = null)
 			: this(new SingleNodeConnectionPool(uri ?? new Uri("http://localhost:9200"))) { }
+		
+		/// <summary>
+		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
+		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
+		/// </summary>
+		public ConnectionConfiguration(string cloudId, BasicAuthenticationCredentials credentials) : this(new CloudConnectionPool(cloudId, credentials)) { }
+
+		/// <summary>
+		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
+		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
+		/// </summary>
+		public ConnectionConfiguration(string cloudId, ApiKeyAuthenticationCredentials credentials) : this(new CloudConnectionPool(cloudId, credentials)) { }
 
 		/// <summary>
 		/// Creates a new instance of <see cref="ConnectionConfiguration"/>
@@ -167,6 +179,14 @@ namespace Elasticsearch.Net
 
 			_urlFormatter = new ElasticsearchUrlFormatter(this);
 			_statusCodeToResponseSuccess = (m, i) => HttpStatusCodeClassifier(m, i);
+			
+			if (connectionPool is CloudConnectionPool cloudPool)
+			{
+				_basicAuthCredentials = cloudPool.BasicCredentials;
+				_apiKeyAuthCredentials = cloudPool.ApiKeyCredentials;
+				_enableHttpCompression = true;
+			}
+
 		}
 
 		protected IElasticsearchSerializer UseThisRequestResponseSerializer { get; set; }

--- a/src/Elasticsearch.Net/Configuration/Security/ApiKeyAuthenticationCredentials.cs
+++ b/src/Elasticsearch.Net/Configuration/Security/ApiKeyAuthenticationCredentials.cs
@@ -9,29 +9,20 @@ namespace Elasticsearch.Net
 	/// </summary>
 	public class ApiKeyAuthenticationCredentials : IDisposable
 	{
-		public ApiKeyAuthenticationCredentials()
-		{
-		}
+		//TODO remove this constructor in 8.0
+		public ApiKeyAuthenticationCredentials() { }
 
-		public ApiKeyAuthenticationCredentials(string id, SecureString apiKey)
-		{
+		public ApiKeyAuthenticationCredentials(string id, SecureString apiKey) => 
 			Base64EncodedApiKey = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{id}:{apiKey.CreateString()}")).CreateSecureString();
-		}
 
-		public ApiKeyAuthenticationCredentials(string id, string apiKey)
-		{
+		public ApiKeyAuthenticationCredentials(string id, string apiKey) => 
 			Base64EncodedApiKey = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{id}:{apiKey}")).CreateSecureString();
-		}
 
-		public ApiKeyAuthenticationCredentials(string base64EncodedApiKey)
-		{
+		public ApiKeyAuthenticationCredentials(string base64EncodedApiKey) => 
 			Base64EncodedApiKey = base64EncodedApiKey.CreateSecureString();
-		}
 
-		public ApiKeyAuthenticationCredentials(SecureString base64EncodedApiKey)
-		{
+		public ApiKeyAuthenticationCredentials(SecureString base64EncodedApiKey) => 
 			Base64EncodedApiKey = base64EncodedApiKey;
-		}
 
 		/// <summary>
 		/// The Base64 encoded api key with which to authenticate

--- a/src/Elasticsearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
+++ b/src/Elasticsearch.Net/Configuration/Security/BasicAuthenticationCredentials.cs
@@ -8,9 +8,8 @@ namespace Elasticsearch.Net
 	/// </summary>
 	public class BasicAuthenticationCredentials : IDisposable
 	{
-		public BasicAuthenticationCredentials()
-		{
-		}
+		//TODO remove this constructor in 8.0
+		public BasicAuthenticationCredentials() { }
 
 		public BasicAuthenticationCredentials(string username, string password)
 		{
@@ -35,5 +34,6 @@ namespace Elasticsearch.Net
 		public string Username { get; set; }
 
 		public void Dispose() => Password?.Dispose();
+		
 	}
 }

--- a/src/Elasticsearch.Net/ConnectionPool/CloudConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/CloudConnectionPool.cs
@@ -7,7 +7,7 @@ namespace Elasticsearch.Net
 	/// An <see cref="IConnectionPool"/> implementation that can be seeded with a cloud id
 	/// and will signal the right defaults for the client to use for Elastic Cloud to <see cref="IConnectionConfigurationValues"/>.
 	///
-	/// <para>Read more about Elastic Cloud Id here</para>
+	/// <para>Read more about Elastic Cloud Id:</para>
 	/// <para>https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html</para>
 	/// </summary>
 	public class CloudConnectionPool : SingleNodeConnectionPool
@@ -80,7 +80,7 @@ namespace Elasticsearch.Net
 
 		private static ParsedCloudId ParseCloudId(string cloudId)
 		{
-			const string exceptionSuffix = "should a string in the form of cluster_name:base_64_data";
+			const string exceptionSuffix = "should be a string in the form of cluster_name:base_64_data";
 			if (string.IsNullOrWhiteSpace(cloudId))
 				throw new ArgumentException($"Parameter {nameof(cloudId)} was null or empty but {exceptionSuffix}", nameof(cloudId));
 

--- a/src/Elasticsearch.Net/ConnectionPool/CloudConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/CloudConnectionPool.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Text;
+
+namespace Elasticsearch.Net 
+{
+	/// <summary>
+	/// An <see cref="IConnectionPool"/> implementation that can be seeded with a cloud id
+	/// and will signal the right defaults for the client to use for Elastic Cloud to <see cref="IConnectionConfigurationValues"/>.
+	///
+	/// <para>Read more about Elastic Cloud Id here</para>
+	/// <para>https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html</para>
+	/// </summary>
+	public class CloudConnectionPool : SingleNodeConnectionPool
+	{
+		/// <summary>
+		/// An <see cref="IConnectionPool"/> implementation that can be seeded with a cloud id
+		/// and will signal the right defaults for the client to use for Elastic Cloud to <see cref="IConnectionConfigurationValues"/>.
+		///
+		/// <para>Read more about Elastic Cloud Id here</para>
+		/// <para>https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html</para>
+		/// </summary>
+		/// <param name="cloudId">
+		/// The Cloud Id, this is available on your cluster's dashboard and is a string in the form of <c>cluster_name:base_64_encoded_string<c>
+		/// <para>Base64 encoded string contains the following tokens in order separated by $:</para>
+		/// <para>* Host Name (mandatory)</para>
+		/// <para>* Elasticsearch UUID (mandatory)</para>
+		/// <para>* Kibana UUID</para>
+		/// <para>* APM UUID</para>
+		/// <para></para>
+		/// <para> We then use these tokens to create the URI to your Elastic Cloud cluster!</para>
+		/// <para></para>
+		/// <para> Read more here: https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html</para>
+		/// </param>
+		public CloudConnectionPool(string cloudId, BasicAuthenticationCredentials credentials, IDateTimeProvider dateTimeProvider = null) : this(ParseCloudId(cloudId), dateTimeProvider) =>
+			BasicCredentials = credentials;
+
+		/// <summary>
+		/// An <see cref="IConnectionPool"/> implementation that can be seeded with a cloud id
+		/// and will signal the right defaults for the client to use for Elastic Cloud to <see cref="IConnectionConfigurationValues"/>.
+		///
+		/// <para>Read more about Elastic Cloud Id here</para>
+		/// <para>https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html</para>
+		/// </summary>
+		/// <param name="cloudId">
+		/// The Cloud Id, this is available on your cluster's dashboard and is a string in the form of <c>cluster_name:base_64_encoded_string<c>
+		/// <para>Base64 encoded string contains the following tokens in order separated by $:</para>
+		/// <para>* Host Name (mandatory)</para>
+		/// <para>* Elasticsearch UUID (mandatory)</para>
+		/// <para>* Kibana UUID</para>
+		/// <para>* APM UUID</para>
+		/// <para></para>
+		/// <para> We then use these tokens to create the URI to your Elastic Cloud cluster!</para>
+		/// <para></para>
+		/// <para> Read more here: https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html</para>
+		/// </param>
+		public CloudConnectionPool(string cloudId, ApiKeyAuthenticationCredentials credentials, IDateTimeProvider dateTimeProvider = null) : this(ParseCloudId(cloudId), dateTimeProvider) =>
+			ApiKeyCredentials  = credentials;
+
+		private CloudConnectionPool(ParsedCloudId parsedCloudId, IDateTimeProvider dateTimeProvider = null) : base(parsedCloudId.Uri, dateTimeProvider) =>
+			ClusterName = parsedCloudId.Name;
+
+		//TODO implement debugger display for IConnectionPool implementations and display it there and its ToString()
+		private string ClusterName { get; }
+		
+		public BasicAuthenticationCredentials BasicCredentials { get; }
+
+		public ApiKeyAuthenticationCredentials ApiKeyCredentials { get; }
+
+		private struct ParsedCloudId
+		{
+			public ParsedCloudId(string clusterName, Uri uri)
+			{
+				Name = clusterName;
+				Uri = uri;
+			}
+
+			public string Name { get; }
+			public Uri Uri { get; }
+		}
+
+		private static ParsedCloudId ParseCloudId(string cloudId)
+		{
+			const string exceptionSuffix = "should a string in the form of cluster_name:base_64_data";
+			if (string.IsNullOrWhiteSpace(cloudId))
+				throw new ArgumentException($"Parameter {nameof(cloudId)} was null or empty but {exceptionSuffix}", nameof(cloudId));
+
+			var tokens = cloudId.Split(new[] { ':' }, 2);
+			if (tokens.Length != 2)
+				throw new ArgumentException($"Parameter {nameof(cloudId)} not in expected format, {exceptionSuffix}", nameof(cloudId));
+
+			var clusterName = tokens[0];
+			var encoded = tokens[1];
+			if (string.IsNullOrWhiteSpace(encoded))
+				throw new ArgumentException($"Parameter {nameof(cloudId)} base_64_data is empty, {exceptionSuffix}", nameof(cloudId));
+
+			var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+			var parts = decoded.Split(new[] { '$' });
+			if (parts.Length < 2)
+				throw new ArgumentException($"Parameter {nameof(cloudId)} decoded base_64_data contains less then 2 tokens, {exceptionSuffix}", nameof(cloudId));
+			
+			var domainName = parts[0].Trim();
+			if (string.IsNullOrWhiteSpace(domainName))
+				throw new ArgumentException($"Parameter {nameof(cloudId)} decoded base_64_data contains no domain name, {exceptionSuffix}", nameof(cloudId));
+			
+			var elasticsearchUuid = parts[1].Trim();
+			if (string.IsNullOrWhiteSpace(elasticsearchUuid))
+				throw new ArgumentException($"Parameter {nameof(cloudId)} decoded base_64_data contains no elasticsearch UUID, {exceptionSuffix}", nameof(cloudId));
+
+			return new ParsedCloudId(clusterName, new Uri($"https://{elasticsearchUuid}.{domainName}"));
+		}
+
+		protected override void DisposeManagedResources()
+		{
+			ApiKeyCredentials?.Dispose();
+			BasicCredentials?.Dispose();
+		}
+	}
+}

--- a/src/Elasticsearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 
 namespace Elasticsearch.Net
 {
-	/// <summary>
-	/// A connection pool to a single node or endpoint
-	/// </summary>
+	/// <summary> A connection pool to a single node or endpoint </summary>
 	public class SingleNodeConnectionPool : IConnectionPool
 	{
 		/// <inheritdoc />

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.cs
@@ -24,7 +24,7 @@ namespace Elasticsearch.Net
 		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
 		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
 		/// <para></para>If you want more control use the <see cref="ElasticLowLevelClient(IConnectionConfigurationValues)"/> constructor and pass an instance of
-		/// <see cref="ConnectionConfiguration" /> that takes <see cref="cloudId"/> in its constructor as well
+		/// <see cref="ConnectionConfiguration" /> that takes <paramref name="cloudId"/> in its constructor as well
 		/// </summary>
 		public ElasticLowLevelClient(string cloudId, BasicAuthenticationCredentials credentials) : this(new ConnectionConfiguration(cloudId, credentials)) { }
 
@@ -32,7 +32,7 @@ namespace Elasticsearch.Net
 		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
 		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
 		/// <para></para>If you want more control use the <see cref="ElasticLowLevelClient(IConnectionConfigurationValues)"/> constructor and pass an instance of
-		/// <see cref="ConnectionConfiguration" /> that takes <see cref="cloudId"/> in its constructor as well
+		/// <see cref="ConnectionConfiguration" /> that takes <paramref name="cloudId"/> in its constructor as well
 		/// </summary>
 		public ElasticLowLevelClient(string cloudId, ApiKeyAuthenticationCredentials credentials) : this(new ConnectionConfiguration(cloudId, credentials)) { }
 

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.cs
@@ -21,6 +21,22 @@ namespace Elasticsearch.Net
 			new Transport<IConnectionConfigurationValues>(settings ?? new ConnectionConfiguration())) { }
 
 		/// <summary>
+		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
+		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
+		/// <para></para>If you want more control use the <see cref="ElasticLowLevelClient(IConnectionConfigurationValues)"/> constructor and pass an instance of
+		/// <see cref="ConnectionConfiguration" /> that takes <see cref="cloudId"/> in its constructor as well
+		/// </summary>
+		public ElasticLowLevelClient(string cloudId, BasicAuthenticationCredentials credentials) : this(new ConnectionConfiguration(cloudId, credentials)) { }
+
+		/// <summary>
+		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
+		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
+		/// <para></para>If you want more control use the <see cref="ElasticLowLevelClient(IConnectionConfigurationValues)"/> constructor and pass an instance of
+		/// <see cref="ConnectionConfiguration" /> that takes <see cref="cloudId"/> in its constructor as well
+		/// </summary>
+		public ElasticLowLevelClient(string cloudId, ApiKeyAuthenticationCredentials credentials) : this(new ConnectionConfiguration(cloudId, credentials)) { }
+
+		/// <summary>
 		/// Instantiate a new low level Elasticsearch client explicitly specifying a custom transport setup
 		/// </summary>
 		public ElasticLowLevelClient(ITransport<IConnectionConfigurationValues> transport)

--- a/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
+++ b/src/Nest/CommonAbstractions/ConnectionSettings/ConnectionSettingsBase.cs
@@ -15,9 +15,7 @@ namespace Nest
 	/// <inheritdoc cref="IConnectionSettingsValues" />
 	public class ConnectionSettings : ConnectionSettingsBase<ConnectionSettings>
 	{
-		/// <summary>
-		/// The default user agent for Nest
-		/// </summary>
+		/// <summary> The default user agent for Nest </summary>
 		public static readonly string DefaultUserAgent =
 			$"elasticsearch-net/{typeof(IConnectionSettingsValues).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion} ({RuntimeInformation.OSDescription}; {RuntimeInformation.FrameworkDescription}; Nest)";
 
@@ -28,8 +26,23 @@ namespace Nest
 		/// </summary>
 		public delegate IElasticsearchSerializer SourceSerializerFactory(IElasticsearchSerializer builtIn, IConnectionSettingsValues values);
 
-		public ConnectionSettings(Uri uri = null)
-			: this(new SingleNodeConnectionPool(uri ?? new Uri("http://localhost:9200"))) { }
+		/// <summary>
+		/// Creates a new instance of connection settings, if <paramref name="uri"/> is not specified will default to connecting to http://localhost:9200
+		/// </summary>
+		/// <param name="uri"></param>
+		public ConnectionSettings(Uri uri = null) : this(new SingleNodeConnectionPool(uri ?? new Uri("http://localhost:9200"))) { }
+
+		/// <summary>
+		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
+		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
+		/// </summary>
+		public ConnectionSettings(string cloudId, BasicAuthenticationCredentials credentials) : this(new CloudConnectionPool(cloudId, credentials)) { }
+
+		/// <summary>
+		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
+		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
+		/// </summary>
+		public ConnectionSettings(string cloudId, ApiKeyAuthenticationCredentials credentials) : this(new CloudConnectionPool(cloudId, credentials)) { }
 
 		/// <summary>
 		/// Instantiate connection settings using a <see cref="SingleNodeConnectionPool" /> using the provided

--- a/src/Nest/ElasticClient.cs
+++ b/src/Nest/ElasticClient.cs
@@ -79,7 +79,7 @@ namespace Nest
 		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
 		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
 		/// <para></para>If you want more control use the <see cref="ElasticClient(IConnectionSettingsValues)"/> constructor and pass an instance of
-		/// <see cref="ConnectionSettings" /> that takes <see cref="cloudId"/> in its constructor as well
+		/// <see cref="ConnectionSettings" /> that takes <paramref name="cloudId"/> in its constructor as well
 		/// </summary>
 		public ElasticClient(string cloudId, BasicAuthenticationCredentials credentials) : this(new ConnectionSettings(cloudId, credentials)) { }
 
@@ -87,7 +87,7 @@ namespace Nest
 		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
 		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
 		/// <para></para>If you want more control use the <see cref="ElasticClient(IConnectionSettingsValues)"/> constructor and pass an instance of
-		/// <see cref="ConnectionSettings" /> that takes <see cref="cloudId"/> in its constructor as well
+		/// <see cref="ConnectionSettings" /> that takes <paramref name="cloudId"/> in its constructor as well
 		/// </summary>
 		public ElasticClient(string cloudId, ApiKeyAuthenticationCredentials credentials) : this(new ConnectionSettings(cloudId, credentials)) { }
 

--- a/src/Nest/ElasticClient.cs
+++ b/src/Nest/ElasticClient.cs
@@ -74,6 +74,22 @@ namespace Nest
 		public ElasticClient() : this(new ConnectionSettings(new Uri("http://localhost:9200"))) { }
 
 		public ElasticClient(Uri uri) : this(new ConnectionSettings(uri)) { }
+		
+		/// <summary>
+		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
+		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
+		/// <para></para>If you want more control use the <see cref="ElasticClient(IConnectionSettingsValues)"/> constructor and pass an instance of
+		/// <see cref="ConnectionSettings" /> that takes <see cref="cloudId"/> in its constructor as well
+		/// </summary>
+		public ElasticClient(string cloudId, BasicAuthenticationCredentials credentials) : this(new ConnectionSettings(cloudId, credentials)) { }
+
+		/// <summary>
+		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
+		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
+		/// <para></para>If you want more control use the <see cref="ElasticClient(IConnectionSettingsValues)"/> constructor and pass an instance of
+		/// <see cref="ConnectionSettings" /> that takes <see cref="cloudId"/> in its constructor as well
+		/// </summary>
+		public ElasticClient(string cloudId, ApiKeyAuthenticationCredentials credentials) : this(new ConnectionSettings(cloudId, credentials)) { }
 
 		public ElasticClient(IConnectionSettingsValues connectionSettings)
 			: this(new Transport<IConnectionSettingsValues>(connectionSettings ?? new ConnectionSettings())) { }

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
+mode: u
 
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype

--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -160,7 +160,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 				Action create = () => new ElasticClient(id, credentials);
 
 				create.Should().Throw<ArgumentException>()
-					.And.Message.Should().Contain("should a string in the form of cluster_name:base_64_data");
+					.And.Message.Should().Contain("should be a string in the form of cluster_name:base_64_data");
 			}
 
 		}

--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -96,7 +96,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 		 *
 		 * `host_name$elasticsearch_uuid$kibana_uuid$apm_uuid`
 		 *
-		 * Out of these only `host_name` and `elasticsearch_uuid` are always available.
+		 * Out of these, only `host_name` and `elasticsearch_uuid` are always available.
 		 * 
 		*/
 		[U] public void CloudConnectionPool()


### PR DESCRIPTION
This PR allows Elastic Cloud users to use their Cloud Id to configure the client much like they would Logstash / Beats see: https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html

This also allows us to set some specific `ConnectionSettings` defaults.