### PR TITLE
Normalize exception from cancelling an observable coordinated operation

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -287,6 +287,8 @@ namespace Elasticsearch.Net
 		{
 			if (!FirstPoolUsageNeedsSniffing) return;
 
+			// TODO cancellationToken could throw here and will bubble out as OperationCancelledException
+			// everywhere else it would bubble out wrapped in a `UnexpectedElasticsearchClientException`
 			var success = await semaphore.WaitAsync(_settings.RequestTimeout, cancellationToken).ConfigureAwait(false);
 			if (!success)
 			{

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -143,6 +143,9 @@ namespace Elasticsearch.Net
 					}
 					catch (Exception killerException)
 					{
+						if (killerException is OperationCanceledException && cancellationToken.IsCancellationRequested)
+							pipeline.AuditCancellationRequested();
+
 						throw new UnexpectedElasticsearchClientException(killerException, seenExceptions)
 						{
 							Request = requestData,

--- a/src/Tests/Tests/Document/Multiple/BulkAll/BulkAllCancellationTokenApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/BulkAll/BulkAllCancellationTokenApiTests.cs
@@ -45,12 +45,13 @@ namespace Tests.Document.Multiple.BulkAll
 			//when we subscribe the observable becomes hot
 			observableBulk.Subscribe(bulkObserver);
 
-			//we wait Nseconds to see some bulks
+			//we wait N seconds to see some bulks
 			handle.WaitOne(TimeSpan.FromSeconds(3));
 			tokenSource.Cancel();
-			//we wait Nseconds to give in flight request a chance to cancel
+			//we wait N seconds to give in flight request a chance to cancel
 			handle.WaitOne(TimeSpan.FromSeconds(3));
-			if (ex != null && !(ex is TaskCanceledException) && !(ex is OperationCanceledException)) throw ex;
+
+			if (ex != null && !(ex is OperationCanceledException)) throw ex;
 
 			seenPages.Should().BeLessThan(pages).And.BeGreaterThan(0);
 			var count = Client.Count<SmallObject>(f => f.Index(index));

--- a/src/Tests/Tests/Document/Multiple/BulkAll/BulkAllDisposeApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/BulkAll/BulkAllDisposeApiTests.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
@@ -50,7 +51,8 @@ namespace Tests.Document.Multiple.BulkAll
 			observableBulk.Dispose();
 			//we wait N seconds to give in flight request a chance to cancel
 			handle.WaitOne(TimeSpan.FromSeconds(3));
-			if (ex != null && !(ex is TaskCanceledException) && !(ex is OperationCanceledException)) throw ex;
+
+			if (ex != null && !(ex is OperationCanceledException)) throw ex;
 
 			seenPages.Should().BeLessThan(pages).And.BeGreaterThan(0);
 			var count = Client.Count<SmallObject>(f => f.Index(index));


### PR DESCRIPTION
Coordinated request observables when aborted could bubble out an `UnexpectedElasticsearchClientException` or an `OperationCancelledException`.

This normalizes what gets passed to `OnError` namely (`OperationCancelledException`)

This is a bug was never released and something that the early termination in `ForEach` that #4014 fixed highlighted. 