### PR TITLE
Add XML docs for index inference on BulkAll

### DIFF
--- a/src/Nest/Document/Multiple/BulkAll/BulkAllRequest.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllRequest.cs
@@ -47,7 +47,11 @@ namespace Nest
 		/// </summary>
 		Action<BulkResponseItemBase, T> DroppedDocumentCallback { get; set; }
 
-		///<summary>Default index for items which don't provide one</summary>
+		///<summary>The index to use for items that don't specify one. By default, will be inferred from <typeparamref name="T"/>.
+		/// If no default index has been mapped for <typeparamref name="T" />
+		/// using <see cref="ConnectionSettingsBase{TConnectionSettings}.DefaultMappingFor{TDocument}"/>
+		/// on <see cref="Nest.ConnectionSettings"/>, an exception will be thrown.
+		/// </summary>
 		IndexName Index { get; set; }
 
 		///<summary>The maximum number of bulk operations we want to have in flight at a time</summary>
@@ -85,7 +89,7 @@ namespace Nest
 		/// non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 		/// </summary>
 		int? WaitForActiveShards { get; set; }
-		
+
 		/// <summary>
 		/// Be notified every time a bulk response returns, this includes retries.
 		/// <see cref="IObserver{T}.OnNext"/> is only called for successful batches.
@@ -152,7 +156,7 @@ namespace Nest
 
 		/// <inheritdoc />
 		public int? WaitForActiveShards { get; set; }
-		
+
 		/// <inheritdoc />
 		public Action<BulkResponse> BulkResponseCallback { get; set; }
 	}
@@ -248,7 +252,7 @@ namespace Nest
 		/// <inheritdoc cref="IBulkAllRequest{T}.DroppedDocumentCallback" />
 		public BulkAllDescriptor<T> DroppedDocumentCallback(Action<BulkResponseItemBase, T> callback) =>
 			Assign(callback, (a, v) => a.DroppedDocumentCallback = v);
-		
+
 		/// <inheritdoc cref="IBulkAllRequest{T}.BulkResponseCallback" />
 		public BulkAllDescriptor<T> BulkResponseCallback(Action<BulkResponse> callback) =>
 			Assign(callback, (a, v) => a.BulkResponseCallback = v);

--- a/src/Nest/Document/Multiple/BulkAll/ElasticClient-BulkAll.cs
+++ b/src/Nest/Document/Multiple/BulkAll/ElasticClient-BulkAll.cs
@@ -7,7 +7,12 @@ namespace Nest
 	public partial interface IElasticClient
 	{
 		/// <summary>
-		/// BulkAll is a generic helper that will partition any lazy stream of documents and send them to Elasticsearch as bulks concurrently
+		/// BulkAll is a generic helper that will partition any lazy stream of documents and send them to Elasticsearch as concurrent bulk requests.
+		/// <para />
+		/// The index to target will be inferred from <typeparamref name="T" />. If no default index has been mapped for <typeparamref name="T" />
+		/// using <see cref="ConnectionSettingsBase{TConnectionSettings}.DefaultMappingFor{TDocument}"/> on <see cref="Nest.ConnectionSettings"/>, an exception will be thrown.
+		/// Inference can be overridden using <see cref="BulkAllDescriptor{T}.Index"/>, and in addition,
+		/// an index can be specified for each document using <see cref="BulkAllDescriptor{T}.BufferToBulk"/>.
 		/// </summary>
 		/// <param name="documents">The lazy stream of documents</param>
 		BulkAllObservable<T> BulkAll<T>(
@@ -18,7 +23,12 @@ namespace Nest
 			where T : class;
 
 		/// <summary>
-		/// BulkAll is a generic helper that will partition any lazy stream of documents and send them to Elasticsearch as bulks concurrently
+		/// BulkAll is a generic helper that will partition any lazy stream of documents and send them to Elasticsearch as concurrent bulk requests
+		/// <para />
+		/// The index to target will be inferred from <typeparamref name="T" />. If no default index has been mapped for <typeparamref name="T" />
+		/// using <see cref="ConnectionSettingsBase{TConnectionSettings}.DefaultMappingFor{TDocument}"/> on <see cref="Nest.ConnectionSettings"/>, an exception will be thrown.
+		/// Inference can be overridden using <see cref="IBulkAllRequest{T}.Index"/>, and in addition,
+		/// an index can be specified for each document using <see cref="IBulkAllRequest{T}.BufferToBulk"/>.
 		/// </summary>
 		BulkAllObservable<T> BulkAll<T>(IBulkAllRequest<T> request, CancellationToken cancellationToken = default) where T : class;
 	}


### PR DESCRIPTION
This commit adds additional XML docs to indicate that Index on `BulkAllRequest<T>` will be inferred from `T`. When a default index has not been mapped for
`T` on `ConnectionSettings`, using `DefaultMappingFor<T>(m => m.IndexName("some_index"))`, an exception will be thrown.

Closes #3951