### PR TITLE
Ensure GeoLocationFormatter returns GeoLocation type

### DIFF
--- a/src/Nest/QueryDsl/Geo/GeoLocationFormatter.cs
+++ b/src/Nest/QueryDsl/Geo/GeoLocationFormatter.cs
@@ -42,7 +42,7 @@ namespace Nest
 					reader.ReadNextBlock();
 			}
 
-			return new GeoCoordinate(lat, lon);
+			return new GeoLocation(lat, lon);
 		}
 
 		public void Serialize(ref JsonWriter writer, GeoLocation value, IJsonFormatterResolver formatterResolver)


### PR DESCRIPTION
The ReindexApiTests were failing on a serialisation roundtrip when dealing with properties that used the GeoLocation type. This manifested due to the inclusion of GeoLocation types in the _source serialisation on commit https://github.com/elastic/elasticsearch-net/commit/5492599e7d5964bbc0c9f7975f81ad5db276ea4e

The `GeoLocationFormatter` was found to be returning a `GeoCoordinate` type and not a `GeoLocation` type.